### PR TITLE
Split MessageAdapter from being a TypeAdapter.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
@@ -65,11 +65,11 @@ final class EnumAdapter<E extends ProtoEnum> extends TypeAdapter<E> {
     }
   }
 
-  @Override public int serializedSize(E value) {
+  @Override int dataSize(E value) {
     return ProtoWriter.varint32Size(value.getValue());
   }
 
-  @Override public void write(E value, ProtoWriter writer) throws IOException {
+  @Override void writeData(E value, ProtoWriter writer) throws IOException {
     writer.writeVarint32(value.getValue());
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MessageAdapter.java
@@ -25,11 +25,7 @@ import okio.Okio;
 
 import static com.squareup.wire.Preconditions.checkNotNull;
 
-public abstract class MessageAdapter<M extends Message> extends TypeAdapter<M> {
-  protected MessageAdapter() {
-    super(WireType.LENGTH_DELIMITED);
-  }
-
+public abstract class MessageAdapter<M extends Message> {
   /**
    * Returns a copy of {@code value} with all redacted fields set to null or an empty list.
    * This operation is recursive: nested messages are themselves redacted in the returned object.
@@ -38,6 +34,9 @@ public abstract class MessageAdapter<M extends Message> extends TypeAdapter<M> {
 
   /** Returns a human-readable version of the given {@code value}. */
   abstract String toString(M value);
+
+  /** The serialized size of non-null {@code value}. */
+  public abstract int serializedSize(M value);
 
   /** Encode {@code value} as a {@code byte[]}. */
   public final byte[] writeBytes(M value) {
@@ -67,11 +66,8 @@ public abstract class MessageAdapter<M extends Message> extends TypeAdapter<M> {
     write(value, new ProtoWriter(sink));
   }
 
-  /** Read an encoded message from {@code source}. */
-  public final M read(BufferedSource source) throws IOException {
-    checkNotNull(source, "source == null");
-    return read(new ProtoReader(source));
-  }
+  /** Encode {@code value} and write it to {@code writer}. */
+  public abstract void write(M value, ProtoWriter writer) throws IOException;
 
   /** Read an encoded message from {@code bytes}. */
   public final M readBytes(byte[] bytes) throws IOException {
@@ -84,4 +80,13 @@ public abstract class MessageAdapter<M extends Message> extends TypeAdapter<M> {
     checkNotNull(stream, "stream == null");
     return read(Okio.buffer(Okio.source(stream)));
   }
+
+  /** Read an encoded message from {@code source}. */
+  public final M read(BufferedSource source) throws IOException {
+    checkNotNull(source, "source == null");
+    return read(new ProtoReader(source));
+  }
+
+  /** Read an encoded message from {@code reader}. */
+  public abstract M read(ProtoReader reader) throws IOException;
 }

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
@@ -59,7 +59,7 @@ import okio.ByteString;
 public final class ProtoWriter {
 
   /** Makes a tag value given a field number and wire type. */
-  static int makeTag(int fieldNumber, WireType wireType) {
+  private static int makeTag(int fieldNumber, WireType wireType) {
     return (fieldNumber << WireType.TAG_TYPE_BITS) | wireType.value();
   }
 
@@ -100,11 +100,8 @@ public final class ProtoWriter {
     this.sink = sink;
   }
 
-  public <T> void write(TypeAdapter<T> adapter, T value) throws IOException {
-    if (adapter.type == WireType.LENGTH_DELIMITED) {
-      writeVarint32(adapter.serializedSize(value));
-    }
-    adapter.write(value, this);
+  public <T> void write(int tag, T value, TypeAdapter<T> adapter) throws IOException {
+    adapter.write(tag, value, this);
   }
 
   void writeByte(int value) throws IOException {

--- a/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
@@ -22,8 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import static com.squareup.wire.ProtoWriter.makeTag;
-
 final class UnknownFieldMap {
 
   static final class Value<T> {
@@ -37,13 +35,12 @@ final class UnknownFieldMap {
       this.adapter = adapter;
     }
 
-    int getSerializedSize() {
-      return adapter.serializedSize(value);
+    int dataSize() {
+      return adapter.dataSize(value);
     }
 
     void write(int tag, ProtoWriter output) throws IOException {
-      output.writeVarint32(makeTag(tag, adapter.type));
-      output.write(adapter, value);
+      output.write(tag, value, adapter);
     }
   }
 
@@ -87,7 +84,7 @@ final class UnknownFieldMap {
     for (Map.Entry<Integer, List<Value>> entry : fieldMap.entrySet()) {
       int tagSize = ProtoWriter.tagSize(entry.getKey());
       for (Value value : entry.getValue()) {
-        size += tagSize + value.getSerializedSize();
+        size += tagSize + value.dataSize();
       }
     }
     return size;


### PR DESCRIPTION
This formalizes (and enforces in the type system) the semantic difference between root messages which do not length-prefix themselves vs. nested messages which do. The message adapters for nested messages are wrapped in a type adapter which adds the length-prefixing behavior to reading and writing.