### PR TITLE
Remove needless half of enum adapter for fetching value.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
@@ -54,10 +54,6 @@ final class EnumAdapter<E extends ProtoEnum> {
     }
   }
 
-  public int toInt(E e) {
-    return e.getValue();
-  }
-
   public E fromInt(int value) {
     int index = isDense ? value - 1 : Arrays.binarySearch(values, value);
     try {

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -190,19 +190,6 @@ public abstract class Message implements Serializable {
   }
 
   /**
-   * Returns the integer value tagged associated with the given enum instance.
-   * If the enum instance is not initialized with an integer tag value, an exception
-   * will be thrown.
-   *
-   * @param <E> the enum class type
-   */
-  @SuppressWarnings("unchecked")
-  public static <E extends Enum & ProtoEnum> int intFromEnum(E value) {
-    EnumAdapter<E> adapter = WIRE.enumAdapter((Class<E>) value.getClass());
-    return adapter.toInt(value);
-  }
-
-  /**
    * Returns the enumerated value tagged with the given integer value for the
    * given enum class. If no enum value in the given class is initialized
    * with the given integer tag value, an exception will be thrown.

--- a/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
@@ -473,7 +473,7 @@ final class MessageAdapter<M extends Message> {
   @SuppressWarnings("unchecked")
   private <E extends ProtoEnum> int getEnumSize(E value) {
     EnumAdapter<E> adapter = (EnumAdapter<E>) wire.enumAdapter(value.getClass());
-    return WireOutput.varint32Size(adapter.toInt(value));
+    return WireOutput.varint32Size(value.getValue());
   }
 
   @SuppressWarnings("unchecked")
@@ -530,8 +530,7 @@ final class MessageAdapter<M extends Message> {
   @SuppressWarnings("unchecked")
   private <E extends ProtoEnum> void writeEnum(E value, WireOutput output)
       throws IOException {
-    EnumAdapter<E> adapter = (EnumAdapter<E>) wire.enumAdapter(value.getClass());
-    output.writeVarint32(adapter.toInt(value));
+    output.writeVarint32(value.getValue());
   }
 
   // Reading

--- a/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
@@ -536,7 +536,7 @@ public class TestAllTypes {
   @Test
   public void testEnums() {
     assertEquals(A, Message.enumFromInt(AllTypes.NestedEnum.class, 1));
-    assertEquals(1, Message.intFromEnum(A));
+    assertEquals(1, A.getValue());
   }
 
   @Test


### PR DESCRIPTION
This was moved to live directly on the instance and can be looked up directly.