### PR TITLE
Implement trimming from the root set.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -955,7 +955,7 @@ public class WireCompiler {
     if (!shouldEmitOptions()) {
       for (ExtendElement declaration : declarations) {
         String name = declaration.qualifiedName();
-        if (!(isFieldOptions(name) || isMessageOptions(name))) {
+        if (!isFieldOptions(name) && !isMessageOptions(name)) {
           return true;
         }
       }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/Loader.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/Loader.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.model;
+
+import com.squareup.protoparser.ProtoFile;
+import com.squareup.wire.IO;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Load proto files and their transitive dependencies, parse them, and prepare for linking. The
+ * returned values are not linked and should not be used prior to linking.
+ */
+public final class Loader {
+  private final String repoPath;
+  private final IO io;
+  private final Set<String> protoFileNames = new LinkedHashSet<String>();
+  private final List<WireProtoFile> loaded = new ArrayList<WireProtoFile>();
+
+  public Loader(String repoPath, IO io) {
+    this.repoPath = repoPath;
+    this.io = io;
+  }
+
+  /** Recursively add {@code protoFile} and its dependencies. */
+  public void add(String protoFileName) throws IOException {
+    if (!protoFileNames.add(protoFileName)) {
+      return;
+    }
+
+    ProtoFile protoFile = io.parse(repoPath + File.separator + protoFileName);
+    WireProtoFile wireProtoFile = WireProtoFile.get(protoFile);
+    loaded.add(wireProtoFile);
+
+    // Recursively add dependencies.
+    for (String dependency : protoFile.dependencies()) {
+      add(dependency);
+    }
+  }
+
+  public List<WireProtoFile> loaded() {
+    return Util.immutableList(loaded);
+  }
+}

--- a/wire-compiler/src/main/java/com/squareup/wire/model/ProtoTypeName.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/ProtoTypeName.java
@@ -45,13 +45,13 @@ public final class ProtoTypeName {
   public static final ProtoTypeName UINT32 = new ProtoTypeName("uint32");
   public static final ProtoTypeName UINT64 = new ProtoTypeName("uint64");
 
-  public static final ProtoTypeName FILE_OPTIONS = get("google.protobuf", "FileOptions");
-  public static final ProtoTypeName MESSAGE_OPTIONS = get("google.protobuf", "MessageOptions");
-  public static final ProtoTypeName FIELD_OPTIONS = get("google.protobuf", "FieldOptions");
-  public static final ProtoTypeName ENUM_OPTIONS = get("google.protobuf", "EnumOptions");
-  public static final ProtoTypeName ENUM_VALUE_OPTIONS = get("google.protobuf", "EnumValueOptions");
-  public static final ProtoTypeName SERVICE_OPTIONS = get("google.protobuf", "ServiceOptions");
-  public static final ProtoTypeName METHOD_OPTIONS = get("google.protobuf", "MethodOptions");
+  static final ProtoTypeName FILE_OPTIONS = get("google.protobuf", "FileOptions");
+  static final ProtoTypeName MESSAGE_OPTIONS = get("google.protobuf", "MessageOptions");
+  static final ProtoTypeName FIELD_OPTIONS = get("google.protobuf", "FieldOptions");
+  static final ProtoTypeName ENUM_OPTIONS = get("google.protobuf", "EnumOptions");
+  static final ProtoTypeName ENUM_VALUE_OPTIONS = get("google.protobuf", "EnumValueOptions");
+  static final ProtoTypeName SERVICE_OPTIONS = get("google.protobuf", "ServiceOptions");
+  static final ProtoTypeName METHOD_OPTIONS = get("google.protobuf", "MethodOptions");
 
   private static final Map<String, ProtoTypeName> SCALAR_TYPES;
   static {
@@ -85,6 +85,10 @@ public final class ProtoTypeName {
     this.protoPackage = protoPackage;
     this.names = names;
     this.isScalar = isScalar;
+  }
+
+  public String packageName() {
+    return protoPackage;
   }
 
   public String simpleName() {

--- a/wire-compiler/src/main/java/com/squareup/wire/model/Pruner.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/Pruner.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.model;
+
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/** Removes unused types and services. */
+public final class Pruner {
+  /** Homogeneous identifiers including type names, service names, and RPC names. */
+  final Set<String> marks = new LinkedHashSet<String>();
+
+  /** Identifiers whose immediate dependencies have not yet been marked. */
+  final Deque<String> queue = new ArrayDeque<String>();
+
+  /**
+   * Returns a new root set that contains only the types in {@code roots} and their transitive
+   * dependencies.
+   *
+   * @param roots a set of identifiers to retain, which may be fully qualified type names, fully
+   *     qualified service names, or service RPCs like {@code package.ServiceName#MethodName}.
+   */
+  public List<WireProtoFile> retainRoots(List<WireProtoFile> protoFiles, Set<String> roots) {
+    if (roots.isEmpty()) throw new IllegalArgumentException();
+    if (!marks.isEmpty()) throw new IllegalStateException();
+
+    Map<String, WireType> typesIndex = buildTypesIndex(protoFiles);
+    Map<String, WireService> servicesIndex = buildServicesIndex(protoFiles);
+
+    // Mark and enqueue the roots.
+    for (String s : roots) {
+      mark(s);
+    }
+
+    // Extensions and options are also roots.
+    for (WireProtoFile protoFile : protoFiles) {
+      for (WireExtend extend : protoFile.wireExtends()) {
+        markExtend(extend);
+      }
+      markOptions(protoFile.options());
+    }
+
+    // Mark everything reachable by what's enqueued, queueing new things as we go.
+    for (String name; (name = queue.poll()) != null;) {
+      if (ProtoTypeName.getScalar(name) != null) {
+        continue; // Skip scalar types.
+      }
+
+      WireType type = typesIndex.get(name);
+      if (type != null) {
+        markType(type);
+        continue;
+      }
+
+      WireService service = servicesIndex.get(name);
+      if (service != null) {
+        markService(service);
+        continue;
+      }
+
+      // If the root set contains a method name like 'Service#Method', only that RPC is marked.
+      int hash = name.indexOf('#');
+      if (hash != -1) {
+        String serviceName = name.substring(0, hash);
+        String rpcName = name.substring(hash + 1);
+        WireService partialService = servicesIndex.get(serviceName);
+        if (partialService != null) {
+          WireRpc rpc = partialService.rpc(rpcName);
+          if (rpc != null) {
+            markOptions(partialService.options());
+            markRpc(rpc);
+            continue;
+          }
+        }
+      }
+
+      throw new IllegalArgumentException("Unexpected type: " + name);
+    }
+
+    List<WireProtoFile> retained = new ArrayList<WireProtoFile>();
+    for (WireProtoFile protoFile : protoFiles) {
+      retained.add(protoFile.retainAll(marks));
+    }
+
+    return Util.immutableList(retained);
+  }
+
+  private static Map<String, WireType> buildTypesIndex(Collection<WireProtoFile> protoFiles) {
+    Map<String, WireType> result = new LinkedHashMap<String, WireType>();
+    for (WireProtoFile protoFile : protoFiles) {
+      for (WireType type : protoFile.types()) {
+        index(result, type);
+      }
+    }
+    return Util.immutableMap(result);
+  }
+
+  private static void index(Map<String, WireType> typesByName, WireType type) {
+    typesByName.put(type.protoTypeName().toString(), type);
+    for (WireType nested : type.nestedTypes()) {
+      index(typesByName, nested);
+    }
+  }
+
+  private static Map<String, WireService> buildServicesIndex(Collection<WireProtoFile> protoFiles) {
+    Map<String, WireService> result = new LinkedHashMap<String, WireService>();
+    for (WireProtoFile protoFile : protoFiles) {
+      for (WireService service : protoFile.services()) {
+        result.put(service.protoTypeName().toString(), service);
+      }
+    }
+    return Util.immutableMap(result);
+  }
+
+  private void mark(ProtoTypeName typeName) {
+    mark(typeName.toString());
+  }
+
+  private void mark(String identifier) {
+    if (marks.add(identifier)) {
+      queue.add(identifier); // The transitive dependencies of this identifier must be visited.
+    }
+  }
+
+  private void markExtend(WireExtend extend) {
+    mark(extend.protoTypeName());
+    markFields(extend.fields());
+  }
+
+  private void markType(WireType type) {
+    markOptions(type.options());
+    for (WireType nestedType : type.nestedTypes()) {
+      mark(nestedType.protoTypeName());
+    }
+    if (type instanceof WireMessage) {
+      markMessage((WireMessage) type);
+    } else if (type instanceof WireEnum) {
+      markEnum((WireEnum) type);
+    }
+  }
+
+  private void markMessage(WireMessage message) {
+    markFields(message.fields());
+    for (WireOneOf oneOf : message.oneOfs()) {
+      markFields(oneOf.fields());
+    }
+  }
+
+  private void markEnum(WireEnum wireEnum) {
+    markOptions(wireEnum.options());
+    for (WireEnumConstant constant : wireEnum.constants()) {
+      markOptions(constant.options());
+    }
+  }
+
+  private void markFields(List<WireField> fields) {
+    for (WireField field : fields) {
+      markField(field);
+    }
+  }
+
+  private void markField(WireField field) {
+    markOptions(field.options());
+    mark(field.type());
+  }
+
+  private void markOptions(List<WireOption> options) {
+    for (WireOption option : options) {
+      if (option.fieldPath() != null) {
+        markFields(option.fieldPath());
+      }
+    }
+  }
+
+  private void markService(WireService service) {
+    markOptions(service.options());
+    for (WireRpc rpc : service.rpcs()) {
+      markRpc(rpc);
+    }
+  }
+
+  private void markRpc(WireRpc rpc) {
+    markOptions(rpc.options());
+    mark(rpc.requestType());
+    mark(rpc.responseType());
+  }
+}

--- a/wire-compiler/src/main/java/com/squareup/wire/model/Util.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/Util.java
@@ -16,7 +16,11 @@
 package com.squareup.wire.model;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 final class Util {
   private Util() {
@@ -60,5 +64,14 @@ final class Util {
 
   public static boolean equal(Object a, Object b) {
     return a == b || (a != null && a.equals(b));
+  }
+
+  /** Returns an immutable copy of {@code list}. */
+  public static <T> List<T> immutableList(Collection<T> list) {
+    return Collections.unmodifiableList(new ArrayList<T>(list));
+  }
+
+  public static <K, V> Map<K, V> immutableMap(Map<K, V> map) {
+    return Collections.unmodifiableMap(new LinkedHashMap<K, V>(map));
   }
 }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireEnum.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireEnum.java
@@ -15,12 +15,10 @@
  */
 package com.squareup.wire.model;
 
-import com.squareup.protoparser.EnumConstantElement;
 import com.squareup.protoparser.EnumElement;
-import com.squareup.protoparser.OptionElement;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 
 public final class WireEnum extends WireType {
   private final ProtoTypeName protoTypeName;
@@ -28,20 +26,11 @@ public final class WireEnum extends WireType {
   private final List<WireEnumConstant> constants;
   private final List<WireOption> options;
 
-  WireEnum(ProtoTypeName protoTypeName, EnumElement element) {
+  WireEnum(ProtoTypeName protoTypeName, EnumElement element, List<WireEnumConstant> constants,
+      List<WireOption> options) {
     this.protoTypeName = protoTypeName;
     this.element = element;
-
-    List<WireEnumConstant> constants = new ArrayList<WireEnumConstant>();
-    for (EnumConstantElement constant : this.element.constants()) {
-      constants.add(new WireEnumConstant(constant));
-    }
     this.constants = Collections.unmodifiableList(constants);
-
-    List<WireOption> options = new ArrayList<WireOption>();
-    for (OptionElement option : element.options()) {
-      options.add(new WireOption(option));
-    }
     this.options = Collections.unmodifiableList(options);
   }
 
@@ -72,5 +61,9 @@ public final class WireEnum extends WireType {
     for (WireOption option : options) {
       option.link(ProtoTypeName.ENUM_OPTIONS, linker);
     }
+  }
+
+  @Override WireType retainAll(Set<String> identifiers) {
+    return identifiers.contains(protoTypeName.toString()) ? this : null;
   }
 }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireEnumConstant.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireEnumConstant.java
@@ -22,17 +22,23 @@ import java.util.Collections;
 import java.util.List;
 
 public final class WireEnumConstant {
+  private final String packageName;
   private final EnumConstantElement element;
   private final List<WireOption> options;
 
-  public WireEnumConstant(EnumConstantElement element) {
+  WireEnumConstant(String packageName, EnumConstantElement element) {
+    this.packageName = packageName;
     this.element = element;
 
     List<WireOption> options = new ArrayList<WireOption>();
     for (OptionElement option : element.options()) {
-      options.add(new WireOption(option));
+      options.add(new WireOption(packageName, option));
     }
     this.options = Collections.unmodifiableList(options);
+  }
+
+  public String packageName() {
+    return packageName;
   }
 
   public String name() {

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireExtend.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireExtend.java
@@ -22,18 +22,24 @@ import java.util.Collections;
 import java.util.List;
 
 public final class WireExtend {
+  private final String packageName;
   private final ExtendElement element;
   private final List<WireField> fields;
   private ProtoTypeName protoTypeName;
 
-  public WireExtend(ExtendElement element) {
+  public WireExtend(String packageName, ExtendElement element) {
+    this.packageName = packageName;
     this.element = element;
 
     List<WireField> fields = new ArrayList<WireField>();
     for (FieldElement field : element.fields()) {
-      fields.add(new WireField(field));
+      fields.add(new WireField(packageName, field));
     }
     this.fields = Collections.unmodifiableList(fields);
+  }
+
+  public String packageName() {
+    return packageName;
   }
 
   public ProtoTypeName protoTypeName() {
@@ -52,6 +58,6 @@ public final class WireExtend {
     for (WireField field : fields) {
       field.link(linker);
     }
-    protoTypeName = linker.wireType(element.name()).protoTypeName();
+    protoTypeName = linker.resolveNamedType(packageName, element.name());
   }
 }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireField.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireField.java
@@ -22,18 +22,24 @@ import java.util.Collections;
 import java.util.List;
 
 public final class WireField {
+  private final String packageName;
   private final FieldElement element;
   private final List<WireOption> options;
   private ProtoTypeName type;
 
-  WireField(FieldElement element) {
+  WireField(String packageName, FieldElement element) {
+    this.packageName = packageName;
     this.element = element;
 
     List<WireOption> options = new ArrayList<WireOption>();
     for (OptionElement option : element.options()) {
-      options.add(new WireOption(option));
+      options.add(new WireOption(packageName, option));
     }
     this.options = Collections.unmodifiableList(options);
+  }
+
+  public String packageName() {
+    return packageName;
   }
 
   public FieldElement.Label label() {
@@ -73,7 +79,7 @@ public final class WireField {
   }
 
   void link(Linker linker) {
-    type = linker.protoTypeName(element.type());
+    type = linker.resolveType(packageName, element.type());
     for (WireOption option : options) {
       option.link(ProtoTypeName.FIELD_OPTIONS, linker);
     }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireOneOf.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireOneOf.java
@@ -22,17 +22,23 @@ import java.util.Collections;
 import java.util.List;
 
 public final class WireOneOf {
+  private final String packageName;
   private final OneOfElement element;
   private final List<WireField> fields;
 
-  WireOneOf(OneOfElement element) {
+  WireOneOf(String packageName, OneOfElement element) {
+    this.packageName = packageName;
     this.element = element;
 
     List<WireField> fields = new ArrayList<WireField>();
     for (FieldElement field : element.fields()) {
-      fields.add(new WireField(field));
+      fields.add(new WireField(packageName, field));
     }
     this.fields = Collections.unmodifiableList(fields);
+  }
+
+  public String packageName() {
+    return packageName;
   }
 
   public String name() {

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireOption.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireOption.java
@@ -19,15 +19,25 @@ import com.squareup.protoparser.OptionElement;
 import java.util.List;
 
 public final class WireOption {
+  private final String packageName;
   private final OptionElement element;
   private List<WireField> fieldPath;
 
-  public WireOption(OptionElement element) {
+  public WireOption(String packageName, OptionElement element) {
+    this.packageName = packageName;
     this.element = element;
+  }
+
+  public String packageName() {
+    return packageName;
   }
 
   public String name() {
     return element.name();
+  }
+
+  public List<WireField> fieldPath() {
+    return fieldPath;
   }
 
   public OptionElement.Kind kind() {
@@ -43,6 +53,6 @@ public final class WireOption {
   }
 
   void link(ProtoTypeName optionType, Linker linker) {
-    fieldPath = linker.fieldPath(optionType, element.name());
+    fieldPath = linker.fieldPath(packageName, optionType, element.name());
   }
 }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireRpc.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireRpc.java
@@ -22,19 +22,25 @@ import java.util.Collections;
 import java.util.List;
 
 public final class WireRpc {
+  private final String packageName;
   private final RpcElement element;
   private final List<WireOption> options;
   private ProtoTypeName requestType;
   private ProtoTypeName responseType;
 
-  WireRpc(RpcElement element) {
+  WireRpc(String packageName, RpcElement element) {
+    this.packageName = packageName;
     this.element = element;
 
     List<WireOption> options = new ArrayList<WireOption>();
     for (OptionElement option : element.options()) {
-      options.add(new WireOption(option));
+      options.add(new WireOption(packageName, option));
     }
     this.options = Collections.unmodifiableList(options);
+  }
+
+  public String packageName() {
+    return packageName;
   }
 
   public String name() {
@@ -58,8 +64,8 @@ public final class WireRpc {
   }
 
   void link(Linker linker) {
-    requestType = linker.protoTypeName(element.requestType());
-    responseType = linker.protoTypeName(element.responseType());
+    requestType = linker.resolveNamedType(packageName, element.requestType().name());
+    responseType = linker.resolveNamedType(packageName, element.responseType().name());
     for (WireOption option : options) {
       option.link(ProtoTypeName.METHOD_OPTIONS, linker);
     }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireType.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireType.java
@@ -15,10 +15,16 @@
  */
 package com.squareup.wire.model;
 
+import com.squareup.protoparser.EnumConstantElement;
 import com.squareup.protoparser.EnumElement;
+import com.squareup.protoparser.FieldElement;
 import com.squareup.protoparser.MessageElement;
+import com.squareup.protoparser.OneOfElement;
+import com.squareup.protoparser.OptionElement;
 import com.squareup.protoparser.TypeElement;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 public abstract class WireType {
   public abstract ProtoTypeName protoTypeName();
@@ -26,13 +32,49 @@ public abstract class WireType {
   public abstract List<WireOption> options();
   public abstract List<WireType> nestedTypes();
   abstract void link(Linker linker);
+  abstract WireType retainAll(Set<String> identifiers);
 
   static WireType get(ProtoTypeName protoTypeName, TypeElement type) {
     if (type instanceof EnumElement) {
-      return new WireEnum(protoTypeName, (EnumElement) type);
+      EnumElement enumElement = (EnumElement) type;
+
+      List<WireEnumConstant> constants = new ArrayList<WireEnumConstant>();
+      for (EnumConstantElement constant : enumElement.constants()) {
+        constants.add(new WireEnumConstant(protoTypeName.packageName(), constant));
+      }
+
+      List<WireOption> options = new ArrayList<WireOption>();
+      for (OptionElement option : enumElement.options()) {
+        options.add(new WireOption(protoTypeName.packageName(), option));
+      }
+
+      return new WireEnum(protoTypeName, enumElement, constants, options);
 
     } else if (type instanceof MessageElement) {
-      return new WireMessage(protoTypeName, (MessageElement) type);
+      MessageElement messageElement = (MessageElement) type;
+      String packageName = protoTypeName.packageName();
+
+      List<WireField> fields = new ArrayList<WireField>();
+      for (FieldElement field : messageElement.fields()) {
+        fields.add(new WireField(packageName, field));
+      }
+
+      List<WireOneOf> oneOfs = new ArrayList<WireOneOf>();
+      for (OneOfElement oneOf : messageElement.oneOfs()) {
+        oneOfs.add(new WireOneOf(packageName, oneOf));
+      }
+
+      List<WireType> nestedTypes = new ArrayList<WireType>();
+      for (TypeElement nestedType : messageElement.nestedElements()) {
+        nestedTypes.add(WireType.get(protoTypeName.nestedType(nestedType.name()), nestedType));
+      }
+
+      List<WireOption> options = new ArrayList<WireOption>();
+      for (OptionElement option : messageElement.options()) {
+        options.add(new WireOption(packageName, option));
+      }
+
+      return new WireMessage(protoTypeName, messageElement, fields, oneOfs, nestedTypes, options);
 
     } else {
       throw new IllegalArgumentException("unexpected type: " + type.getClass());


### PR DESCRIPTION
This trims the in-memory model rather than limiting which types are emitted
during serialization. This approach may be more reusable when using Wire to
target other languages.