### PR TITLE
Apply Builder Pattern to WireCompiler.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/MissingOutputDirectoryWireCompilerException.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MissingOutputDirectoryWireCompilerException.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2013 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+/**
+ * An exception thrown by the {@link WireCompiler} builder when the output directory has
+ * not been specified.
+ */
+public class MissingOutputDirectoryWireCompilerException extends WireCompilerException {
+  public MissingOutputDirectoryWireCompilerException() {
+    super("Missing value for outputDirectory");
+  }
+}

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -31,6 +31,7 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -136,7 +137,7 @@ public final class WireCompiler {
    * </p>
    */
   public static void main(String... args) throws Exception {
-    Builder builder = new Builder();
+    Builder builder = builder();
     String protoPath = null;
 
     int index = 0;
@@ -183,7 +184,11 @@ public final class WireCompiler {
     builder.build().compile();
   }
 
-  public static class Builder {
+  public static Builder builder() {
+    return new Builder(new IO.FileIO());
+  }
+
+  public static final class Builder {
     private String protoPath = System.getProperty("user.dir");
     private String outputDirectory;
     private String registryClass;
@@ -193,7 +198,11 @@ public final class WireCompiler {
     private final Set<String> enumOptions = new LinkedHashSet<String>();
     private Constructor<?> serviceWriterConstructor;
     private final List<String> serviceWriterOptions = new ArrayList<String>();
-    private IO io = new IO.FileIO();
+    private final IO io;
+
+    Builder(IO io) {
+      this.io = io;
+    }
 
     public Builder protoPath(String protoPath) {
       this.protoPath = protoPath;
@@ -216,7 +225,8 @@ public final class WireCompiler {
     }
 
     public Builder addSourceFileNames(String... sourceFileNames) {
-      return addSourceFileNames(Arrays.asList(sourceFileNames));
+      Collections.addAll(this.sourceFileNames, sourceFileNames);
+      return this;
     }
 
     public Builder addSourceFileNames(Collection<String> sourceFileNames) {
@@ -230,7 +240,8 @@ public final class WireCompiler {
     }
 
     public Builder addTypesToEmit(String... typesToEmit) {
-      return addTypesToEmit(Arrays.asList(typesToEmit));
+      Collections.addAll(this.typesToEmit, typesToEmit);
+      return this;
     }
 
     public Builder addTypesToEmit(Collection<String> typesToEmit) {
@@ -249,7 +260,8 @@ public final class WireCompiler {
     }
 
     public Builder addEnumOptions(String... enumOptions) {
-      return addEnumOptions(Arrays.asList(enumOptions));
+      Collections.addAll(this.enumOptions, enumOptions);
+      return this;
     }
 
     public Builder addEnumOptions(Collection<String> enumOptions) {
@@ -268,16 +280,12 @@ public final class WireCompiler {
     }
 
     public Builder addServiceWriterOptions(String... serviceWriterOptions) {
-      return addServiceWriterOptions(Arrays.asList(serviceWriterOptions));
+      Collections.addAll(this.serviceWriterOptions, serviceWriterOptions);
+      return this;
     }
 
     public Builder addServiceWriterOptions(Collection<String> serviceWriterOptions) {
       this.serviceWriterOptions.addAll(serviceWriterOptions);
-      return this;
-    }
-
-    public Builder io(IO io) {
-      this.io = io;
       return this;
     }
 

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -50,7 +50,7 @@ import static javax.lang.model.element.Modifier.PUBLIC;
 import static javax.lang.model.element.Modifier.STATIC;
 
 /** Compiler for Wire protocol buffers. */
-public class WireCompiler {
+public final class WireCompiler {
   static final String LINE_WRAP_INDENT = "    ";
 
   /**
@@ -75,7 +75,7 @@ public class WireCompiler {
   private final String repoPath;
   private final List<String> sourceFileNames;
   private final IO io;
-  private final Set<String> typesToEmit = new LinkedHashSet<String>();
+  private final Set<String> typesToEmit;
   private final Map<String, String> javaSymbolMap = new LinkedHashMap<String, String>();
   private final Set<String> javaSymbols = new LinkedHashSet<String>();
   private final Set<String> enumTypes = new LinkedHashSet<String>();
@@ -136,56 +136,154 @@ public class WireCompiler {
    * </p>
    */
   public static void main(String... args) throws Exception {
+    Builder builder = new Builder();
     String protoPath = null;
-    String javaOut = null;
-    String registryClass = null;
-    List<String> sourceFileNames = new ArrayList<String>();
-    List<String> roots = new ArrayList<String>();
-    boolean emitOptions = true;
-    List<String> enumOptions = new ArrayList<String>();
-    Constructor<?> serviceWriterConstructor = null;
-    List<String> serviceWriterOptions = new ArrayList<String>();
 
     int index = 0;
     while (index < args.length) {
-      if (args[index].startsWith(PROTO_PATH_FLAG)) {
-        protoPath = args[index].substring(PROTO_PATH_FLAG.length());
-      } else if (args[index].startsWith(JAVA_OUT_FLAG)) {
-        javaOut = args[index].substring(JAVA_OUT_FLAG.length());
-      } else if (args[index].startsWith(FILES_FLAG)) {
-        File files = new File(args[index].substring(FILES_FLAG.length()));
-        String[] fileNames = new Scanner(files, "UTF-8").useDelimiter("\\A").next().split("\n");
-        sourceFileNames.addAll(Arrays.asList(fileNames));
-      } else if (args[index].startsWith(ROOTS_FLAG)) {
-        roots.addAll(splitArg(args[index], ROOTS_FLAG.length()));
-      } else if (args[index].startsWith(REGISTRY_CLASS_FLAG)) {
-        registryClass = args[index].substring(REGISTRY_CLASS_FLAG.length());
-      } else if (args[index].equals(NO_OPTIONS_FLAG)) {
-        emitOptions = false;
-      } else if (args[index].startsWith(ENUM_OPTIONS_FLAG)) {
-        enumOptions.addAll(splitArg(args[index], ENUM_OPTIONS_FLAG.length()));
-      } else if (args[index].startsWith(SERVICE_WRITER_FLAG)) {
-        serviceWriterConstructor =
-            loadServiceWriter(args[index].substring(SERVICE_WRITER_FLAG.length()));
-      } else if (args[index].startsWith(SERVICE_WRITER_OPT_FLAG)) {
-        serviceWriterOptions.add(args[index].substring(SERVICE_WRITER_OPT_FLAG.length()));
+      String arg = args[index];
+      if (arg.startsWith(PROTO_PATH_FLAG)) {
+        protoPath = arg.substring(PROTO_PATH_FLAG.length());
+      } else if (arg.startsWith(JAVA_OUT_FLAG)) {
+        builder.outputDirectory(arg.substring(JAVA_OUT_FLAG.length()));
+      } else if (arg.startsWith(FILES_FLAG)) {
+        File files = new File(arg.substring(FILES_FLAG.length()));
+        final String[] sourceFileNames = new Scanner(files, "UTF-8")
+            .useDelimiter("\\A")
+            .next()
+            .split("\n");
+        builder.addSourceFileNames(sourceFileNames);
+      } else if (arg.startsWith(ROOTS_FLAG)) {
+        builder.addTypesToEmit(splitArg(arg, ROOTS_FLAG.length()));
+      } else if (arg.startsWith(REGISTRY_CLASS_FLAG)) {
+        builder.registryClass(arg.substring(REGISTRY_CLASS_FLAG.length()));
+      } else if (arg.equals(NO_OPTIONS_FLAG)) {
+        builder.emitOptions(false);
+      } else if (arg.startsWith(ENUM_OPTIONS_FLAG)) {
+        builder.addEnumOptions(splitArg(arg, ENUM_OPTIONS_FLAG.length()));
+      } else if (arg.startsWith(SERVICE_WRITER_FLAG)) {
+        builder.serviceWriter(arg.substring(SERVICE_WRITER_FLAG.length()));
+      } else if (arg.startsWith(SERVICE_WRITER_OPT_FLAG)) {
+        builder.addServiceWriterOption(arg.substring(SERVICE_WRITER_OPT_FLAG.length()));
       } else {
-        sourceFileNames.add(args[index]);
+        builder.addSourceFileName(arg);
       }
       index++;
     }
-    if (javaOut == null) {
+    if (builder.outputDirectory == null) {
       System.err.println("Must specify " + JAVA_OUT_FLAG + " flag");
       System.exit(1);
     }
     if (protoPath == null) {
-      protoPath = System.getProperty("user.dir");
-      System.err.println(PROTO_PATH_FLAG + " flag not specified, using current dir " + protoPath);
+      System.err.println(PROTO_PATH_FLAG + " flag not specified, using current dir "
+          + builder.protoPath);
+    } else {
+      builder.protoPath(protoPath);
     }
-    WireCompiler wireCompiler =
-        new WireCompiler(protoPath, sourceFileNames, roots, javaOut, registryClass, emitOptions,
-            enumOptions, serviceWriterConstructor, serviceWriterOptions);
-    wireCompiler.compile();
+    builder.build().compile();
+  }
+
+  public static class Builder {
+    private String protoPath = System.getProperty("user.dir");
+    private String outputDirectory;
+    private String registryClass;
+    private final List<String> sourceFileNames = new ArrayList<String>();
+    private final Set<String> typesToEmit = new LinkedHashSet<String>();
+    private boolean emitOptions = true;
+    private final Set<String> enumOptions = new LinkedHashSet<String>();
+    private Constructor<?> serviceWriterConstructor;
+    private final List<String> serviceWriterOptions = new ArrayList<String>();
+    private IO io = new IO.FileIO();
+
+    public Builder protoPath(String protoPath) {
+      this.protoPath = protoPath;
+      return this;
+    }
+
+    public Builder outputDirectory(String outputDirectory) {
+      this.outputDirectory = outputDirectory;
+      return this;
+    }
+
+    public Builder registryClass(String registryClass) {
+      this.registryClass = registryClass;
+      return this;
+    }
+
+    public Builder addSourceFileName(String sourceFileName) {
+      sourceFileNames.add(sourceFileName);
+      return this;
+    }
+
+    public Builder addSourceFileNames(String... sourceFileNames) {
+      return addSourceFileNames(Arrays.asList(sourceFileNames));
+    }
+
+    public Builder addSourceFileNames(Collection<String> sourceFileNames) {
+      sourceFileNames.addAll(sourceFileNames);
+      return this;
+    }
+
+    public Builder addTypeToEmit(String typeToEmit) {
+      typesToEmit.add(typeToEmit);
+      return this;
+    }
+
+    public Builder addTypesToEmit(String... typesToEmit) {
+      return addTypesToEmit(Arrays.asList(typesToEmit));
+    }
+
+    public Builder addTypesToEmit(Collection<String> typesToEmit) {
+      this.typesToEmit.addAll(typesToEmit);
+      return this;
+    }
+
+    public Builder emitOptions(boolean emitOptions) {
+      this.emitOptions = emitOptions;
+      return this;
+    }
+
+    public Builder addEnumOption(String enumOption) {
+      enumOptions.add(enumOption);
+      return this;
+    }
+
+    public Builder addEnumOptions(String... enumOptions) {
+      return addEnumOptions(Arrays.asList(enumOptions));
+    }
+
+    public Builder addEnumOptions(Collection<String> enumOptions) {
+      this.enumOptions.addAll(enumOptions);
+      return this;
+    }
+
+    public Builder serviceWriter(String serviceWriter) {
+      this.serviceWriterConstructor = loadServiceWriter(serviceWriter);
+      return this;
+    }
+
+    public Builder addServiceWriterOption(String serviceWriterOption) {
+      this.serviceWriterOptions.add(serviceWriterOption);
+      return this;
+    }
+
+    public Builder addServiceWriterOptions(String... serviceWriterOptions) {
+      return addServiceWriterOptions(Arrays.asList(serviceWriterOptions));
+    }
+
+    public Builder addServiceWriterOptions(Collection<String> serviceWriterOptions) {
+      this.serviceWriterOptions.addAll(serviceWriterOptions);
+      return this;
+    }
+
+    public Builder io(IO io) {
+      this.io = io;
+      return this;
+    }
+
+    public WireCompiler build() {
+      return new WireCompiler(this);
+    }
   }
 
   private static List<String> splitArg(String arg, int flagLength) {
@@ -221,26 +319,17 @@ public class WireCompiler {
     return null;
   }
 
-  public WireCompiler(String protoPath, List<String> sourceFileNames, List<String> roots,
-      String outputDirectory, String registryClass, boolean emitOptions, List<String> enumOptions,
-      Constructor<?> serviceWriterConstructor, List<String> serviceWriterOptions) {
-    this(protoPath, sourceFileNames, roots, outputDirectory, registryClass, emitOptions,
-        enumOptions, serviceWriterConstructor, serviceWriterOptions, new IO.FileIO());
-  }
-
-  WireCompiler(String protoPath, List<String> sourceFileNames, List<String> roots,
-      String outputDirectory, String registryClass, boolean emitOptions, List<String> enumOptions,
-      Constructor<?> serviceWriterConstructor, List<String> serviceWriterOptions, IO io) {
-    this.repoPath = protoPath;
-    this.typesToEmit.addAll(roots);
-    this.sourceFileNames = sourceFileNames;
-    this.outputDirectory = outputDirectory;
-    this.registryClass = registryClass;
-    this.emitOptions = emitOptions;
-    this.enumOptions = new LinkedHashSet<String>(enumOptions);
-    this.serviceWriterConstructor = serviceWriterConstructor;
-    this.serviceWriterOptions = serviceWriterOptions;
-    this.io = io;
+  private WireCompiler(Builder builder) {
+    this.repoPath = builder.protoPath;
+    this.typesToEmit = builder.typesToEmit;
+    this.sourceFileNames = builder.sourceFileNames;
+    this.outputDirectory = builder.outputDirectory;
+    this.registryClass = builder.registryClass;
+    this.emitOptions = builder.emitOptions;
+    this.enumOptions = builder.enumOptions;
+    this.serviceWriterConstructor = builder.serviceWriterConstructor;
+    this.serviceWriterOptions = builder.serviceWriterOptions;
+    this.io = builder.io;
   }
 
   public void compile() throws IOException {

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -171,17 +171,18 @@ public final class WireCompiler {
       }
       index++;
     }
-    if (builder.outputDirectory == null) {
-      System.err.println("Must specify " + JAVA_OUT_FLAG + " flag");
-      System.exit(1);
-    }
     if (protoPath == null) {
       System.err.println(PROTO_PATH_FLAG + " flag not specified, using current dir "
           + builder.protoPath);
     } else {
       builder.protoPath(protoPath);
     }
-    builder.build().compile();
+    try {
+      builder.build().compile();
+    } catch (MissingOutputDirectoryWireCompilerException e) {
+      System.err.println("Must specify " + JAVA_OUT_FLAG + " flag");
+      System.exit(1);
+    }
   }
 
   public static Builder builder() {
@@ -290,6 +291,9 @@ public final class WireCompiler {
     }
 
     public WireCompiler build() {
+      if (outputDirectory == null || outputDirectory.length() == 0) {
+        throw new MissingOutputDirectoryWireCompilerException();
+      }
       return new WireCompiler(this);
     }
   }

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -18,21 +18,16 @@ package com.squareup.wire;
 import com.squareup.javawriter.JavaWriter;
 import com.squareup.protoparser.ProtoFile;
 import com.squareup.protoparser.ProtoSchemaParser;
+import org.junit.Test;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.StringReader;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 
 public class WireCompilerErrorTest {
 
@@ -79,12 +74,13 @@ public class WireCompilerErrorTest {
   private Map<String, String> compile(String source) {
     StringIO io = new StringIO("test.proto", source);
 
-    @SuppressWarnings("unchecked")
-    WireCompiler compiler = new WireCompiler(".", Arrays.asList("test.proto"),
-        new ArrayList<String>(), ".", null, true, Collections.EMPTY_LIST, null,
-        Collections.EMPTY_LIST, io);
     try {
-      compiler.compile();
+      new WireCompiler.Builder()
+          .protoPath(".")
+          .outputDirectory(".")
+          .addSourceFileName("test.proto")
+          .io(io)
+          .build().compile();
     } catch (IOException e) {
       fail();
     }

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -27,7 +27,10 @@ import java.io.StringWriter;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class WireCompilerErrorTest {
 
@@ -75,11 +78,10 @@ public class WireCompilerErrorTest {
     StringIO io = new StringIO("test.proto", source);
 
     try {
-      new WireCompiler.Builder()
+      new WireCompiler.Builder(io)
           .protoPath(".")
           .outputDirectory(".")
           .addSourceFileName("test.proto")
-          .io(io)
           .build().compile();
     } catch (IOException e) {
       fail();

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -63,7 +63,7 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
   }
 
   private void compileProtos() throws MojoExecutionException {
-    WireCompiler.Builder builder = new WireCompiler.Builder()
+    WireCompiler.Builder builder = WireCompiler.builder()
             .protoPath(protoSourceDirectory)
             .addSourceFileNames(protoFiles)
             .outputDirectory(generatedSourceDirectory)

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -1,10 +1,6 @@
 package com.squareup.wire.mojo;
 
-import com.google.common.base.Joiner;
-import com.google.common.collect.Lists;
 import com.squareup.wire.WireCompiler;
-import java.util.Collections;
-import java.util.List;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -67,33 +63,30 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
   }
 
   private void compileProtos() throws MojoExecutionException {
-    List<String> args = Lists.newArrayList();
-    args.add("--proto_path=" + protoSourceDirectory);
-    args.add("--java_out=" + generatedSourceDirectory);
-    if (noOptions) {
-      args.add("--no_options");
-    }
+    WireCompiler.Builder builder = new WireCompiler.Builder()
+            .protoPath(protoSourceDirectory)
+            .addSourceFileNames(protoFiles)
+            .outputDirectory(generatedSourceDirectory)
+            .emitOptions(!noOptions)
+            .registryClass(registryClass);
     if (enumOptions != null && enumOptions.length > 0) {
-      args.add("--enum_options=" + Joiner.on(',').join(enumOptions));
+      builder.addEnumOptions(enumOptions);
     }
     if (registryClass != null) {
-      args.add("--registry_class=" + registryClass);
+      builder.registryClass(registryClass);
     }
     if (roots != null && roots.length > 0) {
-      args.add("--roots=" + Joiner.on(',').join(roots));
+      builder.addTypesToEmit(roots);
     }
     if (serviceWriter != null) {
-      args.add("--service_writer=" + serviceWriter);
+      builder.serviceWriter(serviceWriter);
     }
-    Collections.addAll(args, protoFiles);
 
-    getLog().info("Invoking wire compiler with arguments:");
-    getLog().info(Joiner.on('\n').join(args));
+    getLog().info("Invoking wire compiler");
     try {
-      // TODO(shawn) we don't have a great programatic interface to the compiler.
       // Not all exceptions should result in MojoFailureExceptions (i.e. bugs in this plugin that
       // invoke the compiler incorrectly).
-      WireCompiler.main(args.toArray(new String[args.size()]));
+      builder.build().compile();
 
       // Add the directory into which generated sources are placed as a compiled source root.
       project.addCompileSourceRoot(generatedSourceDirectory);


### PR DESCRIPTION
The constructors on WireCompiler are hairy and have way too many parameters. This is causing multiple problems:
* It's not clear which argument maps to which parameter when instantiating WireCompiler instances.
* CheckStyle will fail as soon as another parameter is added (the limit is 10)
* There's no clear interface for invoking the compiler programmatically (i.e. https://github.com/square/wire/blob/master/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java#L93)

In my opinion, the builder pattern solves these issues.