### PR TITLE
Redacting lists should empty them, not null them.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -125,24 +125,28 @@ public abstract class Message implements Serializable {
         : unknownFields.fieldMap.values();
   }
 
-  /**
-   * Utility method to return a mutable copy of a given List. Used by generated code.
-   */
-  protected static <T> List<T> copyOf(List<T> source) {
-    return source == null ? null : new ArrayList<T>(source);
+  /** Utility method to return a mutable copy of a given List. Used by generated code. */
+  protected static <T> List<T> copyOf(List<T> list) {
+    if (list == null) {
+      throw new NullPointerException("list == null");
+    }
+    if (list == Collections.emptyList()) {
+      return list;
+    }
+    return new ArrayList<T>(list);
   }
 
-  /**
-   * Utility method to return an immutable copy of a given List. Used by generated code.
-   * If {@code source} is null, {@link Collections#emptyList()} is returned.
-   */
-  protected static <T> List<T> immutableCopyOf(List<T> source) {
-    if (source == null) {
-      return Collections.emptyList();
-    } else if (source instanceof MessageAdapter.ImmutableList) {
-      return source;
+  /** Utility method to return an immutable copy of a given List. Used by generated code. */
+  protected static <T> List<T> immutableCopyOf(List<T> list) {
+    if (list == null) {
+      throw new NullPointerException("list == null");
     }
-    return Collections.unmodifiableList(new ArrayList<T>(source));
+    if (list == Collections.emptyList()) {
+      return list;
+    } else if (list instanceof MessageAdapter.ImmutableList) {
+      return list;
+    }
+    return Collections.unmodifiableList(new ArrayList<T>(list));
   }
 
   /**
@@ -280,7 +284,7 @@ public abstract class Message implements Serializable {
      */
     protected static <T> List<T> canonicalizeList(List<T> list) {
       if (list == null) {
-        return Collections.emptyList();
+        throw new NullPointerException("list == null");
       }
       for (int i = 0, size = list.size(); i < size; i++) {
         T element = list.get(i);

--- a/wire-runtime/src/main/java/com/squareup/wire/Redactor.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Redactor.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -100,7 +101,7 @@ public class Redactor<T extends Message> {
   }
 
   /**
-   * Returns a copy of {@code message} with all redacted fields set to null.
+   * Returns a copy of {@code message} with all redacted fields set to null or an empty list.
    * This operation is recursive: nested messages are themselves redacted in the
    * returned object.
    */
@@ -112,7 +113,12 @@ public class Redactor<T extends Message> {
       Message.Builder<T> builder = (Message.Builder<T>) builderConstructor.newInstance(message);
 
       for (int i = 0, count = redactedFields.size(); i < count; i++) {
-        redactedFields.get(i).set(builder, null);
+        Field redactedField = redactedFields.get(i);
+        Object redactedValue = null;
+        if (redactedField.getType() == List.class) {
+          redactedValue = Collections.emptyList();
+        }
+        redactedField.set(builder, redactedValue);
       }
 
       for (int i = 0, count = messageFields.size(); i < count; i++) {
@@ -123,7 +129,7 @@ public class Redactor<T extends Message> {
 
       return builder.build();
     } catch (Exception e) {
-      throw new AssertionError(e.getMessage());
+      throw new AssertionError(e);
     }
   }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/RedactedTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/RedactedTest.java
@@ -71,9 +71,8 @@ public class RedactedTest {
 
   @Test
   public void testRedactorRepeated() {
-    RedactedRepeated message = new RedactedRepeated.Builder().a(Arrays.asList("a", "b")).build();
-    RedactedRepeated expected =
-        new RedactedRepeated.Builder(message).a(Collections.<String>emptyList()).build();
+    RedactedRepeated message = new RedactedRepeated(Arrays.asList("a", "b"));
+    RedactedRepeated expected = new RedactedRepeated(Collections.<String>emptyList());
     assertThat(Redactor.get(RedactedRepeated.class).redact(message)).isEqualTo(expected);
   }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
@@ -575,15 +575,24 @@ public class TestAllTypes {
   }
 
   @Test
-  public void testNullEnum() {
+  public void testNullInRepeated() {
     try {
       // A null value for a repeated field is not allowed.
       getBuilder().rep_nested_enum(Arrays.asList(A, null, A));
       fail();
     } catch (NullPointerException e) {
+      assertThat(e).hasMessage("Element at index 1 is null");
     }
+  }
 
-    // Should not fail - a null list means the field is cleared.
-    getBuilder().rep_nested_enum(null);
+  @Test
+  public void testNullRepeated() {
+    try {
+      // A null value for a repeated field is not allowed.
+      getBuilder().rep_nested_enum(null);
+      fail();
+    } catch (NullPointerException e) {
+      assertThat(e).hasMessage("list == null");
+    }
   }
 }


### PR DESCRIPTION
Update some 'repeated' handling code to be less-null friendly. They are forbidden, not swept under the rug.