### PR TITLE
Added support for multiple --proto_path arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For example, to compile the file `protos-repo/google/protobuf/descriptor.proto`,
 
 Instead of supplying individual filename arguments on the command line, the `--files` flag may be
 used to specify a single file containing a list of `.proto` files. The file names are interpreted
-relative to the value given for the `--proto_path` flag.
+relative to the paths provided by `--proto_path` flags.
 
     % cat protos.include
     google/protobuf/descriptor.proto
@@ -71,6 +71,9 @@ relative to the value given for the `--proto_path` flag.
 The compiler will (recursively) import any needed `.proto` files from the `protos-repo/` directory,
 but will only generate output for the `.proto` files listed on the command line or in the file
 specified by the `--files` flag.
+
+The `--proto_path` flag may be specified multiple times to provide multiple paths in which to search
+for `.proto` files.
 
 Generating service interfaces
 -----------------------------

--- a/wire-compiler/src/main/java/com/squareup/wire/CommandLineOptions.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/CommandLineOptions.java
@@ -38,7 +38,8 @@ final class CommandLineOptions {
   public static final String QUIET_FLAG = "--quiet";
   public static final String DRY_RUN_FLAG = "--dry_run";
 
-  final String protoPath;
+  final List<String> protoPaths;
+
   final File javaOut;
   final List<String> sourceFileNames;
   final List<String> roots;
@@ -58,7 +59,7 @@ final class CommandLineOptions {
       List<String> serviceFactoryOptions,
       boolean quiet,
       boolean dryRun) {
-    this.protoPath = protoPath;
+    this.protoPaths = Arrays.asList(protoPath);
     this.javaOut = javaOut;
     this.sourceFileNames = sourceFileNames;
     this.roots = roots;
@@ -121,7 +122,7 @@ final class CommandLineOptions {
     List<String> serviceFactoryOptions = new ArrayList<>();
     List<String> roots = new ArrayList<>();
     boolean emitOptions = true;
-    String protoPath = null;
+    List<String> protoPaths = new ArrayList<>();
     File javaOut = null;
     String registryClass = null;
     List<String> enumOptionsList = new ArrayList<>();
@@ -131,7 +132,7 @@ final class CommandLineOptions {
 
     while (index < args.length) {
       if (args[index].startsWith(PROTO_PATH_FLAG)) {
-        protoPath = args[index].substring(PROTO_PATH_FLAG.length());
+        protoPaths.add(args[index].substring(PROTO_PATH_FLAG.length()));
       } else if (args[index].startsWith(JAVA_OUT_FLAG)) {
         javaOut = new File(args[index].substring(JAVA_OUT_FLAG.length()));
       } else if (args[index].startsWith(FILES_FLAG)) {
@@ -166,7 +167,7 @@ final class CommandLineOptions {
       index++;
     }
 
-    this.protoPath = protoPath;
+    this.protoPaths = protoPaths;
     this.javaOut = javaOut;
     this.sourceFileNames = sourceFileNames;
     this.roots = roots;
@@ -202,10 +203,10 @@ final class CommandLineOptions {
     return Arrays.asList(arg.substring(flagLength).split(","));
   }
 
-  public String protoPath() {
-    String result = protoPath;
-    if (result == null) {
-      result = System.getProperty("user.dir");
+  public List<String> protoPaths() {
+    List<String> result = protoPaths;
+    if (result == null || result.isEmpty()) {
+      result = Arrays.asList(System.getProperty("user.dir"));
       System.err.println(CommandLineOptions.PROTO_PATH_FLAG + " flag not specified, "
           + "using current dir " + result);
     }

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -52,7 +52,7 @@ public final class WireCompiler {
   }
 
   WireCompiler(CommandLineOptions options) throws WireException {
-    this(options, Loader.forBaseDirectory(options.protoPath()), JavaGenerator.IO.DEFAULT,
+    this(options, Loader.forSearchPaths(options.protoPaths()), JavaGenerator.IO.DEFAULT,
         new ConsoleWireLogger(options.quiet));
   }
 

--- a/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.java
@@ -1,25 +1,34 @@
 package com.squareup.wire;
 
+import com.google.common.collect.Lists;
 import com.squareup.wire.java.SimpleServiceFactory;
+import org.junit.Test;
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.PrintWriter;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import org.junit.Test;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CommandLineOptionsTest {
 
-  @Test public void protoPath() throws Exception {
+  @Test public void protoPaths() throws Exception {
     CommandLineOptions options = new CommandLineOptions();
-    assertThat(options.protoPath).isNull();
+    assertThat(options.protoPaths).isEmpty();
 
     options = new CommandLineOptions("--proto_path=foo/bar");
-    assertThat(options.protoPath).isEqualTo("foo/bar");
+    assertThat(options.protoPaths).containsOnly("foo/bar");
+
+    List<String> paths = Arrays.asList("foo/bar", "one/two", "three/four");
+    String[] args = Lists.transform(paths, new com.google.common.base.Function<String, String>() {
+      @Override
+      public String apply(String s) {
+        return "--proto_path=" + s;
+      }
+    }).toArray(new String[0]);
+    options = new CommandLineOptions(args);
+    assertThat(options.protoPaths).containsExactlyElementsOf(paths);
   }
 
   @Test public void javaOut() throws Exception{

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
@@ -709,7 +709,7 @@ public class WireCompilerTest {
   private void invokeCompiler(String[] args) throws WireException {
     CommandLineOptions options = new CommandLineOptions(args);
     logger = new StringWireLogger(options.quiet);
-    Loader loader = Loader.forBaseDirectory(options.protoPath());
+    Loader loader = Loader.forSearchPaths(options.protoPaths());
     new WireCompiler(options, loader, JavaGenerator.IO.DEFAULT, logger).compile();
   }
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Loader.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Loader.java
@@ -15,11 +15,13 @@
  */
 package com.squareup.wire.schema;
 
+import com.google.common.base.Joiner;
 import com.squareup.wire.internal.protoparser.ProtoFileElement;
 import com.squareup.wire.internal.protoparser.ProtoParser;
 import java.io.File;
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import okio.Okio;
 import okio.Source;
@@ -34,19 +36,28 @@ public final class Loader {
   }
 
   /** Returns a loader that loads all files from {@code base}. */
-  public static Loader forBaseDirectory(final String base) {
+  public static Loader forSearchPaths(final List<String> paths) {
     IO io = new IO() {
-      @Override public Location locate(String path) throws IOException {
-        return Location.get(base, path);
+      @Override
+      public Location locate(String file) throws IOException {
+        for (String path : paths) {
+          File f = new File(path, file);
+          if (f.exists()) {
+            return Location.get(path, file);
+          }
+        }
+
+        throw new IOException("Could not locate " + file + " within any of the following: "
+                + Joiner.on(", ").join(paths) + ".");
       }
 
-      @Override public Source open(Location location) throws IOException {
-        String sourcePath = location.base() + File.separator + location.path();
-        return Okio.source(new File(sourcePath));
+      @Override
+      public Source open(Location location) throws IOException {
+        return Okio.source(new File(location.base(), location.path()));
       }
 
       @Override public String toString() {
-        return String.format("Loader(%s)", base);
+        return String.format("Loader(%s)", Joiner.on(":").join(paths));
       }
     };
     return new Loader(io);

--- a/wire-schema/src/test/java/com/squareup/wire/schema/LoaderTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/LoaderTest.java
@@ -1,0 +1,43 @@
+package com.squareup.wire.schema;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+/**
+ * Created by edwin.vane on 2015-08-07.
+ */
+public class LoaderTest {
+    @Rule
+    public final TemporaryFolder tempFolder1 = new TemporaryFolder();
+
+    @Rule
+    public final TemporaryFolder tempFolder2 = new TemporaryFolder();
+
+    @Rule
+    public final ExpectedException exception = ExpectedException.none();
+
+    @Test
+    public void locateInMultiplePaths() throws IOException {
+        File file1 = tempFolder1.newFile();
+        File file2 = tempFolder2.newFile();
+
+        Loader loader = Loader.forSearchPaths(Arrays.asList(tempFolder1.getRoot().getPath(), tempFolder2.getRoot().getPath()));
+        loader.load(Arrays.asList(file1.getName(), file2.getName()));
+    }
+
+    @Test
+    public void failLocate() throws IOException {
+        File file = tempFolder2.newFile();
+
+        Loader loader = Loader.forSearchPaths(Arrays.asList(tempFolder1.getRoot().getPath()));
+
+        exception.expect(IOException.class);
+        loader.load(Arrays.asList(file.getName()));
+    }
+}


### PR DESCRIPTION
protoc supports multiple --proto_path arguments to specify extra paths to search for .proto files in. This commit adds similar functionality to wire-compiler.

New tests haven't been added as of yet. Wanted to make sure this commit was functionally ok with the project before spending time on them.

I have plans to update wire-gradle-plugin as well.