### PR TITLE
Reduce memory footprint and data copying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
       <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
-        <version>0.6.0</version>
+        <version>0.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>

--- a/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
+++ b/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
@@ -109,17 +109,20 @@ class MessageTypeAdapter<M extends Message> extends TypeAdapter<M> {
     out.endObject();
   }
 
-  private <M extends ExtendableMessage<?>> void emitExtensions(ExtendableMessage<M> message,
+  @SuppressWarnings("unchecked")
+  private <M extends ExtendableMessage<?>, E> void emitExtensions(ExtendableMessage<M> message,
       JsonWriter out) throws IOException {
-    for (Extension<M, ?> extension : message.getExtensions()) {
-      emitExtension(message, extension, out);
+    if (message.extensionMap == null) return;
+    for (int i = 0; i < message.extensionMap.size(); i++) {
+      Extension<M, E> extension = (Extension<M, E>) message.extensionMap.getExtension(i);
+      E value = (E) message.extensionMap.getExtensionValue(i);
+      emitExtension(extension, value, out);
     }
   }
 
-  private <M extends ExtendableMessage<?>, E> void emitExtension(ExtendableMessage<M> message,
-      Extension<M, E> extension, JsonWriter out) throws IOException {
+  private <M extends ExtendableMessage<?>, E> void emitExtension(Extension<M, E> extension,
+      E value, JsonWriter out) throws IOException {
     out.name(extension.getName());
-    E value = message.getExtension(extension);
     emitJson(out, value, extension.getDatatype(), extension.getLabel());
   }
 

--- a/wire-runtime/pom.xml
+++ b/wire-runtime/pom.xml
@@ -40,5 +40,11 @@
       <version>1</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.intellij</groupId>
+      <artifactId>annotations</artifactId>
+      <version>12.0</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/wire-runtime/src/main/java/com/squareup/wire/ExtendableMessage.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ExtendableMessage.java
@@ -108,9 +108,10 @@ public abstract class ExtendableMessage<T extends ExtendableMessage<?>> extends 
      */
     public <E> ExtendableBuilder<T> setExtension(Extension<T, E> extension, E value) {
       if (extensionMap == null) {
-        extensionMap = new ExtensionMap<T>();
+        extensionMap = new ExtensionMap<T>(extension, value);
+      } else {
+        extensionMap.put(extension, value);
       }
-      extensionMap.put(extension, value);
       return this;
     }
   }

--- a/wire-runtime/src/main/java/com/squareup/wire/ExtensionMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ExtensionMap.java
@@ -16,10 +16,9 @@
 package com.squareup.wire;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Maps {@link Extension} keys to their values.
@@ -28,22 +27,56 @@ import java.util.TreeMap;
  */
 final class ExtensionMap<T extends ExtendableMessage<?>> {
 
-  private final Map<Extension<T, ?>, Object> map = new TreeMap<Extension<T, ?>, Object>();
+  private static final int INITIAL_SIZE = 1;
 
-  /** Constructs an empty ExtensionMap. */
-  public ExtensionMap() {
+  // Entries [0..(size - 1)] contain keys, entries [size..(2 * size - 1)] contain values.
+  // This saves 12 bytes per instance over having separate arrays for keys and values.
+  private Object[] data;
+  private int size;
+
+  /** Constructs an ExtensionMap with a single value. */
+  public <E> ExtensionMap(Extension<T, E> extension, E value) {
+    data = new Object[2 * INITIAL_SIZE];
+    data[0] = extension;
+    data[1] = value;
+    size = 1;
   }
 
   /** Constructs an ExtensionMap that is a copy of an existing ExtensionMap. */
   public ExtensionMap(ExtensionMap<T> other) {
-    map.putAll(other.map);
+    data = other.data.clone();
+    size = other.size;
+  }
+
+  public int size() {
+    return size;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Extension<T, ?> getExtension(int index) {
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException("" + index);
+    }
+    return (Extension<T, ?>) data[index];
+  }
+
+  public Object getExtensionValue(int index) {
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException("" + index);
+    }
+    return data[size + index];
   }
 
   /**
    * Returns a {@link List} of {@link Extension}s in this map in tag order.
    */
+  @SuppressWarnings("unchecked")
   public List<Extension<T, ?>> getExtensions() {
-    return Collections.unmodifiableList(new ArrayList<Extension<T, ?>>(map.keySet()));
+    List<Extension<T, ?>> keyList = new ArrayList<Extension<T, ?>>(size);
+    for (int i = 0; i < size; i++) {
+      keyList.add((Extension<T, ?>) data[i]);
+    }
+    return Collections.unmodifiableList(keyList);
   }
 
   /**
@@ -54,7 +87,8 @@ final class ExtensionMap<T extends ExtendableMessage<?>> {
    */
   @SuppressWarnings("unchecked")
   public <E> E get(Extension<T, E> extension) {
-    return (E) map.get(extension);
+    int index = Arrays.binarySearch(data, 0, size, extension);
+    return index < 0 ? null : (E) data[size + index];
   }
 
   /**
@@ -64,26 +98,90 @@ final class ExtensionMap<T extends ExtendableMessage<?>> {
    * @param <E> the (boxed) Java data type of the {@link Extension} value
    */
   public <E> void put(Extension<T, E> extension, E value) {
-    map.put(extension, value);
+    int index = Arrays.binarySearch(data, 0, size, extension);
+    if (index >= 0) {
+      data[size + index] = value;
+    } else {
+      insert(extension, value, -(index + 1));
+    }
   }
 
-  @Override public boolean equals(Object other) {
-    return other instanceof ExtensionMap && map.equals(((ExtensionMap) other).map);
+  private <E> void insert(Extension<T, E> key, E value, int insertionPoint) {
+    // Grow the array and copy over the initial segment if necessary.
+    Object[] dest = data;
+    if (data.length < 2 * (size + 1)) {
+      dest = new Object[2 * data.length];
+      System.arraycopy(data, 0, dest, 0, insertionPoint);
+    }
+
+    // Make room for the new key and value.
+    if (insertionPoint < size) {
+      // Insert within the existing key section:
+      //
+      // K K K K K V V V V V       K = key, V = value
+      // | | | | | | |  \ \ \
+      // | |  \ \ \ \ \  \ \ \
+      // K K * K K K V V * V V V   * = inserted key or value
+
+      // Slide the rightmost values over by 2 slots.
+      System.arraycopy(data, size + insertionPoint, dest, size + insertionPoint + 2,
+          size - insertionPoint);
+      // Slide the middle section containing the rightmost keys and leftmost values over by 1 slot.
+      System.arraycopy(data, insertionPoint, dest, insertionPoint + 1, size);
+    } else {
+      // Insert immediately after the existing key section:
+      //
+      // K K K K K V V V V V
+      // | | | | |  \ \ \ \ \
+      // | | | | |   \ \ \ \ \
+      // K K K K K * V V V V V *
+
+      // Slide all values over by 1 slot.
+      System.arraycopy(data, size, dest, size + 1, size);
+    }
+
+    size++;
+    data = dest;
+
+    data[insertionPoint] = key;
+    data[size + insertionPoint] = value;
+  }
+
+  @SuppressWarnings("unchecked")
+  @Override public boolean equals(Object o) {
+    if (!(o instanceof ExtensionMap<?>)) {
+      return false;
+    }
+    ExtensionMap<T> other = (ExtensionMap<T>) o;
+    if (size != other.size) {
+      return false;
+    }
+    for (int i = 0; i < 2 * size; i++) {
+      if (!data[i].equals(other.data[i])) {
+        return false;
+      }
+    }
+    return true;
   }
 
   @Override public int hashCode() {
-    return map.hashCode();
+    int result = 0;
+    for (int i = 0; i < 2 * size; i++) {
+      result = result * 37 + data[i].hashCode();
+    }
+    return result;
   }
 
+  @SuppressWarnings("unchecked")
   @Override public String toString() {
     StringBuilder sb = new StringBuilder();
     sb.append("{");
     String sep = "";
-    for (Map.Entry<? extends Extension<?, ?>, Object> entry : map.entrySet()) {
+    for (int i = 0; i < size; i++) {
       sb.append(sep);
-      sb.append(entry.getKey().getTag());
+      sb.append(((Extension<T, ?>) data[i]).getTag());
       sb.append("=");
-      sb.append(entry.getValue());
+      sb.append(data[size + i]);
       sep = ", ";
     }
     sb.append("}");

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -175,6 +175,8 @@ public abstract class Message {
   protected static <T> List<T> immutableCopyOf(List<T> source) {
     if (source == null) {
       return Collections.emptyList();
+    } else if (source instanceof MessageAdapter.ImmutableList) {
+      return source;
     }
     return Collections.unmodifiableList(new ArrayList<T>(source));
   }


### PR DESCRIPTION
@JakeWharton  @swankjesse 

There are three improvements here:
- Deserialize repeated fields directly into an externally-immutable form
- Get rid of expensive TreeMaps to store extensions on messages
- Iterate over extensions more cheaply when serializing
