### PR TITLE
Print boxes for redacted fields instead of omitting it completely

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
@@ -380,14 +380,14 @@ final class MessageAdapter<M extends Message> {
     String sep = "";
     for (FieldInfo fieldInfo : getFields()) {
       Object value = getFieldValue(message, fieldInfo);
-      if (value == null || fieldInfo.redacted) {
+      if (value == null) {
         continue;
       }
       sb.append(sep);
       sep = ", ";
       sb.append(fieldInfo.name);
       sb.append("=");
-      sb.append(value);
+      sb.append(fieldInfo.redacted ? "██" : value);
     }
     if (message instanceof ExtendableMessage<?>) {
       ExtendableMessage<?> extendableMessage = (ExtendableMessage<?>) message;

--- a/wire-runtime/src/test/java/com/squareup/wire/RedactedTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/RedactedTest.java
@@ -29,7 +29,8 @@ public class RedactedTest {
 
   @Test
   public void testRedacted() throws IOException {
-    assertEquals("Redacted{b=b, c=c}", new Redacted.Builder().a("a").b("b").c("c").build().toString());
+    assertEquals("Redacted{a=██, b=b, c=c}",
+        new Redacted.Builder().a("a").b("b").c("c").build().toString());
   }
 
   @Test


### PR DESCRIPTION
This makes it possible to differentiate between null and redacted.

@swankjesse @danrice-square
