### PR TITLE
Detect and forbid conflicts on extension tags.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/Extension.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Extension.java
@@ -256,28 +256,7 @@ public final class Extension<T extends ExtendableMessage<T>, E>
    * Orders Extensions in ascending tag order.
    */
   @Override public int compareTo(Extension<?, ?> o) {
-    if (o == this) {
-      return 0;
-    }
-    if (tag != o.tag) {
-      return tag - o.tag;
-    }
-    if (datatype != o.datatype) {
-      return datatype.value() - o.datatype.value();
-    }
-    if (label != o.label) {
-      return label.value() - o.label.value();
-    }
-    if (extendedType != null && !extendedType.equals(o.extendedType)) {
-      return extendedType.getName().compareTo(o.extendedType.getName());
-    }
-    if (messageType != null && !messageType.equals(o.messageType)) {
-      return messageType.getName().compareTo(o.messageType.getName());
-    }
-    if (enumType != null && !enumType.equals(o.enumType)) {
-      return enumType.getName().compareTo(o.enumType.getName());
-    }
-    return 0;
+    return tag - o.tag;
   }
 
   @Override public boolean equals(Object other) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/Ext_foreign.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/Ext_foreign.java
@@ -11,7 +11,7 @@ public final class Ext_foreign {
   public static final Extension<MessageOptions, ForeignMessage> foreign_message_option = Extension
       .messageExtending(ForeignMessage.class, MessageOptions.class)
       .setName("squareup.protos.foreign.foreign_message_option")
-      .setTag(50005)
+      .setTag(50007)
       .buildOptional();
 
   public static final Extension<EnumValueOptions, Boolean> foreign_enum_value_option = Extension

--- a/wire-runtime/src/test/proto/foreign.proto
+++ b/wire-runtime/src/test/proto/foreign.proto
@@ -32,7 +32,7 @@ message ForeignMessage {
 }
 
 extend google.protobuf.MessageOptions {
-  optional ForeignMessage foreign_message_option = 50005;
+  optional ForeignMessage foreign_message_option = 50007;
 }
 
 extend google.protobuf.EnumValueOptions {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
@@ -56,11 +56,6 @@ public final class Extend {
     return fields;
   }
 
-  void validate(Linker linker) {
-    linker = linker.withContext(this);
-    linker.validateTags(fields);
-  }
-
   void link(Linker linker) {
     linker = linker.withContext(this);
     name = linker.resolveNamedType(packageName, element.name());

--- a/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
@@ -105,7 +105,7 @@ public final class MessageType extends Type {
 
   void validate(Linker linker) {
     linker = linker.withContext(this);
-    linker.validateTags(fieldsAndOneOfFields());
+    linker.validateTags(fieldsAndOneOfFields(), linker.extensions(name()));
     linker.validateEnumConstantNameUniqueness(nestedTypes);
     for (Type type : nestedTypes) {
       type.validate(linker);

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
@@ -476,7 +476,7 @@ public final class SchemaTest {
       assertThat(expected).hasMessage("multiple fields share tag 1:\n"
           + "  1. name1 (message.proto at 4:3)\n"
           + "  2. name2 (message.proto at 5:3)\n"
-          + "  for extend Message (message.proto at 3:1)");
+          + "  for message Message (message.proto at 1:1)");
     }
   }
 


### PR DESCRIPTION
Ths breaks one test case which was trying to keep this working. There's no reason
a well-formed program would do this; it would crash attempting to parse the data
if it were ever encoded.