### PR TITLE
If any of the class names Message then the compiled files will be messed up

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
@@ -131,8 +131,8 @@ public class MessageWriter {
     String name = messageType.getName();
     emitDocumentation(writer, messageType.getDocumentation());
     writer.beginType(name, "class", modifiers,
-        compiler.hasExtensions(messageType) ?
-                "ExtendableMessage<" + name + ">" : "com.squareup.wire.Message");
+        compiler.hasExtensions(messageType)
+                ? "ExtendableMessage<" + name + ">" : "com.squareup.wire.Message");
 
     emitMessageOptions(optionsMap);
     if (compiler.emitOptions()) {
@@ -441,8 +441,8 @@ public class MessageWriter {
   private void emitBuilder(MessageType messageType) throws IOException {
     writer.emitEmptyLine();
     writer.beginType("Builder", "class", EnumSet.of(PUBLIC, STATIC, FINAL),
-        (compiler.hasExtensions(messageType) ?
-                "ExtendableBuilder<" : "com.squareup.wire.Message.Builder<")
+        (compiler.hasExtensions(messageType)
+                ? "ExtendableBuilder<" : "com.squareup.wire.Message.Builder<")
             + messageType.getName()
             + ">");
     emitBuilderFields(messageType);

--- a/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
@@ -131,7 +131,8 @@ public class MessageWriter {
     String name = messageType.getName();
     emitDocumentation(writer, messageType.getDocumentation());
     writer.beginType(name, "class", modifiers,
-        compiler.hasExtensions(messageType) ? "ExtendableMessage<" + name + ">" : "com.squareup.wire.Message");
+        compiler.hasExtensions(messageType) ?
+                "ExtendableMessage<" + name + ">" : "com.squareup.wire.Message");
 
     emitMessageOptions(optionsMap);
     if (compiler.emitOptions()) {
@@ -440,7 +441,8 @@ public class MessageWriter {
   private void emitBuilder(MessageType messageType) throws IOException {
     writer.emitEmptyLine();
     writer.beginType("Builder", "class", EnumSet.of(PUBLIC, STATIC, FINAL),
-        (compiler.hasExtensions(messageType) ? "ExtendableBuilder<" : "com.squareup.wire.Message.Builder<")
+        (compiler.hasExtensions(messageType) ?
+                "ExtendableBuilder<" : "com.squareup.wire.Message.Builder<")
             + messageType.getName()
             + ">");
     emitBuilderFields(messageType);

--- a/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
@@ -131,7 +131,7 @@ public class MessageWriter {
     String name = messageType.getName();
     emitDocumentation(writer, messageType.getDocumentation());
     writer.beginType(name, "class", modifiers,
-        compiler.hasExtensions(messageType) ? "ExtendableMessage<" + name + ">" : "Message");
+        compiler.hasExtensions(messageType) ? "ExtendableMessage<" + name + ">" : "com.squareup.wire.Message");
 
     emitMessageOptions(optionsMap);
     if (compiler.emitOptions()) {
@@ -440,7 +440,7 @@ public class MessageWriter {
   private void emitBuilder(MessageType messageType) throws IOException {
     writer.emitEmptyLine();
     writer.beginType("Builder", "class", EnumSet.of(PUBLIC, STATIC, FINAL),
-        (compiler.hasExtensions(messageType) ? "ExtendableBuilder<" : "Message.Builder<")
+        (compiler.hasExtensions(messageType) ? "ExtendableBuilder<" : "com.squareup.wire.Message.Builder<")
             + messageType.getName()
             + ">");
     emitBuilderFields(messageType);

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -672,9 +672,6 @@ public class WireCompiler {
       boolean hasExtensions = hasExtensions(Arrays.asList(type));
 
       Set<String> imports = new LinkedHashSet<String>();
-      if (hasMessage) {
-        imports.add("com.squareup.wire.Message");
-      }
       if (hasMessage || hasExtensions) {
         if (hasFields(type)) {
           imports.add("com.squareup.wire.ProtoField");

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -93,7 +93,7 @@ public class WireCompilerErrorTest {
         + "  optional int32 f = 1;\n"
         + "}\n");
     String generatedSource = output.get("com.squareup.protos.test.Simple");
-    assertTrue(generatedSource.contains("public final class Simple extends Message {"));
+    assertTrue(generatedSource.contains("public final class Simple extends com.squareup.wire.Message {"));
   }
 
   @Test public void testZeroTag() {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
@@ -2,13 +2,12 @@
 // Source file: ../wire-runtime/src/test/proto/child_pkg.proto
 package com.squareup.wire.protos;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 
 import static com.squareup.wire.Message.Datatype.ENUM;
 
-public final class ChildPackage extends Message {
+public final class ChildPackage extends com.squareup.wire.Message {
 
   public static final ForeignEnum DEFAULT_INNER_FOREIGN_ENUM = ForeignEnum.BAV;
 
@@ -33,7 +32,7 @@ public final class ChildPackage extends Message {
     return result != 0 ? result : (hashCode = inner_foreign_enum != null ? inner_foreign_enum.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<ChildPackage> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<ChildPackage> {
 
     public ForeignEnum inner_foreign_enum;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -5,7 +5,6 @@ package com.squareup.wire.protos.alltypes;
 import com.squareup.wire.ByteString;
 import com.squareup.wire.ExtendableMessage;
 import com.squareup.wire.Extension;
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoEnum;
 import com.squareup.wire.ProtoField;
 import java.util.Collections;
@@ -1228,7 +1227,7 @@ public final class AllTypes extends ExtendableMessage<AllTypes> {
     }
   }
 
-  public static final class NestedMessage extends Message {
+  public static final class NestedMessage extends com.squareup.wire.Message {
 
     public static final Integer DEFAULT_A = 0;
 
@@ -1253,7 +1252,7 @@ public final class AllTypes extends ExtendableMessage<AllTypes> {
       return result != 0 ? result : (hashCode = a != null ? a.hashCode() : 0);
     }
 
-    public static final class Builder extends Message.Builder<NestedMessage> {
+    public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage> {
 
       public Integer a;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -5,7 +5,6 @@ package com.squareup.wire.protos.custom_options;
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.ExtendableMessage;
 import com.squareup.wire.Extension;
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoEnum;
 import com.squareup.wire.ProtoField;
 import java.util.Collections;
@@ -204,7 +203,7 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     }
   }
 
-  public static final class Nested extends Message {
+  public static final class Nested extends com.squareup.wire.Message {
 
     public static final FooBarBazEnum DEFAULT_VALUE = FooBarBazEnum.FOO;
 
@@ -229,7 +228,7 @@ public final class FooBar extends ExtendableMessage<FooBar> {
       return result != 0 ? result : (hashCode = value != null ? value.hashCode() : 0);
     }
 
-    public static final class Builder extends Message.Builder<Nested> {
+    public static final class Builder extends com.squareup.wire.Message.Builder<Nested> {
 
       public FooBarBazEnum value;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -4,7 +4,6 @@ package com.squareup.wire.protos.custom_options;
 
 import com.squareup.wire.ExtendableMessage;
 import com.squareup.wire.Extension;
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoEnum;
 import com.squareup.wire.ProtoField;
 import java.util.Collections;
@@ -163,7 +162,7 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     }
   }
 
-  public static final class Nested extends Message {
+  public static final class Nested extends com.squareup.wire.Message {
 
     public static final FooBarBazEnum DEFAULT_VALUE = FooBarBazEnum.FOO;
 
@@ -188,7 +187,7 @@ public final class FooBar extends ExtendableMessage<FooBar> {
       return result != 0 ? result : (hashCode = value != null ? value.hashCode() : 0);
     }
 
-    public static final class Builder extends Message.Builder<Nested> {
+    public static final class Builder extends com.squareup.wire.Message.Builder<Nested> {
 
       public FooBarBazEnum value;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
@@ -3,11 +3,10 @@
 package com.squareup.wire.protos.custom_options;
 
 import com.google.protobuf.MessageOptions;
-import com.squareup.wire.Message;
 import com.squareup.wire.protos.foreign.Ext_foreign;
 import com.squareup.wire.protos.foreign.ForeignMessage;
 
-public final class MessageWithOptions extends Message {
+public final class MessageWithOptions extends com.squareup.wire.Message {
 
   public static final MessageOptions MESSAGE_OPTIONS = new MessageOptions.Builder()
       .setExtension(Ext_custom_options.my_message_option_one, new FooBar.Builder()
@@ -78,7 +77,7 @@ public final class MessageWithOptions extends Message {
     return 0;
   }
 
-  public static final class Builder extends Message.Builder<MessageWithOptions> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<MessageWithOptions> {
 
     public Builder() {
     }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
@@ -2,9 +2,8 @@
 // Source file: ../wire-runtime/src/test/proto/custom_options.proto
 package com.squareup.wire.protos.custom_options;
 
-import com.squareup.wire.Message;
 
-public final class MessageWithOptions extends Message {
+public final class MessageWithOptions extends com.squareup.wire.Message {
 
   private MessageWithOptions(Builder builder) {
     super(builder);
@@ -20,7 +19,7 @@ public final class MessageWithOptions extends Message {
     return 0;
   }
 
-  public static final class Builder extends Message.Builder<MessageWithOptions> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<MessageWithOptions> {
 
     public Builder() {
     }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/NoFields.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/NoFields.java
@@ -2,9 +2,8 @@
 // Source file: ../wire-runtime/src/test/proto/edge_cases.proto
 package com.squareup.wire.protos.edgecases;
 
-import com.squareup.wire.Message;
 
-public final class NoFields extends Message {
+public final class NoFields extends com.squareup.wire.Message {
 
   private NoFields(Builder builder) {
     super(builder);
@@ -20,7 +19,7 @@ public final class NoFields extends Message {
     return 0;
   }
 
-  public static final class Builder extends Message.Builder<NoFields> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<NoFields> {
 
     public Builder() {
     }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -3,12 +3,11 @@
 package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.ByteString;
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.BYTES;
 
-public final class OneBytesField extends Message {
+public final class OneBytesField extends com.squareup.wire.Message {
 
   public static final ByteString DEFAULT_OPT_BYTES = ByteString.EMPTY;
 
@@ -33,7 +32,7 @@ public final class OneBytesField extends Message {
     return result != 0 ? result : (hashCode = opt_bytes != null ? opt_bytes.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<OneBytesField> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<OneBytesField> {
 
     public ByteString opt_bytes;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/edge_cases.proto
 package com.squareup.wire.protos.edgecases;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class OneField extends Message {
+public final class OneField extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_OPT_INT32 = 0;
 
@@ -32,7 +31,7 @@ public final class OneField extends Message {
     return result != 0 ? result : (hashCode = opt_int32 != null ? opt_int32.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<OneField> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<OneField> {
 
     public Integer opt_int32;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -2,7 +2,6 @@
 // Source file: ../wire-runtime/src/test/proto/person.proto
 package com.squareup.wire.protos.person;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoEnum;
 import com.squareup.wire.ProtoField;
 import java.util.Collections;
@@ -14,7 +13,7 @@ import static com.squareup.wire.Message.Datatype.STRING;
 import static com.squareup.wire.Message.Label.REPEATED;
 import static com.squareup.wire.Message.Label.REQUIRED;
 
-public final class Person extends Message {
+public final class Person extends com.squareup.wire.Message {
 
   public static final String DEFAULT_NAME = "";
   public static final Integer DEFAULT_ID = 0;
@@ -77,7 +76,7 @@ public final class Person extends Message {
     return result;
   }
 
-  public static final class Builder extends Message.Builder<Person> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<Person> {
 
     public String name;
     public Integer id;
@@ -156,7 +155,7 @@ public final class Person extends Message {
     }
   }
 
-  public static final class PhoneNumber extends Message {
+  public static final class PhoneNumber extends com.squareup.wire.Message {
 
     public static final String DEFAULT_NUMBER = "";
     public static final PhoneType DEFAULT_TYPE = PhoneType.HOME;
@@ -199,7 +198,7 @@ public final class Person extends Message {
       return result;
     }
 
-    public static final class Builder extends Message.Builder<PhoneNumber> {
+    public static final class Builder extends com.squareup.wire.Message.Builder<PhoneNumber> {
 
       public String number;
       public PhoneType type;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
@@ -2,7 +2,6 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 /**
@@ -20,7 +19,7 @@ import com.squareup.wire.ProtoField;
  *
  * I -> nothing
  */
-public final class A extends Message {
+public final class A extends com.squareup.wire.Message {
 
   @ProtoField(tag = 1)
   public final B c;
@@ -54,7 +53,7 @@ public final class A extends Message {
     return result;
   }
 
-  public static final class Builder extends Message.Builder<A> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<A> {
 
     public B c;
     public D d;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Label.REQUIRED;
 
-public final class B extends Message {
+public final class B extends com.squareup.wire.Message {
 
   @ProtoField(tag = 1, label = REQUIRED)
   public final C c;
@@ -30,7 +29,7 @@ public final class B extends Message {
     return result != 0 ? result : (hashCode = c != null ? c.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<B> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<B> {
 
     public C c;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class C extends Message {
+public final class C extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_I = 0;
 
@@ -32,7 +31,7 @@ public final class C extends Message {
     return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<C> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<C> {
 
     public Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class D extends Message {
+public final class D extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_I = 0;
 
@@ -32,7 +31,7 @@ public final class D extends Message {
     return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<D> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<D> {
 
     public Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
@@ -2,13 +2,12 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.ENUM;
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class E extends Message {
+public final class E extends com.squareup.wire.Message {
 
   public static final G DEFAULT_G = G.FOO;
 
@@ -44,7 +43,7 @@ public final class E extends Message {
     return result;
   }
 
-  public static final class Builder extends Message.Builder<E> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<E> {
 
     public F f;
     public G g;
@@ -75,7 +74,7 @@ public final class E extends Message {
     }
   }
 
-  public static final class F extends Message {
+  public static final class F extends com.squareup.wire.Message {
 
     public static final Integer DEFAULT_I = 0;
 
@@ -100,7 +99,7 @@ public final class E extends Message {
       return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
     }
 
-    public static final class Builder extends Message.Builder<F> {
+    public static final class Builder extends com.squareup.wire.Message.Builder<F> {
 
       public Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
@@ -2,10 +2,9 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
-public final class H extends Message {
+public final class H extends com.squareup.wire.Message {
 
   @ProtoField(tag = 1)
   public final E.F ef;
@@ -28,7 +27,7 @@ public final class H extends Message {
     return result != 0 ? result : (hashCode = ef != null ? ef.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<H> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<H> {
 
     public E.F ef;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
@@ -2,10 +2,9 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
-public final class J extends Message {
+public final class J extends com.squareup.wire.Message {
 
   @ProtoField(tag = 1)
   public final K k;
@@ -28,7 +27,7 @@ public final class J extends Message {
     return result != 0 ? result : (hashCode = k != null ? k.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<J> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<J> {
 
     public K k;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class K extends Message {
+public final class K extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_I = 0;
 
@@ -32,7 +31,7 @@ public final class K extends Message {
     return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<K> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<K> {
 
     public Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -2,7 +2,6 @@
 // Source file: ../wire-runtime/src/test/proto/simple_message.proto
 package com.squareup.wire.protos.simple;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoEnum;
 import com.squareup.wire.ProtoField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
@@ -19,7 +18,7 @@ import static com.squareup.wire.Message.Label.REQUIRED;
 /**
  * A message for testing.
  */
-public final class SimpleMessage extends Message {
+public final class SimpleMessage extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_OPTIONAL_INT32 = 123;
   public static final NestedEnum DEFAULT_DEFAULT_NESTED_ENUM = NestedEnum.BAZ;
@@ -164,7 +163,7 @@ public final class SimpleMessage extends Message {
     return result;
   }
 
-  public static final class Builder extends Message.Builder<SimpleMessage> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<SimpleMessage> {
 
     public Integer optional_int32;
     public NestedMessage optional_nested_msg;
@@ -301,7 +300,7 @@ public final class SimpleMessage extends Message {
     }
   }
 
-  public static final class NestedMessage extends Message {
+  public static final class NestedMessage extends com.squareup.wire.Message {
 
     public static final Integer DEFAULT_BB = 0;
 
@@ -329,7 +328,7 @@ public final class SimpleMessage extends Message {
       return result != 0 ? result : (hashCode = bb != null ? bb.hashCode() : 0);
     }
 
-    public static final class Builder extends Message.Builder<NestedMessage> {
+    public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage> {
 
       public Integer bb;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/samebasename/single_level.proto
 package com.squareup.wire.protos.single_level;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class Bar extends Message {
+public final class Bar extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_BAZ = 0;
 
@@ -32,7 +31,7 @@ public final class Bar extends Message {
     return result != 0 ? result : (hashCode = baz != null ? baz.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<Bar> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<Bar> {
 
     public Integer baz;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -2,14 +2,13 @@
 // Source file: ../wire-runtime/src/test/proto/samebasename/single_level.proto
 package com.squareup.wire.protos.single_level;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 import java.util.Collections;
 import java.util.List;
 
 import static com.squareup.wire.Message.Label.REPEATED;
 
-public final class Bars extends Message {
+public final class Bars extends com.squareup.wire.Message {
 
   public static final List<Bar> DEFAULT_BARS = Collections.emptyList();
 
@@ -34,7 +33,7 @@ public final class Bars extends Message {
     return result != 0 ? result : (hashCode = bars != null ? bars.hashCode() : 1);
   }
 
-  public static final class Builder extends Message.Builder<Bars> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<Bars> {
 
     public List<Bar> bars;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/single_level.proto
 package com.squareup.wire.protos.single_level;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class Foo extends Message {
+public final class Foo extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_BAR = 0;
 
@@ -32,7 +31,7 @@ public final class Foo extends Message {
     return result != 0 ? result : (hashCode = bar != null ? bar.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<Foo> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<Foo> {
 
     public Integer bar;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -2,14 +2,13 @@
 // Source file: ../wire-runtime/src/test/proto/single_level.proto
 package com.squareup.wire.protos.single_level;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 import java.util.Collections;
 import java.util.List;
 
 import static com.squareup.wire.Message.Label.REPEATED;
 
-public final class Foos extends Message {
+public final class Foos extends com.squareup.wire.Message {
 
   public static final List<Foo> DEFAULT_FOOS = Collections.emptyList();
 
@@ -34,7 +33,7 @@ public final class Foos extends Message {
     return result != 0 ? result : (hashCode = foos != null ? foos.hashCode() : 1);
   }
 
-  public static final class Builder extends Message.Builder<Foos> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<Foos> {
 
     public List<Foo> foos;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -2,12 +2,11 @@
 // Source file: ../wire-runtime/src/test/proto/unknown_fields.proto
 package com.squareup.wire.protos.unknownfields;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
 
-public final class VersionOne extends Message {
+public final class VersionOne extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_I = 0;
 
@@ -32,7 +31,7 @@ public final class VersionOne extends Message {
     return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
   }
 
-  public static final class Builder extends Message.Builder<VersionOne> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<VersionOne> {
 
     public Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -2,7 +2,6 @@
 // Source file: ../wire-runtime/src/test/proto/unknown_fields.proto
 package com.squareup.wire.protos.unknownfields;
 
-import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.FIXED32;
@@ -10,7 +9,7 @@ import static com.squareup.wire.Message.Datatype.FIXED64;
 import static com.squareup.wire.Message.Datatype.INT32;
 import static com.squareup.wire.Message.Datatype.STRING;
 
-public final class VersionTwo extends Message {
+public final class VersionTwo extends com.squareup.wire.Message {
 
   public static final Integer DEFAULT_I = 0;
   public static final Integer DEFAULT_V2_I = 0;
@@ -68,7 +67,7 @@ public final class VersionTwo extends Message {
     return result;
   }
 
-  public static final class Builder extends Message.Builder<VersionTwo> {
+  public static final class Builder extends com.squareup.wire.Message.Builder<VersionTwo> {
 
     public Integer i;
     public Integer v2_i;


### PR DESCRIPTION
i.e. In proto file, we define something like
```
message Message {
	....
}
```

This change uses the full name([packageName].[className]) of com.squareup.wire.Message class in compiled java class instead of class name only. Since the proto could define a message names 'Message', which could mess up everything.

I'm able to fix WireCompilerErrorTest but not the WireCompilerTest, haven't figured out where do all the expected files come from.