### PR TITLE
Drop the oneof choice enum.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -782,7 +782,7 @@ public class WireCompiler {
       if (hasBytesField(types)) {
         imports.add("okio.ByteString");
       }
-      if (hasEnum(types) || hasOneOf(types)) {
+      if (hasEnum(types)) {
         imports.add("com.squareup.wire.ProtoEnum");
       }
       if (hasRepeatedField(types)) {

--- a/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
@@ -16,14 +16,9 @@
 package com.squareup.wire;
 
 import com.squareup.wire.protos.oneof.OneOfMessage;
-
+import java.io.IOException;
 import org.junit.Test;
 
-import java.io.IOException;
-
-import static com.squareup.wire.protos.oneof.OneOfMessage.Choice.BAR;
-import static com.squareup.wire.protos.oneof.OneOfMessage.Choice.CHOICE_NOT_SET;
-import static com.squareup.wire.protos.oneof.OneOfMessage.Choice.FOO;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -37,43 +32,40 @@ public class OneOfTest {
   // (Tag #3 << 3 | LENGTH_DELIMITED) = 26, string length = 6.
   private static final byte[] BAR_BYTES = { 26, 6, 'b', 'a', 'r', 'b', 'a', 'r'};
 
-
   @Test
   public void testOneOf() throws Exception {
     OneOfMessage.Builder builder = new OneOfMessage.Builder();
-    validate(builder, null, null, CHOICE_NOT_SET, INITIAL_BYTES);
+    validate(builder, null, null, INITIAL_BYTES);
 
     builder.foo(17);
-    validate(builder, 17, null, FOO, FOO_BYTES);
+    validate(builder, 17, null, FOO_BYTES);
 
     builder.bar("barbar");
-    validate(builder, null, "barbar", BAR, BAR_BYTES);
+    validate(builder, null, "barbar", BAR_BYTES);
 
     builder.bar(null);
-    validate(builder, null, null, CHOICE_NOT_SET, INITIAL_BYTES);
+    validate(builder, null, null, INITIAL_BYTES);
 
     builder.bar("barbar");
-    validate(builder, null, "barbar", BAR, BAR_BYTES);
+    validate(builder, null, "barbar", BAR_BYTES);
 
     builder.foo(17);
-    validate(builder, 17, null, FOO, FOO_BYTES);
+    validate(builder, 17, null, FOO_BYTES);
 
     builder.foo(null);
-    validate(builder, null, null, CHOICE_NOT_SET, INITIAL_BYTES);
+    validate(builder, null, null, INITIAL_BYTES);
   }
 
   private void validate(OneOfMessage.Builder builder, Integer expectedFoo, String expectedBar,
-      OneOfMessage.Choice expectedChoice, byte[] expectedBytes) throws IOException {
+      byte[] expectedBytes) throws IOException {
     // Check builder fields
     assertEquals(expectedFoo, builder.foo);
     assertEquals(expectedBar, builder.bar);
-    assertEquals(expectedChoice, builder.choice);
 
     // Check message fields.
     OneOfMessage message = builder.build();
     assertEquals(expectedFoo, message.foo);
     assertEquals(expectedBar, message.bar);
-    assertEquals(expectedChoice, message.choice);
 
     // Check serialized bytes.
     byte[] bytes = message.toByteArray();
@@ -83,6 +75,5 @@ public class OneOfTest {
     OneOfMessage newMessage = wire.parseFrom(bytes, OneOfMessage.class);
     assertEquals(expectedFoo, newMessage.foo);
     assertEquals(expectedBar, newMessage.bar);
-    assertEquals(expectedChoice, newMessage.choice);
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -3,7 +3,6 @@
 package com.squareup.wire.protos.oneof;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
 import com.squareup.wire.ProtoField;
 
 import static com.squareup.wire.Message.Datatype.INT32;
@@ -28,45 +27,13 @@ public final class OneOfMessage extends Message {
   @ProtoField(tag = 3, type = STRING, label = ONE_OF)
   public final String bar;
 
-  /**
-   * Must have a foo or a bar.
-   */
-  public final Choice choice;
-
-  public enum Choice
-      implements ProtoEnum {
-    CHOICE_NOT_SET(0),
-    FOO(1),
-    BAR(3);
-
-    private final int value;
-
-    Choice(int value) {
-      this.value = value;
-    }
-
-    public int getValue() {
-      return value;
-    }
-
-    public static Choice valueOf(int value) {
-      switch (value) {
-        case 0: return CHOICE_NOT_SET;
-        case 1: return FOO;
-        case 3: return BAR;
-      }
-      return null;
-    }
-  }
-
-  public OneOfMessage(Integer foo, String bar, Choice choice) {
+  public OneOfMessage(Integer foo, String bar) {
     this.foo = foo;
     this.bar = bar;
-    this.choice = choice;
   }
 
   private OneOfMessage(Builder builder) {
-    this(builder.foo, builder.bar, builder.choice);
+    this(builder.foo, builder.bar);
     setBuilder(builder);
   }
 
@@ -95,8 +62,6 @@ public final class OneOfMessage extends Message {
     public Integer foo;
     public String bar;
 
-    public Choice choice = Choice.CHOICE_NOT_SET;
-
     public Builder() {
     }
 
@@ -105,7 +70,6 @@ public final class OneOfMessage extends Message {
       if (message == null) return;
       this.foo = message.foo;
       this.bar = message.bar;
-      this.choice = message.choice;
     }
 
     /**
@@ -115,7 +79,6 @@ public final class OneOfMessage extends Message {
       this.foo = foo;
 
       this.bar = null;
-      this.choice = foo == null ? Choice.CHOICE_NOT_SET : Choice.FOO;
       return this;
     }
 
@@ -126,7 +89,6 @@ public final class OneOfMessage extends Message {
       this.bar = bar;
 
       this.foo = null;
-      this.choice = bar == null ? Choice.CHOICE_NOT_SET : Choice.BAR;
       return this;
     }
 


### PR DESCRIPTION
It is particularly weird in JSON encoding, since it may be
either absent or redundant.

Checking the presence of a oneof with a series of null checks
is simpler and safer.