### PR TITLE
Use WireType instead of Message.Datatype.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/java/TypeWriter.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/java/TypeWriter.java
@@ -32,6 +32,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoEnum;
 import com.squareup.wire.ProtoField;
 import com.squareup.wire.WireCompilerException;
+import com.squareup.wire.WireType;
 import com.squareup.wire.schema.EnumConstant;
 import com.squareup.wire.schema.EnumType;
 import com.squareup.wire.schema.Extend;
@@ -42,7 +43,6 @@ import com.squareup.wire.schema.Options;
 import com.squareup.wire.schema.ProtoFile;
 import com.squareup.wire.schema.Schema;
 import com.squareup.wire.schema.Type;
-import com.squareup.wire.WireType;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
@@ -300,22 +300,7 @@ public final class TypeWriter {
 
     int tag = field.tag();
     result.addMember("tag", String.valueOf(tag));
-
-    boolean isScalar = field.type().isScalar();
-    boolean isEnum = javaGenerator.isEnum(field.type());
-
-    String fieldType;
-    if (isScalar) {
-      fieldType = field.type().toString().toUpperCase(Locale.US);
-    } else if (isEnum) {
-      fieldType = "ENUM";
-    } else {
-      fieldType = null;
-    }
-
-    if (fieldType != null) {
-      result.addMember("type", "$T.$L", Message.Datatype.class, fieldType);
-    }
+    result.addMember("type", "$S", field.type().toString());
 
     if (!field.isOptional()) {
       if (field.isPacked()) {
@@ -791,9 +776,11 @@ public final class TypeWriter {
     if (field.type().isScalar()) {
       initializer.add(".$LExtending($T.class)\n", field.type(), extendType);
     } else if (javaGenerator.isEnum(field.type())) {
-      initializer.add(".enumExtending($T.class, $T.class)\n", fieldType, extendType);
+      initializer.add(".enumExtending($S, $T.class, $T.class)\n",
+          field.type(), fieldType, extendType);
     } else {
-      initializer.add(".messageExtending($T.class, $T.class)\n", fieldType, extendType);
+      initializer.add(".messageExtending($S, $T.class, $T.class)\n",
+          field.type(), fieldType, extendType);
     }
 
     initializer.add(".setName($S)\n", protoFile.packageName() + "." + field.name());

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -119,532 +119,535 @@ public final class AllTypes extends Message<AllTypes> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer opt_int32;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.UINT32
+      type = "uint32"
   )
   public final Integer opt_uint32;
 
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.SINT32
+      type = "sint32"
   )
   public final Integer opt_sint32;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.FIXED32
+      type = "fixed32"
   )
   public final Integer opt_fixed32;
 
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.SFIXED32
+      type = "sfixed32"
   )
   public final Integer opt_sfixed32;
 
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.INT64
+      type = "int64"
   )
   public final Long opt_int64;
 
   @ProtoField(
       tag = 7,
-      type = Message.Datatype.UINT64
+      type = "uint64"
   )
   public final Long opt_uint64;
 
   @ProtoField(
       tag = 8,
-      type = Message.Datatype.SINT64
+      type = "sint64"
   )
   public final Long opt_sint64;
 
   @ProtoField(
       tag = 9,
-      type = Message.Datatype.FIXED64
+      type = "fixed64"
   )
   public final Long opt_fixed64;
 
   @ProtoField(
       tag = 10,
-      type = Message.Datatype.SFIXED64
+      type = "sfixed64"
   )
   public final Long opt_sfixed64;
 
   @ProtoField(
       tag = 11,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean opt_bool;
 
   @ProtoField(
       tag = 12,
-      type = Message.Datatype.FLOAT
+      type = "float"
   )
   public final Float opt_float;
 
   @ProtoField(
       tag = 13,
-      type = Message.Datatype.DOUBLE
+      type = "double"
   )
   public final Double opt_double;
 
   @ProtoField(
       tag = 14,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String opt_string;
 
   @ProtoField(
       tag = 15,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString opt_bytes;
 
   @ProtoField(
       tag = 16,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
   public final NestedEnum opt_nested_enum;
 
   @ProtoField(
-      tag = 17
+      tag = 17,
+      type = "squareup.protos.alltypes.AllTypes.NestedMessage"
   )
   public final NestedMessage opt_nested_message;
 
   @ProtoField(
       tag = 101,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_int32;
 
   @ProtoField(
       tag = 102,
-      type = Message.Datatype.UINT32,
+      type = "uint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_uint32;
 
   @ProtoField(
       tag = 103,
-      type = Message.Datatype.SINT32,
+      type = "sint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sint32;
 
   @ProtoField(
       tag = 104,
-      type = Message.Datatype.FIXED32,
+      type = "fixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
   @ProtoField(
       tag = 105,
-      type = Message.Datatype.SFIXED32,
+      type = "sfixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
   @ProtoField(
       tag = 106,
-      type = Message.Datatype.INT64,
+      type = "int64",
       label = Message.Label.REQUIRED
   )
   public final Long req_int64;
 
   @ProtoField(
       tag = 107,
-      type = Message.Datatype.UINT64,
+      type = "uint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_uint64;
 
   @ProtoField(
       tag = 108,
-      type = Message.Datatype.SINT64,
+      type = "sint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sint64;
 
   @ProtoField(
       tag = 109,
-      type = Message.Datatype.FIXED64,
+      type = "fixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_fixed64;
 
   @ProtoField(
       tag = 110,
-      type = Message.Datatype.SFIXED64,
+      type = "sfixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
   @ProtoField(
       tag = 111,
-      type = Message.Datatype.BOOL,
+      type = "bool",
       label = Message.Label.REQUIRED
   )
   public final Boolean req_bool;
 
   @ProtoField(
       tag = 112,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.REQUIRED
   )
   public final Float req_float;
 
   @ProtoField(
       tag = 113,
-      type = Message.Datatype.DOUBLE,
+      type = "double",
       label = Message.Label.REQUIRED
   )
   public final Double req_double;
 
   @ProtoField(
       tag = 114,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REQUIRED
   )
   public final String req_string;
 
   @ProtoField(
       tag = 115,
-      type = Message.Datatype.BYTES,
+      type = "bytes",
       label = Message.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
   @ProtoField(
       tag = 116,
-      type = Message.Datatype.ENUM,
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
   @ProtoField(
       tag = 117,
+      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
   @ProtoField(
       tag = 201,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @ProtoField(
       tag = 202,
-      type = Message.Datatype.UINT32,
+      type = "uint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
   @ProtoField(
       tag = 203,
-      type = Message.Datatype.SINT32,
+      type = "sint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
   @ProtoField(
       tag = 204,
-      type = Message.Datatype.FIXED32,
+      type = "fixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
   @ProtoField(
       tag = 205,
-      type = Message.Datatype.SFIXED32,
+      type = "sfixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
   @ProtoField(
       tag = 206,
-      type = Message.Datatype.INT64,
+      type = "int64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
   @ProtoField(
       tag = 207,
-      type = Message.Datatype.UINT64,
+      type = "uint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
   @ProtoField(
       tag = 208,
-      type = Message.Datatype.SINT64,
+      type = "sint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
   @ProtoField(
       tag = 209,
-      type = Message.Datatype.FIXED64,
+      type = "fixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
   @ProtoField(
       tag = 210,
-      type = Message.Datatype.SFIXED64,
+      type = "sfixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
   @ProtoField(
       tag = 211,
-      type = Message.Datatype.BOOL,
+      type = "bool",
       label = Message.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
   @ProtoField(
       tag = 212,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> rep_float;
 
   @ProtoField(
       tag = 213,
-      type = Message.Datatype.DOUBLE,
+      type = "double",
       label = Message.Label.REPEATED
   )
   public final List<Double> rep_double;
 
   @ProtoField(
       tag = 214,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REPEATED
   )
   public final List<String> rep_string;
 
   @ProtoField(
       tag = 215,
-      type = Message.Datatype.BYTES,
+      type = "bytes",
       label = Message.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
   @ProtoField(
       tag = 216,
-      type = Message.Datatype.ENUM,
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @ProtoField(
       tag = 217,
+      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
   @ProtoField(
       tag = 301,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
   @ProtoField(
       tag = 302,
-      type = Message.Datatype.UINT32,
+      type = "uint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
   @ProtoField(
       tag = 303,
-      type = Message.Datatype.SINT32,
+      type = "sint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
   @ProtoField(
       tag = 304,
-      type = Message.Datatype.FIXED32,
+      type = "fixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
   @ProtoField(
       tag = 305,
-      type = Message.Datatype.SFIXED32,
+      type = "sfixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
   @ProtoField(
       tag = 306,
-      type = Message.Datatype.INT64,
+      type = "int64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_int64;
 
   @ProtoField(
       tag = 307,
-      type = Message.Datatype.UINT64,
+      type = "uint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
   @ProtoField(
       tag = 308,
-      type = Message.Datatype.SINT64,
+      type = "sint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
   @ProtoField(
       tag = 309,
-      type = Message.Datatype.FIXED64,
+      type = "fixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
   @ProtoField(
       tag = 310,
-      type = Message.Datatype.SFIXED64,
+      type = "sfixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
   @ProtoField(
       tag = 311,
-      type = Message.Datatype.BOOL,
+      type = "bool",
       label = Message.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
   @ProtoField(
       tag = 312,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.PACKED
   )
   public final List<Float> pack_float;
 
   @ProtoField(
       tag = 313,
-      type = Message.Datatype.DOUBLE,
+      type = "double",
       label = Message.Label.PACKED
   )
   public final List<Double> pack_double;
 
   @ProtoField(
       tag = 316,
-      type = Message.Datatype.ENUM,
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @ProtoField(
       tag = 401,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer default_int32;
 
   @ProtoField(
       tag = 402,
-      type = Message.Datatype.UINT32
+      type = "uint32"
   )
   public final Integer default_uint32;
 
   @ProtoField(
       tag = 403,
-      type = Message.Datatype.SINT32
+      type = "sint32"
   )
   public final Integer default_sint32;
 
   @ProtoField(
       tag = 404,
-      type = Message.Datatype.FIXED32
+      type = "fixed32"
   )
   public final Integer default_fixed32;
 
   @ProtoField(
       tag = 405,
-      type = Message.Datatype.SFIXED32
+      type = "sfixed32"
   )
   public final Integer default_sfixed32;
 
   @ProtoField(
       tag = 406,
-      type = Message.Datatype.INT64
+      type = "int64"
   )
   public final Long default_int64;
 
   @ProtoField(
       tag = 407,
-      type = Message.Datatype.UINT64
+      type = "uint64"
   )
   public final Long default_uint64;
 
   @ProtoField(
       tag = 408,
-      type = Message.Datatype.SINT64
+      type = "sint64"
   )
   public final Long default_sint64;
 
   @ProtoField(
       tag = 409,
-      type = Message.Datatype.FIXED64
+      type = "fixed64"
   )
   public final Long default_fixed64;
 
   @ProtoField(
       tag = 410,
-      type = Message.Datatype.SFIXED64
+      type = "sfixed64"
   )
   public final Long default_sfixed64;
 
   @ProtoField(
       tag = 411,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean default_bool;
 
   @ProtoField(
       tag = 412,
-      type = Message.Datatype.FLOAT
+      type = "float"
   )
   public final Float default_float;
 
   @ProtoField(
       tag = 413,
-      type = Message.Datatype.DOUBLE
+      type = "double"
   )
   public final Double default_double;
 
   @ProtoField(
       tag = 414,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String default_string;
 
   @ProtoField(
       tag = 415,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString default_bytes;
 
   @ProtoField(
       tag = 416,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
   public final NestedEnum default_nested_enum;
 
@@ -1637,7 +1640,7 @@ public final class AllTypes extends Message<AllTypes> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32
+        type = "int32"
     )
     public final Integer a;
 

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/Ext_all_types.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/Ext_all_types.java
@@ -104,13 +104,13 @@ public final class Ext_all_types {
       .buildOptional();
 
   public static final Extension<AllTypes, AllTypes.NestedEnum> ext_opt_nested_enum = Extension
-      .enumExtending(AllTypes.NestedEnum.class, AllTypes.class)
+      .enumExtending("squareup.protos.alltypes.AllTypes.NestedEnum", AllTypes.NestedEnum.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_opt_nested_enum")
       .setTag(1016)
       .buildOptional();
 
   public static final Extension<AllTypes, AllTypes.NestedMessage> ext_opt_nested_message = Extension
-      .messageExtending(AllTypes.NestedMessage.class, AllTypes.class)
+      .messageExtending("squareup.protos.alltypes.AllTypes.NestedMessage", AllTypes.NestedMessage.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_opt_nested_message")
       .setTag(1017)
       .buildOptional();
@@ -206,13 +206,13 @@ public final class Ext_all_types {
       .buildRepeated();
 
   public static final Extension<AllTypes, List<AllTypes.NestedEnum>> ext_rep_nested_enum = Extension
-      .enumExtending(AllTypes.NestedEnum.class, AllTypes.class)
+      .enumExtending("squareup.protos.alltypes.AllTypes.NestedEnum", AllTypes.NestedEnum.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_rep_nested_enum")
       .setTag(1116)
       .buildRepeated();
 
   public static final Extension<AllTypes, List<AllTypes.NestedMessage>> ext_rep_nested_message = Extension
-      .messageExtending(AllTypes.NestedMessage.class, AllTypes.class)
+      .messageExtending("squareup.protos.alltypes.AllTypes.NestedMessage", AllTypes.NestedMessage.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_rep_nested_message")
       .setTag(1117)
       .buildRepeated();
@@ -296,7 +296,7 @@ public final class Ext_all_types {
       .buildPacked();
 
   public static final Extension<AllTypes, List<AllTypes.NestedEnum>> ext_pack_nested_enum = Extension
-      .enumExtending(AllTypes.NestedEnum.class, AllTypes.class)
+      .enumExtending("squareup.protos.alltypes.AllTypes.NestedEnum", AllTypes.NestedEnum.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_pack_nested_enum")
       .setTag(1216)
       .buildPacked();

--- a/wire-runtime/src/main/java/com/squareup/wire/Extension.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Extension.java
@@ -18,7 +18,6 @@ package com.squareup.wire;
 import java.util.List;
 import okio.ByteString;
 
-import static com.squareup.wire.Message.Datatype;
 import static com.squareup.wire.Message.Label;
 
 /**
@@ -59,24 +58,24 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
     private final Class<T> extendedType;
     private final Class<? extends Message> messageType;
     private final Class<? extends ProtoEnum> enumType;
-    private final Datatype datatype;
+    private final WireType type;
     private String name = null;
     private int tag = -1;
     private Label label = null;
 
-    private Builder(Class<T> extendedType, Datatype datatype) {
+    private Builder(Class<T> extendedType, WireType type) {
       this.extendedType = extendedType;
       this.messageType = null;
       this.enumType = null;
-      this.datatype = datatype;
+      this.type = type;
     }
 
     private Builder(Class<T> extendedType, Class<? extends Message> messageType,
-        Class<? extends ProtoEnum> enumType, Datatype datatype) {
+        Class<? extends ProtoEnum> enumType, WireType type) {
       this.extendedType = extendedType;
       this.messageType = messageType;
       this.enumType = enumType;
-      this.datatype = datatype;
+      this.type = type;
     }
 
     public Builder<T, E> setName(String name) {
@@ -92,21 +91,19 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
     public Extension<T, E> buildOptional() {
       this.label = Label.OPTIONAL;
       validate();
-      return new Extension<T, E>(extendedType, messageType, enumType, name, tag, label, datatype);
+      return new Extension<T, E>(extendedType, messageType, enumType, name, tag, label, type);
     }
 
     public Extension<T, List<E>> buildRepeated() {
       this.label = Label.REPEATED;
       validate();
-      return new Extension<T, List<E>>(extendedType, messageType, enumType, name, tag, label,
-          datatype);
+      return new Extension<T, List<E>>(extendedType, messageType, enumType, name, tag, label, type);
     }
 
     public Extension<T, List<E>> buildPacked() {
       this.label = Label.PACKED;
       validate();
-      return new Extension<T, List<E>>(extendedType, messageType, enumType, name, tag, label,
-          datatype);
+      return new Extension<T, List<E>>(extendedType, messageType, enumType, name, tag, label, type);
     }
 
     private void validate() {
@@ -116,8 +113,8 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
       if (name == null) {
         throw new IllegalArgumentException("name == null");
       }
-      if (datatype == null) {
-        throw new IllegalArgumentException("datatype == null");
+      if (type == null) {
+        throw new IllegalArgumentException("type == null");
       }
       if (label == null) {
         throw new IllegalArgumentException("label == null");
@@ -125,105 +122,95 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
       if (tag <= 0) {
         throw new IllegalArgumentException("tag == " + tag);
       }
-      if (datatype == Datatype.MESSAGE) {
-        if (messageType == null || enumType != null) {
-          throw new IllegalStateException("Message w/o messageType or w/ enumType");
-        }
-      } else if (datatype == Datatype.ENUM) {
-        if (messageType != null || enumType == null) {
-          throw new IllegalStateException("Enum w/ messageType or w/o enumType");
-        }
-      } else {
-        if (messageType != null || enumType != null) {
-          throw new IllegalStateException("Scalar w/ messageType or enumType");
-        }
+      if (!(type.isScalar() ^ messageType != null ^ enumType != null)) {
+        throw new IllegalStateException("type must be a scalar, enum, or message");
       }
     }
   }
 
   public static <T extends Message<T>> Builder<T, Integer> int32Extending(
       Class<T> extendedType) {
-    return new Builder<T, Integer>(extendedType, Datatype.INT32);
+    return new Builder<T, Integer>(extendedType, WireType.INT32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> sint32Extending(
       Class<T> extendedType) {
-    return new Builder<T, Integer>(extendedType, Datatype.SINT32);
+    return new Builder<T, Integer>(extendedType, WireType.SINT32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> uint32Extending(
       Class<T> extendedType) {
-    return new Builder<T, Integer>(extendedType, Datatype.UINT32);
+    return new Builder<T, Integer>(extendedType, WireType.UINT32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> fixed32Extending(
       Class<T> extendedType) {
-    return new Builder<T, Integer>(extendedType, Datatype.FIXED32);
+    return new Builder<T, Integer>(extendedType, WireType.FIXED32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> sfixed32Extending(
       Class<T> extendedType) {
-    return new Builder<T, Integer>(extendedType, Datatype.SFIXED32);
+    return new Builder<T, Integer>(extendedType, WireType.SFIXED32);
   }
 
   public static <T extends Message<T>> Builder<T, Long> int64Extending(
       Class<T> extendedType) {
-    return new Builder<T, Long>(extendedType, Datatype.INT64);
+    return new Builder<T, Long>(extendedType, WireType.INT64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> sint64Extending(
       Class<T> extendedType) {
-    return new Builder<T, Long>(extendedType, Datatype.SINT64);
+    return new Builder<T, Long>(extendedType, WireType.SINT64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> uint64Extending(
       Class<T> extendedType) {
-    return new Builder<T, Long>(extendedType, Datatype.UINT64);
+    return new Builder<T, Long>(extendedType, WireType.UINT64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> fixed64Extending(
       Class<T> extendedType) {
-    return new Builder<T, Long>(extendedType, Datatype.FIXED64);
+    return new Builder<T, Long>(extendedType, WireType.FIXED64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> sfixed64Extending(
       Class<T> extendedType) {
-    return new Builder<T, Long>(extendedType, Datatype.SFIXED64);
+    return new Builder<T, Long>(extendedType, WireType.SFIXED64);
   }
 
   public static <T extends Message<T>> Builder<T, Boolean> boolExtending(
       Class<T> extendedType) {
-    return new Builder<T, Boolean>(extendedType, Datatype.BOOL);
+    return new Builder<T, Boolean>(extendedType, WireType.BOOL);
   }
 
   public static <T extends Message<T>> Builder<T, String> stringExtending(
       Class<T> extendedType) {
-    return new Builder<T, String>(extendedType, Datatype.STRING);
+    return new Builder<T, String>(extendedType, WireType.STRING);
   }
 
   public static <T extends Message<T>> Builder<T, ByteString> bytesExtending(
       Class<T> extendedType) {
-    return new Builder<T, ByteString>(extendedType, Datatype.BYTES);
+    return new Builder<T, ByteString>(extendedType, WireType.BYTES);
   }
 
   public static <T extends Message<T>> Builder<T, Float> floatExtending(
       Class<T> extendedType) {
-    return new Builder<T, Float>(extendedType, Datatype.FLOAT);
+    return new Builder<T, Float>(extendedType, WireType.FLOAT);
   }
 
   public static <T extends Message<T>> Builder<T, Double> doubleExtending(
       Class<T> extendedType) {
-    return new Builder<T, Double>(extendedType, Datatype.DOUBLE);
+    return new Builder<T, Double>(extendedType, WireType.DOUBLE);
   }
 
   public static <T extends Message<T>, E extends Enum & ProtoEnum> Builder<T, E> //
-  enumExtending(Class<E> enumType, Class<T> extendedType) {
-    return new Builder<T, E>(extendedType, null, enumType, Datatype.ENUM);
+  enumExtending(String type, Class<E> enumType, Class<T> extendedType) {
+    return new Builder<T, E>(extendedType, null, enumType, WireType.get(type));
   }
 
   public static <T extends Message<T>, M extends Message> Builder<T, M> messageExtending(
-      Class<M> messageType, Class<T> extendedType) {
-    return new Builder<T, M>(extendedType, messageType, null, Datatype.MESSAGE);
+      String type, Class<M> messageType, Class<T> extendedType) {
+    return new Builder<T, M>(extendedType, messageType, null, WireType.get(type));
   }
 
   private final Class<T> extendedType;
@@ -231,15 +218,15 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
   private final Class<? extends ProtoEnum> enumType;
   private final String name;
   private final int tag;
-  private final Datatype datatype;
+  private final WireType type;
   private final Label label;
 
   private Extension(Class<T> extendedType, Class<? extends Message> messageType,
-      Class<? extends ProtoEnum> enumType, String name, int tag, Label label, Datatype datatype) {
+      Class<? extends ProtoEnum> enumType, String name, int tag, Label label, WireType type) {
     this.extendedType = extendedType;
     this.name = name;
     this.tag = tag;
-    this.datatype = datatype;
+    this.type = type;
     this.label = label;
     this.messageType = messageType;
     this.enumType = enumType;
@@ -269,7 +256,7 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
 
   @Override public int hashCode() {
     int hash = tag;
-    hash = hash * 37 + datatype.hashCode();
+    hash = hash * 37 + type.hashCode();
     hash = hash * 37 + label.hashCode();
     hash = hash * 37 + extendedType.hashCode();
     hash = hash * 37 + (messageType != null ? messageType.hashCode() : 0);
@@ -278,7 +265,7 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
   }
 
   @Override public String toString() {
-    return String.format("[%s %s %s = %d]", label, datatype, name, tag);
+    return String.format("[%s %s %s = %d]", label, type, name, tag);
   }
 
   public Class<T> getExtendedType() {
@@ -301,8 +288,8 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
     return tag;
   }
 
-  public Datatype getDatatype() {
-    return datatype;
+  public WireType getType() {
+    return type;
   }
 
   public Label getLabel() {

--- a/wire-runtime/src/main/java/com/squareup/wire/FieldBinding.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/FieldBinding.java
@@ -46,7 +46,7 @@ final class FieldBinding<M extends Message<M>, B extends Message.Builder<M, B>> 
   public final Message.Label label;
   public final String name;
   public final int tag;
-  public final Message.Datatype datatype;
+  public final WireType type;
   public final boolean redacted;
   public final WireAdapter<?> singleAdapter;
   public final WireAdapter<?> adapter;
@@ -60,7 +60,7 @@ final class FieldBinding<M extends Message<M>, B extends Message.Builder<M, B>> 
     this.label = protoField.label();
     this.name = messageField.getName();
     this.tag = protoField.tag();
-    this.datatype = protoField.type();
+    this.type = WireType.get(protoField.type());
     this.redacted = protoField.redacted();
     this.singleAdapter = singleAdapter;
     this.adapter = singleAdapter.withLabel(label);

--- a/wire-runtime/src/main/java/com/squareup/wire/FieldEncoding.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/FieldEncoding.java
@@ -42,16 +42,16 @@ public enum FieldEncoding {
     return value;
   }
 
-  Message.Datatype datatype() {
+  WireType datatype() {
     switch (this) {
       case VARINT:
-        return Message.Datatype.UINT64;
+        return WireType.UINT64;
       case FIXED32:
-        return Message.Datatype.FIXED32;
+        return WireType.FIXED32;
       case FIXED64:
-        return Message.Datatype.FIXED64;
+        return WireType.FIXED64;
       case LENGTH_DELIMITED:
-        return Message.Datatype.BYTES;
+        return WireType.BYTES;
       default:
         throw new AssertionError();
     }

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -32,12 +32,6 @@ public abstract class Message<T extends Message<T>> implements Serializable {
   // Hidden Wire instance that can perform work that does not require knowledge of extensions.
   static final Wire WIRE = new Wire();
 
-  /** A protocol buffer data type. */
-  public enum Datatype {
-    INT32, INT64, UINT32, UINT64, SINT32, SINT64, BOOL, ENUM, STRING, BYTES, MESSAGE,
-    FIXED32, SFIXED32, FIXED64, SFIXED64, FLOAT, DOUBLE
-  }
-
   /** A protocol buffer label. */
   public enum Label {
     REQUIRED, OPTIONAL, REPEATED, ONE_OF,

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoField.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoField.java
@@ -33,11 +33,11 @@ public @interface ProtoField {
   int tag();
 
   /**
-   * The field's protocol buffer datatype, e.g., {@code Datatype#INT32},
-   * {@code Datatype#MESSAGE}, or {@code Datatype#ENUM}. Defaults to
-   * {@code Datatype#MESSAGE}.
+   * The field's protocol buffer data type. This is either a scalar (like {@code int32} or {@code
+   * string}), a message type (like {@code squareup.protos.Person}), or an enum type (like {@code
+   * squareup.protos.CurrencyCode}).
    */
-  Message.Datatype type() default Message.Datatype.MESSAGE;
+  String type();
 
   /**
    * The field's protocol buffer label, one of {@link Label#OPTIONAL},

--- a/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
@@ -170,7 +170,7 @@ final class TagMap {
     int runEnd = runStart + 1;
     while (runEnd < size
         && extensions[runEnd].getTag() == extension.getTag()
-        && extensions[runEnd].getDatatype() == extension.getDatatype()) {
+        && extensions[runEnd].getType().equals(extension.getType())) {
       runEnd++;
     }
     return runEnd;
@@ -201,7 +201,7 @@ final class TagMap {
   private void transcode(List<Object> list, Extension<?, ?> sourceExtension,
       Object value, Extension<?, ?> targetExtension) {
     // If the adapter we're expecting has already been applied, we're done.
-    if (sourceExtension.getDatatype() == targetExtension.getDatatype()) {
+    if (sourceExtension.getType().equals(targetExtension.getType())) {
       list.add(value);
       return;
     }
@@ -262,7 +262,7 @@ final class TagMap {
 
   @SuppressWarnings("unchecked") // Caller beware! Assumes the extension and value match at runtime.
   private WireAdapter<Object> adapter(Extension<?, ?> extension) {
-    return (WireAdapter<Object>) WireAdapter.get(Message.WIRE, extension.getDatatype(),
+    return (WireAdapter<Object>) WireAdapter.get(Message.WIRE, extension.getType(),
         extension.getMessageType(), extension.getEnumType());
   }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -23,7 +23,7 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String name;
 
@@ -32,42 +32,48 @@ public final class DescriptorProto extends Message<DescriptorProto> {
    */
   @ProtoField(
       tag = 8,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String doc;
 
   @ProtoField(
       tag = 2,
+      type = "google.protobuf.FieldDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> field;
 
   @ProtoField(
       tag = 6,
+      type = "google.protobuf.FieldDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 
   @ProtoField(
       tag = 3,
+      type = "google.protobuf.DescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<DescriptorProto> nested_type;
 
   @ProtoField(
       tag = 4,
+      type = "google.protobuf.EnumDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
   @ProtoField(
       tag = 5,
+      type = "google.protobuf.DescriptorProto.ExtensionRange",
       label = Message.Label.REPEATED
   )
   public final List<ExtensionRange> extension_range;
 
   @ProtoField(
-      tag = 7
+      tag = 7,
+      type = "google.protobuf.MessageOptions"
   )
   public final MessageOptions options;
 
@@ -210,13 +216,13 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32
+        type = "int32"
     )
     public final Integer start;
 
     @ProtoField(
         tag = 2,
-        type = Message.Datatype.INT32
+        type = "int32"
     )
     public final Integer end;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -22,7 +22,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String name;
 
@@ -31,18 +31,20 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
    */
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String doc;
 
   @ProtoField(
       tag = 2,
+      type = "google.protobuf.EnumValueDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<EnumValueDescriptorProto> value;
 
   @ProtoField(
-      tag = 3
+      tag = 3,
+      type = "google.protobuf.EnumOptions"
   )
   public final EnumOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -17,6 +17,7 @@ public final class EnumOptions extends Message<EnumOptions> {
    */
   @ProtoField(
       tag = 999,
+      type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -23,7 +23,7 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String name;
 
@@ -32,18 +32,19 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
    */
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String doc;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer number;
 
   @ProtoField(
-      tag = 3
+      tag = 3,
+      type = "google.protobuf.EnumValueOptions"
   )
   public final EnumValueOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -17,6 +17,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
    */
   @ProtoField(
       tag = 999,
+      type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
@@ -34,7 +34,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String name;
 
@@ -43,19 +43,19 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @ProtoField(
       tag = 9,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String doc;
 
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer number;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.ENUM
+      type = "google.protobuf.FieldDescriptorProto.Label"
   )
   public final Label label;
 
@@ -65,7 +65,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.ENUM
+      type = "google.protobuf.FieldDescriptorProto.Type"
   )
   public final Type type;
 
@@ -78,7 +78,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String type_name;
 
@@ -88,7 +88,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String extendee;
 
@@ -101,12 +101,13 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @ProtoField(
       tag = 7,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String default_value;
 
   @ProtoField(
-      tag = 8
+      tag = 8,
+      type = "google.protobuf.FieldOptions"
   )
   public final FieldOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -31,7 +31,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.ENUM
+      type = "google.protobuf.FieldOptions.CType"
   )
   public final CType ctype;
 
@@ -43,7 +43,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean packed;
 
@@ -55,7 +55,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean deprecated;
 
@@ -75,7 +75,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @ProtoField(
       tag = 9,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String experimental_map_key;
 
@@ -84,6 +84,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @ProtoField(
       tag = 999,
+      type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -25,7 +25,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String name;
 
@@ -34,7 +34,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String _package;
 
@@ -43,7 +43,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REPEATED
   )
   public final List<String> dependency;
@@ -53,30 +53,35 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @ProtoField(
       tag = 4,
+      type = "google.protobuf.DescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<DescriptorProto> message_type;
 
   @ProtoField(
       tag = 5,
+      type = "google.protobuf.EnumDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
   @ProtoField(
       tag = 6,
+      type = "google.protobuf.ServiceDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<ServiceDescriptorProto> service;
 
   @ProtoField(
       tag = 7,
+      type = "google.protobuf.FieldDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 
   @ProtoField(
-      tag = 8
+      tag = 8,
+      type = "google.protobuf.FileOptions"
   )
   public final FileOptions options;
 
@@ -87,7 +92,8 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    * development tools.
    */
   @ProtoField(
-      tag = 9
+      tag = 9,
+      type = "google.protobuf.SourceCodeInfo"
   )
   public final SourceCodeInfo source_code_info;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -18,6 +18,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
 
   @ProtoField(
       tag = 1,
+      type = "google.protobuf.FileDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<FileDescriptorProto> file;

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -66,7 +66,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String java_package;
 
@@ -79,7 +79,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @ProtoField(
       tag = 8,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String java_outer_classname;
 
@@ -93,7 +93,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @ProtoField(
       tag = 10,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean java_multiple_files;
 
@@ -105,13 +105,13 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @ProtoField(
       tag = 20,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean java_generate_equals_and_hash;
 
   @ProtoField(
       tag = 9,
-      type = Message.Datatype.ENUM
+      type = "google.protobuf.FileOptions.OptimizeMode"
   )
   public final OptimizeMode optimize_for;
 
@@ -129,19 +129,19 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @ProtoField(
       tag = 16,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean cc_generic_services;
 
   @ProtoField(
       tag = 17,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean java_generic_services;
 
   @ProtoField(
       tag = 18,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean py_generic_services;
 
@@ -150,6 +150,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @ProtoField(
       tag = 999,
+      type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -39,7 +39,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    */
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean message_set_wire_format;
 
@@ -50,7 +50,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    */
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean no_standard_descriptor_accessor;
 
@@ -59,6 +59,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    */
   @ProtoField(
       tag = 999,
+      type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
@@ -24,7 +24,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String name;
 
@@ -33,7 +33,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
    */
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String doc;
 
@@ -43,18 +43,19 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
    */
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String input_type;
 
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String output_type;
 
   @ProtoField(
-      tag = 4
+      tag = 4,
+      type = "google.protobuf.MethodOptions"
   )
   public final MethodOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -21,6 +21,7 @@ public final class MethodOptions extends Message<MethodOptions> {
    */
   @ProtoField(
       tag = 999,
+      type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -22,12 +22,13 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String name;
 
   @ProtoField(
       tag = 2,
+      type = "google.protobuf.MethodDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<MethodDescriptorProto> method;
@@ -37,12 +38,13 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
    */
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String doc;
 
   @ProtoField(
-      tag = 3
+      tag = 3,
+      type = "google.protobuf.ServiceOptions"
   )
   public final ServiceOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -21,6 +21,7 @@ public final class ServiceOptions extends Message<ServiceOptions> {
    */
   @ProtoField(
       tag = 999,
+      type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -66,6 +66,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
    */
   @ProtoField(
       tag = 1,
+      type = "google.protobuf.SourceCodeInfo.Location",
       label = Message.Label.REPEATED
   )
   public final List<Location> location;
@@ -190,7 +191,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
      */
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32,
+        type = "int32",
         label = Message.Label.PACKED
     )
     public final List<Integer> path;
@@ -204,7 +205,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
      */
     @ProtoField(
         tag = 2,
-        type = Message.Datatype.INT32,
+        type = "int32",
         label = Message.Label.PACKED
     )
     public final List<Integer> span;

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -39,6 +39,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
   @ProtoField(
       tag = 2,
+      type = "google.protobuf.UninterpretedOption.NamePart",
       label = Message.Label.REPEATED
   )
   public final List<NamePart> name;
@@ -49,37 +50,37 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
    */
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String identifier_value;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.UINT64
+      type = "uint64"
   )
   public final Long positive_int_value;
 
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.INT64
+      type = "int64"
   )
   public final Long negative_int_value;
 
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.DOUBLE
+      type = "double"
   )
   public final Double double_value;
 
   @ProtoField(
       tag = 7,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString string_value;
 
   @ProtoField(
       tag = 8,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String aggregate_value;
 
@@ -219,14 +220,14 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.STRING,
+        type = "string",
         label = Message.Label.REQUIRED
     )
     public final String name_part;
 
     @ProtoField(
         tag = 2,
-        type = Message.Datatype.BOOL,
+        type = "bool",
         label = Message.Label.REQUIRED
     )
     public final Boolean is_extension;

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -83,7 +83,7 @@ public final class Bar extends Message<Bar> {
 
       @ProtoField(
           tag = 1,
-          type = Message.Datatype.STRING
+          type = "string"
       )
       public final String boo;
 

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -12,7 +12,8 @@ public final class Foo extends Message<Foo> {
   private static final long serialVersionUID = 0L;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.differentpackage.bar.Bar.Baz.Moo"
   )
   public final Bar.Baz.Moo moo;
 

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
@@ -83,7 +83,7 @@ public final class Bar extends Message<Bar> {
 
       @ProtoField(
           tag = 1,
-          type = Message.Datatype.STRING
+          type = "string"
       )
       public final String boo;
 

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
@@ -12,7 +12,8 @@ public final class Foo extends Message<Foo> {
   private static final long serialVersionUID = 0L;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.foobar.Bar.Baz.Moo"
   )
   public final Bar.Baz.Moo moo;
 

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
@@ -15,7 +15,7 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
@@ -15,7 +15,7 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
@@ -15,7 +15,7 @@ public final class LetsDataRequest extends Message<LetsDataRequest> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
@@ -15,7 +15,7 @@ public final class LetsDataResponse extends Message<LetsDataResponse> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -15,7 +15,7 @@ public final class SendDataRequest extends Message<SendDataRequest> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -15,7 +15,7 @@ public final class SendDataResponse extends Message<SendDataResponse> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/TagMapTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/TagMapTest.java
@@ -38,7 +38,7 @@ public final class TagMapTest {
       .setTag(2)
       .buildOptional();
   final Extension<FileOptions, Type> extensionC
-      = Extension.enumExtending(Type.class, FileOptions.class)
+      = Extension.enumExtending("google.protobuf.FileOptions", Type.class, FileOptions.class)
       .setName("c")
       .setTag(3)
       .buildOptional();

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -225,15 +225,17 @@ public class WireTest {
   @Test
   public void extensionToString() {
     assertThat(Ext_simple_message.fooext.toString()).isEqualTo(
-        "[REPEATED INT32 squareup.protos.simple.fooext = 125]");
+        "[REPEATED int32 squareup.protos.simple.fooext = 125]");
     assertThat(Ext_simple_message.barext.toString()).isEqualTo(
-        "[OPTIONAL INT32 squareup.protos.simple.barext = 126]");
+        "[OPTIONAL int32 squareup.protos.simple.barext = 126]");
     assertThat(Ext_simple_message.bazext.toString()).isEqualTo(
-        "[OPTIONAL INT32 squareup.protos.simple.bazext = 127]");
+        "[OPTIONAL int32 squareup.protos.simple.bazext = 127]");
     assertThat(Ext_simple_message.nested_message_ext.toString()).isEqualTo(
-        "[OPTIONAL MESSAGE squareup.protos.simple.nested_message_ext = 128]");
+        "[OPTIONAL squareup.protos.simple.SimpleMessage.NestedMessage "
+            + "squareup.protos.simple.nested_message_ext = 128]");
     assertThat(Ext_simple_message.nested_enum_ext.toString()).isEqualTo(
-        "[OPTIONAL ENUM squareup.protos.simple.nested_enum_ext = 129]");
+        "[OPTIONAL squareup.protos.simple.SimpleMessage.NestedEnum"
+            + " squareup.protos.simple.nested_enum_ext = 129]");
   }
 
   @Test

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
@@ -15,7 +15,7 @@ public final class ChildPackage extends Message<ChildPackage> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.foreign.ForeignEnum"
   )
   public final ForeignEnum inner_foreign_enum;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -15,14 +15,14 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
 
   @ProtoField(
       tag = 201,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @ProtoField(
       tag = 301,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_int32;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -119,532 +119,535 @@ public final class AllTypes extends Message<AllTypes> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer opt_int32;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.UINT32
+      type = "uint32"
   )
   public final Integer opt_uint32;
 
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.SINT32
+      type = "sint32"
   )
   public final Integer opt_sint32;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.FIXED32
+      type = "fixed32"
   )
   public final Integer opt_fixed32;
 
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.SFIXED32
+      type = "sfixed32"
   )
   public final Integer opt_sfixed32;
 
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.INT64
+      type = "int64"
   )
   public final Long opt_int64;
 
   @ProtoField(
       tag = 7,
-      type = Message.Datatype.UINT64
+      type = "uint64"
   )
   public final Long opt_uint64;
 
   @ProtoField(
       tag = 8,
-      type = Message.Datatype.SINT64
+      type = "sint64"
   )
   public final Long opt_sint64;
 
   @ProtoField(
       tag = 9,
-      type = Message.Datatype.FIXED64
+      type = "fixed64"
   )
   public final Long opt_fixed64;
 
   @ProtoField(
       tag = 10,
-      type = Message.Datatype.SFIXED64
+      type = "sfixed64"
   )
   public final Long opt_sfixed64;
 
   @ProtoField(
       tag = 11,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean opt_bool;
 
   @ProtoField(
       tag = 12,
-      type = Message.Datatype.FLOAT
+      type = "float"
   )
   public final Float opt_float;
 
   @ProtoField(
       tag = 13,
-      type = Message.Datatype.DOUBLE
+      type = "double"
   )
   public final Double opt_double;
 
   @ProtoField(
       tag = 14,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String opt_string;
 
   @ProtoField(
       tag = 15,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString opt_bytes;
 
   @ProtoField(
       tag = 16,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
   public final NestedEnum opt_nested_enum;
 
   @ProtoField(
-      tag = 17
+      tag = 17,
+      type = "squareup.protos.alltypes.AllTypes.NestedMessage"
   )
   public final NestedMessage opt_nested_message;
 
   @ProtoField(
       tag = 101,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_int32;
 
   @ProtoField(
       tag = 102,
-      type = Message.Datatype.UINT32,
+      type = "uint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_uint32;
 
   @ProtoField(
       tag = 103,
-      type = Message.Datatype.SINT32,
+      type = "sint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sint32;
 
   @ProtoField(
       tag = 104,
-      type = Message.Datatype.FIXED32,
+      type = "fixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
   @ProtoField(
       tag = 105,
-      type = Message.Datatype.SFIXED32,
+      type = "sfixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
   @ProtoField(
       tag = 106,
-      type = Message.Datatype.INT64,
+      type = "int64",
       label = Message.Label.REQUIRED
   )
   public final Long req_int64;
 
   @ProtoField(
       tag = 107,
-      type = Message.Datatype.UINT64,
+      type = "uint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_uint64;
 
   @ProtoField(
       tag = 108,
-      type = Message.Datatype.SINT64,
+      type = "sint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sint64;
 
   @ProtoField(
       tag = 109,
-      type = Message.Datatype.FIXED64,
+      type = "fixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_fixed64;
 
   @ProtoField(
       tag = 110,
-      type = Message.Datatype.SFIXED64,
+      type = "sfixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
   @ProtoField(
       tag = 111,
-      type = Message.Datatype.BOOL,
+      type = "bool",
       label = Message.Label.REQUIRED
   )
   public final Boolean req_bool;
 
   @ProtoField(
       tag = 112,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.REQUIRED
   )
   public final Float req_float;
 
   @ProtoField(
       tag = 113,
-      type = Message.Datatype.DOUBLE,
+      type = "double",
       label = Message.Label.REQUIRED
   )
   public final Double req_double;
 
   @ProtoField(
       tag = 114,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REQUIRED
   )
   public final String req_string;
 
   @ProtoField(
       tag = 115,
-      type = Message.Datatype.BYTES,
+      type = "bytes",
       label = Message.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
   @ProtoField(
       tag = 116,
-      type = Message.Datatype.ENUM,
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
   @ProtoField(
       tag = 117,
+      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
   @ProtoField(
       tag = 201,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @ProtoField(
       tag = 202,
-      type = Message.Datatype.UINT32,
+      type = "uint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
   @ProtoField(
       tag = 203,
-      type = Message.Datatype.SINT32,
+      type = "sint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
   @ProtoField(
       tag = 204,
-      type = Message.Datatype.FIXED32,
+      type = "fixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
   @ProtoField(
       tag = 205,
-      type = Message.Datatype.SFIXED32,
+      type = "sfixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
   @ProtoField(
       tag = 206,
-      type = Message.Datatype.INT64,
+      type = "int64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
   @ProtoField(
       tag = 207,
-      type = Message.Datatype.UINT64,
+      type = "uint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
   @ProtoField(
       tag = 208,
-      type = Message.Datatype.SINT64,
+      type = "sint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
   @ProtoField(
       tag = 209,
-      type = Message.Datatype.FIXED64,
+      type = "fixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
   @ProtoField(
       tag = 210,
-      type = Message.Datatype.SFIXED64,
+      type = "sfixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
   @ProtoField(
       tag = 211,
-      type = Message.Datatype.BOOL,
+      type = "bool",
       label = Message.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
   @ProtoField(
       tag = 212,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> rep_float;
 
   @ProtoField(
       tag = 213,
-      type = Message.Datatype.DOUBLE,
+      type = "double",
       label = Message.Label.REPEATED
   )
   public final List<Double> rep_double;
 
   @ProtoField(
       tag = 214,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REPEATED
   )
   public final List<String> rep_string;
 
   @ProtoField(
       tag = 215,
-      type = Message.Datatype.BYTES,
+      type = "bytes",
       label = Message.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
   @ProtoField(
       tag = 216,
-      type = Message.Datatype.ENUM,
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @ProtoField(
       tag = 217,
+      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
   @ProtoField(
       tag = 301,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
   @ProtoField(
       tag = 302,
-      type = Message.Datatype.UINT32,
+      type = "uint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
   @ProtoField(
       tag = 303,
-      type = Message.Datatype.SINT32,
+      type = "sint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
   @ProtoField(
       tag = 304,
-      type = Message.Datatype.FIXED32,
+      type = "fixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
   @ProtoField(
       tag = 305,
-      type = Message.Datatype.SFIXED32,
+      type = "sfixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
   @ProtoField(
       tag = 306,
-      type = Message.Datatype.INT64,
+      type = "int64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_int64;
 
   @ProtoField(
       tag = 307,
-      type = Message.Datatype.UINT64,
+      type = "uint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
   @ProtoField(
       tag = 308,
-      type = Message.Datatype.SINT64,
+      type = "sint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
   @ProtoField(
       tag = 309,
-      type = Message.Datatype.FIXED64,
+      type = "fixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
   @ProtoField(
       tag = 310,
-      type = Message.Datatype.SFIXED64,
+      type = "sfixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
   @ProtoField(
       tag = 311,
-      type = Message.Datatype.BOOL,
+      type = "bool",
       label = Message.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
   @ProtoField(
       tag = 312,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.PACKED
   )
   public final List<Float> pack_float;
 
   @ProtoField(
       tag = 313,
-      type = Message.Datatype.DOUBLE,
+      type = "double",
       label = Message.Label.PACKED
   )
   public final List<Double> pack_double;
 
   @ProtoField(
       tag = 316,
-      type = Message.Datatype.ENUM,
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @ProtoField(
       tag = 401,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer default_int32;
 
   @ProtoField(
       tag = 402,
-      type = Message.Datatype.UINT32
+      type = "uint32"
   )
   public final Integer default_uint32;
 
   @ProtoField(
       tag = 403,
-      type = Message.Datatype.SINT32
+      type = "sint32"
   )
   public final Integer default_sint32;
 
   @ProtoField(
       tag = 404,
-      type = Message.Datatype.FIXED32
+      type = "fixed32"
   )
   public final Integer default_fixed32;
 
   @ProtoField(
       tag = 405,
-      type = Message.Datatype.SFIXED32
+      type = "sfixed32"
   )
   public final Integer default_sfixed32;
 
   @ProtoField(
       tag = 406,
-      type = Message.Datatype.INT64
+      type = "int64"
   )
   public final Long default_int64;
 
   @ProtoField(
       tag = 407,
-      type = Message.Datatype.UINT64
+      type = "uint64"
   )
   public final Long default_uint64;
 
   @ProtoField(
       tag = 408,
-      type = Message.Datatype.SINT64
+      type = "sint64"
   )
   public final Long default_sint64;
 
   @ProtoField(
       tag = 409,
-      type = Message.Datatype.FIXED64
+      type = "fixed64"
   )
   public final Long default_fixed64;
 
   @ProtoField(
       tag = 410,
-      type = Message.Datatype.SFIXED64
+      type = "sfixed64"
   )
   public final Long default_sfixed64;
 
   @ProtoField(
       tag = 411,
-      type = Message.Datatype.BOOL
+      type = "bool"
   )
   public final Boolean default_bool;
 
   @ProtoField(
       tag = 412,
-      type = Message.Datatype.FLOAT
+      type = "float"
   )
   public final Float default_float;
 
   @ProtoField(
       tag = 413,
-      type = Message.Datatype.DOUBLE
+      type = "double"
   )
   public final Double default_double;
 
   @ProtoField(
       tag = 414,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String default_string;
 
   @ProtoField(
       tag = 415,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString default_bytes;
 
   @ProtoField(
       tag = 416,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
   public final NestedEnum default_nested_enum;
 
@@ -1637,7 +1640,7 @@ public final class AllTypes extends Message<AllTypes> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32
+        type = "int32"
     )
     public final Integer a;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/Ext_all_types.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/Ext_all_types.java
@@ -104,13 +104,13 @@ public final class Ext_all_types {
       .buildOptional();
 
   public static final Extension<AllTypes, AllTypes.NestedEnum> ext_opt_nested_enum = Extension
-      .enumExtending(AllTypes.NestedEnum.class, AllTypes.class)
+      .enumExtending("squareup.protos.alltypes.AllTypes.NestedEnum", AllTypes.NestedEnum.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_opt_nested_enum")
       .setTag(1016)
       .buildOptional();
 
   public static final Extension<AllTypes, AllTypes.NestedMessage> ext_opt_nested_message = Extension
-      .messageExtending(AllTypes.NestedMessage.class, AllTypes.class)
+      .messageExtending("squareup.protos.alltypes.AllTypes.NestedMessage", AllTypes.NestedMessage.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_opt_nested_message")
       .setTag(1017)
       .buildOptional();
@@ -206,13 +206,13 @@ public final class Ext_all_types {
       .buildRepeated();
 
   public static final Extension<AllTypes, List<AllTypes.NestedEnum>> ext_rep_nested_enum = Extension
-      .enumExtending(AllTypes.NestedEnum.class, AllTypes.class)
+      .enumExtending("squareup.protos.alltypes.AllTypes.NestedEnum", AllTypes.NestedEnum.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_rep_nested_enum")
       .setTag(1116)
       .buildRepeated();
 
   public static final Extension<AllTypes, List<AllTypes.NestedMessage>> ext_rep_nested_message = Extension
-      .messageExtending(AllTypes.NestedMessage.class, AllTypes.class)
+      .messageExtending("squareup.protos.alltypes.AllTypes.NestedMessage", AllTypes.NestedMessage.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_rep_nested_message")
       .setTag(1117)
       .buildRepeated();
@@ -296,7 +296,7 @@ public final class Ext_all_types {
       .buildPacked();
 
   public static final Extension<AllTypes, List<AllTypes.NestedEnum>> ext_pack_nested_enum = Extension
-      .enumExtending(AllTypes.NestedEnum.class, AllTypes.class)
+      .enumExtending("squareup.protos.alltypes.AllTypes.NestedEnum", AllTypes.NestedEnum.class, AllTypes.class)
       .setName("squareup.protos.alltypes.ext_pack_nested_enum")
       .setTag(1216)
       .buildPacked();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/Ext_custom_options.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/Ext_custom_options.java
@@ -14,7 +14,7 @@ import java.util.List;
 
 public final class Ext_custom_options {
   public static final Extension<MessageOptions, FooBar> my_message_option_one = Extension
-      .messageExtending(FooBar.class, MessageOptions.class)
+      .messageExtending("squareup.protos.custom_options.FooBar", FooBar.class, MessageOptions.class)
       .setName("squareup.protos.custom_options.my_message_option_one")
       .setTag(50001)
       .buildOptional();
@@ -26,25 +26,25 @@ public final class Ext_custom_options {
       .buildOptional();
 
   public static final Extension<MessageOptions, FooBar> my_message_option_three = Extension
-      .messageExtending(FooBar.class, MessageOptions.class)
+      .messageExtending("squareup.protos.custom_options.FooBar", FooBar.class, MessageOptions.class)
       .setName("squareup.protos.custom_options.my_message_option_three")
       .setTag(50003)
       .buildOptional();
 
   public static final Extension<MessageOptions, FooBar.FooBarBazEnum> my_message_option_four = Extension
-      .enumExtending(FooBar.FooBarBazEnum.class, MessageOptions.class)
+      .enumExtending("squareup.protos.custom_options.FooBar.FooBarBazEnum", FooBar.FooBarBazEnum.class, MessageOptions.class)
       .setName("squareup.protos.custom_options.my_message_option_four")
       .setTag(50004)
       .buildOptional();
 
   public static final Extension<MessageOptions, FooBar> my_message_option_five = Extension
-      .messageExtending(FooBar.class, MessageOptions.class)
+      .messageExtending("squareup.protos.custom_options.FooBar", FooBar.class, MessageOptions.class)
       .setName("squareup.protos.custom_options.my_message_option_five")
       .setTag(50005)
       .buildOptional();
 
   public static final Extension<MessageOptions, FooBar> my_message_option_six = Extension
-      .messageExtending(FooBar.class, MessageOptions.class)
+      .messageExtending("squareup.protos.custom_options.FooBar", FooBar.class, MessageOptions.class)
       .setName("squareup.protos.custom_options.my_message_option_six")
       .setTag(50006)
       .buildOptional();
@@ -62,13 +62,13 @@ public final class Ext_custom_options {
       .buildOptional();
 
   public static final Extension<FieldOptions, FooBar.FooBarBazEnum> my_field_option_three = Extension
-      .enumExtending(FooBar.FooBarBazEnum.class, FieldOptions.class)
+      .enumExtending("squareup.protos.custom_options.FooBar.FooBarBazEnum", FooBar.FooBarBazEnum.class, FieldOptions.class)
       .setName("squareup.protos.custom_options.my_field_option_three")
       .setTag(60003)
       .buildOptional();
 
   public static final Extension<FieldOptions, FooBar> my_field_option_four = Extension
-      .messageExtending(FooBar.class, FieldOptions.class)
+      .messageExtending("squareup.protos.custom_options.FooBar", FooBar.class, FieldOptions.class)
       .setName("squareup.protos.custom_options.my_field_option_four")
       .setTag(60004)
       .buildOptional();
@@ -80,7 +80,7 @@ public final class Ext_custom_options {
       .buildOptional();
 
   public static final Extension<EnumValueOptions, FooBar.More> complex_enum_value_option = Extension
-      .messageExtending(FooBar.More.class, EnumValueOptions.class)
+      .messageExtending("squareup.protos.custom_options.FooBar.More", FooBar.More.class, EnumValueOptions.class)
       .setName("squareup.protos.custom_options.complex_enum_value_option")
       .setTag(70001)
       .buildOptional();
@@ -92,13 +92,13 @@ public final class Ext_custom_options {
       .buildOptional();
 
   public static final Extension<FooBar, FooBar.FooBarBazEnum> ext = Extension
-      .enumExtending(FooBar.FooBarBazEnum.class, FooBar.class)
+      .enumExtending("squareup.protos.custom_options.FooBar.FooBarBazEnum", FooBar.FooBarBazEnum.class, FooBar.class)
       .setName("squareup.protos.custom_options.ext")
       .setTag(101)
       .buildOptional();
 
   public static final Extension<FooBar, List<FooBar.FooBarBazEnum>> rep = Extension
-      .enumExtending(FooBar.FooBarBazEnum.class, FooBar.class)
+      .enumExtending("squareup.protos.custom_options.FooBar.FooBarBazEnum", FooBar.FooBarBazEnum.class, FooBar.class)
       .setName("squareup.protos.custom_options.rep")
       .setTag(102)
       .buildRepeated();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/Ext_custom_options.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/Ext_custom_options.java.noOptions
@@ -17,7 +17,7 @@ public final class Ext_custom_options {
       .buildOptional();
 
   public static final Extension<EnumValueOptions, FooBar.More> complex_enum_value_option = Extension
-      .messageExtending(FooBar.More.class, EnumValueOptions.class)
+      .messageExtending("squareup.protos.custom_options.FooBar.More", FooBar.More.class, EnumValueOptions.class)
       .setName("squareup.protos.custom_options.complex_enum_value_option")
       .setTag(70001)
       .buildOptional();
@@ -29,13 +29,13 @@ public final class Ext_custom_options {
       .buildOptional();
 
   public static final Extension<FooBar, FooBar.FooBarBazEnum> ext = Extension
-      .enumExtending(FooBar.FooBarBazEnum.class, FooBar.class)
+      .enumExtending("squareup.protos.custom_options.FooBar.FooBarBazEnum", FooBar.FooBarBazEnum.class, FooBar.class)
       .setName("squareup.protos.custom_options.ext")
       .setTag(101)
       .buildOptional();
 
   public static final Extension<FooBar, List<FooBar.FooBarBazEnum>> rep = Extension
-      .enumExtending(FooBar.FooBarBazEnum.class, FooBar.class)
+      .enumExtending("squareup.protos.custom_options.FooBar.FooBarBazEnum", FooBar.FooBarBazEnum.class, FooBar.class)
       .setName("squareup.protos.custom_options.rep")
       .setTag(102)
       .buildRepeated();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -78,42 +78,44 @@ public final class FooBar extends Message<FooBar> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer foo;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String bar;
 
   @ProtoField(
-      tag = 3
+      tag = 3,
+      type = "squareup.protos.custom_options.FooBar.Nested"
   )
   public final Nested baz;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.UINT64
+      type = "uint64"
   )
   public final Long qux;
 
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> fred;
 
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.DOUBLE
+      type = "double"
   )
   public final Double daisy;
 
   @ProtoField(
       tag = 7,
+      type = "squareup.protos.custom_options.FooBar",
       label = Message.Label.REPEATED
   )
   public final List<FooBar> nested;
@@ -243,7 +245,7 @@ public final class FooBar extends Message<FooBar> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.ENUM
+        type = "squareup.protos.custom_options.FooBar.FooBarBazEnum"
     )
     public final FooBarBazEnum value;
 
@@ -298,7 +300,7 @@ public final class FooBar extends Message<FooBar> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32,
+        type = "int32",
         label = Message.Label.REPEATED
     )
     public final List<Integer> serial;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -28,42 +28,44 @@ public final class FooBar extends Message<FooBar> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer foo;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String bar;
 
   @ProtoField(
-      tag = 3
+      tag = 3,
+      type = "squareup.protos.custom_options.FooBar.Nested"
   )
   public final Nested baz;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.UINT64
+      type = "uint64"
   )
   public final Long qux;
 
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.FLOAT,
+      type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> fred;
 
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.DOUBLE
+      type = "double"
   )
   public final Double daisy;
 
   @ProtoField(
       tag = 7,
+      type = "squareup.protos.custom_options.FooBar",
       label = Message.Label.REPEATED
   )
   public final List<FooBar> nested;
@@ -193,7 +195,7 @@ public final class FooBar extends Message<FooBar> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.ENUM
+        type = "squareup.protos.custom_options.FooBar.FooBarBazEnum"
     )
     public final FooBarBazEnum value;
 
@@ -248,7 +250,7 @@ public final class FooBar extends Message<FooBar> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32,
+        type = "int32",
         label = Message.Label.REPEATED
     )
     public final List<Integer> serial;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -15,7 +15,7 @@ public final class OneBytesField extends Message<OneBytesField> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.BYTES
+      type = "bytes"
   )
   public final ByteString opt_bytes;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
@@ -15,7 +15,7 @@ public final class OneField extends Message<OneField> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer opt_int32;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -15,12 +15,13 @@ public final class Recursive extends Message<Recursive> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer value;
 
   @ProtoField(
-      tag = 2
+      tag = 2,
+      type = "squareup.protos.edgecases.Recursive"
   )
   public final Recursive recursive;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/Ext_foreign.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/Ext_foreign.java
@@ -9,7 +9,7 @@ import java.lang.Boolean;
 
 public final class Ext_foreign {
   public static final Extension<MessageOptions, ForeignMessage> foreign_message_option = Extension
-      .messageExtending(ForeignMessage.class, MessageOptions.class)
+      .messageExtending("squareup.protos.foreign.ForeignMessage", ForeignMessage.class, MessageOptions.class)
       .setName("squareup.protos.foreign.foreign_message_option")
       .setTag(50007)
       .buildOptional();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -15,7 +15,7 @@ public final class ForeignMessage extends Message<ForeignMessage> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Ext_one_extension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Ext_one_extension.java
@@ -6,7 +6,7 @@ import com.squareup.wire.Extension;
 
 public final class Ext_one_extension {
   public static final Extension<OneExtension, Foo> foo = Extension
-      .messageExtending(Foo.class, OneExtension.class)
+      .messageExtending("squareup.protos.one_extension.Foo", Foo.class, OneExtension.class)
       .setName("squareup.protos.one_extension.foo")
       .setTag(1000)
       .buildOptional();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
@@ -15,7 +15,7 @@ public final class Foo extends Message<Foo> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String bar;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -15,7 +15,7 @@ public final class OneExtension extends Message<OneExtension> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String id;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -21,7 +21,7 @@ public final class OneOfMessage extends Message<OneOfMessage> {
    */
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer foo;
 
@@ -30,7 +30,7 @@ public final class OneOfMessage extends Message<OneOfMessage> {
    */
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String bar;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -26,7 +26,7 @@ public final class Person extends Message<Person> {
    */
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REQUIRED
   )
   public final String name;
@@ -36,7 +36,7 @@ public final class Person extends Message<Person> {
    */
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.REQUIRED
   )
   public final Integer id;
@@ -46,7 +46,7 @@ public final class Person extends Message<Person> {
    */
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String email;
 
@@ -55,6 +55,7 @@ public final class Person extends Message<Person> {
    */
   @ProtoField(
       tag = 4,
+      type = "squareup.protos.person.Person.PhoneNumber",
       label = Message.Label.REPEATED
   )
   public final List<PhoneNumber> phone;
@@ -193,7 +194,7 @@ public final class Person extends Message<Person> {
      */
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.STRING,
+        type = "string",
         label = Message.Label.REQUIRED
     )
     public final String number;
@@ -203,7 +204,7 @@ public final class Person extends Message<Person> {
      */
     @ProtoField(
         tag = 2,
-        type = Message.Datatype.ENUM
+        type = "squareup.protos.person.Person.PhoneType"
     )
     public final PhoneType type;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Ext_redacted_test.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Ext_redacted_test.java
@@ -14,7 +14,7 @@ public final class Ext_redacted_test {
       .buildOptional();
 
   public static final Extension<Redacted, RedactedExtension> extension = Extension
-      .messageExtending(RedactedExtension.class, Redacted.class)
+      .messageExtending("squareup.protos.redacted_test.RedactedExtension", RedactedExtension.class, Redacted.class)
       .setName("squareup.protos.redacted_test.extension")
       .setTag(10)
       .buildOptional();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -17,13 +17,13 @@ public final class NotRedacted extends Message<NotRedacted> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String a;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String b;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
@@ -28,20 +28,20 @@ public final class Redacted extends Message<Redacted> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING,
+      type = "string",
       redacted = true
   )
   public final String a;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String b;
 
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String c;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -15,17 +15,19 @@ public final class RedactedChild extends Message<RedactedChild> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String a;
 
   @ProtoField(
-      tag = 2
+      tag = 2,
+      type = "squareup.protos.redacted_test.Redacted"
   )
   public final Redacted b;
 
   @ProtoField(
-      tag = 3
+      tag = 3,
+      type = "squareup.protos.redacted_test.NotRedacted"
   )
   public final NotRedacted c;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -11,7 +11,8 @@ public final class RedactedCycleA extends Message<RedactedCycleA> {
   private static final long serialVersionUID = 0L;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.protos.redacted_test.RedactedCycleB"
   )
   public final RedactedCycleB b;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -11,7 +11,8 @@ public final class RedactedCycleB extends Message<RedactedCycleB> {
   private static final long serialVersionUID = 0L;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.protos.redacted_test.RedactedCycleA"
   )
   public final RedactedCycleA a;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -22,14 +22,14 @@ public final class RedactedExtension extends Message<RedactedExtension> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING,
+      type = "string",
       redacted = true
   )
   public final String d;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String e;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -20,7 +20,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REPEATED,
       redacted = true
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -20,7 +20,7 @@ public final class RedactedRequired extends Message<RedactedRequired> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REQUIRED,
       redacted = true
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
@@ -26,12 +26,14 @@ public final class A extends Message<A> {
   private static final long serialVersionUID = 0L;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.protos.roots.B"
   )
   public final B c;
 
   @ProtoField(
-      tag = 2
+      tag = 2,
+      type = "squareup.protos.roots.D"
   )
   public final D d;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
@@ -12,6 +12,7 @@ public final class B extends Message<B> {
 
   @ProtoField(
       tag = 1,
+      type = "squareup.protos.roots.C",
       label = Message.Label.REQUIRED
   )
   public final C c;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
@@ -15,7 +15,7 @@ public final class C extends Message<C> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
@@ -15,7 +15,7 @@ public final class D extends Message<D> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
@@ -14,13 +14,14 @@ public final class E extends Message<E> {
   public static final G DEFAULT_G = G.FOO;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.protos.roots.E.F"
   )
   public final F f;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.roots.G"
   )
   public final G g;
 
@@ -92,7 +93,7 @@ public final class E extends Message<E> {
 
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32
+        type = "int32"
     )
     public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/Ext_roots.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/Ext_roots.java
@@ -6,7 +6,7 @@ import com.squareup.wire.Extension;
 
 public final class Ext_roots {
   public static final Extension<I, J> j = Extension
-      .messageExtending(J.class, I.class)
+      .messageExtending("squareup.protos.roots.J", J.class, I.class)
       .setName("squareup.protos.roots.j")
       .setTag(1000)
       .buildOptional();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
@@ -11,7 +11,8 @@ public final class H extends Message<H> {
   private static final long serialVersionUID = 0L;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.protos.roots.E.F"
   )
   public final E.F ef;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
@@ -15,7 +15,7 @@ public final class I extends Message<I> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
@@ -11,7 +11,8 @@ public final class J extends Message<J> {
   private static final long serialVersionUID = 0L;
 
   @ProtoField(
-      tag = 1
+      tag = 1,
+      type = "squareup.protos.roots.K"
   )
   public final K k;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
@@ -15,7 +15,7 @@ public final class K extends Message<K> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/Ext_simple_message.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/Ext_simple_message.java
@@ -27,13 +27,13 @@ public final class Ext_simple_message {
       .buildOptional();
 
   public static final Extension<ExternalMessage, SimpleMessage.NestedMessage> nested_message_ext = Extension
-      .messageExtending(SimpleMessage.NestedMessage.class, ExternalMessage.class)
+      .messageExtending("squareup.protos.simple.SimpleMessage.NestedMessage", SimpleMessage.NestedMessage.class, ExternalMessage.class)
       .setName("squareup.protos.simple.nested_message_ext")
       .setTag(128)
       .buildOptional();
 
   public static final Extension<ExternalMessage, SimpleMessage.NestedEnum> nested_enum_ext = Extension
-      .enumExtending(SimpleMessage.NestedEnum.class, ExternalMessage.class)
+      .enumExtending("squareup.protos.simple.SimpleMessage.NestedEnum", SimpleMessage.NestedEnum.class, ExternalMessage.class)
       .setName("squareup.protos.simple.nested_enum_ext")
       .setTag(129)
       .buildOptional();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -15,7 +15,7 @@ public final class ExternalMessage extends Message<ExternalMessage> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.FLOAT
+      type = "float"
   )
   public final Float f;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -44,7 +44,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer optional_int32;
 
@@ -53,6 +53,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 2,
+      type = "squareup.protos.simple.SimpleMessage.NestedMessage",
       deprecated = true
   )
   @Deprecated
@@ -62,13 +63,14 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    * An optional ExternalMessage
    */
   @ProtoField(
-      tag = 3
+      tag = 3,
+      type = "squareup.protos.simple.ExternalMessage"
   )
   public final ExternalMessage optional_external_msg;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.simple.SimpleMessage.NestedEnum"
   )
   public final NestedEnum default_nested_enum;
 
@@ -77,7 +79,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.INT32,
+      type = "int32",
       label = Message.Label.REQUIRED
   )
   public final Integer required_int32;
@@ -87,7 +89,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.DOUBLE,
+      type = "double",
       label = Message.Label.REPEATED,
       deprecated = true
   )
@@ -99,7 +101,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 7,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.foreign.ForeignEnum"
   )
   public final ForeignEnum default_foreign_enum;
 
@@ -108,7 +110,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 8,
-      type = Message.Datatype.ENUM
+      type = "squareup.protos.foreign.ForeignEnum"
   )
   public final ForeignEnum no_default_foreign_enum;
 
@@ -117,7 +119,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 9,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String _package;
 
@@ -126,7 +128,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 10,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String result;
 
@@ -135,7 +137,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 11,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String other;
 
@@ -144,7 +146,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @ProtoField(
       tag = 12,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String o;
 
@@ -367,7 +369,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
      */
     @ProtoField(
         tag = 1,
-        type = Message.Datatype.INT32
+        type = "int32"
     )
     public final Integer bb;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
@@ -15,7 +15,7 @@ public final class Bar extends Message<Bar> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer baz;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -14,6 +14,7 @@ public final class Bars extends Message<Bars> {
 
   @ProtoField(
       tag = 1,
+      type = "single_level.Bar",
       label = Message.Label.REPEATED
   )
   public final List<Bar> bars;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
@@ -15,7 +15,7 @@ public final class Foo extends Message<Foo> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer bar;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -14,6 +14,7 @@ public final class Foos extends Message<Foos> {
 
   @ProtoField(
       tag = 1,
+      type = "single_level.Foo",
       label = Message.Label.REPEATED
   )
   public final List<Foo> foos;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -15,7 +15,7 @@ public final class VersionOne extends Message<VersionOne> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -27,37 +27,37 @@ public final class VersionTwo extends Message<VersionTwo> {
 
   @ProtoField(
       tag = 1,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer i;
 
   @ProtoField(
       tag = 2,
-      type = Message.Datatype.INT32
+      type = "int32"
   )
   public final Integer v2_i;
 
   @ProtoField(
       tag = 3,
-      type = Message.Datatype.STRING
+      type = "string"
   )
   public final String v2_s;
 
   @ProtoField(
       tag = 4,
-      type = Message.Datatype.FIXED32
+      type = "fixed32"
   )
   public final Integer v2_f32;
 
   @ProtoField(
       tag = 5,
-      type = Message.Datatype.FIXED64
+      type = "fixed64"
   )
   public final Long v2_f64;
 
   @ProtoField(
       tag = 6,
-      type = Message.Datatype.STRING,
+      type = "string",
       label = Message.Label.REPEATED
   )
   public final List<String> v2_rs;


### PR DESCRIPTION
The nice upside of this change is that we now include the protobuf type name
like squareup.protos.person.Person in the annotation where it is known.

The other nice impact of this is we don't have the weird pseudotypes ENUM
and MESSAGE that don't correspond to anything on the wire.

The drawback is that the generated @ProtoField enum now uses a string instead
of an enum constant for known scalars.