### PR TITLE
Omit MessageType from the @ProtoField annotation.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/java/TypeWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/java/TypeWriter.java
@@ -325,11 +325,6 @@ public final class TypeWriter {
       }
     }
 
-    if (field.isRepeated() && !isScalar) {
-      String key = isEnum ? "enumType" : "messageType";
-      result.addMember(key, "$T.class", messageType);
-    }
-
     if (field.isDeprecated()) {
       result.addMember("deprecated", "true");
     }

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -444,15 +444,13 @@ public final class AllTypes extends Message<AllTypes> {
   @ProtoField(
       tag = 216,
       type = Message.Datatype.ENUM,
-      label = Message.Label.REPEATED,
-      enumType = NestedEnum.class
+      label = Message.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @ProtoField(
       tag = 217,
-      label = Message.Label.REPEATED,
-      messageType = NestedMessage.class
+      label = Message.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
@@ -550,8 +548,7 @@ public final class AllTypes extends Message<AllTypes> {
   @ProtoField(
       tag = 316,
       type = Message.Datatype.ENUM,
-      label = Message.Label.PACKED,
-      enumType = NestedEnum.class
+      label = Message.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoField.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoField.java
@@ -47,18 +47,6 @@ public @interface ProtoField {
   Label label() default Label.OPTIONAL;
 
   /**
-   * For repeated Message fields, the underlying Message type.
-   */
-  // The exact supertype 'Message.class' is used as a sentinel for 'no value'.
-  Class<? extends Message> messageType() default Message.class;
-
-  /**
-   * For repeated Enum fields, the underlying Enum type.
-   */
-  // The exact supertype 'ProtoEnum.class' is used as a sentinel for 'no value'.
-  Class<? extends ProtoEnum> enumType() default ProtoEnum.class;
-
-  /**
    * True if the field is marked as deprecated.
    */
   boolean deprecated() default false;

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -38,36 +38,31 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
   @ProtoField(
       tag = 2,
-      label = Message.Label.REPEATED,
-      messageType = FieldDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> field;
 
   @ProtoField(
       tag = 6,
-      label = Message.Label.REPEATED,
-      messageType = FieldDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 
   @ProtoField(
       tag = 3,
-      label = Message.Label.REPEATED,
-      messageType = DescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<DescriptorProto> nested_type;
 
   @ProtoField(
       tag = 4,
-      label = Message.Label.REPEATED,
-      messageType = EnumDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
   @ProtoField(
       tag = 5,
-      label = Message.Label.REPEATED,
-      messageType = ExtensionRange.class
+      label = Message.Label.REPEATED
   )
   public final List<ExtensionRange> extension_range;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -37,8 +37,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
 
   @ProtoField(
       tag = 2,
-      label = Message.Label.REPEATED,
-      messageType = EnumValueDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<EnumValueDescriptorProto> value;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -17,8 +17,7 @@ public final class EnumOptions extends Message<EnumOptions> {
    */
   @ProtoField(
       tag = 999,
-      label = Message.Label.REPEATED,
-      messageType = UninterpretedOption.class
+      label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -17,8 +17,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
    */
   @ProtoField(
       tag = 999,
-      label = Message.Label.REPEATED,
-      messageType = UninterpretedOption.class
+      label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -84,8 +84,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @ProtoField(
       tag = 999,
-      label = Message.Label.REPEATED,
-      messageType = UninterpretedOption.class
+      label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -53,29 +53,25 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @ProtoField(
       tag = 4,
-      label = Message.Label.REPEATED,
-      messageType = DescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<DescriptorProto> message_type;
 
   @ProtoField(
       tag = 5,
-      label = Message.Label.REPEATED,
-      messageType = EnumDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
   @ProtoField(
       tag = 6,
-      label = Message.Label.REPEATED,
-      messageType = ServiceDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<ServiceDescriptorProto> service;
 
   @ProtoField(
       tag = 7,
-      label = Message.Label.REPEATED,
-      messageType = FieldDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -18,8 +18,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
 
   @ProtoField(
       tag = 1,
-      label = Message.Label.REPEATED,
-      messageType = FileDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<FileDescriptorProto> file;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -150,8 +150,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @ProtoField(
       tag = 999,
-      label = Message.Label.REPEATED,
-      messageType = UninterpretedOption.class
+      label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -59,8 +59,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    */
   @ProtoField(
       tag = 999,
-      label = Message.Label.REPEATED,
-      messageType = UninterpretedOption.class
+      label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -21,8 +21,7 @@ public final class MethodOptions extends Message<MethodOptions> {
    */
   @ProtoField(
       tag = 999,
-      label = Message.Label.REPEATED,
-      messageType = UninterpretedOption.class
+      label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -28,8 +28,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
 
   @ProtoField(
       tag = 2,
-      label = Message.Label.REPEATED,
-      messageType = MethodDescriptorProto.class
+      label = Message.Label.REPEATED
   )
   public final List<MethodDescriptorProto> method;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -21,8 +21,7 @@ public final class ServiceOptions extends Message<ServiceOptions> {
    */
   @ProtoField(
       tag = 999,
-      label = Message.Label.REPEATED,
-      messageType = UninterpretedOption.class
+      label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -66,8 +66,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
    */
   @ProtoField(
       tag = 1,
-      label = Message.Label.REPEATED,
-      messageType = Location.class
+      label = Message.Label.REPEATED
   )
   public final List<Location> location;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -39,8 +39,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
   @ProtoField(
       tag = 2,
-      label = Message.Label.REPEATED,
-      messageType = NamePart.class
+      label = Message.Label.REPEATED
   )
   public final List<NamePart> name;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -444,15 +444,13 @@ public final class AllTypes extends Message<AllTypes> {
   @ProtoField(
       tag = 216,
       type = Message.Datatype.ENUM,
-      label = Message.Label.REPEATED,
-      enumType = NestedEnum.class
+      label = Message.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @ProtoField(
       tag = 217,
-      label = Message.Label.REPEATED,
-      messageType = NestedMessage.class
+      label = Message.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
@@ -550,8 +548,7 @@ public final class AllTypes extends Message<AllTypes> {
   @ProtoField(
       tag = 316,
       type = Message.Datatype.ENUM,
-      label = Message.Label.PACKED,
-      enumType = NestedEnum.class
+      label = Message.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -114,8 +114,7 @@ public final class FooBar extends Message<FooBar> {
 
   @ProtoField(
       tag = 7,
-      label = Message.Label.REPEATED,
-      messageType = FooBar.class
+      label = Message.Label.REPEATED
   )
   public final List<FooBar> nested;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -64,8 +64,7 @@ public final class FooBar extends Message<FooBar> {
 
   @ProtoField(
       tag = 7,
-      label = Message.Label.REPEATED,
-      messageType = FooBar.class
+      label = Message.Label.REPEATED
   )
   public final List<FooBar> nested;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -55,8 +55,7 @@ public final class Person extends Message<Person> {
    */
   @ProtoField(
       tag = 4,
-      label = Message.Label.REPEATED,
-      messageType = PhoneNumber.class
+      label = Message.Label.REPEATED
   )
   public final List<PhoneNumber> phone;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -14,8 +14,7 @@ public final class Bars extends Message<Bars> {
 
   @ProtoField(
       tag = 1,
-      label = Message.Label.REPEATED,
-      messageType = Bar.class
+      label = Message.Label.REPEATED
   )
   public final List<Bar> bars;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -14,8 +14,7 @@ public final class Foos extends Message<Foos> {
 
   @ProtoField(
       tag = 1,
-      label = Message.Label.REPEATED,
-      messageType = Foo.class
+      label = Message.Label.REPEATED
   )
   public final List<Foo> foos;
 


### PR DESCRIPTION
It's not much more work to get it from the field itself, and it will
work better if we support custom wire adapters.