### PR TITLE
Fixed wire-compiler tests. They were failing on Windows.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -247,7 +247,7 @@ public class WireCompiler {
     Map<String, ProtoFile> parsedFiles = new LinkedHashMap<String, ProtoFile>();
 
     for (String sourceFilename : sourceFileNames) {
-      String sourcePath = repoPath + File.separator + sourceFilename;
+      String sourcePath = repoPath + "/" + sourceFilename;
       ProtoFile protoFile = io.parse(sourcePath);
       parsedFiles.put(sourcePath, protoFile);
 
@@ -576,7 +576,7 @@ public class WireCompiler {
     // Load symbols from imports
     for (String dependency : protoFile.getDependencies()) {
       if (!loadedDependencies.contains(dependency)) {
-        String dep = repoPath + File.separator + dependency;
+        String dep = repoPath + "/" + dependency;
         ProtoFile dependencyFile = io.parse(dep);
         loadSymbols(dependencyFile);
         loadedDependencies.add(dependency);
@@ -668,7 +668,7 @@ public class WireCompiler {
     // Load symbols from imports
     for (String dependency : protoFile.getDependencies()) {
       if (!loadedDependencies.contains(dependency)) {
-        String dep = repoPath + File.separator + dependency;
+        String dep = repoPath + "/" + dependency;
         ProtoFile dependencyFile = io.parse(dep);
         loadSymbolsHelper(dependencyFile, loadedDependencies, pass);
         loadedDependencies.add(dependency);


### PR DESCRIPTION
I am using Windows, and there were a few problems in tests. I fixed the following on `wire-compiler` project, mainly on `WireCompilerTest` class:

1.  Relying on "current working directory" (`new File(".")`) was not working correctly on Windows. Instead I relied on searching classpath for "target/test-classes" directory and take its parent.

2. Temp directory moved under "target" in order to be cleaned automatically by Maven "clean" task. This is not related to using Windows, it's a general better idea.

3. Scanner instances were not closed. This prevented `cleanup()` from working correctly on Windows - files could not be deleted, since they were still open.

I would greatly appreciate if you could review my fixes and merge them into your code. 

David.