### PR TITLE
Feature parity of Mojo with CLI.

### DIFF
--- a/wire-maven-plugin/pom.xml
+++ b/wire-maven-plugin/pom.xml
@@ -9,7 +9,6 @@
     <version>1.3.0-SNAPSHOT</version>
   </parent>
 
-  <groupId>com.squareup.wire</groupId>
   <artifactId>wire-maven-plugin</artifactId>
   <name>Wire Protocol Buffer Maven Plugin</name>
   <packaging>maven-plugin</packaging>


### PR DESCRIPTION
Add support for roots, not emitting options, and the registry class.

Closes #107. 
