### PR TITLE
Pare down the unknown fields map.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -120,8 +120,8 @@ public abstract class Message implements Serializable {
   }
 
   // Increase visibility for testing
-  protected Collection<List<UnknownFieldMap.FieldValue>> unknownFields() {
-    return unknownFields == null ? Collections.<List<UnknownFieldMap.FieldValue>>emptySet()
+  protected Collection<List<UnknownFieldMap.Value>> unknownFields() {
+    return unknownFields == null ? Collections.<List<UnknownFieldMap.Value>>emptySet()
         : unknownFields.fieldMap.values();
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
@@ -24,229 +24,152 @@ import okio.ByteString;
 
 final class UnknownFieldMap {
 
-  abstract static class FieldValue {
-    private final int tag;
-    private final WireType wireType;
+  abstract static class Value {
+    final int tag;
 
-    public FieldValue(int tag, WireType wireType) {
+    public Value(int tag) {
       this.tag = tag;
-      this.wireType = wireType;
     }
 
-    public static VarintFieldValue varint(int tag, Long value) {
-      return new VarintFieldValue(tag, value);
-    }
-
-    public static Fixed32FieldValue fixed32(int tag, Integer value) {
-      return new Fixed32FieldValue(tag, value);
-    }
-
-    public static Fixed64FieldValue fixed64(int tag, Long value) {
-      return new Fixed64FieldValue(tag, value);
-    }
-
-    public static LengthDelimitedFieldValue lengthDelimited(int tag, ByteString value) {
-      return new LengthDelimitedFieldValue(tag, value);
-    }
-
-    public abstract int getSerializedSize();
-
-    public abstract void write(int tag, WireOutput output) throws IOException;
-
-    public int getTag() {
-      return tag;
-    }
-
-    public WireType getWireType() {
-      return wireType;
-    }
-
-    public Integer getAsInteger() {
-      throw new IllegalStateException();
-    }
-
-    public Long getAsLong() {
-      throw new IllegalStateException();
-    }
-
-    public ByteString getAsBytes() {
-      throw new IllegalStateException();
-    }
+    /** The size of the tag and value when serialized. */
+    abstract int getSerializedSize();
+    abstract void write(int tag, WireOutput output) throws IOException;
   }
 
-  static final class VarintFieldValue extends FieldValue {
-    private final Long value;
+  static final class VarintValue extends Value {
+    final Long value;
 
-    public VarintFieldValue(int tag, Long value) {
-      super(tag, WireType.VARINT);
+    public VarintValue(int tag, Long value) {
+      super(tag);
       this.value = value;
     }
 
-    @Override public int getSerializedSize() {
-      return WireOutput.varint64Size(value);
+    @Override int getSerializedSize() {
+      return WireOutput.varintTagSize(tag) + WireOutput.varint64Size(value);
     }
 
-    @Override public void write(int tag, WireOutput output) throws IOException {
+    @Override void write(int tag, WireOutput output) throws IOException {
       output.writeTag(tag, WireType.VARINT);
       output.writeVarint64(value);
     }
-
-    @Override public Long getAsLong() {
-      return value;
-    }
   }
 
-  static final class Fixed32FieldValue extends FieldValue {
-    private final Integer value;
+  static final class Fixed32Value extends Value {
+    final Integer value;
 
-    public Fixed32FieldValue(int tag, Integer value) {
-      super(tag, WireType.FIXED32);
+    Fixed32Value(int tag, Integer value) {
+      super(tag);
       this.value = value;
     }
 
-    @Override public int getSerializedSize() {
-      return WireType.FIXED_32_SIZE;
+    @Override int getSerializedSize() {
+      return WireOutput.varintTagSize(tag) + WireType.FIXED_32_SIZE;
     }
 
-    @Override public void write(int tag, WireOutput output) throws IOException {
+    @Override void write(int tag, WireOutput output) throws IOException {
       output.writeTag(tag, WireType.FIXED32);
       output.writeFixed32(value);
     }
-
-    @Override public Integer getAsInteger() {
-      return value;
-    }
   }
 
-  static final class Fixed64FieldValue extends FieldValue {
-    private final Long value;
+  static final class Fixed64Value extends Value {
+    final Long value;
 
-    public Fixed64FieldValue(int tag, Long value) {
-      super(tag, WireType.FIXED64);
+    Fixed64Value(int tag, Long value) {
+      super(tag);
       this.value = value;
     }
 
-    @Override public int getSerializedSize() {
-      return WireType.FIXED_64_SIZE;
+    @Override int getSerializedSize() {
+      return WireOutput.varintTagSize(tag) + WireType.FIXED_64_SIZE;
     }
 
-    @Override public void write(int tag, WireOutput output) throws IOException {
+    @Override void write(int tag, WireOutput output) throws IOException {
       output.writeTag(tag, WireType.FIXED64);
       output.writeFixed64(value);
     }
-
-    @Override public Long getAsLong() {
-      return value;
-    }
   }
 
-  static final class LengthDelimitedFieldValue extends FieldValue {
-    private final ByteString value;
+  static final class LengthDelimitedValue extends Value {
+    final ByteString value;
 
-    public LengthDelimitedFieldValue(int tag, ByteString value) {
-      super(tag, WireType.LENGTH_DELIMITED);
+    LengthDelimitedValue(int tag, ByteString value) {
+      super(tag);
       this.value = value;
     }
 
-    @Override public int getSerializedSize() {
-      return WireOutput.varint32Size(value.size()) + value.size();
+    @Override int getSerializedSize() {
+      return WireOutput.varintTagSize(tag) + WireOutput.varint32Size(value.size()) + value.size();
     }
 
-    @Override public void write(int tag, WireOutput output) throws IOException {
+    @Override void write(int tag, WireOutput output) throws IOException {
       output.writeTag(tag, WireType.LENGTH_DELIMITED);
       output.writeVarint32(value.size());
       output.writeRawBytes(value);
     }
-
-    @Override public ByteString getAsBytes() {
-      return value;
-    }
   }
 
-  Map<Integer, List<FieldValue>> fieldMap;
+  final Map<Integer, List<Value>> fieldMap;
 
   UnknownFieldMap() {
+    this(null);
   }
 
   UnknownFieldMap(UnknownFieldMap other) {
-    if (other.fieldMap != null) {
-      ensureFieldMap().putAll(other.fieldMap);
+    if (other != null && other.fieldMap != null) {
+      fieldMap = new TreeMap<Integer, List<Value>>(other.fieldMap);
+    } else {
+      fieldMap = new TreeMap<Integer, List<Value>>();
     }
   }
 
   void addVarint(int tag, Long value) throws IOException {
-    addElement(ensureFieldMap(), tag, value, WireType.VARINT);
+    addElement(tag, new VarintValue(tag, value));
   }
 
   void addFixed32(int tag, Integer value) throws IOException {
-    addElement(ensureFieldMap(), tag, value, WireType.FIXED32);
+    addElement(tag, new Fixed32Value(tag, value));
   }
 
   void addFixed64(int tag, Long value) throws IOException {
-    addElement(ensureFieldMap(), tag, value, WireType.FIXED64);
+    addElement(tag, new Fixed64Value(tag, value));
   }
 
   void addLengthDelimited(int tag, ByteString value) throws IOException {
-    addElement(ensureFieldMap(), tag, value, WireType.LENGTH_DELIMITED);
-  }
-
-  private Map<Integer, List<FieldValue>> ensureFieldMap() {
-    if (fieldMap == null) {
-      fieldMap = new TreeMap<Integer, List<FieldValue>>();
-    }
-    return fieldMap;
+    addElement(tag, new LengthDelimitedValue(tag, value));
   }
 
   /**
    * @throws IOException if the added element's type doesn't match the types of the other elements
    *     with the same tag.
    */
-  private <T> void addElement(Map<Integer, List<FieldValue>> map, int tag, T value,
-      WireType wireType) throws IOException {
-    List<FieldValue> values = map.get(tag);
+  private void addElement(int tag, Value value) throws IOException {
+    List<Value> values = fieldMap.get(tag);
     if (values == null) {
-      values = new ArrayList<FieldValue>();
-      map.put(tag, values);
+      values = new ArrayList<Value>();
+      fieldMap.put(tag, values);
+    } else if (values.get(0).getClass() != value.getClass()) {
+      throw new IOException(String.format("Wire type %s differs from previous type %s for tag %s",
+          value.getClass().getSimpleName(), values.get(0).getClass().getSimpleName(), tag));
     }
-    FieldValue fieldValue;
-    switch (wireType) {
-      case VARINT: fieldValue = FieldValue.varint(tag, (Long) value); break;
-      case FIXED32: fieldValue = FieldValue.fixed32(tag, (Integer) value); break;
-      case FIXED64: fieldValue = FieldValue.fixed64(tag, (Long) value); break;
-      case LENGTH_DELIMITED:
-        fieldValue = FieldValue.lengthDelimited(tag, (ByteString) value);
-        break;
-      default:
-        throw new IllegalArgumentException("Unsupported wireType = " + wireType);
-    }
-    if (values.size() > 0 && values.get(0).getWireType() != fieldValue.getWireType()) {
-      throw new IOException(String.format(
-          "Wire type %s differs from previous type %s for tag %s", fieldValue.getWireType(),
-          values.get(0).getWireType(), tag));
-    }
-    values.add(fieldValue);
+    values.add(value);
   }
 
   int getSerializedSize() {
     int size = 0;
-    if (fieldMap != null) {
-      for (Map.Entry<Integer, List<FieldValue>> entry : fieldMap.entrySet()) {
-        for (FieldValue value : entry.getValue()) {
-          size += WireOutput.varintTagSize(entry.getKey());
-          size += value.getSerializedSize();
-        }
+    for (Map.Entry<Integer, List<Value>> entry : fieldMap.entrySet()) {
+      for (Value value : entry.getValue()) {
+        size += value.getSerializedSize();
       }
     }
     return size;
   }
 
   void write(WireOutput output) throws IOException {
-    if (fieldMap != null) {
-      for (Map.Entry<Integer, List<FieldValue>> entry : fieldMap.entrySet()) {
-        int tag = entry.getKey();
-        for (FieldValue value : entry.getValue()) {
-          value.write(tag, output);
-        }
+    for (Map.Entry<Integer, List<Value>> entry : fieldMap.entrySet()) {
+      int tag = entry.getKey();
+      for (Value value : entry.getValue()) {
+        value.write(tag, output);
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/ParseTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/ParseTest.java
@@ -76,7 +76,7 @@ public final class ParseTest {
       fail();
     } catch (IOException expected) {
       assertThat(expected).hasMessage(
-          "Wire type VARINT differs from previous type LENGTH_DELIMITED for tag 2");
+          "Wire type VarintValue differs from previous type LengthDelimitedValue for tag 2");
     }
   }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire;
 
+import com.squareup.wire.UnknownFieldMap.VarintValue;
 import com.squareup.wire.protos.RepeatedAndPacked;
 import com.squareup.wire.protos.person.Person;
 import com.squareup.wire.protos.person.Person.PhoneNumber;
@@ -320,12 +321,13 @@ public class WireTest {
     assertThat(result.phone.get(0).type).isNull();
 
     // The value 17 will be stored as an unknown varint with tag number 2
-    Collection<List<UnknownFieldMap.FieldValue>> unknownFields = result.phone.get(0).unknownFields();
+    Collection<List<UnknownFieldMap.Value>> unknownFields = result.phone.get(0).unknownFields();
     assertThat(unknownFields).hasSize(1);
-    List<UnknownFieldMap.FieldValue> fieldValues = unknownFields.iterator().next();
-    assertThat(fieldValues).hasSize(1);
-    assertThat(fieldValues.get(0).getTag()).isEqualTo(2);
-    assertThat(fieldValues.get(0).getAsLong()).isEqualTo(Long.valueOf(17L));
+    List<UnknownFieldMap.Value> values = unknownFields.iterator().next();
+    assertThat(values).hasSize(1);
+    VarintValue value = (VarintValue) values.get(0);
+    assertThat(value.tag).isEqualTo(2);
+    assertThat(value.value).isEqualTo(Long.valueOf(17L));
 
     // Serialize again, value is preserved
     byte[] newData = adapter.writeBytes(result);

--- a/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
@@ -570,7 +570,7 @@ public class TestAllTypes {
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessage(
-          "Wire type FIXED32 differs from previous type VARINT for tag 10000");
+          "Wire type Fixed32Value differs from previous type VarintValue for tag 10000");
     }
   }
 


### PR DESCRIPTION
* Remove a bunch of methods in favor of direct field access.
* Directly create value objects removing indirections and the use of WireType.
* Eagerly create the field map as the unknown field map itself is lazily created in Message.
* Move tag size calculation into the values for parity with 'write()'.