### PR TITLE
Don't return groups to callers of ProtoReader.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
@@ -185,10 +185,6 @@ public final class ProtoWriter {
     this.sink = sink;
   }
 
-  public <T> void write(int tag, T value, TypeAdapter<T> adapter) throws IOException {
-    adapter.write(tag, value, this);
-  }
-
   void writeByte(int value) throws IOException {
     sink.writeByte(value);
   }

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeEnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeEnumAdapter.java
@@ -69,7 +69,7 @@ final class RuntimeEnumAdapter<E extends ProtoEnum> extends TypeAdapter<E> {
     return ProtoWriter.varint32Size(value.getValue());
   }
 
-  @Override public void writeData(E value, ProtoWriter writer) throws IOException {
+  @Override public void write(ProtoWriter writer, E value) throws IOException {
     writer.writeVarint32(value.getValue());
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -20,7 +20,6 @@ import java.io.Serializable;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
-import java.net.ProtocolException;
 import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -32,10 +31,6 @@ import java.util.Set;
 
 import static com.squareup.wire.Message.Builder;
 import static com.squareup.wire.Message.Label;
-import static com.squareup.wire.TypeAdapter.BYTES;
-import static com.squareup.wire.TypeAdapter.FIXED32;
-import static com.squareup.wire.TypeAdapter.FIXED64;
-import static com.squareup.wire.TypeAdapter.UINT64;
 
 final class RuntimeMessageAdapter<M extends Message> extends MessageAdapter<M> {
   private final Wire wire;
@@ -208,7 +203,7 @@ final class RuntimeMessageAdapter<M extends Message> extends MessageAdapter<M> {
     for (TagBinding<M, Builder<M>> tagBinding : tagBindingsForMessage(message).values()) {
       Object value = tagBinding.get(message);
       if (value == null) continue;
-      ((TypeAdapter<Object>) tagBinding.adapter).write(tagBinding.tag, value, writer);
+      ((TypeAdapter<Object>) tagBinding.adapter).writeTagged(writer, tagBinding.tag, value);
     }
     message.writeUnknownFieldMap(writer);
   }
@@ -258,12 +253,11 @@ final class RuntimeMessageAdapter<M extends Message> extends MessageAdapter<M> {
     Builder<M> builder = newBuilder();
     Storage storage = new Storage();
 
-    while (input.hasNext()) {
-      int tag = input.readTag();
-
+    for (int tag; (tag = input.nextTag()) != -1;) {
       TagBinding<M, Builder<M>> tagBinding = tagBindings.get(tag);
       if (tagBinding == null) {
-        readUnknownField(builder, input, tag);
+        TypeAdapter<?> typeAdapter = unknownTypeAdapter(input.peekType());
+        readUnknownField(builder, input, tag, typeAdapter);
         continue;
       }
       Label label = tagBinding.label;
@@ -274,7 +268,7 @@ final class RuntimeMessageAdapter<M extends Message> extends MessageAdapter<M> {
         long token = input.beginLengthDelimited();
         while (input.hasNext()) {
           try {
-            Object value = input.value(adapter);
+            Object value = adapter.read(input);
             storage.add(tag, value);
           } catch (RuntimeEnumAdapter.EnumConstantNotFoundException e) {
             // An unknown Enum value was encountered, store it as an unknown field
@@ -286,7 +280,7 @@ final class RuntimeMessageAdapter<M extends Message> extends MessageAdapter<M> {
         // Read a single value
         Object value;
         try {
-          value = input.value(adapter);
+          value = adapter.read(input);
         } catch (RuntimeEnumAdapter.EnumConstantNotFoundException e) {
           // An unknown Enum value was encountered, store it as an unknown field
           builder.addVarint(tag, e.value);
@@ -309,30 +303,25 @@ final class RuntimeMessageAdapter<M extends Message> extends MessageAdapter<M> {
     return builder.build();
   }
 
-  private void readUnknownField(Builder builder, ProtoReader input, int tag)
-      throws IOException {
-    WireType type = input.peekType();
+  /** Returns a type adapter that reads {@code type} without interpretation. */
+  private TypeAdapter<?> unknownTypeAdapter(WireType type) {
     switch (type) {
       case VARINT:
-        builder.ensureUnknownFieldMap().add(tag, input.readVarint64(), UINT64);
-        break;
+        return TypeAdapter.UINT64;
       case FIXED32:
-        builder.ensureUnknownFieldMap().add(tag, input.readFixed32(), FIXED32);
-        break;
+        return TypeAdapter.FIXED32;
       case FIXED64:
-        builder.ensureUnknownFieldMap().add(tag, input.readFixed64(), FIXED64);
-        break;
+        return TypeAdapter.FIXED64;
       case LENGTH_DELIMITED:
-        builder.ensureUnknownFieldMap().add(tag, input.readBytes(), BYTES);
-        break;
-      /* Skip any groups found in the input */
-      case START_GROUP:
-        input.skipGroup();
-        break;
-      case END_GROUP:
-        break;
-      default: throw new ProtocolException("Unknown wire type: " + type);
+        return TypeAdapter.BYTES;
+      default:
+        throw new AssertionError();
     }
+  }
+
+  private <T> void readUnknownField(
+      Builder builder, ProtoReader input, int tag, TypeAdapter<T> typeAdapter) throws IOException {
+    builder.ensureUnknownFieldMap().add(tag, typeAdapter.read(input), typeAdapter);
   }
 
   private static class Storage {

--- a/wire-runtime/src/main/java/com/squareup/wire/TypeAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TypeAdapter.java
@@ -93,15 +93,15 @@ public abstract class TypeAdapter<E> {
   }
 
   /** Write non-null {@code value} to {@code writer}. */
-  public abstract void writeData(E value, ProtoWriter writer) throws IOException;
+  public abstract void write(ProtoWriter writer, E value) throws IOException;
 
   /** Write {@code tag} and non-null {@code value} to {@code writer}. */
-  void write(int tag, E value, ProtoWriter writer) throws IOException {
+  void writeTagged(ProtoWriter writer, int tag, E value) throws IOException {
     writer.writeTag(tag, type);
     if (type == WireType.LENGTH_DELIMITED) {
       writer.writeVarint32(dataSize(value));
     }
-    writeData(value, writer);
+    write(writer, value);
   }
 
   /** Read a non-null value from {@code reader}. */
@@ -113,7 +113,7 @@ public abstract class TypeAdapter<E> {
       return FIXED_BOOL_SIZE;
     }
 
-    @Override public void writeData(Boolean value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Boolean value) throws IOException {
       writer.writeByte(value ? 1 : 0);
     }
 
@@ -130,7 +130,7 @@ public abstract class TypeAdapter<E> {
       return int32Size(value);
     }
 
-    @Override public void writeData(Integer value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Integer value) throws IOException {
       writer.writeSignedVarint32(value);
     }
 
@@ -144,7 +144,7 @@ public abstract class TypeAdapter<E> {
       return varint32Size(value);
     }
 
-    @Override public void writeData(Integer value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Integer value) throws IOException {
       writer.writeVarint32(value);
     }
 
@@ -158,7 +158,7 @@ public abstract class TypeAdapter<E> {
       return varint32Size(encodeZigZag32(value));
     }
 
-    @Override public void writeData(Integer value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Integer value) throws IOException {
       writer.writeVarint32(encodeZigZag32(value));
     }
 
@@ -172,7 +172,7 @@ public abstract class TypeAdapter<E> {
       return FIXED_32_SIZE;
     }
 
-    @Override public void writeData(Integer value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Integer value) throws IOException {
       writer.writeFixed32(value);
     }
 
@@ -187,7 +187,7 @@ public abstract class TypeAdapter<E> {
       return varint64Size(value);
     }
 
-    @Override public void writeData(Long value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Long value) throws IOException {
       writer.writeVarint64(value);
     }
 
@@ -202,7 +202,7 @@ public abstract class TypeAdapter<E> {
       return varint64Size(encodeZigZag64(value));
     }
 
-    @Override public void writeData(Long value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Long value) throws IOException {
       writer.writeVarint64(encodeZigZag64(value));
     }
 
@@ -216,7 +216,7 @@ public abstract class TypeAdapter<E> {
       return FIXED_64_SIZE;
     }
 
-    @Override public void writeData(Long value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Long value) throws IOException {
       writer.writeFixed64(value);
     }
 
@@ -231,7 +231,7 @@ public abstract class TypeAdapter<E> {
       return FIXED_32_SIZE;
     }
 
-    @Override public void writeData(Float value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Float value) throws IOException {
       writer.writeFixed32(floatToIntBits(value));
     }
 
@@ -245,7 +245,7 @@ public abstract class TypeAdapter<E> {
       return FIXED_64_SIZE;
     }
 
-    @Override public void writeData(Double value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Double value) throws IOException {
       writer.writeFixed64(doubleToLongBits(value));
     }
 
@@ -259,7 +259,7 @@ public abstract class TypeAdapter<E> {
       return utf8Length(value);
     }
 
-    @Override public void writeData(String value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, String value) throws IOException {
       ByteString bytes = ByteString.encodeUtf8(value);
       writer.writeBytes(bytes);
     }
@@ -274,7 +274,7 @@ public abstract class TypeAdapter<E> {
       return value.size();
     }
 
-    @Override public void writeData(ByteString value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, ByteString value) throws IOException {
       writer.writeBytes(value);
     }
 
@@ -289,7 +289,7 @@ public abstract class TypeAdapter<E> {
         return adapter.serializedSize(value);
       }
 
-      @Override public void writeData(M value, ProtoWriter writer) throws IOException {
+      @Override public void write(ProtoWriter writer, M value) throws IOException {
         adapter.write(value, writer);
       }
 
@@ -328,9 +328,9 @@ public abstract class TypeAdapter<E> {
         return size;
       }
 
-      @Override public void writeData(List<T> value, ProtoWriter writer) throws IOException {
+      @Override public void write(ProtoWriter writer, List<T> value) throws IOException {
         for (int i = 0, count = value.size(); i < count; i++) {
-          adapter.writeData(value.get(i), writer);
+          adapter.write(writer, value.get(i));
         }
       }
 
@@ -370,13 +370,13 @@ public abstract class TypeAdapter<E> {
         return size;
       }
 
-      @Override public void writeData(List<T> value, ProtoWriter writer) throws IOException {
+      @Override public void write(ProtoWriter writer, List<T> value) throws IOException {
         throw new UnsupportedOperationException();
       }
 
-      @Override void write(int tag, List<T> value, ProtoWriter writer) throws IOException {
+      @Override void writeTagged(ProtoWriter writer, int tag, List<T> value) throws IOException {
         for (int i = 0, count = value.size(); i < count; i++) {
-          adapter.write(tag, value.get(i), writer);
+          adapter.writeTagged(writer, tag, value.get(i));
         }
       }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/UnknownFieldMap.java
@@ -40,7 +40,7 @@ final class UnknownFieldMap {
     }
 
     void write(int tag, ProtoWriter output) throws IOException {
-      output.write(tag, value, adapter);
+      adapter.writeTagged(output, tag, value);
     }
   }
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/SchemaTypeAdapterFactory.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/SchemaTypeAdapterFactory.java
@@ -117,7 +117,7 @@ final class SchemaTypeAdapterFactory {
       throw new UnsupportedOperationException();
     }
 
-    @Override public void writeData(Object value, ProtoWriter writer) throws IOException {
+    @Override public void write(ProtoWriter writer, Object value) throws IOException {
       throw new UnsupportedOperationException();
     }
 
@@ -150,9 +150,7 @@ final class SchemaTypeAdapterFactory {
     @Override public Map<String, Object> read(ProtoReader reader) throws IOException {
       Map<String, Object> result = new LinkedHashMap<>();
 
-      while (reader.hasNext()) {
-        int tag = reader.readTag();
-
+      for (int tag; (tag = reader.nextTag()) != -1;) {
         FieldAdapter fieldAdapter = fieldAdapters.get(tag);
         if (fieldAdapter == null) {
           fieldAdapter = new FieldAdapter(


### PR DESCRIPTION
This means alternate code that uses ProtoReader doesn't need to know
that groups even exist.