### PR TITLE
Fully-qualify generated calls to Arrays.asList

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/OptionsMapMaker.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/OptionsMapMaker.java
@@ -381,7 +381,6 @@ public class OptionsMapMaker {
     return (Map<String, Object>) entry;
   }
 
-
   @SuppressWarnings("unchecked")
   String createOptionInitializer(Object listOrMap, String parentType,
       String parentField, String fieldType, boolean skipAsList, int level) {
@@ -395,7 +394,7 @@ public class OptionsMapMaker {
       FieldInfo fieldInfo = compiler.getField(dollarName);
       boolean emitAsList = !skipAsList && fieldInfo != null && fieldInfo.isRepeated();
       if (emitAsList) {
-        sb.append("asList(");
+        sb.append("java.util.Arrays.asList(");
       }
       String shortName = compiler.shortenJavaName(fullyQualifiedName);
       sb.append("new ").append(shortName).append(".Builder()");
@@ -439,7 +438,7 @@ public class OptionsMapMaker {
         sb.append(")");
       }
     } else if (listOrMap instanceof List) {
-      sb.append("asList(");
+      sb.append("java.util.Arrays.asList(");
       String sep = "\n";
       for (Object objectValue : (List<Object>) listOrMap) {
         sb.append(sep);

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -17,7 +17,6 @@ package com.squareup.wire;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -260,10 +259,6 @@ public abstract class Message {
     if (a != null && a.isEmpty()) a = null;
     if (b != null && b.isEmpty()) b = null;
     return a == b || (a != null && a.equals(b));
-  }
-
-  protected static <T> List<T> asList(T... a) {
-    return Arrays.asList(a);
   }
 
   @SuppressWarnings("unchecked")

--- a/wire-runtime/src/test/java/com/squareup/wire/CustomOptionsTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/CustomOptionsTest.java
@@ -80,7 +80,7 @@ public class CustomOptionsTest {
         option_five.getExtension(Ext_custom_options.rep));
 
     Assert.assertEquals(new Integer(17), FooBar.FooBarBazEnum.FOO.enum_value_option);
-    Assert.assertEquals(new Integer(99), FooBar.FooBarBazEnum.FOO.complex_enum_value_option.serial);
+    Assert.assertEquals(Arrays.asList(99, 199), FooBar.FooBarBazEnum.FOO.complex_enum_value_option.serial);
     Assert.assertEquals(null, FooBar.FooBarBazEnum.FOO.foreign_enum_value_option);
     Assert.assertEquals(null, FooBar.FooBarBazEnum.BAR.enum_value_option);
     Assert.assertEquals(Boolean.TRUE, FooBar.FooBarBazEnum.BAR.foreign_enum_value_option);

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -42,12 +42,12 @@ public final class FooBar extends ExtendableMessage<FooBar> {
           .baz(new Nested.Builder()
               .value(FooBarBazEnum.BAR)
               .build())
-          .fred(asList(
+          .fred(java.util.Arrays.asList(
               444.0F,
               555.0F))
-          .nested(asList(new FooBar.Builder()
+          .nested(java.util.Arrays.asList(new FooBar.Builder()
               .foo(33)
-              .fred(asList(
+              .fred(java.util.Arrays.asList(
                   100.0F,
                   200.0F))
               .build()))
@@ -265,13 +265,13 @@ public final class FooBar extends ExtendableMessage<FooBar> {
 
   public static final class More extends Message {
 
-    public static final Integer DEFAULT_SERIAL = 0;
+    public static final List<Integer> DEFAULT_SERIAL = Collections.emptyList();
 
-    @ProtoField(tag = 1, type = INT32)
-    public final Integer serial;
+    @ProtoField(tag = 1, type = INT32, label = REPEATED)
+    public final List<Integer> serial;
 
-    public More(Integer serial) {
-      this.serial = serial;
+    public More(List<Integer> serial) {
+      this.serial = immutableCopyOf(serial);
     }
 
     private More(Builder builder) {
@@ -289,12 +289,12 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = serial != null ? serial.hashCode() : 0);
+      return result != 0 ? result : (hashCode = serial != null ? serial.hashCode() : 1);
     }
 
     public static final class Builder extends Message.Builder<More> {
 
-      public Integer serial;
+      public List<Integer> serial;
 
       public Builder() {
       }
@@ -302,11 +302,11 @@ public final class FooBar extends ExtendableMessage<FooBar> {
       public Builder(More message) {
         super(message);
         if (message == null) return;
-        this.serial = message.serial;
+        this.serial = copyOf(message.serial);
       }
 
-      public Builder serial(Integer serial) {
-        this.serial = serial;
+      public Builder serial(List<Integer> serial) {
+        this.serial = checkForNulls(serial);
         return this;
       }
 
@@ -320,7 +320,9 @@ public final class FooBar extends ExtendableMessage<FooBar> {
   public enum FooBarBazEnum
       implements ProtoEnum {
     FOO(1, new More.Builder()
-        .serial(99)
+        .serial(java.util.Arrays.asList(
+            99,
+            199))
         .build(), 17, null),
     BAR(2, null, null, true),
     BAZ(3, null, 18, false);

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -223,13 +223,13 @@ public final class FooBar extends ExtendableMessage<FooBar> {
 
   public static final class More extends Message {
 
-    public static final Integer DEFAULT_SERIAL = 0;
+    public static final List<Integer> DEFAULT_SERIAL = Collections.emptyList();
 
-    @ProtoField(tag = 1, type = INT32)
-    public final Integer serial;
+    @ProtoField(tag = 1, type = INT32, label = REPEATED)
+    public final List<Integer> serial;
 
-    public More(Integer serial) {
-      this.serial = serial;
+    public More(List<Integer> serial) {
+      this.serial = immutableCopyOf(serial);
     }
 
     private More(Builder builder) {
@@ -247,12 +247,12 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = serial != null ? serial.hashCode() : 0);
+      return result != 0 ? result : (hashCode = serial != null ? serial.hashCode() : 1);
     }
 
     public static final class Builder extends Message.Builder<More> {
 
-      public Integer serial;
+      public List<Integer> serial;
 
       public Builder() {
       }
@@ -260,11 +260,11 @@ public final class FooBar extends ExtendableMessage<FooBar> {
       public Builder(More message) {
         super(message);
         if (message == null) return;
-        this.serial = message.serial;
+        this.serial = copyOf(message.serial);
       }
 
-      public Builder serial(Integer serial) {
-        this.serial = serial;
+      public Builder serial(List<Integer> serial) {
+        this.serial = checkForNulls(serial);
         return this;
       }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
@@ -17,7 +17,7 @@ public final class MessageWithOptions extends Message {
               .value(FooBar.FooBarBazEnum.BAZ)
               .build())
           .qux(-1L)
-          .fred(asList(
+          .fred(java.util.Arrays.asList(
               123.0F,
               321.0F))
           .daisy(456.0D)
@@ -29,12 +29,12 @@ public final class MessageWithOptions extends Message {
           .baz(new FooBar.Nested.Builder()
               .value(FooBar.FooBarBazEnum.BAR)
               .build())
-          .fred(asList(
+          .fred(java.util.Arrays.asList(
               444.0F,
               555.0F))
-          .nested(asList(new FooBar.Builder()
+          .nested(java.util.Arrays.asList(new FooBar.Builder()
               .foo(33)
-              .fred(asList(
+              .fred(java.util.Arrays.asList(
                   100.0F,
                   200.0F))
               .build()))
@@ -45,15 +45,15 @@ public final class MessageWithOptions extends Message {
           .build())
       .setExtension(Ext_custom_options.my_message_option_five, new FooBar.Builder()
           .setExtension(Ext_custom_options.ext, FooBar.FooBarBazEnum.BAZ)
-          .setExtension(Ext_custom_options.rep, asList(
+          .setExtension(Ext_custom_options.rep, java.util.Arrays.asList(
               FooBar.FooBarBazEnum.FOO,
               FooBar.FooBarBazEnum.BAZ))
           .build())
       .setExtension(Ext_custom_options.my_message_option_six, new FooBar.Builder()
-          .setExtension(Ext_custom_options.rep, asList(
+          .setExtension(Ext_custom_options.rep, java.util.Arrays.asList(
               FooBar.FooBarBazEnum.FOO,
               FooBar.FooBarBazEnum.BAR))
-          .nested(asList(
+          .nested(java.util.Arrays.asList(
               new FooBar.Builder()
                   .foo(44)
                   .setExtension(Ext_custom_options.ext, FooBar.FooBarBazEnum.BAR)

--- a/wire-runtime/src/test/proto/custom_options.proto
+++ b/wire-runtime/src/test/proto/custom_options.proto
@@ -40,12 +40,12 @@ message FooBar {
   }
 
   message More {
-    optional int32 serial = 1;
+    repeated int32 serial = 1;
   }
 
   enum FooBarBazEnum {
     option enum_option = true;
-    FOO = 1 [enum_value_option=17, complex_enum_value_option={ serial: 99 }];
+    FOO = 1 [enum_value_option=17, complex_enum_value_option={ serial: [ 99, 199 ] }];
     BAR = 2 [squareup.protos.foreign.foreign_enum_value_option=true];
     BAZ = 3 [enum_value_option=18, squareup.protos.foreign.foreign_enum_value_option=false];
   }


### PR DESCRIPTION
@JakeWharton 

Fixes https://github.com/square/wire/issues/163. Eventually we would like to emit a static import for this case, but this should suffice for now.
