### PR TITLE
Extend qualification should take place in file scope.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/parser/ProtoQualifier.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/parser/ProtoQualifier.java
@@ -40,7 +40,8 @@ final class ProtoQualifier {
       List<ExtendDeclaration> qualifiedExtendDeclarations =
           new ArrayList<ExtendDeclaration>(extendDeclarations.size());
       for (ExtendDeclaration extendDeclaration : extendDeclarations) {
-        qualifiedExtendDeclarations.add(fullyQualifyExtendDeclaration(extendDeclaration, allTypes));
+        qualifiedExtendDeclarations.add(
+            fullyQualifyExtendDeclaration(protoFile.getPackageName(), extendDeclaration, allTypes));
       }
 
       // Create a new proto file using our new types, services, and extends.
@@ -99,11 +100,10 @@ final class ProtoQualifier {
   }
 
   /** Update an extend declaration to only refer to fully-qualified or primitive types. */
-  static ExtendDeclaration fullyQualifyExtendDeclaration(ExtendDeclaration extendDeclaration,
-      Set<String> allTypes) {
-    String qualifiedName = extendDeclaration.getFullyQualifiedName();
+  static ExtendDeclaration fullyQualifyExtendDeclaration(String scope,
+      ExtendDeclaration extendDeclaration, Set<String> allTypes) {
     List<Field> fields = extendDeclaration.getFields();
-    List<Field> qualifiedFields = fullyQualifyFields(fields, qualifiedName, allTypes);
+    List<Field> qualifiedFields = fullyQualifyFields(fields, scope, allTypes);
 
     return new ExtendDeclaration(extendDeclaration.getName(),
         extendDeclaration.getFullyQualifiedName(), extendDeclaration.getDocumentation(),

--- a/wire-compiler/src/test/java/com/squareup/wire/parser/ProtoQualifierTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/parser/ProtoQualifierTest.java
@@ -127,6 +127,22 @@ public class ProtoQualifierTest {
         new MessageType.Field(REQUIRED, "wire.Foo", "foo", 1, "", NO_OPTIONS);
     ExtendDeclaration expected = new ExtendDeclaration("Bar", "wire.Bar", "", asList(expected1));
 
-    assertThat(fullyQualifyExtendDeclaration(extend, allTypes)).isEqualTo(expected);
+    assertThat(fullyQualifyExtendDeclaration("wire", extend, allTypes)).isEqualTo(expected);
+  }
+
+  @Test public void fullyQualifyExtendDescriptorTest() {
+    Set<String> allTypes = ImmutableSet.of("wire.Foo");
+
+    MessageType.Field f1 = new MessageType.Field(REQUIRED, "Foo", "foo", 1, "", NO_OPTIONS);
+    ExtendDeclaration extend =
+        new ExtendDeclaration("FieldOptions", "google.protobuf.FieldOptions", "", asList(f1));
+
+    MessageType.Field expected1 =
+        new MessageType.Field(REQUIRED, "wire.Foo", "foo", 1, "", NO_OPTIONS);
+    ExtendDeclaration expected =
+        new ExtendDeclaration("FieldOptions", "google.protobuf.FieldOptions", "",
+            asList(expected1));
+
+    assertThat(fullyQualifyExtendDeclaration("wire", extend, allTypes)).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
Prior to this change resolution of types would take place in the scope of the fully-qualified name of the type you were extending. This was incorrect behavior.

For example,

``` java
extend google.protobuf.FieldOptions {
  optional Foo foo = 1;
}

enum Foo {}
```
