### PR TITLE
okio -> 1.5.0 (latest)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
       <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
-        <version>1.2.0</version>
+        <version>1.5.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.gson</groupId>


### PR DESCRIPTION
update it, due to 1.2.0 being 8 months old

ran `mvn clean verify` without issues. Also signed the contributing agreement.