### PR TITLE
Remove unnecessary use of map of enum to tag.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
@@ -21,20 +21,17 @@ import java.util.Map;
 /**
  * Converts values of an enum to and from integers.
  */
-final class EnumAdapter<E extends Enum> {
+final class EnumAdapter<E extends ProtoEnum> {
   private final Map<Integer, E> fromInt = new LinkedHashMap<Integer, E>();
-  private final Map<E, Integer> toInt = new LinkedHashMap<E, Integer>();
 
   EnumAdapter(Class<E> type) {
     for (E value : type.getEnumConstants()) {
-      int tag = ((ProtoEnum) value).getValue();
-      fromInt.put(tag, value);
-      toInt.put(value, tag);
+      fromInt.put(value.getValue(), value);
     }
   }
 
   public int toInt(E e) {
-    return toInt.get(e);
+    return e.getValue();
   }
 
   public E fromInt(int value) {

--- a/wire-runtime/src/main/java/com/squareup/wire/Extension.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Extension.java
@@ -58,7 +58,7 @@ public final class Extension<T extends ExtendableMessage<?>, E>
   public static final class Builder<T extends ExtendableMessage<?>, E> {
     private final Class<T> extendedType;
     private final Class<? extends Message> messageType;
-    private final Class<? extends Enum> enumType;
+    private final Class<? extends ProtoEnum> enumType;
     private final Datatype datatype;
     private String name = null;
     private int tag = -1;
@@ -72,7 +72,7 @@ public final class Extension<T extends ExtendableMessage<?>, E>
     }
 
     private Builder(Class<T> extendedType, Class<? extends Message> messageType,
-        Class<? extends Enum> enumType, Datatype datatype) {
+        Class<? extends ProtoEnum> enumType, Datatype datatype) {
       this.extendedType = extendedType;
       this.messageType = messageType;
       this.enumType = enumType;
@@ -222,8 +222,8 @@ public final class Extension<T extends ExtendableMessage<?>, E>
     return new Builder<T, Double>(extendedType, Datatype.DOUBLE);
   }
 
-  public static <T extends ExtendableMessage<?>, E extends Enum> Builder<T, E> enumExtending(
-      Class<E> enumType, Class<T> extendedType) {
+  public static <T extends ExtendableMessage<?>, E extends Enum & ProtoEnum> Builder<T, E> //
+  enumExtending(Class<E> enumType, Class<T> extendedType) {
     return new Builder<T, E>(extendedType, null, enumType, Datatype.ENUM);
   }
 
@@ -234,14 +234,14 @@ public final class Extension<T extends ExtendableMessage<?>, E>
 
   private final Class<T> extendedType;
   private final Class<? extends Message> messageType;
-  private final Class<? extends Enum> enumType;
+  private final Class<? extends ProtoEnum> enumType;
   private final String name;
   private final int tag;
   private final Datatype datatype;
   private final Label label;
 
   private Extension(Class<T> extendedType, Class<? extends Message> messageType,
-      Class<? extends Enum> enumType, String name, int tag, Label label, Datatype datatype) {
+      Class<? extends ProtoEnum> enumType, String name, int tag, Label label, Datatype datatype) {
     this.extendedType = extendedType;
     this.name = name;
     this.tag = tag;
@@ -305,7 +305,7 @@ public final class Extension<T extends ExtendableMessage<?>, E>
     return messageType;
   }
 
-  public Class<? extends Enum> getEnumType() {
+  public Class<? extends ProtoEnum> getEnumType() {
     return enumType;
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -182,7 +182,7 @@ public abstract class Message {
    * @param <E> the enum class type
    */
   @SuppressWarnings("unchecked")
-  public static <E extends Enum> int intFromEnum(E value) {
+  public static <E extends Enum & ProtoEnum> int intFromEnum(E value) {
     EnumAdapter<E> adapter = WIRE.enumAdapter((Class<E>) value.getClass());
     return adapter.toInt(value);
   }
@@ -194,7 +194,7 @@ public abstract class Message {
    *
    * @param <E> the enum class type
    */
-  public static <E extends Enum> E enumFromInt(Class<E> enumClass, int value) {
+  public static <E extends Enum & ProtoEnum> E enumFromInt(Class<E> enumClass, int value) {
     EnumAdapter<E> adapter = WIRE.enumAdapter(enumClass);
     return adapter.fromInt(value);
   }

--- a/wire-runtime/src/main/java/com/squareup/wire/Wire.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Wire.java
@@ -34,8 +34,8 @@ public final class Wire {
       BuilderAdapter<? extends Message.Builder>> builderAdapters =
           new LinkedHashMap<Class<? extends Message.Builder>,
               BuilderAdapter<? extends Message.Builder>>();
-  private final Map<Class<? extends Enum>, EnumAdapter<? extends Enum>> enumAdapters =
-      new LinkedHashMap<Class<? extends Enum>, EnumAdapter<? extends Enum>>();
+  private final Map<Class<? extends ProtoEnum>, EnumAdapter<? extends ProtoEnum>> enumAdapters =
+      new LinkedHashMap<Class<? extends ProtoEnum>, EnumAdapter<? extends ProtoEnum>>();
 
   // Visible to MessageAdapter
   final ExtensionRegistry registry;
@@ -101,7 +101,7 @@ public final class Wire {
    * Returns an enum adapter for {@code enumClass}.
    */
   @SuppressWarnings("unchecked")
-  synchronized <E extends Enum> EnumAdapter<E> enumAdapter(Class<E> enumClass) {
+  synchronized <E extends ProtoEnum> EnumAdapter<E> enumAdapter(Class<E> enumClass) {
     EnumAdapter<E> adapter = (EnumAdapter<E>) enumAdapters.get(enumClass);
     if (adapter == null) {
       adapter = new EnumAdapter<E>(enumClass);


### PR DESCRIPTION
Since enums now have direct access to their tag via `getValue()`, alter the generic bounds to facilitate direct access.

@swankjesse @danrice-square 
