### PR TITLE
Bump JavaWriter to 2.4.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
       <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>javawriter</artifactId>
-        <version>2.2.1</version>
+        <version>2.4.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
@@ -134,14 +134,12 @@ public class MessageWriter {
       for (Map.Entry<String, ?> entry : optionsMap.entrySet()) {
         String fqName = entry.getKey();
         ExtensionInfo info = compiler.getExtension(fqName);
-        sb.append(WireCompiler.NEW_LINE_INDENT_LINE_WRAP_INDENT);
-        sb.append(String.format(".setExtension(Ext_%s.%s, %s)",
+        sb.append(String.format("%n.setExtension(Ext_%s.%s, %s)",
             info.location, compiler.getTrailingSegment(fqName),
             compiler.getOptionsMapMaker().createOptionInitializer(entry.getValue(), "", "",
-                info.fqType, false, 1)));
+                info.fqType, false, 0)));
       }
-      sb.append(WireCompiler.NEW_LINE_INDENT_LINE_WRAP_INDENT);
-      sb.append(".build()");
+      sb.append("\n.build()");
       writer.emitEmptyLine();
       writer.emitField("MessageOptions", "MESSAGE_OPTIONS", EnumSet.of(PUBLIC, STATIC, FINAL),
           sb.toString());
@@ -187,14 +185,12 @@ public class MessageWriter {
       if (info == null) {
         throw new WireCompilerException("No extension info for " + fqName);
       }
-      sb.append(WireCompiler.NEW_LINE_INDENT_LINE_WRAP_INDENT);
-      sb.append(String.format(".setExtension(Ext_%s.%s, %s)",
+      sb.append(String.format("%n.setExtension(Ext_%s.%s, %s)",
           info.location,
           compiler.getTrailingSegment(fqName), compiler.getOptionsMapMaker()
-          .createOptionInitializer(entry.getValue(), "", "", info.fqType, false, 1)));
+          .createOptionInitializer(entry.getValue(), "", "", info.fqType, false, 0)));
     }
-    sb.append(WireCompiler.NEW_LINE_INDENT_LINE_WRAP_INDENT);
-    sb.append(".build()");
+    sb.append("\n.build()");
     writer.emitField("FieldOptions", "FIELD_OPTIONS_" + fieldName.toUpperCase(Locale.US),
         EnumSet.of(PUBLIC, STATIC, FINAL), sb.toString());
   }

--- a/wire-compiler/src/main/java/com/squareup/wire/OptionsMapMaker.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/OptionsMapMaker.java
@@ -363,7 +363,7 @@ public class OptionsMapMaker {
         if (isMetadata(key)) {
           continue;
         }
-        sb.append("\n  ");
+        sb.append("\n");
         indent(sb, level);
         sb.append(".");
 
@@ -391,15 +391,15 @@ public class OptionsMapMaker {
             nestedFieldType, false, level);
         sb.append(optionInitializer).append(")");
       }
-      sb.append("\n  ");
+      sb.append("\n");
       indent(sb, level);
       sb.append(".build()");
       if (emitAsList) {
         sb.append(")");
       }
     } else if (listOrMap instanceof List) {
-      sb.append("asList(\n");
-      String sep = "  ";
+      sb.append("asList(");
+      String sep = "\n";
       for (Object objectValue : (List<Object>) listOrMap) {
         sb.append(sep);
         indent(sb, level);
@@ -409,7 +409,7 @@ public class OptionsMapMaker {
           sb.append(createOptionInitializer(objectValue, parentType, parentField, fieldType, true,
               level));
         }
-        sep = ",\n  ";
+        sep = ",\n";
       }
       sb.append(")");
     } else {

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -49,10 +49,7 @@ import static javax.lang.model.element.Modifier.STATIC;
 /** Compiler for Wire protocol buffers. */
 public class WireCompiler {
 
-  static final String INDENT = "  ";
   static final String LINE_WRAP_INDENT = "    ";
-  static final String INDENT_LINE_WRAP_INDENT = INDENT + LINE_WRAP_INDENT;
-  static final String NEW_LINE_INDENT_LINE_WRAP_INDENT = "\n" + INDENT_LINE_WRAP_INDENT;
 
   /**
    * Field options that don't trigger generation of a FIELD_OPTIONS_* field.
@@ -400,9 +397,7 @@ public class WireCompiler {
       StringBuilder classes = new StringBuilder("unmodifiableList(asList(\n");
       int extensionsCount = extensionClasses.size();
       for (int i = 0; i < extensionsCount; i++) {
-        String extensionClass = extensionClasses.get(i);
-        classes.append(INDENT_LINE_WRAP_INDENT);
-        classes.append(extensionClass);
+        classes.append(extensionClasses.get(i));
         classes.append(".class");
         if (i < extensionsCount - 1) {
           classes.append(",\n");
@@ -868,25 +863,22 @@ public class WireCompiler {
         String labelString = getLabelString(field, isEnum);
         if (isScalar) {
           initialValue = String.format("Extension%n"
-              + "%1$s.%2$sExtending(%3$s.class)%n"
-              + "%1$s.setName(\"%4$s\")%n"
-              + "%1$s.setTag(%5$d)%n"
-              + "%1$s.build%6$s()", INDENT_LINE_WRAP_INDENT, field.getType(), className, fqName,
-              tag, labelString);
+              + ".%1$sExtending(%2$s.class)%n"
+              + ".setName(\"%3$s\")%n"
+              + ".setTag(%4$d)%n"
+              + ".build%5$s()", field.getType(), className, fqName, tag, labelString);
         } else if (isEnum) {
           initialValue = String.format("Extension%n"
-              + "%1$s.enumExtending(%2$s.class, %3$s.class)%n"
-              + "%1$s.setName(\"%4$s\")%n"
-              + "%1$s.setTag(%5$d)%n"
-              + "%1$s.build%6$s()", INDENT_LINE_WRAP_INDENT, type, className, fqName, tag,
-              labelString);
+              + ".enumExtending(%1$s.class, %2$s.class)%n"
+              + ".setName(\"%3$s\")%n"
+              + ".setTag(%4$d)%n"
+              + ".build%5$s()", type, className, fqName, tag, labelString);
         } else {
           initialValue = String.format("Extension%n"
-              + "%1$s.messageExtending(%2$s.class, %3$s.class)%n"
-              + "%1$s.setName(\"%4$s\")%n"
-              + "%1$s.setTag(%5$d)%n"
-              + "%1$s.build%6$s()", INDENT_LINE_WRAP_INDENT, type, className, fqName, tag,
-              labelString);
+              + ".messageExtending(%1$s.class, %2$s.class)%n"
+              + ".setName(\"%3$s\")%n"
+              + ".setTag(%4$d)%n"
+              + ".build%5$s()", type, className, fqName, tag, labelString);
         }
 
         if (FieldInfo.isRepeated(field)) {


### PR DESCRIPTION
JavaWriter now handles indentation of multi-line field initializers itself.

@danrice-square 
