### PR TITLE
Split out the RxJavaServiceWriter into old and new versions

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/RxJavaServiceWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/RxJavaServiceWriter.java
@@ -11,11 +11,8 @@ import java.util.Locale;
 import java.util.Set;
 import javax.lang.model.element.Modifier;
 
-/**
- * A ServiceWriter that generates simple RxJava/Retrofit-compatible interfaces.
- */
+/** A ServiceWriter that generates simple RxJava/Retrofit-compatible interfaces. */
 public class RxJavaServiceWriter extends ServiceWriter {
-
   String requestType;
   String responseType;
   String func1Type;
@@ -26,11 +23,11 @@ public class RxJavaServiceWriter extends ServiceWriter {
 
   @Override
   public void emitService(Service service, Set<String> importedTypes) throws IOException {
+    importedTypes.add("javax.inject.Inject");
     if (!service.getMethods().isEmpty()) {
       importedTypes.add("retrofit.http.Body");
       importedTypes.add("retrofit.http.POST");
-      importedTypes.add("javax.inject.Inject");
-      importedTypes.add("rx.util.functions.Func1");
+      importedTypes.add("rx.functions.Func1");
     }
 
     writer.emitImports(importedTypes);
@@ -63,11 +60,11 @@ public class RxJavaServiceWriter extends ServiceWriter {
       writer.emitField(func1Type, getMethodName(method),
           EnumSet.of(Modifier.PRIVATE, Modifier.FINAL),
           "\nnew " + func1Type + "() {\n"
-          + "  @Override\n"
-          + "  public " + responseType + " call(" + requestType + " request) {\n"
-          + "    return endpoint." + getMethodName(method) + "(request);\n"
-          + "  }\n"
-          + "}");
+              + "  @Override\n"
+              + "  public " + responseType + " call(" + requestType + " request) {\n"
+              + "    return endpoint." + getMethodName(method) + "(request);\n"
+              + "  }\n"
+              + "}");
     }
 
     writer.emitEmptyLine();

--- a/wire-runtime/pom.xml
+++ b/wire-runtime/pom.xml
@@ -31,7 +31,7 @@
     <dependency>
       <groupId>com.netflix.rxjava</groupId>
       <artifactId>rxjava-core</artifactId>
-      <version>0.14.8</version>
+      <version>0.18.3</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/wire-runtime/src/test/java/com/squareup/services/RxJavaService.java
+++ b/wire-runtime/src/test/java/com/squareup/services/RxJavaService.java
@@ -7,7 +7,7 @@ import com.squareup.services.anotherpackage.SendDataResponse;
 import javax.inject.Inject;
 import retrofit.http.Body;
 import retrofit.http.POST;
-import rx.util.functions.Func1;
+import rx.functions.Func1;
 
 /**
  * An example service.


### PR DESCRIPTION
RxJava moved Func1 in release 0.17, which breaks the code generated by `RxJavaServiceWriter`.  This allows generating code for pre- and post-0.17 versions.

@danrice-square @loganj 
