### PR TITLE
Place the __UNDEFINED__ enum value at the end so it does not affect ordinal()

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
@@ -115,16 +115,6 @@ public class MessageWriter {
       List<EnumType.Value> values = enumType.getValues();
       List<String> undefinedInitializers = new ArrayList<String>();
 
-      writer.emitJavadoc("Wire-generated value, do not access from application code.");
-      if (values.isEmpty()) {
-        writer.emitEnumValue("__UNDEFINED__(UNDEFINED_VALUE)", true);
-      } else {
-        undefinedInitializers.add("UNDEFINED_VALUE");
-        addNullEnumValueOptionInitializers(values.get(0), options, mapMaker, undefinedInitializers);
-        writer.emitEnumValue("__UNDEFINED__(" + join(undefinedInitializers, ", ") + ")", false);
-      }
-      writer.emitEmptyLine();
-
       for (int i = 0, count = values.size(); i < count; i++) {
         EnumType.Value value = values.get(i);
         MessageWriter.emitDocumentation(writer, value.getDocumentation());
@@ -137,8 +127,17 @@ public class MessageWriter {
         initializers.add(String.valueOf(tag));
         addEnumValueOptionInitializers(value, options, mapMaker, initializers);
 
-        writer.emitEnumValue(value.getName() + "(" + join(initializers, ", ") + ")",
-            (i == count - 1));
+        writer.emitEnumValue(value.getName() + "(" + join(initializers, ", ") + ")", false);
+      }
+
+      writer.emitEmptyLine();
+      writer.emitJavadoc("Wire-generated value, do not access from application code.");
+      if (values.isEmpty()) {
+        writer.emitEnumValue("__UNDEFINED__(UNDEFINED_VALUE)", true);
+      } else {
+        undefinedInitializers.add("UNDEFINED_VALUE");
+        addNullEnumValueOptionInitializers(values.get(0), options, mapMaker, undefinedInitializers);
+        writer.emitEnumValue("__UNDEFINED__(" + join(undefinedInitializers, ", ") + ")", true);
       }
 
       if (compiler.emitOptions()) {

--- a/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
@@ -75,8 +75,9 @@ final class MessageAdapter<M extends Message> {
       if (datatype == Datatype.ENUM) {
         this.enumType = (Class<? extends ProtoEnum>) enumOrMessageType;
         this.messageType = null;
-        // The first defined value of a {@link ProtoEnum} is always {@code __UNDEFINED__}.
-        this.undefinedEnumValue = enumType.getEnumConstants()[0];
+        // The last defined value of a {@link ProtoEnum} is always {@code __UNDEFINED__}.
+        ProtoEnum[] enumConstants = enumType.getEnumConstants();
+        this.undefinedEnumValue = enumConstants[enumConstants.length - 1];
       } else if (datatype == Datatype.MESSAGE) {
         this.messageType = (Class<? extends Message>) enumOrMessageType;
         this.enumType = null;

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoEnum.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoEnum.java
@@ -19,7 +19,7 @@ package com.squareup.wire;
  * Interface for generated {@link Enum} values to help serialization and
  * deserialization.
  *
- * The first enum value defined in any implementing class must be named {@code __UNDEFINED__}
+ * The last enum value defined in any implementing class must be named {@code __UNDEFINED__}
  * and have the value {@link #UNDEFINED_VALUE}. Application code should never access this value
  * directly. Withing a parsed Message, it represents an unknown enum value which may have been
  * defined in a version of the protocol buffer definitions later than the one used to build the

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1221,12 +1221,12 @@ public final class AllTypes extends ExtendableMessage<AllTypes> {
 
   public enum NestedEnum
       implements ProtoEnum {
+    A(1),
+
     /**
      * Wire-generated value, do not access from application code.
      */
-    __UNDEFINED__(UNDEFINED_VALUE),
-
-    A(1);
+    __UNDEFINED__(UNDEFINED_VALUE);
 
     private final int value;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -320,16 +320,16 @@ public final class FooBar extends ExtendableMessage<FooBar> {
 
   public enum FooBarBazEnum
       implements ProtoEnum {
-    /**
-     * Wire-generated value, do not access from application code.
-     */
-    __UNDEFINED__(UNDEFINED_VALUE, null, null, null),
-
     FOO(1, new More.Builder()
         .serial(99)
         .build(), 17, null),
     BAR(2, null, null, true),
-    BAZ(3, null, 18, false);
+    BAZ(3, null, 18, false),
+
+    /**
+     * Wire-generated value, do not access from application code.
+     */
+    __UNDEFINED__(UNDEFINED_VALUE, null, null, null);
 
     public static final EnumOptions ENUM_OPTIONS = new EnumOptions.Builder()
         .setExtension(Ext_custom_options.enum_option, true)

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -278,14 +278,14 @@ public final class FooBar extends ExtendableMessage<FooBar> {
 
   public enum FooBarBazEnum
       implements ProtoEnum {
+    FOO(1, 17),
+    BAR(2, null),
+    BAZ(3, 18),
+
     /**
      * Wire-generated value, do not access from application code.
      */
-    __UNDEFINED__(UNDEFINED_VALUE, null),
-
-    FOO(1, 17),
-    BAR(2, null),
-    BAZ(3, 18);
+    __UNDEFINED__(UNDEFINED_VALUE, null);
 
     private final int value;
     public final Integer enum_value_option;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
@@ -6,13 +6,13 @@ import com.squareup.wire.ProtoEnum;
 
 public enum ForeignEnum
     implements ProtoEnum {
+  BAV(0),
+  BAX(1),
+
   /**
    * Wire-generated value, do not access from application code.
    */
-  __UNDEFINED__(UNDEFINED_VALUE),
-
-  BAV(0),
-  BAX(1);
+  __UNDEFINED__(UNDEFINED_VALUE);
 
   private final int value;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -141,17 +141,17 @@ public final class Person extends Message {
 
   public enum PhoneType
       implements ProtoEnum {
-    /**
-     * Wire-generated value, do not access from application code.
-     */
-    __UNDEFINED__(UNDEFINED_VALUE),
-
     MOBILE(0),
     HOME(1),
     /**
      * Could be phone or fax.
      */
-    WORK(2);
+    WORK(2),
+
+    /**
+     * Wire-generated value, do not access from application code.
+     */
+    __UNDEFINED__(UNDEFINED_VALUE);
 
     private final int value;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
@@ -6,13 +6,13 @@ import com.squareup.wire.ProtoEnum;
 
 public enum G
     implements ProtoEnum {
+  FOO(1),
+  BAR(2),
+
   /**
    * Wire-generated value, do not access from application code.
    */
-  __UNDEFINED__(UNDEFINED_VALUE),
-
-  FOO(1),
-  BAR(2);
+  __UNDEFINED__(UNDEFINED_VALUE);
 
   private final int value;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -370,14 +370,14 @@ public final class SimpleMessage extends Message {
 
   public enum NestedEnum
       implements ProtoEnum {
+    FOO(1),
+    BAR(2),
+    BAZ(3),
+
     /**
      * Wire-generated value, do not access from application code.
      */
-    __UNDEFINED__(UNDEFINED_VALUE),
-
-    FOO(1),
-    BAR(2),
-    BAZ(3);
+    __UNDEFINED__(UNDEFINED_VALUE);
 
     private final int value;
 


### PR DESCRIPTION
@loganj 

Previously the `__UNDEFINED__` value appeared at the beginning of the list of enum values. However, it's not uncommon for client code to call ordinal() on an enum and serialize/deserialize the resulting value. That means that the previous addition of `__UNDEFINED__` could amount to a breaking change for such code.
