### PR TITLE
Field bindings cache their adapters.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
@@ -61,8 +61,7 @@ final class EnumAdapter<E extends ProtoEnum> extends TypeAdapter<E> {
     try {
       return constants[index];
     } catch (IndexOutOfBoundsException e) {
-      throw new IllegalArgumentException(
-          "Unknown enum tag " + value + " for " + type.getCanonicalName());
+      throw new EnumConstantNotFoundException(value, type);
     }
   }
 
@@ -76,5 +75,14 @@ final class EnumAdapter<E extends ProtoEnum> extends TypeAdapter<E> {
 
   @Override public E read(ProtoReader reader) throws IOException {
     return fromInt(reader.readVarint32());
+  }
+
+  static final class EnumConstantNotFoundException extends IllegalArgumentException {
+    final int value;
+
+    EnumConstantNotFoundException(int value, Class<?> type) {
+      super("Unknown enum tag " + value + " for " + type.getCanonicalName());
+      this.value = value;
+    }
   }
 }


### PR DESCRIPTION
This front-loads resolution of adapters so that read, write, and size calculation can all be done quickly. This also cleans up the duplicated read/write/size code for determining the type.

Due to the lack of root messages omitting a length-prefix, there's a minor hack in this PR which reads the length prefix manually for nested messages (since their type adapters omit it). There are a few options for eliminating this in the future that will be explored. This also isn't the end of the refactoring to make type adapters completely first-class citizens but it gets them much farther along.