### PR TITLE
added service_writer compiler flag

### DIFF
--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -83,7 +83,7 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
       args.add("--roots=" + Joiner.on(',').join(roots));
     }
     if (serviceWriter != null) {
-        args.add("--service_writer=" + serviceWriter);
+      args.add("--service_writer=" + serviceWriter);
     }
     Collections.addAll(args, protoFiles);
 


### PR DESCRIPTION
I noticed wire-maven-plugin doesn't have the service_writer compiler flag so since I need it, I added. 
Thanks !
