### PR TITLE
Add Additional statements for exporting individual Enum Values See #74

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>javawriter</artifactId>
-        <version>2.2.1</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
@@ -93,12 +93,30 @@ public class MessageWriter {
       writer.endType();
     } else if (type instanceof EnumType) {
       EnumType enumType = (EnumType) type;
-      writer.beginType(enumType.getName(), "enum", EnumSet.of(PUBLIC));
-      for (EnumType.Value value : enumType.getValues()) {
+      writer.beginType(enumType.getName(), "enum", EnumSet.of(PUBLIC), null, "ProtoEnum");
+      List<EnumType.Value> values = enumType.getValues();
+      for (int i = 0, count = values.size(); i < count; i++) {
+        EnumType.Value value = values.get(i);
         MessageWriter.emitDocumentation(writer, value.getDocumentation());
-        writer.emitAnnotation(ProtoEnum.class, value.getTag());
-        writer.emitEnumValue(value.getName());
+        writer.emitEnumValue(value.getName() + "(" + value.getTag() + ")", (i == count - 1));
       }
+
+      // Output Private tag field
+      writer.emitEmptyLine();
+      writer.emitField("int", "value", EnumSet.of(PRIVATE, FINAL));
+      writer.emitEmptyLine();
+
+      // Private Constructor
+      writer.beginConstructor(EnumSet.of(PRIVATE), "int", "value");
+      writer.emitStatement("this.value = value");
+      writer.endConstructor();
+      writer.emitEmptyLine();
+
+      // Public Getter
+      writer.emitAnnotation(Override.class);
+      writer.beginMethod("int", "getValue", EnumSet.of(PUBLIC));
+      writer.emitStatement("return value");
+      writer.endMethod();
       writer.endType();
     }
   }

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1211,9 +1211,20 @@ public final class AllTypes extends ExtendableMessage<AllTypes> {
     }
   }
 
