### PR TITLE
Add extension registry type and adding to existing adapters.

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
@@ -28,7 +28,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class GsonTest {
 
-  private final Wire wire = new Wire(Ext_all_types.class);
+  private final Wire wire = new Wire(new ExtensionRegistry(Ext_all_types.class));
 
   private static final String JSON_BASE = "\"opt_int32\":111,"
       + "\"opt_uint32\":112,"

--- a/wire-runtime/src/main/java/com/squareup/wire/ExtensionRegistry.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ExtensionRegistry.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2015 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+public final class ExtensionRegistry {
+  private final Map<Class<? extends Message>, List<Extension<?, ?>>> messageToExtensions =
+      new LinkedHashMap<Class<? extends Message>, List<Extension<?, ?>>>();
+
+  /**
+   * Creates a new instance that can encode and decode the extensions specified in
+   * {@code extensionClasses}. Typically the classes in this list are generated and start with the
+   * "Ext_" prefix.
+   */
+  public ExtensionRegistry(Class<?>... extensionClasses) {
+    this(Arrays.asList(extensionClasses));
+  }
+
+  /**
+   * Creates a new instance that can encode and decode the extensions specified in
+   * {@code extensionClasses}. Typically the classes in this list are generated and start with the
+   * "Ext_" prefix.
+   */
+  public ExtensionRegistry(List<Class<?>> extensionClasses) {
+    for (Class<?> extensionClass : extensionClasses) {
+      for (Field field : extensionClass.getDeclaredFields()) {
+        if (field.getType().equals(Extension.class)) {
+          try {
+            registerExtension((Extension) field.get(null));
+          } catch (IllegalAccessException e) {
+            throw new AssertionError(e);
+          }
+        }
+      }
+    }
+  }
+
+  private <T extends ExtendableMessage<T>, E> void registerExtension(Extension<T, E> extension) {
+    Class<? extends Message> messageClass = extension.getExtendedType();
+    List<Extension<?, ?>> extensions = messageToExtensions.get(messageClass);
+    if (extensions == null) {
+      extensions = new ArrayList<Extension<?, ?>>();
+      messageToExtensions.put(messageClass, extensions);
+    }
+    extensions.add(extension);
+  }
+
+  @SuppressWarnings("unchecked")
+  public List<Extension<?, ?>> extensions(Class<? extends Message> messageClass) {
+    List<Extension<?, ?>> map = messageToExtensions.get(messageClass);
+    return map != null ? map : Collections.<Extension<?, ?>>emptyList();
+  }
+}

--- a/wire-runtime/src/main/java/com/squareup/wire/WireAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/WireAdapter.java
@@ -75,6 +75,14 @@ public abstract class WireAdapter<E> {
     }
   }
 
+  /**
+   * Returns an adapter for the same type but with knowledge of the extensions in
+   * {@code extensionRegistry} when parsing. This only affects adapters for message types.
+   */
+  public WireAdapter<E> withExtensions(ExtensionRegistry extensionRegistry) {
+    return this;
+  }
+
   /** Returns the redacted form of {@code value}. */
   public E redact(E value) {
     return null;

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -176,7 +176,7 @@ public class WireTest {
     assertThat(msg.optional_external_msg.getExtension(
         Ext_simple_message.nested_enum_ext)).isEqualTo(SimpleMessage.NestedEnum.BAZ);
 
-    Wire wire = new Wire(Ext_simple_message.class);
+    Wire wire = new Wire(new ExtensionRegistry(Ext_simple_message.class));
     WireAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
 
     byte[] result = adapter.encode(msg);
@@ -200,9 +200,9 @@ public class WireTest {
         .build();
 
     Wire wireNoExt = new Wire();
+    ExtensionRegistry simpleMessageExtensions = new ExtensionRegistry(Ext_simple_message.class);
     WireAdapter<SimpleMessage> adapterNoExt = wireNoExt.adapter(SimpleMessage.class);
-    Wire wireExt = new Wire(Ext_simple_message.class);
-    WireAdapter<SimpleMessage> adapterExt = wireExt.adapter(SimpleMessage.class);
+    WireAdapter<SimpleMessage> adapterExt = adapterNoExt.withExtensions(simpleMessageExtensions);
 
     byte[] data = adapterNoExt.encode(msg);
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
@@ -16,6 +16,7 @@
 package com.squareup.wire.protobuf;
 
 import com.squareup.wire.Extension;
+import com.squareup.wire.ExtensionRegistry;
 import com.squareup.wire.Message;
 import com.squareup.wire.Wire;
 import com.squareup.wire.WireAdapter;
@@ -135,7 +136,7 @@ public class TestAllTypes {
   }
 
   private final AllTypes allTypes = createAllTypes();
-  private final Wire wire = new Wire(Ext_all_types.class);
+  private final Wire wire = new Wire(new ExtensionRegistry(Ext_all_types.class));
   private final WireAdapter<AllTypes> adapter = wire.adapter(AllTypes.class);
 
   private AllTypes createAllTypes(int numRepeated) {


### PR DESCRIPTION
This allows an adapter with no knowledge of extensions to be augmented with extension information to use when parsing messages.

The API of `ExtensionsRegistry` matches that of Wire for simplicity of migration but we should look at if there's a better type in the future.