### PR TITLE
Escape escape characters which appear on Windows paths.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -762,7 +762,7 @@ public class WireCompiler {
     try {
       writer = io.getJavaWriter(artifact);
       writer.emitSingleLineComment(CODE_GENERATED_BY_WIRE);
-      writer.emitSingleLineComment("Source file: %s", sourceFileName);
+      writer.emitSingleLineComment("Source file: %s", sourceFileName.replace("\\", "\\\\"));
       writer.emitPackage(getJavaPackage());
 
       List<TypeElement> types = new ArrayList<TypeElement>();


### PR DESCRIPTION
The current test setup does not afford an easy way to test this.

Closes #196.