-  public enum NestedEnum {
-    @ProtoEnum(1)
-    A,
+  public enum NestedEnum
+      implements ProtoEnum {
+    A(1);
+
+    private final int value;
+
+    private NestedEnum(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 
   public static final class NestedMessage extends Message {

--- a/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
@@ -15,32 +15,21 @@
  */
 package com.squareup.wire;
 
-import java.lang.reflect.Field;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
- * Converts values of an enum to and from integers using {@link ProtoEnum}
- * annotations.
+ * Converts values of an enum to and from integers.
  */
 final class EnumAdapter<E extends Enum> {
   private final Map<Integer, E> fromInt = new LinkedHashMap<Integer, E>();
   private final Map<E, Integer> toInt = new LinkedHashMap<E, Integer>();
 
   EnumAdapter(Class<E> type) {
-    // Record values for each constant annotated with '@ProtoEnum'.
     for (E value : type.getEnumConstants()) {
-      try {
-        Field f = type.getField(value.name());
-        if (f.isAnnotationPresent(ProtoEnum.class)) {
-          ProtoEnum annotation = f.getAnnotation(ProtoEnum.class);
-          int tag = annotation.value();
-          fromInt.put(tag, value);
-          toInt.put(value, tag);
-        }
-      } catch (NoSuchFieldException e) {
-        throw new RuntimeException(e);
-      }
+      int tag = ((ProtoEnum) value).getValue();
+      fromInt.put(tag, value);
+      toInt.put(value, tag);
     }
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -176,7 +176,7 @@ public abstract class Message {
 
   /**
    * Returns the integer value tagged associated with the given enum instance.
-   * If the enum value is not annotated with a {@link ProtoEnum} annotation, an exception
+   * If the enum instance is not initialized with an integer tag value, an exception
    * will be thrown.
    *
    * @param <E> the enum class type
@@ -189,8 +189,8 @@ public abstract class Message {
 
   /**
    * Returns the enumerated value tagged with the given integer value for the
-   * given enum class. If no enum value in the given class is annotated with a {@link ProtoEnum}
-   * annotation having the given value, null is returned.
+   * given enum class. If no enum value in the given class is initialized
+   * with the given integer tag value, an exception will be thrown.
    *
    * @param <E> the enum class type
    */

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoEnum.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoEnum.java
@@ -15,19 +15,13 @@
  */
 package com.squareup.wire;
 
-import java.lang.annotation.ElementType;
-import java.lang.annotation.Retention;
-import java.lang.annotation.RetentionPolicy;
-import java.lang.annotation.Target;
-
-
 /**
- * Annotates generated {@link Enum} values with metadata for serialization and
+ * Interface for generated {@link Enum} values to help serialization and
  * deserialization.
  */
-@Target(ElementType.FIELD)
-@Retention(RetentionPolicy.RUNTIME)
-public @interface ProtoEnum {
-  /** The value of the enum constant, as declared in the .proto source file. */
-  int value();
+public interface ProtoEnum {
+  /**
+   * The tag value of an enum constant.
+   */
+  int getValue();
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -202,15 +202,24 @@ public final class FieldOptions extends ExtendableMessage<FieldOptions> {
     }
   }
 
-  public enum CType {
+  public enum CType
+      implements ProtoEnum {
     /**
      * Default mode.
      */
-    @ProtoEnum(0)
-    STRING,
-    @ProtoEnum(1)
-    CORD,
-    @ProtoEnum(2)
-    STRING_PIECE,
+    STRING(0),
+    CORD(1),
+    STRING_PIECE(2);
+
+    private final int value;
+
+    private CType(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1212,9 +1212,20 @@ public final class AllTypes extends ExtendableMessage<AllTypes> {
     }
   }
 
-  public enum NestedEnum {
-    @ProtoEnum(1)
-    A,
+  public enum NestedEnum
+      implements ProtoEnum {
+    A(1);
+
+    private final int value;
+
+    private NestedEnum(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 
   public static final class NestedMessage extends Message {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -254,12 +254,21 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     }
   }
 
-  public enum FooBarBazEnum {
-    @ProtoEnum(1)
-    FOO,
-    @ProtoEnum(2)
-    BAR,
-    @ProtoEnum(3)
-    BAZ,
+  public enum FooBarBazEnum
+      implements ProtoEnum {
+    FOO(1),
+    BAR(2),
+    BAZ(3);
+
+    private final int value;
+
+    private FooBarBazEnum(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -213,12 +213,21 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     }
   }
 
-  public enum FooBarBazEnum {
-    @ProtoEnum(1)
-    FOO,
-    @ProtoEnum(2)
-    BAR,
-    @ProtoEnum(3)
-    BAZ,
+  public enum FooBarBazEnum
+      implements ProtoEnum {
+    FOO(1),
+    BAR(2),
+    BAZ(3);
+
+    private final int value;
+
+    private FooBarBazEnum(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
@@ -4,9 +4,19 @@ package com.squareup.wire.protos.foreign;
 
 import com.squareup.wire.ProtoEnum;
 
-public enum ForeignEnum {
-  @ProtoEnum(0)
-  BAV,
-  @ProtoEnum(1)
-  BAX,
+public enum ForeignEnum
+    implements ProtoEnum {
+  BAV(0),
+  BAX(1);
+
+  private final int value;
+
+  private ForeignEnum(int value) {
+    this.value = value;
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -135,16 +135,25 @@ public final class Person extends Message {
     }
   }
 
-  public enum PhoneType {
-    @ProtoEnum(0)
-    MOBILE,
-    @ProtoEnum(1)
-    HOME,
+  public enum PhoneType
+      implements ProtoEnum {
+    MOBILE(0),
+    HOME(1),
     /**
      * Could be phone or fax.
      */
-    @ProtoEnum(2)
-    WORK,
+    WORK(2);
+
+    private final int value;
+
+    private PhoneType(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 
   public static final class PhoneNumber extends Message {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
@@ -4,9 +4,19 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.ProtoEnum;
 
-public enum G {
-  @ProtoEnum(1)
-  FOO,
-  @ProtoEnum(2)
-  BAR,
+public enum G
+    implements ProtoEnum {
+  FOO(1),
+  BAR(2);
+
+  private final int value;
+
+  private G(int value) {
+    this.value = value;
+  }
+
+  @Override
+  public int getValue() {
+    return value;
+  }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -353,12 +353,21 @@ public final class SimpleMessage extends Message {
     }
   }
 
-  public enum NestedEnum {
-    @ProtoEnum(1)
-    FOO,
-    @ProtoEnum(2)
-    BAR,
-    @ProtoEnum(3)
-    BAZ,
+  public enum NestedEnum
+      implements ProtoEnum {
+    FOO(1),
+    BAR(2),
+    BAZ(3);
+
+    private final int value;
+
+    private NestedEnum(int value) {
+      this.value = value;
+    }
+
+    @Override
+    public int getValue() {
+      return value;
+    }
   }
 }


### PR DESCRIPTION
After exposing last enum method in [https://github.com/square/javawriter/pull/42] I have added additional statements which allow individual Enum values to be exposed. 

Now Enums look like this:

``` java
public enum FooBarBazEnum {
    @ProtoEnum(1)
    FOO,
    @ProtoEnum(2)
    BAR,
    @ProtoEnum(3)
    BAZ;
    public static final Integer FOO_VALUE = 1;
    public static final Integer BAR_VALUE = 2;
    public static final Integer BAZ_VALUE = 3;
  }
```

This change would require a SNAPSHOT version of JavaWriter and I am not quite sure which tests it's going to break and need fixing. 

Comments? @danrice-square 
