### PR TITLE
Use 0 for the cached size to workaround Gson magic.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -61,8 +61,8 @@ public abstract class Message implements Serializable {
   /** Set to null until a field is added. */
   private transient UnknownFieldMap unknownFields;
 
-  /** If not {@code -1} then the serialized size of this message. */
-  transient int cachedSerializedSize = -1;
+  /** If not {@code 0} then the serialized size of this message. */
+  transient int cachedSerializedSize = 0;
 
   /** If non-zero, the hash code of this message. Accessed by generated code. */
   protected transient int hashCode = 0;

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -151,9 +151,7 @@ final class RuntimeMessageAdapter<M extends Message> extends TypeAdapter<M> {
 
   @Override public int encodedSize(M message) {
     int cachedSerializedSize = message.cachedSerializedSize;
-    if (cachedSerializedSize != -1) {
-      return cachedSerializedSize;
-    }
+    if (cachedSerializedSize != 0) return cachedSerializedSize;
 
     int size = 0;
     for (TagBinding<M, Builder<M>> tagBinding : tagBindingsForMessage(message).values()) {


### PR DESCRIPTION
Unfortunately we've got some users that rely on Gson's magic no-constructor-call
allocation of message instances, and these come back with 0 already cached when
that isn't the actual serialized size.

Work around by just changing the sentinel value. The drawback is that objects
that are actually 0 won't benefit from caching. This is an acceptable tradeoff;
those are the fastest to serialize anyway.