### PR TITLE
Introduce MessageAdapter for reading and writing instances.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -101,11 +101,8 @@ public abstract class Message implements Serializable {
   /** Set to null until a field is added. */
   private transient UnknownFieldMap unknownFields;
 
-  /** False upon construction or deserialization. */
-  private transient boolean haveCachedSerializedSize;
-
-  /** If {@code haveCachedSerializedSize} is true, the serialized size of this message. */
-  private transient int cachedSerializedSize;
+  /** If not {@code -1} then the serialized size of this message. */
+  transient int cachedSerializedSize = -1;
 
   /** If non-zero, the hash code of this message. Accessed by generated code. */
   protected transient int hashCode = 0;
@@ -160,46 +157,13 @@ public abstract class Message implements Serializable {
     return adapter.fromInt(value);
   }
 
-  @SuppressWarnings("unchecked")
-  public byte[] toByteArray() {
-    return WIRE.messageAdapter((Class<Message>) getClass()).toByteArray(this);
-  }
-
-  public void writeTo(byte[] output) {
-    writeTo(output, 0, output.length);
-  }
-
-  public void writeTo(byte[] output, int offset, int count) {
-    write(WireOutput.newInstance(output, offset, count));
-  }
-
-  @SuppressWarnings("unchecked")
-  private void write(WireOutput output) {
-    MessageAdapter<Message> adapter = WIRE.messageAdapter((Class<Message>) getClass());
-    try {
-      adapter.write(this, output);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   void writeUnknownFieldMap(WireOutput output) throws IOException {
     if (unknownFields != null) {
       unknownFields.write(output);
     }
   }
 
-  @SuppressWarnings("unchecked")
-  public int getSerializedSize() {
-    if (!haveCachedSerializedSize) {
-      MessageAdapter<Message> adapter = WIRE.messageAdapter((Class<Message>) getClass());
-      cachedSerializedSize = adapter.getSerializedSize(this);
-      haveCachedSerializedSize = true;
-    }
-    return cachedSerializedSize;
-  }
-
-  public int getUnknownFieldsSerializedSize() {
+  int getUnknownFieldsSerializedSize() {
     return unknownFields == null ? 0 : unknownFields.getSerializedSize();
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/MessageSerializedForm.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MessageSerializedForm.java
@@ -27,15 +27,17 @@ final class MessageSerializedForm implements Serializable {
   private final Class<? extends Message> messageClass;
 
   public MessageSerializedForm(Message message, Class<? extends Message> messageClass) {
-    this.bytes = message.toByteArray();
+    //noinspection unchecked
+    this.bytes = Message.WIRE.adapter((Class<Message>) messageClass).writeBytes(message);
     this.messageClass = messageClass;
   }
 
   Object readResolve() throws ObjectStreamException {
+    MessageAdapter<? extends Message> adapter = Message.WIRE.adapter(messageClass);
     try {
       // Extensions are not supported at this time. Extension fields will be added to the
       // unknownFields map.
-      return Message.WIRE.parseFrom(bytes, messageClass);
+      return adapter.readBytes(bytes);
     } catch (IOException e) {
       throw new StreamCorruptedException(e.getMessage());
     }

--- a/wire-runtime/src/main/java/com/squareup/wire/Preconditions.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Preconditions.java
@@ -4,17 +4,10 @@ final class Preconditions {
   private Preconditions() {
   }
 
-  /** Throw {@link NullPointerException} for variable {@code name} if {@code o} is null. */
-  static void checkNotNull(Object o, String name) {
+  /** Throw {@link NullPointerException} with {@code message} if {@code o} is null. */
+  static void checkNotNull(Object o, String message) {
     if (o == null) {
-      throw new NullPointerException(name + " == null");
-    }
-  }
-
-  /** Throw {@link IllegalArgumentException} with {@code message} if {@code assertion} is false. */
-  static void checkArgument(boolean assertion, String message) {
-    if (!assertion) {
-      throw new IllegalArgumentException(message);
+      throw new NullPointerException(message);
     }
   }
 }

--- a/wire-runtime/src/main/java/com/squareup/wire/Wire.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Wire.java
@@ -15,17 +15,11 @@
  */
 package com.squareup.wire;
 
-import java.io.IOException;
-import java.io.InputStream;
 import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import okio.Source;
-
-import static com.squareup.wire.Preconditions.checkArgument;
-import static com.squareup.wire.Preconditions.checkNotNull;
 
 /**
  * Encode and decode Wire protocol buffers.
@@ -70,6 +64,11 @@ public final class Wire {
     }
   }
 
+  /** Returns an adapter for reading and writing {@code type}, creating it if necessary. */
+  public <M extends Message> MessageAdapter<M> adapter(Class<M> type) {
+    return messageAdapter(type);
+  }
+
   /**
    * Returns a message adapter for {@code messageType}.
    */
@@ -94,59 +93,6 @@ public final class Wire {
       enumAdapters.put(enumClass, adapter);
     }
     return adapter;
-  }
-
-  /**
-   * Reads a message of type {@code messageClass} from {@code bytes} and returns
-   * it.
-   */
-  public <M extends Message> M parseFrom(byte[] bytes, Class<M> messageClass) throws IOException {
-    checkNotNull(bytes, "bytes");
-    checkNotNull(messageClass, "messageClass");
-    return parseFrom(WireInput.newInstance(bytes), messageClass);
-  }
-
-  /**
-   * Reads a message of type {@code messageClass} from the given range of {@code
-   * bytes} and returns it.
-   */
-  public <M extends Message> M parseFrom(byte[] bytes, int offset, int count, Class<M> messageClass)
-      throws IOException {
-    checkNotNull(bytes, "bytes");
-    checkArgument(offset >= 0, "offset < 0");
-    checkArgument(count >= 0, "count < 0");
-    checkArgument(offset + count <= bytes.length, "offset + count > bytes");
-    checkNotNull(messageClass, "messageClass");
-    return parseFrom(WireInput.newInstance(bytes, offset, count), messageClass);
-  }
-
-  /**
-   * Reads a message of type {@code messageClass} from the given {@link InputStream} and returns it.
-   */
-  public <M extends Message> M parseFrom(InputStream input, Class<M> messageClass)
-      throws IOException {
-    checkNotNull(input, "input");
-    checkNotNull(messageClass, "messageClass");
-    return parseFrom(WireInput.newInstance(input), messageClass);
-  }
-
-  /**
-   * Reads a message of type {@code messageClass} from the given {@link Source} and returns it.
-   */
-  public <M extends Message> M parseFrom(Source input, Class<M> messageClass)
-      throws IOException {
-    checkNotNull(input, "input");
-    checkNotNull(messageClass, "messageClass");
-    return parseFrom(WireInput.newInstance(input), messageClass);
-  }
-
-  /**
-   * Reads a message of type {@code messageClass} from {@code input} and returns it.
-   */
-  private <M extends Message> M parseFrom(WireInput input, Class<M> messageClass)
-      throws IOException {
-    MessageAdapter<M> adapter = messageAdapter(messageClass);
-    return adapter.read(input);
   }
 
   /**

--- a/wire-runtime/src/main/java/com/squareup/wire/WireInput.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/WireInput.java
@@ -35,13 +35,9 @@ package com.squareup.wire;
 
 import java.io.EOFException;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.charset.Charset;
-import okio.Buffer;
 import okio.BufferedSource;
 import okio.ByteString;
-import okio.Okio;
-import okio.Source;
 
 /**
  * Reads and decodes protocol message fields.
@@ -60,30 +56,6 @@ final class WireInput {
       "Protocol message end-group tag did not match expected tag.";
   private static final String ENCOUNTERED_A_MALFORMED_VARINT =
       "WireInput encountered a malformed varint.";
-
-  /**
-   * Create a new WireInput wrapping the given byte array.
-   */
-  public static WireInput newInstance(byte[] buf) {
-    return new WireInput(new Buffer().write(buf));
-  }
-
-  /**
-   * Create a new WireInput wrapping the given byte array slice.
-   */
-  public static WireInput newInstance(byte[] buf, int offset, int count) {
-    return new WireInput(new Buffer().write(buf, offset, count));
-  }
-
-  public static WireInput newInstance(InputStream source) {
-    return new WireInput(Okio.buffer(Okio.source(source)));
-  }
-
-  public static WireInput newInstance(Source source) {
-    return new WireInput(Okio.buffer(source));
-  }
-
-  // -----------------------------------------------------------------
 
   /**
    * Attempt to read a field tag, returning zero if we have reached EOF.
@@ -262,7 +234,7 @@ final class WireInput {
   /** The last tag that was read. */
   private int lastTag;
 
-  private WireInput(BufferedSource source) {
+  WireInput(BufferedSource source) {
     this.source = source;
   }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
@@ -24,13 +24,14 @@ import static org.junit.Assert.assertEquals;
 
 public class OneOfTest {
 
-  private static final Wire wire = new Wire();
-
   private static final byte[] INITIAL_BYTES = {};
   // (Tag #1 << 3 | VARINT) = 8.
   private static final byte[] FOO_BYTES = { 8, 17 };
   // (Tag #3 << 3 | LENGTH_DELIMITED) = 26, string length = 6.
   private static final byte[] BAR_BYTES = { 26, 6, 'b', 'a', 'r', 'b', 'a', 'r'};
+
+  private final Wire wire = new Wire();
+  private final MessageAdapter<OneOfMessage> adapter = wire.adapter(OneOfMessage.class);
 
   @Test
   public void testOneOf() throws Exception {
@@ -68,11 +69,11 @@ public class OneOfTest {
     assertEquals(expectedBar, message.bar);
 
     // Check serialized bytes.
-    byte[] bytes = message.toByteArray();
+    byte[] bytes = adapter.writeBytes(message);
     assertArrayEquals(expectedBytes, bytes);
 
     // Check result of deserialization.
-    OneOfMessage newMessage = wire.parseFrom(bytes, OneOfMessage.class);
+    OneOfMessage newMessage = adapter.readBytes(bytes);
     assertEquals(expectedFoo, newMessage.foo);
     assertEquals(expectedBar, newMessage.bar);
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/ParseTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/ParseTest.java
@@ -33,7 +33,7 @@ public final class ParseTest {
     // tag 1 / type 0: 456
     // tag 2 / type 0: 789
     ByteString data = ByteString.decodeHex("08c803109506");
-    OneField oneField = wire.parseFrom(data.toByteArray(), OneField.class);
+    OneField oneField = wire.adapter(OneField.class).readBytes(data.toByteArray());
     assertEquals(new OneField.Builder().opt_int32(456).build(), oneField);
   }
 
@@ -42,7 +42,7 @@ public final class ParseTest {
     // tag 2 / type 7: 789
     ByteString data = ByteString.decodeHex("08c803179506");
     try {
-      wire.parseFrom(data.toByteArray(), OneField.class);
+      wire.adapter(OneField.class).readBytes(data.toByteArray());
       fail();
     } catch (IOException expected) {
       assertEquals("No WireType for type 7", expected.getMessage());
@@ -53,7 +53,7 @@ public final class ParseTest {
     // tag 1 / 3-byte length-delimited string: 0x109506
     // (0x109506 is a well-formed proto message that sets tag 2 to 456).
     ByteString data = ByteString.decodeHex("0a03109506");
-    OneField oneField = wire.parseFrom(data.toByteArray(), OneField.class);
+    OneField oneField = wire.adapter(OneField.class).readBytes(data.toByteArray());
     assertEquals(oneField, new OneField.Builder().opt_int32(3).build());
   }
 
@@ -61,7 +61,7 @@ public final class ParseTest {
     // tag 1 / 4-byte length delimited string: 0x000000 (3 bytes)
     ByteString data = ByteString.decodeHex("0a04000000");
     try {
-      wire.parseFrom(data.toByteArray(), OneBytesField.class);
+      wire.adapter(OneBytesField.class).readBytes(data.toByteArray());
       fail();
     } catch (EOFException expected) {
     }
@@ -72,7 +72,7 @@ public final class ParseTest {
     // tag 2 / type 0: 456
     ByteString data = ByteString.decodeHex("120300000010c803");
     try {
-      wire.parseFrom(data.toByteArray(), OneField.class);
+      wire.adapter(OneField.class).readBytes(data.toByteArray());
       fail();
     } catch (IOException expected) {
       assertEquals("Wire type VARINT differs from previous type LENGTH_DELIMITED for tag 2",
@@ -84,7 +84,7 @@ public final class ParseTest {
     // tag 1 / type 0: 456
     // tag 1 / type 0: 789
     ByteString data = ByteString.decodeHex("08c803089506");
-    OneField oneField = wire.parseFrom(data.toByteArray(), OneField.class);
+    OneField oneField = wire.adapter(OneField.class).readBytes(data.toByteArray());
     assertEquals(oneField, new OneField.Builder().opt_int32(789).build());
   }
 
@@ -95,7 +95,8 @@ public final class ParseTest {
         + "412621260125e125c125a12581256125412521250124e124c124a12481246124412421240123e123c123a123"
         + "81236123412321230122e122c122a12281226122412221220121e121c121a12181216121412121210120e120"
         + "c120a1208120612041202120008c803");
-    Recursive recursive = wire.parseFrom(data.toByteArray(), Recursive.class);
+    Recursive recursive =
+        wire.adapter(Recursive.class).readBytes(data.toByteArray());
     assertEquals(456, recursive.value.intValue());
   }
 
@@ -107,7 +108,7 @@ public final class ParseTest {
         + "23a12381236123412321230122e122c122a12281226122412221220121e121c121a121812161214121212101"
         + "20e120c120a1208120612041202120008c803");
     try {
-      wire.parseFrom(data.toByteArray(), Recursive.class);
+      wire.adapter(Recursive.class).readBytes(data.toByteArray());
       fail();
     } catch (IOException expected) {
       assertEquals("Wire recursion limit exceeded", expected.getMessage());

--- a/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
@@ -27,6 +27,8 @@ import static org.junit.Assert.assertNotSame;
 public class UnknownFieldsTest {
 
   private final Wire wire = new Wire();
+  private final MessageAdapter<VersionOne> v1Adapter = wire.adapter(VersionOne.class);
+  private final MessageAdapter<VersionTwo> v2Adapter = wire.adapter(VersionTwo.class);
 
   @Test
   public void testUnknownFields() throws IOException {
@@ -46,23 +48,23 @@ public class UnknownFieldsTest {
     assertEquals(new Long(98765L), v2.v2_f64);
     assertEquals(Arrays.asList("1", "2"), v2.v2_rs);
     // Serialized
-    byte[] v2Bytes = v2.toByteArray();
+    byte[] v2Bytes = v2Adapter.writeBytes(v2);
 
     // Parse
-    VersionOne v1 = wire.parseFrom(v2Bytes, VersionOne.class);
+    VersionOne v1 = v1Adapter.readBytes(v2Bytes);
     // v.1 fields are visible, v.2 fields are in unknownFieldSet
     assertEquals(new Integer(111), v1.i);
     // Serialized output should still contain the v.2 fields
-    byte[] v1Bytes = v1.toByteArray();
+    byte[] v1Bytes = v1Adapter.writeBytes(v1);
 
     // Unknown fields don't participate in equals() and hashCode()
     VersionOne v1Simple = new VersionOne.Builder().i(111).build();
     assertEquals(v1Simple, v1);
     assertEquals(v1Simple.hashCode(), v1.hashCode());
-    assertNotSame(v1Simple.toByteArray(), v1.toByteArray());
+    assertNotSame(v1Adapter.writeBytes(v1Simple), v1Adapter.writeBytes(v1));
 
     // Re-parse
-    VersionTwo v2B = wire.parseFrom(v1Bytes, VersionTwo.class);
+    VersionTwo v2B = v2Adapter.readBytes(v1Bytes);
     assertEquals(new Integer(111), v2B.i);
     assertEquals(new Integer(12345), v2B.v2_i);
     assertEquals("222", v2B.v2_s);
@@ -73,9 +75,9 @@ public class UnknownFieldsTest {
     // "Modify" v1 via a merged builder, serialize, and re-parse
     VersionOne v1Modified = new VersionOne.Builder(v1).i(777).build();
     assertEquals(new Integer(777), v1Modified.i);
-    byte[] v1ModifiedBytes = v1Modified.toByteArray();
+    byte[] v1ModifiedBytes = v1Adapter.writeBytes(v1Modified);
 
-    VersionTwo v2C = wire.parseFrom(v1ModifiedBytes, VersionTwo.class);
+    VersionTwo v2C = v2Adapter.readBytes(v1ModifiedBytes);
     assertEquals(new Integer(777), v2C.i);
     assertEquals(new Integer(12345), v2C.v2_i);
     assertEquals("222", v2C.v2_s);


### PR DESCRIPTION
This exposes a public API for an internal concept which is a class instance that is responsible for reading and writing protos of a specific type. This allows consumers to cache these instances for use while serializing to/from bytes. With this change all other means of reading and writing encoded data have been removed except for `toByteArray()` on instances.

Additionally, a few types and a lot of methods were removed from being exposed the public API as they are implementation details of serialization.

Closes #209. Closes #167.