### PR TITLE
Unknown repeated fields

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
@@ -243,8 +243,8 @@ final class UnknownFieldMap {
     int size = 0;
     if (fieldMap != null) {
       for (Map.Entry<Integer, List<FieldValue>> entry : fieldMap.entrySet()) {
-        size += WireOutput.varintTagSize(entry.getKey());
         for (FieldValue value : entry.getValue()) {
+          size += WireOutput.varintTagSize(entry.getKey());
           size += value.getSerializedSize();
         }
       }

--- a/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
@@ -18,6 +18,7 @@ package com.squareup.wire;
 import com.squareup.wire.protos.unknownfields.VersionOne;
 import com.squareup.wire.protos.unknownfields.VersionTwo;
 import java.io.IOException;
+import java.util.Arrays;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -35,6 +36,7 @@ public class UnknownFieldsTest {
        .v2_s("222")
        .v2_f32(67890)
        .v2_f64(98765L)
+       .v2_rs(Arrays.asList("1", "2"))
        .build();
     assertEquals(new Integer(111), v2.i);
     // Check v.2 fields
@@ -42,6 +44,7 @@ public class UnknownFieldsTest {
     assertEquals("222", v2.v2_s);
     assertEquals(new Integer(67890), v2.v2_f32);
     assertEquals(new Long(98765L), v2.v2_f64);
+    assertEquals(Arrays.asList("1", "2"), v2.v2_rs);
     // Serialized
     byte[] v2Bytes = v2.toByteArray();
 
@@ -65,6 +68,7 @@ public class UnknownFieldsTest {
     assertEquals("222", v2B.v2_s);
     assertEquals(new Integer(67890), v2B.v2_f32);
     assertEquals(new Long(98765L), v2B.v2_f64);
+    assertEquals(Arrays.asList("1", "2"), v2B.v2_rs);
 
     // "Modify" v1 via a merged builder, serialize, and re-parse
     VersionOne v1Modified = new VersionOne.Builder(v1).i(777).build();
@@ -77,5 +81,6 @@ public class UnknownFieldsTest {
     assertEquals("222", v2C.v2_s);
     assertEquals(new Integer(67890), v2C.v2_f32);
     assertEquals(new Long(98765L), v2C.v2_f64);
+    assertEquals(Arrays.asList("1", "2"), v2C.v2_rs);
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -4,11 +4,14 @@ package com.squareup.wire.protos.unknownfields;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoField;
+import java.util.Collections;
+import java.util.List;
 
 import static com.squareup.wire.Message.Datatype.FIXED32;
 import static com.squareup.wire.Message.Datatype.FIXED64;
 import static com.squareup.wire.Message.Datatype.INT32;
 import static com.squareup.wire.Message.Datatype.STRING;
+import static com.squareup.wire.Message.Label.REPEATED;
 
 public final class VersionTwo extends Message {
   private static final long serialVersionUID = 0L;
@@ -18,6 +21,7 @@ public final class VersionTwo extends Message {
   public static final String DEFAULT_V2_S = "";
   public static final Integer DEFAULT_V2_F32 = 0;
   public static final Long DEFAULT_V2_F64 = 0L;
+  public static final List<String> DEFAULT_V2_RS = Collections.emptyList();
 
   @ProtoField(tag = 1, type = INT32)
   public final Integer i;
@@ -34,16 +38,20 @@ public final class VersionTwo extends Message {
   @ProtoField(tag = 5, type = FIXED64)
   public final Long v2_f64;
 
-  public VersionTwo(Integer i, Integer v2_i, String v2_s, Integer v2_f32, Long v2_f64) {
+  @ProtoField(tag = 6, type = STRING, label = REPEATED)
+  public final List<String> v2_rs;
+
+  public VersionTwo(Integer i, Integer v2_i, String v2_s, Integer v2_f32, Long v2_f64, List<String> v2_rs) {
     this.i = i;
     this.v2_i = v2_i;
     this.v2_s = v2_s;
     this.v2_f32 = v2_f32;
     this.v2_f64 = v2_f64;
+    this.v2_rs = immutableCopyOf(v2_rs);
   }
 
   private VersionTwo(Builder builder) {
-    this(builder.i, builder.v2_i, builder.v2_s, builder.v2_f32, builder.v2_f64);
+    this(builder.i, builder.v2_i, builder.v2_s, builder.v2_f32, builder.v2_f64, builder.v2_rs);
     setBuilder(builder);
   }
 
@@ -56,7 +64,8 @@ public final class VersionTwo extends Message {
         && equals(v2_i, o.v2_i)
         && equals(v2_s, o.v2_s)
         && equals(v2_f32, o.v2_f32)
-        && equals(v2_f64, o.v2_f64);
+        && equals(v2_f64, o.v2_f64)
+        && equals(v2_rs, o.v2_rs);
   }
 
   @Override
@@ -68,6 +77,7 @@ public final class VersionTwo extends Message {
       result = result * 37 + (v2_s != null ? v2_s.hashCode() : 0);
       result = result * 37 + (v2_f32 != null ? v2_f32.hashCode() : 0);
       result = result * 37 + (v2_f64 != null ? v2_f64.hashCode() : 0);
+      result = result * 37 + (v2_rs != null ? v2_rs.hashCode() : 1);
       hashCode = result;
     }
     return result;
@@ -80,6 +90,7 @@ public final class VersionTwo extends Message {
     public String v2_s;
     public Integer v2_f32;
     public Long v2_f64;
+    public List<String> v2_rs;
 
     public Builder() {
     }
@@ -92,6 +103,7 @@ public final class VersionTwo extends Message {
       this.v2_s = message.v2_s;
       this.v2_f32 = message.v2_f32;
       this.v2_f64 = message.v2_f64;
+      this.v2_rs = copyOf(message.v2_rs);
     }
 
     public Builder i(Integer i) {
@@ -116,6 +128,11 @@ public final class VersionTwo extends Message {
 
     public Builder v2_f64(Long v2_f64) {
       this.v2_f64 = v2_f64;
+      return this;
+    }
+
+    public Builder v2_rs(List<String> v2_rs) {
+      this.v2_rs = checkForNulls(v2_rs);
       return this;
     }
 

--- a/wire-runtime/src/test/proto/unknown_fields.proto
+++ b/wire-runtime/src/test/proto/unknown_fields.proto
@@ -28,4 +28,5 @@ message VersionTwo {
   optional string v2_s = 3;
   optional fixed32 v2_f32 = 4;
   optional fixed64 v2_f64 = 5;
+  repeated string v2_rs = 6;
 }


### PR DESCRIPTION
Fix for issue #195 : "wire-runtime crashes when re-serializing unknown repeated fields."

When writing a repeated unknown field, we were writing the tag value before each repetition, but only allocating enough space for a single tag value at the front of the section.

We are now allocating enough space for each tag write.