### PR TITLE
Move name-to-tag lookup map into Gson.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
@@ -1,7 +1,6 @@
 package com.squareup.wire;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +27,7 @@ abstract class TagMap<T> {
         }
       };
 
-  List<T> values;
+  final List<T> values;
 
   /**
    * Creates a TagMap based on the entries of an incoming map.
@@ -69,10 +68,6 @@ abstract class TagMap<T> {
 
   protected TagMap(Map<Integer, T> map) {
     this.values = sortedValues(map);
-  }
-
-  public Collection<T> values() {
-    return values;
   }
 
   public abstract T get(int tag);

--- a/wire-runtime/src/test/java/com/squareup/wire/TagMapTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/TagMapTest.java
@@ -101,7 +101,7 @@ public class TagMapTest {
 
   private String joinValues(TagMap<String> tagMap) {
     StringBuilder sb = new StringBuilder();
-    for (String s : tagMap.values()) {
+    for (String s : tagMap.values) {
       if (sb.length() > 0) {
         sb.append(" ");
       }


### PR DESCRIPTION
This is the only place it was used so there was no point in wasting the Map allocation on every MessageAdapter for the proto-only case.