### PR TITLE
Drop the Storage step when decoding.

### DIFF
--- a/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
+++ b/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
@@ -93,7 +93,7 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
       emitJson(out, value, tagBinding.datatype, tagBinding.label);
     }
 
-    TagMap tagMap = message.unknownFields();
+    TagMap tagMap = message.tagMap();
     if (tagMap != null) {
       for (Extension<?, ?> extension : tagMap.extensions(true)) {
         if (extension.isUnknown()) {
@@ -182,8 +182,8 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
 
     while (in.peek() == JsonToken.NAME) {
       String name = in.nextName();
-      FieldBinding<M, B> fieldBinding = fieldBindings.get(name);
 
+      FieldBinding<M, B> fieldBinding = fieldBindings.get(name);
       if (fieldBinding != null) {
         Object value = parseValue(fieldBinding.label, singleType(fieldBinding), parse(in));
         fieldBinding.set(builder, value);

--- a/wire-runtime/src/main/java/com/squareup/wire/ImmutableList.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ImmutableList.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2013 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.RandomAccess;
+
+/** An immutable list that avoids copies during decoding. */
+final class ImmutableList<T> extends AbstractList<T>
+    implements Cloneable, RandomAccess, Serializable {
+  final List<T> list = new ArrayList<T>();
+
+  @Override public Object clone() {
+    return this;
+  }
+
+  @Override public int size() {
+    return list.size();
+  }
+
+  @Override public T get(int i) {
+    return list.get(i);
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return Collections.unmodifiableList(list);
+  }
+}

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.wire;
 
-import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -80,7 +79,7 @@ public abstract class Message<T extends Message<T>> implements Serializable {
   }
 
   // Increase visibility for testing
-  TagMap unknownFields() {
+  TagMap tagMap() {
     return tagMap != null
         ? new TagMap(tagMap)
         : new TagMap();
@@ -99,7 +98,7 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     if (list == null) {
       throw new NullPointerException("list == null");
     }
-    if (list == Collections.emptyList() || list instanceof RuntimeMessageAdapter.ImmutableList) {
+    if (list == Collections.emptyList() || list instanceof ImmutableList) {
       return list;
     }
     return Collections.unmodifiableList(new ArrayList<T>(list));
@@ -117,13 +116,7 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     return adapter.fromInt(value);
   }
 
-  void writeUnknownFieldMap(ProtoWriter output) throws IOException {
-    if (tagMap != null) {
-      tagMap.encode(output);
-    }
-  }
-
-  int getUnknownFieldsSerializedSize() {
+  int tagMapEncodedSize() {
     return tagMap == null ? 0 : tagMap.encodedSize();
   }
 
@@ -201,31 +194,31 @@ public abstract class Message<T extends Message<T>> implements Serializable {
      * Adds a {@code varint} value to the unknown field set with the given tag number.
      */
     public void addVarint(int tag, long value) {
-      ensureUnknownFieldMap().add(tag, FieldEncoding.VARINT, value);
+      ensureTagMap().add(tag, FieldEncoding.VARINT, value);
     }
 
     /**
      * Adds a {@code fixed32} value to the unknown field set with the given tag number.
      */
     public void addFixed32(int tag, int value) {
-      ensureUnknownFieldMap().add(tag, FieldEncoding.FIXED32, value);
+      ensureTagMap().add(tag, FieldEncoding.FIXED32, value);
     }
 
     /**
      * Adds a {@code fixed64} value to the unknown field set with the given tag number.
      */
     public void addFixed64(int tag, long value) {
-      ensureUnknownFieldMap().add(tag, FieldEncoding.FIXED64, value);
+      ensureTagMap().add(tag, FieldEncoding.FIXED64, value);
     }
 
     /**
      * Adds a length delimited value to the unknown field set with the given tag number.
      */
     public void addLengthDelimited(int tag, ByteString value) {
-      ensureUnknownFieldMap().add(tag, FieldEncoding.LENGTH_DELIMITED, value);
+      ensureTagMap().add(tag, FieldEncoding.LENGTH_DELIMITED, value);
     }
 
-    TagMap ensureUnknownFieldMap() {
+    TagMap ensureTagMap() {
       if (tagMap == null) {
         tagMap = new TagMap();
       }

--- a/wire-runtime/src/main/java/com/squareup/wire/MessageSerializedForm.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MessageSerializedForm.java
@@ -35,8 +35,7 @@ final class MessageSerializedForm implements Serializable {
   Object readResolve() throws ObjectStreamException {
     WireAdapter<? extends Message> adapter = Message.WIRE.adapter(messageClass);
     try {
-      // Extensions are not supported at this time. Extension fields will be added to the
-      // unknownFields map.
+      // Extensions will be decoded as unknown values.
       return adapter.decode(bytes);
     } catch (IOException e) {
       throw new StreamCorruptedException(e.getMessage());

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -214,7 +214,7 @@ public class WireTest {
 
     // Original value shows up as an extension.
     assertThat(msg.toString()).contains("squareup.protos.simple.nested_enum_ext=BAZ");
-    // New value is placed into the unknown field map.
+    // New value is unknown in the tag map.
     assertThat(newMsg.toString()).contains("ExternalMessage{129=[17]}");
 
     // Serialized outputs are the same.
@@ -336,9 +336,9 @@ public class WireTest {
     assertThat(result.phone.get(0).type).isNull();
 
     // The value 17 will be stored as an unknown varint with tag number 2
-    TagMap unknownFields = ((Message) result.phone.get(0)).unknownFields();
-    assertThat(unknownFields.size()).isEqualTo(1);
-    assertThat(unknownFields.firstWithTag(2)).isEqualTo(17L);
+    TagMap tagMap = ((Message) result.phone.get(0)).tagMap();
+    assertThat(tagMap.size()).isEqualTo(1);
+    assertThat(tagMap.firstWithTag(2)).isEqualTo(17L);
 
     // Serialize again, value is preserved
     byte[] newData = adapter.encode(result);


### PR DESCRIPTION
Now that tag maps handle multiplicity, just go right to the field.