### PR TITLE
Remove redundant 'private' modifier from enum constructor.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/MessageWriter.java
@@ -147,7 +147,7 @@ public class MessageWriter {
         parameters.add(trailingSegment(option.name));
       }
 
-      writer.beginConstructor(EnumSet.of(PRIVATE), parameters, null);
+      writer.beginConstructor(Collections.<Modifier>emptySet(), parameters, null);
       writer.emitStatement("this.value = value");
       for (EnumValueOptionInfo option : options) {
         String name = trailingSegment(option.name);

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1233,7 +1233,7 @@ public final class AllTypes extends ExtendableMessage<AllTypes> {
 
     private final int value;
 
-    private NestedEnum(int value) {
+    NestedEnum(int value) {
       this.value = value;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -339,7 +339,7 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     public final Integer enum_value_option;
     public final Boolean foreign_enum_value_option;
 
-    private FooBarBazEnum(int value, More complex_enum_value_option, Integer enum_value_option, Boolean foreign_enum_value_option) {
+    FooBarBazEnum(int value, More complex_enum_value_option, Integer enum_value_option, Boolean foreign_enum_value_option) {
       this.value = value;
       this.complex_enum_value_option = complex_enum_value_option;
       this.enum_value_option = enum_value_option;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -287,7 +287,7 @@ public final class FooBar extends ExtendableMessage<FooBar> {
     private final int value;
     public final Integer enum_value_option;
 
-    private FooBarBazEnum(int value, Integer enum_value_option) {
+    FooBarBazEnum(int value, Integer enum_value_option) {
       this.value = value;
       this.enum_value_option = enum_value_option;
     }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
@@ -11,7 +11,7 @@ public enum ForeignEnum
 
   private final int value;
 
-  private ForeignEnum(int value) {
+  ForeignEnum(int value) {
     this.value = value;
   }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -151,7 +151,7 @@ public final class Person extends Message {
 
     private final int value;
 
-    private PhoneType(int value) {
+    PhoneType(int value) {
       this.value = value;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
@@ -11,7 +11,7 @@ public enum G
 
   private final int value;
 
-  private G(int value) {
+  G(int value) {
     this.value = value;
   }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -375,7 +375,7 @@ public final class SimpleMessage extends Message {
 
     private final int value;
 
-    private NestedEnum(int value) {
+    NestedEnum(int value) {
       this.value = value;
     }
 


### PR DESCRIPTION
Enums can only be constructed in their constants and IntelliJ flags the redundancy as a warning.