### PR TITLE
added the --files argument to the maven plugin

### DIFF
--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -3,8 +3,13 @@ package com.squareup.wire.mojo;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.squareup.wire.WireCompiler;
+
+import java.io.File;
+import java.io.FileNotFoundException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Scanner;
+
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
@@ -48,6 +53,12 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
   @Parameter(property = "wire.protoFiles", required = true)
   private String[] protoFiles;
 
+  /**
+   * File containing new line separated list of proto files.
+   */
+  @Parameter(property = "wire.files")
+  private String files;
+
   @Parameter(
       property = "wire.generatedSourceDirectory",
       defaultValue = "${project.build.directory}/generated-sources/wire")
@@ -86,6 +97,17 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
       args.add("--service_writer=" + serviceWriter);
     }
     Collections.addAll(args, protoFiles);
+
+    if (files != null) {
+        File filePointer = new File(files);
+        String[] fileNames;
+        try {
+            fileNames = new Scanner(filePointer, "UTF-8").useDelimiter("\\A").next().split("\n");
+        } catch (FileNotFoundException ex) {
+            throw new MojoExecutionException("Error processing argument " + files, ex);
+        }
+        Collections.addAll(args, fileNames);
+    }
 
     getLog().info("Invoking wire compiler with arguments:");
     getLog().info(Joiner.on('\n').join(args));

--- a/wire-maven-plugin/src/test/resources/exemplar/pom.xml
+++ b/wire-maven-plugin/src/test/resources/exemplar/pom.xml
@@ -33,7 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.6</java.version>
     <!-- TODO(shawn) pass in dependencies of the currently built wire artifact. -->
-    <wire.version>1.5.2-SNAPSHOT</wire.version>
+    <wire.version>1.8.0-SNAPSHOT</wire.version>
   </properties>
 
   <dependencies>
@@ -54,6 +54,7 @@
       <plugin>
         <groupId>com.squareup.wire</groupId>
         <artifactId>wire-maven-plugin</artifactId>
+        <version>${wire.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>
@@ -61,6 +62,7 @@
               <goal>generate-sources</goal>
             </goals>
             <configuration>
+              <files>proto.include</files>
               <protoFiles>
                 <param>squareup/wire/exemplar.proto</param>
               </protoFiles>

--- a/wire-maven-plugin/src/test/resources/exemplar/proto.include
+++ b/wire-maven-plugin/src/test/resources/exemplar/proto.include
@@ -1,0 +1,1 @@
+squareup/wire/exemplar_two.proto

--- a/wire-maven-plugin/src/test/resources/exemplar/src/main/java/com/squareup/wire/exemplar/Exemplar.java
+++ b/wire-maven-plugin/src/test/resources/exemplar/src/main/java/com/squareup/wire/exemplar/Exemplar.java
@@ -1,11 +1,15 @@
 package com.squareup.wire.exemplar;
 
 import com.squareup.protos.wire.exemplar.MuchAwesome;
+import com.squareup.protos.wire.exemplar.MuchAwesome2;
 
 public class Exemplar {
 
   public static void main(String[] args) {
     MuchAwesome doge = new MuchAwesome.Builder().very_proto("Wow!").build();
+    System.out.println(doge.toString());
+
+    MuchAwesome2 doge2 = new MuchAwesome.Builder().very_proto2("Wow!").build();
     System.out.println(doge.toString());
   }
 }

--- a/wire-maven-plugin/src/test/resources/exemplar/src/main/proto/squareup/wire/exemplar_two.proto
+++ b/wire-maven-plugin/src/test/resources/exemplar/src/main/proto/squareup/wire/exemplar_two.proto
@@ -1,0 +1,9 @@
+package squareup.wire.exemplar;
+
+option java_package = "com.squareup.protos.wire.exemplar";
+option java_multiple_files = true;
+option java_generic_services = true;
+
+message MuchAwesome2 {
+  optional string very_proto2 = 1;
+}


### PR DESCRIPTION
Added `--files` support to maven-plugin.

> Instead of supplying individual filename arguments on the command line, the --files flag may be used to specify a single file containing a list of .proto files. The file names are interpreted relative to the value given for the --proto_path flag.