### PR TITLE
Fork MessageWriter to use JavaPoet.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>19.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>protoparser</artifactId>
         <version>4.0.3</version>
@@ -81,6 +86,11 @@
         <groupId>junit</groupId>
         <artifactId>junit</artifactId>
         <version>4.10</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup</groupId>
+        <artifactId>javapoet</artifactId>
+        <version>1.2.0-SNAPSHOT</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/wire-compiler/pom.xml
+++ b/wire-compiler/pom.xml
@@ -31,6 +31,14 @@
       <artifactId>okio</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.squareup</groupId>
+      <artifactId>javapoet</artifactId>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/wire-compiler/src/main/java/com/squareup/wire/IO.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/IO.java
@@ -1,9 +1,11 @@
 // Copyright 2013 Square, Inc.
 package com.squareup.wire;
 
+import com.squareup.javapoet.JavaFile;
 import com.squareup.javawriter.JavaWriter;
 import com.squareup.protoparser.ProtoFile;
 import com.squareup.protoparser.ProtoParser;
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -30,6 +32,8 @@ public interface IO {
   JavaWriter getJavaWriter(OutputArtifact outputArtifact)
       throws IOException;
 
+  void write(OutputArtifact outputArtifact, JavaFile javaFile) throws IOException;
+
   /**
    * Concrete implementation of the IO interface that proxies to the file system.
    */
@@ -47,6 +51,11 @@ public interface IO {
         throws IOException {
       artifact.dir().mkdirs();
       return new JavaWriter(new OutputStreamWriter(new FileOutputStream(artifact.file()), UTF_8));
+    }
+
+    @Override public void write(OutputArtifact outputArtifact, JavaFile javaFile)
+        throws IOException {
+      javaFile.writeTo(new File(outputArtifact.outputDirectory()));
     }
   }
 }

--- a/wire-compiler/src/main/java/com/squareup/wire/OutputArtifact.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/OutputArtifact.java
@@ -1,6 +1,9 @@
 package com.squareup.wire;
 
+import com.squareup.javapoet.ClassName;
 import java.io.File;
