### PR TITLE
Push more read/write/size functionality into the type adapters.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
@@ -73,7 +73,7 @@ final class EnumAdapter<E extends ProtoEnum> extends TypeAdapter<E> {
     writer.writeVarint32(value.getValue());
   }
 
-  @Override public E read(ProtoReader reader) throws IOException {
+  @Override E read(ProtoReader reader) throws IOException {
     return fromInt(reader.readVarint32());
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoReader.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoReader.java
@@ -68,7 +68,7 @@ public final class ProtoReader {
   /** The type of the next value to be read. */
   private WireType nextType;
 
-  ProtoReader(BufferedSource source) {
+  public ProtoReader(BufferedSource source) {
     this.source = source;
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
@@ -96,7 +96,7 @@ public final class ProtoWriter {
 
   private final BufferedSink sink;
 
-  ProtoWriter(BufferedSink sink) {
+  public ProtoWriter(BufferedSink sink) {
     this.sink = sink;
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
@@ -35,8 +35,8 @@ final class UnknownFieldMap {
       this.adapter = adapter;
     }
 
-    int dataSize() {
-      return adapter.dataSize(value);
+    int serializedSize(int tag) {
+      return adapter.serializedSize(tag, value);
     }
 
     void write(int tag, ProtoWriter output) throws IOException {
@@ -82,9 +82,9 @@ final class UnknownFieldMap {
   int getSerializedSize() {
     int size = 0;
     for (Map.Entry<Integer, List<Value>> entry : fieldMap.entrySet()) {
-      int tagSize = ProtoWriter.tagSize(entry.getKey());
+      int tag = entry.getKey();
       for (Value value : entry.getValue()) {
-        size += tagSize + value.dataSize();
+        size += value.serializedSize(tag);
       }
     }
     return size;


### PR DESCRIPTION
Unfortunately, due to the behavior of erroneous enum retaining in the unknown field map, reflective reading still requires manual parsing using the raw type adapter for a single value.