### PR TITLE
Expose proto paths in the maven plugin.

### DIFF
--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -18,14 +18,10 @@ import org.apache.maven.project.MavenProject;
  */
 @Mojo(name = "generate-sources", defaultPhase = LifecyclePhase.GENERATE_SOURCES)
 public class WireGenerateSourcesMojo extends AbstractMojo {
-
-  /**
-   * The root of the proto source directory.
-   */
   @Parameter(
-      property = "wire.protoSourceDirectory",
+      property = "wire.protoPaths",
       defaultValue = "${project.basedir}/src/main/proto")
-  private String protoSourceDirectory;
+  private String[] protoPaths;
 
   @Parameter(property = "wire.noOptions")
   private boolean noOptions;
@@ -43,7 +39,7 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
   private String registryClass;
 
   /**
-   * List of proto files to compile relative to ${protoSourceDirectory}.
+   * List of proto files to compile relative to ${protoPaths}.
    */
   @Parameter(property = "wire.protoFiles", required = true)
   private String[] protoFiles;
@@ -68,7 +64,9 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
 
   private void compileProtos() throws MojoExecutionException {
     List<String> args = Lists.newArrayList();
-    args.add("--proto_path=" + protoSourceDirectory);
+    for (String protoPath : protoPaths) {
+      args.add("--proto_path=" + protoPath);
+    }
     args.add("--java_out=" + generatedSourceDirectory);
     if (noOptions) {
       args.add("--no_options");

--- a/wire-maven-plugin/src/test/resources/exemplar/pom.xml
+++ b/wire-maven-plugin/src/test/resources/exemplar/pom.xml
@@ -33,7 +33,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.6</java.version>
     <!-- TODO(shawn) pass in dependencies of the currently built wire artifact. -->
-    <wire.version>1.5.2-SNAPSHOT</wire.version>
+    <wire.version>2.0.0-SNAPSHOT</wire.version>
   </properties>
 
   <dependencies>
@@ -54,6 +54,7 @@
       <plugin>
         <groupId>com.squareup.wire</groupId>
         <artifactId>wire-maven-plugin</artifactId>
+        <version>${wire.version}</version>
         <executions>
           <execution>
             <phase>generate-sources</phase>


### PR DESCRIPTION
This remove the old protoSourceDirectory parameter which only permitted
a single parameter.