+
+import static com.google.common.base.Preconditions.checkArgument;
 
 /**
  * A container class that represents an artifact output from the compiler.
@@ -14,6 +17,12 @@ final class OutputArtifact {
     this.outputDirectory = outputDirectory;
     this.className = className;
     this.javaPackage = javaPackage;
+  }
+
+  public OutputArtifact(String javaOut, ClassName className) {
+    this(javaOut, className.packageName(), className.simpleName());
+    checkArgument(className.enclosingClassName() == null,
+        "cannot output a nested class!");
   }
 
   public String outputDirectory() {

--- a/wire-compiler/src/main/java/com/squareup/wire/internal/Util.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/internal/Util.java
@@ -13,30 +13,18 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.wire.model;
+package com.squareup.wire.internal;
 
+import com.squareup.wire.model.WireOption;
 import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-final class Util {
+import static com.google.common.base.Preconditions.checkNotNull;
+
+public final class Util {
   private Util() {
-  }
-
-  public static <T> T checkNotNull(T value, String name) {
-    if (value == null) {
-      throw new NullPointerException(name + " == null");
-    }
-    return value;
-  }
-
-  public static void checkState(boolean assertion) {
-    if (!assertion) {
-      throw new IllegalStateException();
-    }
   }
 
   public static <T> List<T> concatenate(List<T> a, T b) {
@@ -62,16 +50,20 @@ final class Util {
     return found;
   }
 
-  public static boolean equal(Object a, Object b) {
-    return a == b || (a != null && a.equals(b));
-  }
-
-  /** Returns an immutable copy of {@code list}. */
-  public static <T> List<T> immutableList(Collection<T> list) {
-    return Collections.unmodifiableList(new ArrayList<T>(list));
-  }
-
-  public static <K, V> Map<K, V> immutableMap(Map<K, V> map) {
-    return Collections.unmodifiableMap(new LinkedHashMap<K, V>(map));
+  /**
+   * Returns true if any of the options in {@code options} matches both of the regular expressions
+   * provided: its name matches the option's name and its value matches the option's value.
+   */
+  public static boolean optionMatches(
+      List<WireOption> options, String namePattern, String valuePattern) {
+    Matcher nameMatcher = Pattern.compile(namePattern).matcher("");
+    Matcher valueMatcher = Pattern.compile(valuePattern).matcher("");
+    for (WireOption option : options) {
+      if (nameMatcher.reset(option.name()).matches()
+          && valueMatcher.reset(String.valueOf(option.value())).matches()) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/wire-compiler/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.java;
+
+import com.google.common.collect.ImmutableMap;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.wire.ExtendableMessage;
+import com.squareup.wire.Message;
+import com.squareup.wire.internal.Util;
+import com.squareup.wire.model.ProtoTypeName;
+import com.squareup.wire.model.WireEnum;
+import com.squareup.wire.model.WireEnumConstant;
+import com.squareup.wire.model.WireOption;
+import com.squareup.wire.model.WireProtoFile;
+import com.squareup.wire.model.WireType;
+import java.util.List;
+import java.util.Map;
+import okio.ByteString;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+/**
+ * Converts proto definitions into Java source code.
+ *
+ * <p>This can map type names from protocol buffers (like {@code uint32}, {@code string}, or {@code
+ * squareup.protos.person.Person} to the corresponding Java names (like {@code int}, {@code
+ * java.lang.String}, or {@code com.squareup.protos.person.Person}).
+ */
+public final class JavaGenerator {
+  public static final ClassName BYTE_STRING = ClassName.get(ByteString.class);
+  public static final ClassName STRING = ClassName.get(String.class);
+  public static final ClassName LIST = ClassName.get(List.class);
+  public static final ClassName EXTENDABLE_BUILDER
+      = (ClassName) TypeName.get(ExtendableMessage.ExtendableBuilder.class);
+  public static final ClassName BUILDER = (ClassName) TypeName.get(Message.Builder.class);
+
+  private static final Map<ProtoTypeName, TypeName> SCALAR_TYPES_MAP =
+      ImmutableMap.<ProtoTypeName, TypeName>builder()
+          .put(ProtoTypeName.BOOL, TypeName.BOOLEAN.box())
+          .put(ProtoTypeName.BYTES, ClassName.get(ByteString.class))
+          .put(ProtoTypeName.DOUBLE, TypeName.DOUBLE.box())
+          .put(ProtoTypeName.FLOAT, TypeName.FLOAT.box())
+          .put(ProtoTypeName.FIXED32, TypeName.INT.box())
+          .put(ProtoTypeName.FIXED64, TypeName.LONG.box())
+          .put(ProtoTypeName.INT32, TypeName.INT.box())
+          .put(ProtoTypeName.INT64, TypeName.LONG.box())
+          .put(ProtoTypeName.SFIXED32, TypeName.INT.box())
+          .put(ProtoTypeName.SFIXED64, TypeName.LONG.box())
+          .put(ProtoTypeName.SINT32, TypeName.INT.box())
+          .put(ProtoTypeName.SINT64, TypeName.LONG.box())
+          .put(ProtoTypeName.STRING, ClassName.get(String.class))
+          .put(ProtoTypeName.UINT32, TypeName.INT.box())
+          .put(ProtoTypeName.UINT64, TypeName.LONG.box())
+          .build();
+
+  private final ImmutableMap<ProtoTypeName, TypeName> wireToJava;
+  private final ImmutableMap<ProtoTypeName, WireType> wireToType;
+
+  public JavaGenerator(
+      ImmutableMap<ProtoTypeName, TypeName> wireToJava,
+      ImmutableMap<ProtoTypeName, WireType> wireToType) {
+    this.wireToJava = wireToJava;
+    this.wireToType = wireToType;
+  }
+
+  public static JavaGenerator get(List<WireProtoFile> wireProtoFiles) {
+    ImmutableMap.Builder<ProtoTypeName, TypeName> wireToJava = ImmutableMap.builder();
+    ImmutableMap.Builder<ProtoTypeName, WireType> wireToType = ImmutableMap.builder();
+    wireToJava.putAll(SCALAR_TYPES_MAP);
+
+    for (WireProtoFile wireProtoFile : wireProtoFiles) {
+      String javaPackage = javaPackage(wireProtoFile);
+      putAll(wireToJava, wireToType, javaPackage, null, wireProtoFile.types());
+    }
+
+    return new JavaGenerator(wireToJava.build(), wireToType.build());
+  }
+
+  private static void putAll(ImmutableMap.Builder<ProtoTypeName, TypeName> wireToJava,
+      ImmutableMap.Builder<ProtoTypeName, WireType> wireToType, String javaPackage,
+      ClassName enclosingClassName, List<WireType> types) {
+    for (WireType type : types) {
+      ClassName className = enclosingClassName != null
+          ? enclosingClassName.nestedClass(type.protoTypeName().simpleName())
+          : ClassName.get(javaPackage, type.protoTypeName().simpleName());
+      wireToJava.put(type.protoTypeName(), className);
+      wireToType.put(type.protoTypeName(), type);
+      putAll(wireToJava, wireToType, javaPackage, className, type.nestedTypes());
+    }
+  }
+
+  public TypeName typeName(ProtoTypeName protoTypeName) {
+    TypeName candidate = wireToJava.get(protoTypeName);
+    checkArgument(candidate != null, "unexpected type %s", protoTypeName);
+    return candidate;
+  }
+
+  private static String javaPackage(WireProtoFile wireProtoFile) {
+    WireOption javaPackageOption = Util.findOption(wireProtoFile.options(), "java_package");
+    if (javaPackageOption != null) {
+      return String.valueOf(javaPackageOption.value());
+    } else if (wireProtoFile.packageName() != null) {
+      return wireProtoFile.packageName();
+    } else {
+      return "";
+    }
+  }
+
+  public boolean isEnum(ProtoTypeName type) {
+    WireType wireType = wireToType.get(type);
+    return wireType instanceof WireEnum;
+  }
+
+  public WireEnumConstant enumDefault(ProtoTypeName type) {
+    WireEnum wireEnum = (WireEnum) wireToType.get(type);
+    return wireEnum.constants().get(0);
+  }
+
+  public static TypeName listOf(TypeName type) {
+    return ParameterizedTypeName.get(LIST, type);
+  }
+}

--- a/wire-compiler/src/main/java/com/squareup/wire/java/TypeWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/java/TypeWriter.java
@@ -1,0 +1,652 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.java;
+
+import com.google.common.base.Charsets;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableSet;
+import com.squareup.javapoet.AnnotationSpec;
+import com.squareup.javapoet.ClassName;
+import com.squareup.javapoet.CodeBlock;
+import com.squareup.javapoet.FieldSpec;
+import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.ParameterizedTypeName;
+import com.squareup.javapoet.TypeName;
+import com.squareup.javapoet.TypeSpec;
+import com.squareup.wire.ExtendableMessage;
+import com.squareup.wire.Message;
+import com.squareup.wire.ProtoEnum;
+import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireCompilerException;
+import com.squareup.wire.internal.Util;
+import com.squareup.wire.model.WireEnum;
+import com.squareup.wire.model.WireEnumConstant;
+import com.squareup.wire.model.WireField;
+import com.squareup.wire.model.WireMessage;
+import com.squareup.wire.model.WireOneOf;
+import com.squareup.wire.model.WireOption;
+import com.squareup.wire.model.WireType;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import okio.ByteString;
+
+import static javax.lang.model.element.Modifier.FINAL;
+import static javax.lang.model.element.Modifier.PRIVATE;
+import static javax.lang.model.element.Modifier.PUBLIC;
+import static javax.lang.model.element.Modifier.STATIC;
+
+public final class TypeWriter {
+  private static final ImmutableSet<String> JAVA_KEYWORDS = ImmutableSet.of(
+      "abstract", "assert", "boolean", "break", "byte", "case", "catch", "char",
+      "class", "const", "continue", "default", "do", "double", "else", "enum", "extends",
+      "final", "finally", "float", "for", "goto", "if", "implements", "import", "instanceof",
+      "int", "interface", "long", "native", "new", "package", "private", "protected", "public",
+      "return", "short", "static", "strictfp", "super", "switch", "synchronized", "this",
+      "throw", "throws", "transient", "try", "void", "volatile", "while");
+
+  private final JavaGenerator javaGenerator;
+  private final boolean emitOptions;
+
+  public TypeWriter(JavaGenerator javaGenerator, boolean emitOptions) {
+    this.javaGenerator = javaGenerator;
+    this.emitOptions = emitOptions;
+  }
+
+  /** Returns the generated code for {@code type}, which may be a top-level or a nested type. */
+  public TypeSpec toTypeSpec(WireType type) {
+    if (type instanceof WireMessage) {
+      return toTypeSpec((WireMessage) type);
+    } else if (type instanceof WireEnum) {
+      return toTypeSpec((WireEnum) type);
+    } else {
+      throw new IllegalArgumentException("unexpected type: " + type);
+    }
+  }
+
+  private TypeSpec toTypeSpec(WireEnum type) {
+    ClassName typeName = (ClassName) javaGenerator.typeName(type.protoTypeName());
+
+    TypeSpec.Builder builder = TypeSpec.enumBuilder(typeName.simpleName())
+        .addModifiers(PUBLIC)
+        .addSuperinterface(ProtoEnum.class);
+
+    if (!type.documentation().isEmpty()) {
+      builder.addJavadoc("$L\n", type.documentation());
+    }
+
+    // TODO(jwilson): options.
+
+    for (WireEnumConstant constant : type.constants()) {
+      Object[] enumArgs = new Object[1];
+      String[] enumArgsFormat = new String[1];
+
+      enumArgs[0] = constant.tag();
+      enumArgsFormat[0] = "$L";
+
+      TypeSpec.Builder constantBuilder = TypeSpec.anonymousClassBuilder(
+          Joiner.on(", ").join(enumArgsFormat), enumArgs);
+      if (!constant.documentation().isEmpty()) {
+        constantBuilder.addJavadoc("$L\n", constant.documentation());
+      }
+
+      builder.addEnumConstant(constant.name(), constantBuilder.build());
+
+      // TODO(jwilson): initializers.
+    }
+
+    // Output Private tag field
+    builder.addField(TypeName.INT, "value", PRIVATE, FINAL);
+
+    // TODO(jwilson): extensions.
+
+    MethodSpec.Builder constructorBuilder = MethodSpec.constructorBuilder();
+    constructorBuilder.addParameter(TypeName.INT, "value");
+    constructorBuilder.addStatement("this.value = value");
+    // TODO(jwilson): private constructor extensions.
+    builder.addMethod(constructorBuilder.build());
+
+    // Public Getter
+    builder.addMethod(MethodSpec.methodBuilder("getValue")
+        .addAnnotation(Override.class)
+        .addModifiers(PUBLIC)
+        .returns(TypeName.INT)
+        .addStatement("return value")
+        .build());
+
+    return builder.build();
+  }
+
+  private TypeSpec toTypeSpec(WireMessage type) {
+    ClassName javaType = (ClassName) javaGenerator.typeName(type.protoTypeName());
+    ClassName builderJavaType = javaType.nestedClass("Builder");
+
+    TypeSpec.Builder builder = TypeSpec.classBuilder(javaType.simpleName());
+    builder.addModifiers(PUBLIC, FINAL);
+
+    if (javaType.enclosingClassName() != null) {
+      builder.addModifiers(STATIC);
+    }
+
+    if (!type.documentation().isEmpty()) {
+      builder.addJavadoc("$L\n", type.documentation());
+    }
+
+    // TODO(jwilson): extendable messages.
+    if (false) {
+      builder.superclass(ExtendableMessage.class);
+    } else {
+      builder.superclass(Message.class);
+    }
+
+    builder.addField(FieldSpec.builder(TypeName.LONG, "serialVersionUID")
+        .addModifiers(PRIVATE, STATIC, FINAL)
+        .initializer("$LL", 0L)
+        .build());
+
+    for (WireField field : type.fieldsAndOneOfFields()) {
+      TypeName fieldType = fieldType(field);
+
+      if (field.type().isScalar()
+          || javaGenerator.isEnum(field.type())
+          || field.isRepeated()) {
+        builder.addField(defaultField(field, fieldType));
+      }
+
+      String name = sanitize(field.name());
+      FieldSpec.Builder fieldBuilder = FieldSpec.builder(fieldType, name, PUBLIC, FINAL);
+      fieldBuilder.addAnnotation(protoFieldAnnotation(field, javaGenerator.typeName(field.type())));
+      if (!field.documentation().isEmpty()) {
+        fieldBuilder.addJavadoc("$L\n", field.documentation());
+      }
+      if (field.isDeprecated()) {
+        fieldBuilder.addAnnotation(Deprecated.class);
+      }
+      builder.addField(fieldBuilder.build());
+    }
+
+    builder.addMethod(messageFieldsConstructor(type));
+    builder.addMethod(messageBuilderConstructor(type, builderJavaType));
+    builder.addMethod(messageEquals(type));
+    builder.addMethod(messageHashCode(type));
+    builder.addType(builder(type, javaType, builderJavaType));
+
+    for (WireType nestedType : type.nestedTypes()) {
+      builder.addType(toTypeSpec(nestedType));
+    }
+
+    return builder.build();
+  }
+
+  private TypeName fieldType(WireField field) {
+    TypeName messageType = javaGenerator.typeName(field.type());
+    return field.isRepeated() ? JavaGenerator.listOf(messageType) : messageType;
+  }
+
+  // Example:
+  //
+  // public static final Integer DEFAULT_OPT_INT32 = 123;
+  //
+  private FieldSpec defaultField(WireField field, TypeName fieldType) {
+    String defaultFieldName = "DEFAULT_" + field.name().toUpperCase(Locale.US);
+    return FieldSpec.builder(fieldType, defaultFieldName, PUBLIC, STATIC, FINAL)
+        .initializer(defaultValue(field))
+        .build();
+  }
+
+  // Example:
+  //
+  // @ProtoField(
+  //   tag = 1,
+  //   type = INT32
+  // )
+  //
+  private AnnotationSpec protoFieldAnnotation(WireField field, TypeName messageType) {
+    AnnotationSpec.Builder result = AnnotationSpec.builder(ProtoField.class);
+
+    int tag = field.tag();
+    result.addMember("tag", String.valueOf(tag));
+
+    boolean isScalar = field.type().isScalar();
+    boolean isEnum = javaGenerator.isEnum(field.type());
+
+    String fieldType;
+    if (isScalar) {
+      fieldType = field.type().toString().toUpperCase(Locale.US);
+    } else if (isEnum) {
+      fieldType = "ENUM";
+    } else {
+      fieldType = null;
+    }
+
+    if (fieldType != null) {
+      result.addMember("type", "$T.$L", Message.Datatype.class, fieldType);
+    }
+
+    if (!field.isOptional()) {
+      String label;
+      if (field.isPacked() && (isEnum || field.type().isPackableScalar())) {
+        label = "PACKED";
+      } else {
+        label = field.label().toString();
+      }
+      result.addMember("label", "$T.$L", Message.Label.class, label);
+    }
+
+    if (field.isRepeated() && !isScalar) {
+      String key = isEnum ? "enumType" : "messageType";
+      result.addMember(key, "$T.class", messageType);
+    }
+
+    if (field.isDeprecated()) {
+      result.addMember("deprecated", "true");
+    }
+
+    // We allow any package name to be used as long as it ends with '.redacted'.
+    if (Util.optionMatches(field.options(), ".*\\.redacted", "true")) {
+      result.addMember("redacted", "true");
+    }
+
+    return result.build();
+  }
+
+  // Example:
+  //
+  // public SimpleMessage(int optional_int32, long optional_int64) {
+  //   this.optional_int32 = optional_int32;
+  //   this.optional_int64 = optional_int64;
+  // }
+  //
+  private MethodSpec messageFieldsConstructor(WireMessage type) {
+    MethodSpec.Builder result = MethodSpec.constructorBuilder();
+    result.addModifiers(PUBLIC);
+    for (WireField field : type.fieldsAndOneOfFields()) {
+      TypeName javaType = fieldType(field);
+      String sanitizedName = sanitize(field.name());
+      result.addParameter(javaType, sanitizedName);
+      if (field.isRepeated()) {
+        result.addStatement("this.$L = immutableCopyOf($L)", sanitizedName, sanitizedName);
+      } else {
+        result.addStatement("this.$L = $L", sanitizedName, sanitizedName);
+      }
+    }
+    return result.build();
+  }
+
+  // Example:
+  //
+  // private SimpleMessage(Builder builder) {
+  //   this(builder.optional_int32, builder.optional_int64);
+  //   setBuilder(builder);
+  // }
+  //
+  private MethodSpec messageBuilderConstructor(WireMessage type, ClassName builderJavaType) {
+    MethodSpec.Builder result = MethodSpec.constructorBuilder()
+        .addModifiers(PRIVATE)
+        .addParameter(builderJavaType, "builder");
+
+    List<WireField> fields = type.fieldsAndOneOfFields();
+    if (fields.size() > 0) {
+      result.addCode("this(");
+      for (int i = 0; i < fields.size(); i++) {
+        if (i > 0) result.addCode(", ");
+        WireField field = fields.get(i);
+        result.addCode("builder.$L", sanitize(field.name()));
+      }
+      result.addCode(");\n");
+    }
+    result.addStatement("setBuilder(builder)");
+    return result.build();
+  }
+
+  // Example:
+  //
+  // @Override
+  // public boolean equals(Object other) {
+  //   if (other == this) return true;
+  //   if (!(other instanceof SimpleMessage)) return false;
+  //   SimpleMessage o = (SimpleMessage) other;
+  //   if (!Wire.equals(optional_int32, o.optional_int32)) return false;
+  //   return true;
+  //
+  private MethodSpec messageEquals(WireMessage type) {
+    TypeName javaType = javaGenerator.typeName(type.protoTypeName());
+    MethodSpec.Builder result = MethodSpec.methodBuilder("equals")
+        .addAnnotation(Override.class)
+        .addModifiers(PUBLIC)
+        .returns(boolean.class)
+        .addParameter(Object.class, "other");
+
+    List<WireField> fields = type.fieldsAndOneOfFields();
+    if (fields.isEmpty()) {
+      result.addStatement("return other instanceof $T", javaType);
+      return result.build();
+    }
+
+    result.addStatement("if (other == this) return true");
+    result.addStatement("if (!(other instanceof $T)) return false", javaType);
+
+    // TODO(jwilson): extensions!
+    //if (compiler.hasExtensions(messageType)) {
+    //  writer.emitStatement("if (!extensionsEqual(o)) return false");
+    //}
+
+    if (fields.size() == 1) {
+      String name = sanitize(fields.get(0).name());
+      result.addStatement("return equals($L, (($T) other).$L)",
+          addThisIfOneOf(name, "other", "o"), javaType, name);
+      return result.build();
+    }
+
+    result.addStatement("$T o = ($T) other", javaType, javaType);
+    result.addCode("$[return ");
+    for (int i = 0; i < fields.size(); i++) {
+      if (i > 0) result.addCode("\n&& ");
+      WireField field = fields.get(i);
+      String name = sanitize(field.name());
+      result.addCode("equals($L, o.$L)", addThisIfOneOf(name, "other", "o"), name);
+    }
+    result.addCode(";\n$]");
+
+    return result.build();
+  }
+
+  // Example:
+  //
+  // @Override
+  // public int hashCode() {
+  //   if (hashCode == 0) {
+  //     int result = super.extensionsHashCode();
+  //     result = result * 37 + (f != null ? f.hashCode() : 0);
+  //     hashCode = result;
+  //   }
+  //   return hashCode;
+  // }
+  //
+  // For repeated fields, the final "0" in the example above changes to a "1"
+  // in order to be the same as the system hash code for an empty list.
+  //
+  private MethodSpec messageHashCode(WireMessage type) {
+    MethodSpec.Builder result = MethodSpec.methodBuilder("hashCode")
+        .addAnnotation(Override.class)
+        .addModifiers(PUBLIC)
+        .returns(int.class);
+
+    List<WireField> fields = type.fieldsAndOneOfFields();
+    if (fields.isEmpty()) {
+      result.addStatement("return 0");
+      return result.build();
+    }
+
+    if (fields.size() == 1) {
+      WireField field = fields.get(0);
+      String name = sanitize(field.name());
+      result.addStatement("int result = hashCode");
+      result.addStatement(
+          "return result != 0 ? result : (hashCode = $L != null ? $L.hashCode() : $L)",
+          addThisIfOneOf(name, "result"), addThisIfOneOf(name, "result"), nullHashValue(field));
+      return result.build();
+    }
+
+    result.addStatement("int result = hashCode");
+    result.beginControlFlow("if (result == 0)");
+    boolean afterFirstAssignment = false;
+    // TODO(jwilson): extensions!
+    //if (compiler.hasExtensions(messageType)) {
+    //  writer.emitStatement("result = extensionsHashCode()");
+    //  afterFirstAssignment = true;
+    //}
+    for (WireField field : fields) {
+      String name = sanitize(field.name());
+      name = addThisIfOneOf(name, "result");
+      if (afterFirstAssignment) {
+        result.addStatement("result = result * 37 + ($L != null ? $L.hashCode() : $L)",
+            name, name, nullHashValue(field));
+      } else {
+        result.addStatement("result = $L != null ? $L.hashCode() : $L",
+            name, name, nullHashValue(field));
+        afterFirstAssignment = true;
+      }
+    }
+    result.addStatement("hashCode = result");
+    result.endControlFlow();
+    result.addStatement("return result");
+    return result.build();
+  }
+
+  private TypeSpec builder(WireMessage type, ClassName javaType, TypeName builderType) {
+    TypeSpec.Builder result = TypeSpec.classBuilder("Builder")
+        .addModifiers(PUBLIC, STATIC, FINAL);
+
+    if (false) {
+      // TODO(jwilson):
+      result.superclass(ParameterizedTypeName.get(JavaGenerator.EXTENDABLE_BUILDER, javaType));
+    } else {
+      result.superclass(ParameterizedTypeName.get(JavaGenerator.BUILDER, javaType));
+    }
+
+    List<WireField> fields = type.fieldsAndOneOfFields();
+    for (WireField field : fields) {
+      TypeName fieldJavaType = fieldType(field);
+      result.addField(fieldJavaType, sanitize(field.name()), PUBLIC);
+    }
+
+    result.addMethod(builderNoArgsConstructor());
+    result.addMethod(builderCopyConstructor(type));
+
+    for (WireField field : type.fields()) {
+      result.addMethod(setter(builderType, null, field));
+    }
+
+    for (WireOneOf oneOf : type.oneOfs()) {
+      for (WireField field : oneOf.fields()) {
+        result.addMethod(setter(builderType, oneOf, field));
+      }
+    }
+
+    result.addMethod(builderBuild(type, javaType));
+
+    // TODO(jwilson): extensions!
+    //if (compiler.hasExtensions(messageType)) emitBuilderSetExtension(writer, messageType);
+
+    return result.build();
+  }
+
+  // Example:
+  //
+  // public Builder() {
+  // }
+  //
+  private MethodSpec builderNoArgsConstructor() {
+    return MethodSpec.constructorBuilder()
+        .addModifiers(PUBLIC)
+        .build();
+  }
+
+  // Example:
+  //
+  // public Builder(SimpleMessage message) {
+  //   super(message);
+  //   if (message == null) return;
+  //   this.optional_int32 = message.optional_int32;
+  //   ...
+  // }
+  //
+  private MethodSpec builderCopyConstructor(WireMessage message) {
+    TypeName javaType = javaGenerator.typeName(message.protoTypeName());
+
+    MethodSpec.Builder result = MethodSpec.constructorBuilder()
+        .addModifiers(PUBLIC)
+        .addParameter(javaType, "message");
+    result.addStatement("super(message)");
+
+    List<WireField> fields = message.fieldsAndOneOfFields();
+    if (!fields.isEmpty()) {
+      result.addStatement("if (message == null) return");
+    }
+
+    for (WireField field : fields) {
+      String fieldName = sanitize(field.name());
+      if (field.isRepeated()) {
+        result.addStatement("this.$L = copyOf(message.$L)", fieldName, fieldName);
+      } else {
+        result.addStatement("this.$L = message.$L", fieldName, fieldName);
+      }
+    }
+
+    return result.build();
+  }
+
+  private MethodSpec setter(TypeName builderType, WireOneOf oneOf, WireField field) {
+    TypeName javaType = fieldType(field);
+    String fieldName = sanitize(field.name());
+
+    MethodSpec.Builder result = MethodSpec.methodBuilder(fieldName)
+        .addModifiers(PUBLIC)
+        .addParameter(javaType, fieldName)
+        .returns(builderType);
+
+    if (!field.documentation().isEmpty()) {
+      result.addJavadoc("$L\n", field.documentation());
+    }
+
+    if (field.isDeprecated()) {
+      result.addAnnotation(Deprecated.class);
+    }
+
+    if (field.isRepeated()) {
+      result.addStatement("this.$L = checkForNulls($L)", fieldName, fieldName);
+    } else {
+      result.addStatement("this.$L = $L", fieldName, fieldName);
+
+      if (oneOf != null) {
+        for (WireField other : oneOf.fields()) {
+          if (field != other) {
+            result.addStatement("this.$L = null", sanitize(other.name()));
+          }
+        }
+      }
+    }
+
+    result.addStatement("return this");
+    return result.build();
+  }
+
+  // Example:
+  //
+  // @Override
+  // public SimpleMessage build() {
+  //   checkRequiredFields();
+  //   return new SimpleMessage(this);
+  // }
+  //
+  // The call to checkRequiredFields will be emitted only if the message has
+  // required fields.
+  //
+  private MethodSpec builderBuild(WireMessage message, ClassName javaType) {
+    MethodSpec.Builder result = MethodSpec.methodBuilder("build")
+        .addAnnotation(Override.class)
+        .addModifiers(PUBLIC)
+        .returns(javaType);
+    if (message.hasRequiredFields()) {
+      result.addStatement("checkRequiredFields()");
+    }
+    result.addStatement("return new $T(this)", javaType);
+    return result.build();
+  }
+
+  private CodeBlock defaultValue(WireField field) {
+    if (field.isRepeated()) {
+      return codeBlock("$T.emptyList()", Collections.class);
+    }
+
+    WireOption fieldDefault = field.getDefault();
+    TypeName javaType = fieldType(field);
+
+    if (field.type().isScalar()) {
+      Object initialValue = fieldDefault != null ? fieldDefault.value() : null;
+      return fieldInitializer(javaType, initialValue);
+    }
+
+    if (fieldDefault != null) {
+      return codeBlock("$T.$L", javaType, fieldDefault.value());
+    }
+
+    if (javaGenerator.isEnum(field.type())) {
+      WireEnumConstant defaultValue = javaGenerator.enumDefault(field.type());
+      return codeBlock("$T.$L", javaType, defaultValue.name());
+    }
+
+    throw new WireCompilerException("Field " + field + " cannot have default value");
+  }
+
+  private CodeBlock fieldInitializer(TypeName type, Object value) {
+    if (type.equals(TypeName.BOOLEAN.box())) {
+      return codeBlock("$L", value != null ? value : false);
+
+    } else if (type.equals(TypeName.INT.box())) {
+      return codeBlock("$L", value != null
+          ? new BigDecimal(String.valueOf(value)).intValue()
+          : 0);
+
+    } else if (type.equals(TypeName.LONG.box())) {
+      return codeBlock("$LL", value != null
+          ? Long.toString(new BigDecimal(String.valueOf(value)).longValue())
+          : 0L);
+
+    } else if (type.equals(TypeName.FLOAT.box())) {
+      return codeBlock("$Lf", value != null ? String.valueOf(value) : 0f);
+
+    } else if (type.equals(TypeName.DOUBLE.box())) {
+      return codeBlock("$Ld", value != null ? String.valueOf(value) : 0d);
+
+    } else if (type.equals(JavaGenerator.STRING)) {
+      return codeBlock("$S", value != null ? (String) value : "");
+
+    } else if (type.equals(JavaGenerator.BYTE_STRING)) {
+      if (value == null) {
+        return codeBlock("$T.EMPTY", ByteString.class);
+      } else {
+        return codeBlock("$T.decodeBase64($S)", ByteString.class,
+            ByteString.of(String.valueOf(value).getBytes(Charsets.ISO_8859_1)).base64());
+      }
+    } else {
+      throw new WireCompilerException(type + " is not an allowed scalar type");
+    }
+  }
+
+  private String addThisIfOneOf(String name, String... matches) {
+    for (String match : matches) {
+      if (match.equals(name)) {
+        return "this." + name;
+      }
+    }
+    return name;
+  }
+
+  private static String sanitize(String name) {
+    return JAVA_KEYWORDS.contains(name) ? "_" + name : name;
+  }
+
+  private static CodeBlock codeBlock(String format, Object... args) {
+    return CodeBlock.builder().add(format, args).build();
+  }
+
+  private int nullHashValue(WireField field) {
+    return field.isRepeated() ? 1 : 0;
+  }
+}

--- a/wire-compiler/src/main/java/com/squareup/wire/model/Linker.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/Linker.java
@@ -16,6 +16,7 @@
 package com.squareup.wire.model;
 
 import com.squareup.protoparser.DataType;
+import com.squareup.wire.internal.Util;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/wire-compiler/src/main/java/com/squareup/wire/model/Loader.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/Loader.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.model;
 
+import com.google.common.collect.ImmutableList;
 import com.squareup.protoparser.ProtoFile;
 import com.squareup.wire.IO;
 import java.io.File;
@@ -45,8 +46,9 @@ public final class Loader {
       return;
     }
 
-    ProtoFile protoFile = io.parse(repoPath + File.separator + protoFileName);
-    WireProtoFile wireProtoFile = WireProtoFile.get(protoFile);
+    String sourcePath = repoPath + File.separator + protoFileName;
+    ProtoFile protoFile = io.parse(sourcePath);
+    WireProtoFile wireProtoFile = WireProtoFile.get(sourcePath, protoFile);
     loaded.add(wireProtoFile);
 
     // Recursively add dependencies.
@@ -56,6 +58,6 @@ public final class Loader {
   }
 
   public List<WireProtoFile> loaded() {
-    return Util.immutableList(loaded);
+    return ImmutableList.copyOf(loaded);
   }
 }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/ProtoTypeName.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/ProtoTypeName.java
@@ -15,14 +15,16 @@
  */
 package com.squareup.wire.model;
 
+import com.squareup.wire.internal.Util;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
-import static com.squareup.wire.model.Util.checkNotNull;
-import static com.squareup.wire.model.Util.checkState;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 /**
  * Names a protocol buffer message, enumerated type or a scalar. This class models a fully-qualified
@@ -95,6 +97,20 @@ public final class ProtoTypeName {
     return names.get(names.size() - 1);
   }
 
+  /** Returns the enclosing type, or null if this type is not nested in another type. */
+  public ProtoTypeName enclosingTypeName() {
+    if (names.size() == 1) return null;
+    return new ProtoTypeName(protoPackage, names.subList(0, names.size() - 1), isScalar);
+  }
+
+  public boolean isScalar() {
+    return isScalar;
+  }
+
+  public boolean isPackableScalar() {
+    return isScalar && !equals(STRING) && !equals(BYTES);
+  }
+
   public static ProtoTypeName get(String protoPackage, String name) {
     checkNotNull(name, "name");
     return new ProtoTypeName(protoPackage, Collections.singletonList(name), false);
@@ -112,7 +128,7 @@ public final class ProtoTypeName {
 
   @Override public boolean equals(Object o) {
     return o instanceof ProtoTypeName
-        && Util.equal(((ProtoTypeName) o).protoPackage, protoPackage)
+        && Objects.equals(((ProtoTypeName) o).protoPackage, protoPackage)
         && ((ProtoTypeName) o).names.equals(names)
         && ((ProtoTypeName) o).isScalar == isScalar;
   }

--- a/wire-compiler/src/main/java/com/squareup/wire/model/Pruner.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/Pruner.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.wire.model;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -102,7 +104,7 @@ public final class Pruner {
       retained.add(protoFile.retainAll(marks));
     }
 
-    return Util.immutableList(retained);
+    return ImmutableList.copyOf(retained);
   }
 
   private static Map<String, WireType> buildTypesIndex(Collection<WireProtoFile> protoFiles) {
@@ -112,7 +114,7 @@ public final class Pruner {
         index(result, type);
       }
     }
-    return Util.immutableMap(result);
+    return ImmutableMap.copyOf(result);
   }
 
   private static void index(Map<String, WireType> typesByName, WireType type) {
@@ -129,7 +131,7 @@ public final class Pruner {
         result.put(service.protoTypeName().toString(), service);
       }
     }
-    return Util.immutableMap(result);
+    return ImmutableMap.copyOf(result);
   }
 
   private void mark(ProtoTypeName typeName) {

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireField.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireField.java
@@ -17,6 +17,7 @@ package com.squareup.wire.model;
 
 import com.squareup.protoparser.FieldElement;
 import com.squareup.protoparser.OptionElement;
+import com.squareup.wire.internal.Util;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,6 +45,18 @@ public final class WireField {
 
   public FieldElement.Label label() {
     return element.label();
+  }
+
+  public boolean isRepeated() {
+    return label() == FieldElement.Label.REPEATED;
+  }
+
+  public boolean isOptional() {
+    return label() == FieldElement.Label.OPTIONAL;
+  }
+
+  public boolean isRequired() {
+    return label() == FieldElement.Label.REQUIRED;
   }
 
   public ProtoTypeName type() {

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireMessage.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireMessage.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.model;
 
+import com.google.common.collect.ImmutableList;
 import com.squareup.protoparser.ExtensionsElement;
 import com.squareup.protoparser.MessageElement;
 import java.util.ArrayList;
@@ -35,10 +36,10 @@ public final class WireMessage extends WireType {
       List<WireType> nestedTypes, List<WireOption> options) {
     this.protoTypeName = protoTypeName;
     this.element = element;
-    this.fields = Util.immutableList(fields);
-    this.oneOfs = Util.immutableList(oneOfs);
-    this.nestedTypes = Util.immutableList(nestedTypes);
-    this.options = Util.immutableList(options);
+    this.fields = ImmutableList.copyOf(fields);
+    this.oneOfs = ImmutableList.copyOf(oneOfs);
+    this.nestedTypes = ImmutableList.copyOf(nestedTypes);
+    this.options = ImmutableList.copyOf(options);
   }
 
   @Override public ProtoTypeName protoTypeName() {
@@ -59,6 +60,22 @@ public final class WireMessage extends WireType {
 
   public List<WireField> fields() {
     return fields;
+  }
+
+  public boolean hasRequiredFields() {
+    for (WireField field : fieldsAndOneOfFields()) {
+      if (field.isRequired()) return true;
+    }
+    return false;
+  }
+
+  public List<WireField> fieldsAndOneOfFields() {
+    ImmutableList.Builder<WireField> result = ImmutableList.builder();
+    result.addAll(fields);
+    for (WireOneOf oneOf : oneOfs) {
+      result.addAll(oneOf.fields());
+    }
+    return result.build();
   }
 
   /** Returns the field named {@code name}, or null if this type has no such field. */

--- a/wire-compiler/src/main/java/com/squareup/wire/model/WireProtoFile.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/model/WireProtoFile.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.model;
 
+import com.google.common.collect.ImmutableList;
 import com.squareup.protoparser.ExtendElement;
 import com.squareup.protoparser.OptionElement;
 import com.squareup.protoparser.ProtoFile;
@@ -25,22 +26,24 @@ import java.util.List;
 import java.util.Set;
 
 public final class WireProtoFile {
+  private final String sourcePath;
   private final ProtoFile protoFile;
   private final List<WireType> types;
   private final List<WireService> services;
   private final List<WireExtend> wireExtends;
   private final List<WireOption> options;
 
-  private WireProtoFile(ProtoFile protoFile, List<WireType> types, List<WireService> services,
-      List<WireExtend> wireExtends, List<WireOption> options) {
+  private WireProtoFile(String sourcePath, ProtoFile protoFile, List<WireType> types,
+      List<WireService> services, List<WireExtend> wireExtends, List<WireOption> options) {
+    this.sourcePath = sourcePath;
     this.protoFile = protoFile;
-    this.types = Util.immutableList(types);
-    this.services = Util.immutableList(services);
-    this.wireExtends = Util.immutableList(wireExtends);
-    this.options = Util.immutableList(options);
+    this.types = ImmutableList.copyOf(types);
+    this.services = ImmutableList.copyOf(services);
+    this.wireExtends = ImmutableList.copyOf(wireExtends);
+    this.options = ImmutableList.copyOf(options);
   }
 
-  public static WireProtoFile get(ProtoFile protoFile) {
+  public static WireProtoFile get(String sourcePath, ProtoFile protoFile) {
     String packageName = protoFile.packageName();
 
     List<WireType> types = new ArrayList<WireType>();
@@ -65,7 +68,11 @@ public final class WireProtoFile {
       options.add(new WireOption(packageName, option));
     }
 
-    return new WireProtoFile(protoFile, types, services, wireExtends, options);
+    return new WireProtoFile(sourcePath, protoFile, types, services, wireExtends, options);
+  }
+
+  public String sourcePath() {
+    return sourcePath;
   }
 
   public String packageName() {
@@ -106,6 +113,7 @@ public final class WireProtoFile {
       }
     }
 
-    return new WireProtoFile(protoFile, retainedTypes, retainedServices, wireExtends, options);
+    return new WireProtoFile(
+        sourcePath, protoFile, retainedTypes, retainedServices, wireExtends, options);
   }
 }

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire;
 
+import com.squareup.javapoet.JavaFile;
 import com.squareup.javawriter.JavaWriter;
 import com.squareup.protoparser.ProtoFile;
 import com.squareup.protoparser.ProtoParser;
@@ -69,6 +70,13 @@ public class WireCompilerErrorTest {
         output.put(entry.getKey(), entry.getValue().toString());
       }
       return output;
+    }
+
+    @Override public void write(OutputArtifact outputArtifact, JavaFile javaFile)
+        throws IOException {
+      StringWriter writer = new StringWriter();
+      writers.put(outputArtifact.fullClassName(), writer);
+      javaFile.writeTo(writer);
     }
   }
 

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
@@ -774,6 +774,6 @@ public class WireCompilerTest {
     // Normalize CRLF -> LF
     expected = expected.replace("\r\n", "\n");
     actual = actual.replace("\r\n", "\n");
-    assertEquals(expected, actual);
+    assertEquals(expectedFile.toString(), expected, actual);
   }
 }

--- a/wire-compiler/src/test/java/com/squareup/wire/model/ProtoTypeNameTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/model/ProtoTypeNameTest.java
@@ -18,7 +18,9 @@ package com.squareup.wire.model;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
 
 public final class ProtoTypeNameTest {
   @Test public void getScalar() throws Exception {
@@ -37,5 +39,29 @@ public final class ProtoTypeNameTest {
 
     ProtoTypeName phoneType = person.nestedType("PhoneType");
     assertEquals("squareup.protos.person.Person.PhoneType", phoneType.toString());
+  }
+
+  @Test public void enclosingTypeName() throws Exception {
+    assertEquals(null, ProtoTypeName.STRING.enclosingTypeName());
+
+    ProtoTypeName person = ProtoTypeName.get("squareup.protos.person", "Person");
+    assertEquals(null, person.enclosingTypeName());
+
+    ProtoTypeName phoneType = person.nestedType("PhoneType");
+    assertEquals(person, phoneType.enclosingTypeName());
+  }
+
+  @Test public void isScalar() throws Exception {
+    assertTrue(ProtoTypeName.INT32.isScalar());
+    assertTrue(ProtoTypeName.STRING.isScalar());
+    assertTrue(ProtoTypeName.BYTES.isScalar());
+    assertFalse(ProtoTypeName.get("squareup.protos.person", "Person").isScalar());
+  }
+
+  @Test public void isPackableScalar() throws Exception {
+    assertTrue(ProtoTypeName.INT32.isPackableScalar());
+    assertFalse(ProtoTypeName.STRING.isPackableScalar());
+    assertFalse(ProtoTypeName.BYTES.isPackableScalar());
+    assertFalse(ProtoTypeName.get("squareup.protos.person", "Person").isPackableScalar());
   }
 }


### PR DESCRIPTION
This creates a new class TypeWriter that is mostly a conversion
of MessageWriter, but it uses linked Wire types instead of the
unlinked protoparser types.

This is successfully passing 12 of the 35 WireCompiler tests
with slight alterations to imports (JavaPoet doesn't yet support
static imports.)

The options and extensions are still to be completed. That work
should be straightforward, but I'm saving it for a follow up.
Hopefully with that change I can switch the default to be the
new JavaPoet backend.

Also add a dependency on Guava (we should have had this long ago)
and also on the snapshot of JavaPoet (which we need to include
documentation on enum constants).