### PR TITLE
Remove varint implementation detail from tag size method name.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
@@ -77,7 +77,7 @@ final class ProtoWriter {
   }
 
   /** Compute the number of bytes that would be needed to encode a tag. */
-  static int varintTagSize(int tag) {
+  static int tagSize(int tag) {
     return varint32Size(makeTag(tag, WireType.VARINT));
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/ReflectiveMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ReflectiveMessageAdapter.java
@@ -271,7 +271,7 @@ final class ReflectiveMessageAdapter<M extends Message> extends MessageAdapter<M
    * Returns the serialized size in bytes of the given tag and value.
    */
   private int getSerializedSize(int tag, Object value, Datatype datatype) {
-    return ProtoWriter.varintTagSize(tag) + getSerializedSizeNoTag(value, datatype);
+    return ProtoWriter.tagSize(tag) + getSerializedSizeNoTag(value, datatype);
   }
 
   /**

--- a/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
@@ -46,7 +46,7 @@ final class UnknownFieldMap {
     }
 
     @Override int getSerializedSize() {
-      return ProtoWriter.varintTagSize(tag) + ProtoWriter.varint64Size(value);
+      return ProtoWriter.tagSize(tag) + ProtoWriter.varint64Size(value);
     }
 
     @Override void write(int tag, ProtoWriter output) throws IOException {
@@ -64,7 +64,7 @@ final class UnknownFieldMap {
     }
 
     @Override int getSerializedSize() {
-      return ProtoWriter.varintTagSize(tag) + WireType.FIXED_32_SIZE;
+      return ProtoWriter.tagSize(tag) + WireType.FIXED_32_SIZE;
     }
 
     @Override void write(int tag, ProtoWriter output) throws IOException {
@@ -82,7 +82,7 @@ final class UnknownFieldMap {
     }
 
     @Override int getSerializedSize() {
-      return ProtoWriter.varintTagSize(tag) + WireType.FIXED_64_SIZE;
+      return ProtoWriter.tagSize(tag) + WireType.FIXED_64_SIZE;
     }
 
     @Override void write(int tag, ProtoWriter output) throws IOException {
@@ -100,7 +100,7 @@ final class UnknownFieldMap {
     }
 
     @Override int getSerializedSize() {
-      return ProtoWriter.varintTagSize(tag) + ProtoWriter.varint32Size(value.size()) + value.size();
+      return ProtoWriter.tagSize(tag) + ProtoWriter.varint32Size(value.size()) + value.size();
     }
 
     @Override void write(int tag, ProtoWriter output) throws IOException {


### PR DESCRIPTION
Both makeTag and writeTag do not 'leak' the implementation of a tag on the wire.