### PR TITLE
Allow .proto sources with no package name

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/OptionsMapMaker.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/OptionsMapMaker.java
@@ -279,7 +279,7 @@ public class OptionsMapMaker {
       return compiler.getInitializerForType(stringValue, javaTypeName);
     } else if (compiler.isEnum(fieldType)) {
       String javaName = compiler.javaName(fieldType);
-      String javaPackage = compiler.getProtoFile().getJavaPackage();
+      String javaPackage = compiler.getJavaPackage();
       if (javaName.startsWith(javaPackage + ".")) {
         javaName = javaName.substring(javaPackage.length() + 1);
       }
@@ -435,7 +435,7 @@ public class OptionsMapMaker {
       String key = entry.getKey();
 
       ExtensionInfo info = compiler.getExtension(key);
-      if (info != null && !info.fqLocation.startsWith(compiler.getProtoFile().getJavaPackage())) {
+      if (info != null && !info.fqLocation.startsWith(compiler.getJavaPackage())) {
         types.add(info.fqLocation);
       }
 

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -29,6 +29,7 @@ import java.util.Locale;
 import java.util.Map;
 import org.junit.Test;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -139,5 +140,12 @@ public class WireCompilerErrorTest {
     } catch (WireCompilerException e) {
       assertTrue(e.getMessage().toLowerCase(Locale.US).contains("duplicate enum value quix"));
     }
+  }
+
+  @Test public void testNoPackageNameIsLegal() {
+    Map<String, String> output = compile("message Simple { optional int32 f = 1; }");
+    assertTrue(output.containsKey(".Simple"));
+    // Output should not have a 'package' declaration.
+    assertFalse(output.get(".Simple").contains("package"));
   }
 }


### PR DESCRIPTION
This fixes https://github.com/square/wire/issues/105.
