### PR TITLE
Rename everything.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ For example, to compile the file `protos-repo/google/protobuf/descriptor.proto`,
     package com.google.protobuf;
 
     import com.squareup.wire.Message;
-    import com.squareup.wire.ProtoField;
+    import com.squareup.wire.WireField;
     import java.util.Collections;
     import java.util.List;
 
@@ -115,7 +115,7 @@ to construct an instance manually:
 Note that field names are not converted to camel case.
 
 Wire messages contain a `public final` field for each field of the protocol buffer message.
-Each field is annotated with a `@ProtoField` annotation containing the field metadata required
+Each field is annotated with a `@WireField` annotation containing the field metadata required
 by the Wire runtime.
 
 Numeric and boolean values are stored using boxed primitive types (e.g., Integer or Long).

--- a/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
+++ b/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
@@ -101,22 +101,22 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
 
           out.name(Integer.toString(extension.getTag()));
           out.beginArray();
-          if (extension.getType() == WireType.UINT64) {
+          if (extension.getType() == ProtoType.UINT64) {
             out.value("varint");
             for (Object o : values) {
               out.value((Long) o);
             }
-          } else if (extension.getType() == WireType.FIXED32) {
+          } else if (extension.getType() == ProtoType.FIXED32) {
             out.value("fixed32");
             for (Object o : values) {
               out.value((Integer) o);
             }
-          } else if (extension.getType() == WireType.FIXED64) {
+          } else if (extension.getType() == ProtoType.FIXED64) {
             out.value("fixed64");
             for (Object o : values) {
               out.value((Long) o);
             }
-          } else if (extension.getType() == WireType.BYTES) {
+          } else if (extension.getType() == ProtoType.BYTES) {
             out.value("length-delimited");
             for (Object o : values) {
               out.value(((ByteString) o).base64());
@@ -137,9 +137,9 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
   }
 
   @SuppressWarnings("unchecked")
-  private void emitJson(JsonWriter out, Object value, WireType type, Label label)
+  private void emitJson(JsonWriter out, Object value, ProtoType type, Label label)
       throws IOException {
-    if (type == WireType.UINT64) {
+    if (type == ProtoType.UINT64) {
       if (label.isRepeated()) {
         List<Long> longs = (List<Long>) value;
         out.beginArray();

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -3,8 +3,8 @@
 package com.squareup.wire.protos.alltypes;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -117,535 +117,535 @@ public final class AllTypes extends Message<AllTypes> {
 
   public static final NestedEnum DEFAULT_DEFAULT_NESTED_ENUM = NestedEnum.A;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
   public final Integer opt_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "uint32"
   )
   public final Integer opt_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "sint32"
   )
   public final Integer opt_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "fixed32"
   )
   public final Integer opt_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "sfixed32"
   )
   public final Integer opt_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "int64"
   )
   public final Long opt_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "uint64"
   )
   public final Long opt_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "sint64"
   )
   public final Long opt_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 9,
       type = "fixed64"
   )
   public final Long opt_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 10,
       type = "sfixed64"
   )
   public final Long opt_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 11,
       type = "bool"
   )
   public final Boolean opt_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 12,
       type = "float"
   )
   public final Float opt_float;
 
-  @ProtoField(
+  @WireField(
       tag = 13,
       type = "double"
   )
   public final Double opt_double;
 
-  @ProtoField(
+  @WireField(
       tag = 14,
       type = "string"
   )
   public final String opt_string;
 
-  @ProtoField(
+  @WireField(
       tag = 15,
       type = "bytes"
   )
   public final ByteString opt_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 16,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
   public final NestedEnum opt_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 17,
       type = "squareup.protos.alltypes.AllTypes.NestedMessage"
   )
   public final NestedMessage opt_nested_message;
 
-  @ProtoField(
+  @WireField(
       tag = 101,
       type = "int32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 102,
       type = "uint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 103,
       type = "sint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 104,
       type = "fixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 105,
       type = "sfixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 106,
       type = "int64",
       label = Message.Label.REQUIRED
   )
   public final Long req_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 107,
       type = "uint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 108,
       type = "sint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 109,
       type = "fixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 110,
       type = "sfixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 111,
       type = "bool",
       label = Message.Label.REQUIRED
   )
   public final Boolean req_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 112,
       type = "float",
       label = Message.Label.REQUIRED
   )
   public final Float req_float;
 
-  @ProtoField(
+  @WireField(
       tag = 113,
       type = "double",
       label = Message.Label.REQUIRED
   )
   public final Double req_double;
 
-  @ProtoField(
+  @WireField(
       tag = 114,
       type = "string",
       label = Message.Label.REQUIRED
   )
   public final String req_string;
 
-  @ProtoField(
+  @WireField(
       tag = 115,
       type = "bytes",
       label = Message.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 116,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 117,
       type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
-  @ProtoField(
+  @WireField(
       tag = 201,
       type = "int32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 202,
       type = "uint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 203,
       type = "sint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 204,
       type = "fixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 205,
       type = "sfixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 206,
       type = "int64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 207,
       type = "uint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 208,
       type = "sint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 209,
       type = "fixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 210,
       type = "sfixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 211,
       type = "bool",
       label = Message.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 212,
       type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> rep_float;
 
-  @ProtoField(
+  @WireField(
       tag = 213,
       type = "double",
       label = Message.Label.REPEATED
   )
   public final List<Double> rep_double;
 
-  @ProtoField(
+  @WireField(
       tag = 214,
       type = "string",
       label = Message.Label.REPEATED
   )
   public final List<String> rep_string;
 
-  @ProtoField(
+  @WireField(
       tag = 215,
       type = "bytes",
       label = Message.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 216,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 217,
       type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
-  @ProtoField(
+  @WireField(
       tag = 301,
       type = "int32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 302,
       type = "uint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 303,
       type = "sint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 304,
       type = "fixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 305,
       type = "sfixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 306,
       type = "int64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 307,
       type = "uint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 308,
       type = "sint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 309,
       type = "fixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 310,
       type = "sfixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 311,
       type = "bool",
       label = Message.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 312,
       type = "float",
       label = Message.Label.PACKED
   )
   public final List<Float> pack_float;
 
-  @ProtoField(
+  @WireField(
       tag = 313,
       type = "double",
       label = Message.Label.PACKED
   )
   public final List<Double> pack_double;
 
-  @ProtoField(
+  @WireField(
       tag = 316,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 401,
       type = "int32"
   )
   public final Integer default_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 402,
       type = "uint32"
   )
   public final Integer default_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 403,
       type = "sint32"
   )
   public final Integer default_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 404,
       type = "fixed32"
   )
   public final Integer default_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 405,
       type = "sfixed32"
   )
   public final Integer default_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 406,
       type = "int64"
   )
   public final Long default_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 407,
       type = "uint64"
   )
   public final Long default_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 408,
       type = "sint64"
   )
   public final Long default_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 409,
       type = "fixed64"
   )
   public final Long default_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 410,
       type = "sfixed64"
   )
   public final Long default_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 411,
       type = "bool"
   )
   public final Boolean default_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 412,
       type = "float"
   )
   public final Float default_float;
 
-  @ProtoField(
+  @WireField(
       tag = 413,
       type = "double"
   )
   public final Double default_double;
 
-  @ProtoField(
+  @WireField(
       tag = 414,
       type = "string"
   )
   public final String default_string;
 
-  @ProtoField(
+  @WireField(
       tag = 415,
       type = "bytes"
   )
   public final ByteString default_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 416,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
@@ -1618,7 +1618,7 @@ public final class AllTypes extends Message<AllTypes> {
     }
   }
 
-  public enum NestedEnum implements ProtoEnum {
+  public enum NestedEnum implements WireEnum {
     A(1);
 
     private final int value;
@@ -1638,7 +1638,7 @@ public final class AllTypes extends Message<AllTypes> {
 
     public static final Integer DEFAULT_A = 0;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32"
     )

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -21,7 +21,7 @@ import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeName;
 import com.squareup.wire.Extension;
 import com.squareup.wire.Message;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.EnumConstant;
 import com.squareup.wire.schema.EnumType;
 import com.squareup.wire.schema.Extend;
@@ -55,34 +55,34 @@ public final class JavaGenerator {
   public static final TypeName FIELD_OPTIONS = ClassName.get("com.google.protobuf", "FieldOptions");
   public static final TypeName ENUM_OPTIONS = ClassName.get("com.google.protobuf", "EnumOptions");
 
-  private static final Map<WireType, TypeName> SCALAR_TYPES_MAP =
-      ImmutableMap.<WireType, TypeName>builder()
-          .put(WireType.BOOL, TypeName.BOOLEAN.box())
-          .put(WireType.BYTES, ClassName.get(ByteString.class))
-          .put(WireType.DOUBLE, TypeName.DOUBLE.box())
-          .put(WireType.FLOAT, TypeName.FLOAT.box())
-          .put(WireType.FIXED32, TypeName.INT.box())
-          .put(WireType.FIXED64, TypeName.LONG.box())
-          .put(WireType.INT32, TypeName.INT.box())
-          .put(WireType.INT64, TypeName.LONG.box())
-          .put(WireType.SFIXED32, TypeName.INT.box())
-          .put(WireType.SFIXED64, TypeName.LONG.box())
-          .put(WireType.SINT32, TypeName.INT.box())
-          .put(WireType.SINT64, TypeName.LONG.box())
-          .put(WireType.STRING, ClassName.get(String.class))
-          .put(WireType.UINT32, TypeName.INT.box())
-          .put(WireType.UINT64, TypeName.LONG.box())
+  private static final Map<ProtoType, TypeName> SCALAR_TYPES_MAP =
+      ImmutableMap.<ProtoType, TypeName>builder()
+          .put(ProtoType.BOOL, TypeName.BOOLEAN.box())
+          .put(ProtoType.BYTES, ClassName.get(ByteString.class))
+          .put(ProtoType.DOUBLE, TypeName.DOUBLE.box())
+          .put(ProtoType.FLOAT, TypeName.FLOAT.box())
+          .put(ProtoType.FIXED32, TypeName.INT.box())
+          .put(ProtoType.FIXED64, TypeName.LONG.box())
+          .put(ProtoType.INT32, TypeName.INT.box())
+          .put(ProtoType.INT64, TypeName.LONG.box())
+          .put(ProtoType.SFIXED32, TypeName.INT.box())
+          .put(ProtoType.SFIXED64, TypeName.LONG.box())
+          .put(ProtoType.SINT32, TypeName.INT.box())
+          .put(ProtoType.SINT64, TypeName.LONG.box())
+          .put(ProtoType.STRING, ClassName.get(String.class))
+          .put(ProtoType.UINT32, TypeName.INT.box())
+          .put(ProtoType.UINT64, TypeName.LONG.box())
           .build();
 
   private static final String URL_CHARS = "[-!#$%&'()*+,./0-9:;=?@A-Z\\[\\]_a-z~]";
 
   private final Schema schema;
-  private final ImmutableMap<WireType, TypeName> nameToJavaName;
+  private final ImmutableMap<ProtoType, TypeName> nameToJavaName;
   private final ImmutableMap<Field, ProtoFile> extensionFieldToFile;
 
   private JavaGenerator(
       Schema schema,
-      ImmutableMap<WireType, TypeName> nameToJavaName,
+      ImmutableMap<ProtoType, TypeName> nameToJavaName,
       ImmutableMap<Field, ProtoFile> extensionFieldToFile) {
     this.schema = schema;
     this.nameToJavaName = nameToJavaName;
@@ -90,7 +90,7 @@ public final class JavaGenerator {
   }
 
   public static JavaGenerator get(Schema schema) {
-    ImmutableMap.Builder<WireType, TypeName> nameToJavaName = ImmutableMap.builder();
+    ImmutableMap.Builder<ProtoType, TypeName> nameToJavaName = ImmutableMap.builder();
     ImmutableMap.Builder<Field, ProtoFile> extensionFieldToFile = ImmutableMap.builder();
     nameToJavaName.putAll(SCALAR_TYPES_MAP);
 
@@ -112,7 +112,7 @@ public final class JavaGenerator {
     return new JavaGenerator(schema, nameToJavaName.build(), extensionFieldToFile.build());
   }
 
-  private static void putAll(ImmutableMap.Builder<WireType, TypeName> wireToJava,
+  private static void putAll(ImmutableMap.Builder<ProtoType, TypeName> wireToJava,
       String javaPackage, ClassName enclosingClassName, List<Type> types) {
     for (Type type : types) {
       ClassName className = enclosingClassName != null
@@ -136,9 +136,9 @@ public final class JavaGenerator {
     return protoFile != null ? extensionsClass(protoFile) : null;
   }
 
-  public TypeName typeName(WireType wireType) {
-    TypeName candidate = nameToJavaName.get(wireType);
-    checkArgument(candidate != null, "unexpected type %s", wireType);
+  public TypeName typeName(ProtoType protoType) {
+    TypeName candidate = nameToJavaName.get(protoType);
+    checkArgument(candidate != null, "unexpected type %s", protoType);
     return candidate;
   }
 
@@ -153,12 +153,11 @@ public final class JavaGenerator {
     }
   }
 
-  public boolean isEnum(WireType type) {
-    Type wireType = schema.getType(type);
-    return wireType instanceof EnumType;
+  public boolean isEnum(ProtoType type) {
+    return schema.getType(type) instanceof EnumType;
   }
 
-  public EnumConstant enumDefault(WireType type) {
+  public EnumConstant enumDefault(ProtoType type) {
     EnumType wireEnum = (EnumType) schema.getType(type);
     return wireEnum.constants().get(0);
   }

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/TypeWriter.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/TypeWriter.java
@@ -29,9 +29,9 @@ import com.squareup.javapoet.TypeName;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.javapoet.WildcardTypeName;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
-import com.squareup.wire.WireType;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.EnumConstant;
 import com.squareup.wire.schema.EnumType;
 import com.squareup.wire.schema.Extend;
@@ -92,7 +92,7 @@ public final class TypeWriter {
 
     TypeSpec.Builder builder = TypeSpec.enumBuilder(typeName.simpleName())
         .addModifiers(PUBLIC)
-        .addSuperinterface(ProtoEnum.class);
+        .addSuperinterface(WireEnum.class);
 
     if (!type.documentation().isEmpty()) {
       builder.addJavadoc("$L\n", JavaGenerator.sanitizeJavadoc(type.documentation()));
@@ -214,7 +214,7 @@ public final class TypeWriter {
 
       String name = sanitize(field.name());
       FieldSpec.Builder fieldBuilder = FieldSpec.builder(fieldType, name, PUBLIC, FINAL);
-      fieldBuilder.addAnnotation(protoFieldAnnotation(field, javaGenerator.typeName(field.type())));
+      fieldBuilder.addAnnotation(wireFieldAnnotation(field, javaGenerator.typeName(field.type())));
       if (!field.documentation().isEmpty()) {
         fieldBuilder.addJavadoc("$L\n", JavaGenerator.sanitizeJavadoc(field.documentation()));
       }
@@ -289,13 +289,13 @@ public final class TypeWriter {
 
   // Example:
   //
-  // @ProtoField(
+  // @WireField(
   //   tag = 1,
   //   type = INT32
   // )
   //
-  private AnnotationSpec protoFieldAnnotation(Field field, TypeName messageType) {
-    AnnotationSpec.Builder result = AnnotationSpec.builder(ProtoField.class);
+  private AnnotationSpec wireFieldAnnotation(Field field, TypeName messageType) {
+    AnnotationSpec.Builder result = AnnotationSpec.builder(WireField.class);
 
     int tag = field.tag();
     result.addMember("tag", String.valueOf(tag));
@@ -648,7 +648,7 @@ public final class TypeWriter {
     throw new IllegalStateException("Field " + field + " cannot have default value");
   }
 
-  private CodeBlock fieldInitializer(WireType type, Object value) {
+  private CodeBlock fieldInitializer(ProtoType type, Object value) {
     TypeName javaType = javaGenerator.typeName(type);
 
     if (value instanceof List) {
@@ -749,7 +749,7 @@ public final class TypeWriter {
         .build());
 
     for (Extend extend : protoFile.extendList()) {
-      WireType extendType = extend.type();
+      ProtoType extendType = extend.type();
       TypeName javaType = javaGenerator.typeName(extendType);
 
       if (!emitOptions && (extendType.equals(Options.FIELD_OPTIONS)

--- a/wire-runtime/src/main/java/com/squareup/wire/Extension.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Extension.java
@@ -57,13 +57,13 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
   public static final class Builder<T extends Message<T>, E> {
     private final Class<T> extendedType;
     private final Class<? extends Message> messageType;
-    private final Class<? extends ProtoEnum> enumType;
-    private final WireType type;
+    private final Class<? extends WireEnum> enumType;
+    private final ProtoType type;
     private String name = null;
     private int tag = -1;
     private Label label = null;
 
-    private Builder(Class<T> extendedType, WireType type) {
+    private Builder(Class<T> extendedType, ProtoType type) {
       this.extendedType = extendedType;
       this.messageType = null;
       this.enumType = null;
@@ -71,7 +71,7 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
     }
 
     private Builder(Class<T> extendedType, Class<? extends Message> messageType,
-        Class<? extends ProtoEnum> enumType, WireType type) {
+        Class<? extends WireEnum> enumType, ProtoType type) {
       this.extendedType = extendedType;
       this.messageType = messageType;
       this.enumType = enumType;
@@ -130,99 +130,99 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
 
   public static <T extends Message<T>> Builder<T, Integer> int32Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.INT32);
+    return new Builder<>(extendedType, ProtoType.INT32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> sint32Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.SINT32);
+    return new Builder<>(extendedType, ProtoType.SINT32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> uint32Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.UINT32);
+    return new Builder<>(extendedType, ProtoType.UINT32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> fixed32Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.FIXED32);
+    return new Builder<>(extendedType, ProtoType.FIXED32);
   }
 
   public static <T extends Message<T>> Builder<T, Integer> sfixed32Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.SFIXED32);
+    return new Builder<>(extendedType, ProtoType.SFIXED32);
   }
 
   public static <T extends Message<T>> Builder<T, Long> int64Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.INT64);
+    return new Builder<>(extendedType, ProtoType.INT64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> sint64Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.SINT64);
+    return new Builder<>(extendedType, ProtoType.SINT64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> uint64Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.UINT64);
+    return new Builder<>(extendedType, ProtoType.UINT64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> fixed64Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.FIXED64);
+    return new Builder<>(extendedType, ProtoType.FIXED64);
   }
 
   public static <T extends Message<T>> Builder<T, Long> sfixed64Extending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.SFIXED64);
+    return new Builder<>(extendedType, ProtoType.SFIXED64);
   }
 
   public static <T extends Message<T>> Builder<T, Boolean> boolExtending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.BOOL);
+    return new Builder<>(extendedType, ProtoType.BOOL);
   }
 
   public static <T extends Message<T>> Builder<T, String> stringExtending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.STRING);
+    return new Builder<>(extendedType, ProtoType.STRING);
   }
 
   public static <T extends Message<T>> Builder<T, ByteString> bytesExtending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.BYTES);
+    return new Builder<>(extendedType, ProtoType.BYTES);
   }
 
   public static <T extends Message<T>> Builder<T, Float> floatExtending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.FLOAT);
+    return new Builder<>(extendedType, ProtoType.FLOAT);
   }
 
   public static <T extends Message<T>> Builder<T, Double> doubleExtending(
       Class<T> extendedType) {
-    return new Builder<>(extendedType, WireType.DOUBLE);
+    return new Builder<>(extendedType, ProtoType.DOUBLE);
   }
 
-  public static <T extends Message<T>, E extends Enum & ProtoEnum> Builder<T, E> //
+  public static <T extends Message<T>, E extends Enum & WireEnum> Builder<T, E> //
   enumExtending(String type, Class<E> enumType, Class<T> extendedType) {
-    return new Builder<>(extendedType, null, enumType, WireType.get(type));
+    return new Builder<>(extendedType, null, enumType, ProtoType.get(type));
   }
 
   public static <T extends Message<T>, M extends Message> Builder<T, M> messageExtending(
       String type, Class<M> messageType, Class<T> extendedType) {
-    return new Builder<>(extendedType, messageType, null, WireType.get(type));
+    return new Builder<>(extendedType, messageType, null, ProtoType.get(type));
   }
 
   private final Class<T> extendedType;
   private final Class<? extends Message> messageType;
-  private final Class<? extends ProtoEnum> enumType;
+  private final Class<? extends WireEnum> enumType;
   private final String name;
   private final int tag;
-  private final WireType type;
+  private final ProtoType type;
   private final Label label;
 
   private Extension(Class<T> extendedType, Class<? extends Message> messageType,
-      Class<? extends ProtoEnum> enumType, String name, int tag, Label label, WireType type) {
+      Class<? extends WireEnum> enumType, String name, int tag, Label label, ProtoType type) {
     this.extendedType = extendedType;
     this.name = name;
     this.tag = tag;
@@ -276,7 +276,7 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
     return messageType;
   }
 
-  public Class<? extends ProtoEnum> getEnumType() {
+  public Class<? extends WireEnum> getEnumType() {
     return enumType;
   }
 
@@ -288,7 +288,7 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
     return tag;
   }
 
-  public WireType getType() {
+  public ProtoType getType() {
     return type;
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/FieldBinding.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/FieldBinding.java
@@ -46,22 +46,22 @@ final class FieldBinding<M extends Message<M>, B extends Message.Builder<M, B>> 
   public final Message.Label label;
   public final String name;
   public final int tag;
-  public final WireType type;
+  public final ProtoType type;
   public final boolean redacted;
-  public final WireAdapter<?> singleAdapter;
-  public final WireAdapter<?> adapter;
+  public final ProtoAdapter<?> singleAdapter;
+  public final ProtoAdapter<?> adapter;
 
   private final Field messageField;
   private final Field builderField;
   private final Method builderMethod;
 
-  FieldBinding(ProtoField protoField, WireAdapter<?> singleAdapter,
+  FieldBinding(WireField wireField, ProtoAdapter<?> singleAdapter,
       Field messageField, Class<B> builderType) {
-    this.label = protoField.label();
+    this.label = wireField.label();
     this.name = messageField.getName();
-    this.tag = protoField.tag();
-    this.type = WireType.get(protoField.type());
-    this.redacted = protoField.redacted();
+    this.tag = wireField.tag();
+    this.type = ProtoType.get(wireField.type());
+    this.redacted = wireField.redacted();
     this.singleAdapter = singleAdapter;
     this.adapter = singleAdapter.withLabel(label);
     this.messageField = messageField;

--- a/wire-runtime/src/main/java/com/squareup/wire/FieldEncoding.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/FieldEncoding.java
@@ -42,16 +42,16 @@ public enum FieldEncoding {
     return value;
   }
 
-  WireType datatype() {
+  ProtoType datatype() {
     switch (this) {
       case VARINT:
-        return WireType.UINT64;
+        return ProtoType.UINT64;
       case FIXED32:
-        return WireType.FIXED32;
+        return ProtoType.FIXED32;
       case FIXED64:
-        return WireType.FIXED64;
+        return ProtoType.FIXED64;
       case LENGTH_DELIMITED:
-        return WireType.BYTES;
+        return ProtoType.BYTES;
       default:
         throw new AssertionError();
     }
@@ -61,16 +61,16 @@ public enum FieldEncoding {
    * Returns a Wire adapter that reads this field encoding without interpretation. For example,
    * messages are returned as byte strings and enums are returned as integers.
    */
-  public WireAdapter<?> rawWireAdapter() {
+  public ProtoAdapter<?> rawProtoAdapter() {
     switch (this) {
       case VARINT:
-        return WireAdapter.UINT64;
+        return ProtoAdapter.UINT64;
       case FIXED32:
-        return WireAdapter.FIXED32;
+        return ProtoAdapter.FIXED32;
       case FIXED64:
-        return WireAdapter.FIXED64;
+        return ProtoAdapter.FIXED64;
       case LENGTH_DELIMITED:
-        return WireAdapter.BYTES;
+        return ProtoAdapter.BYTES;
       default:
         throw new AssertionError();
     }

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -105,7 +105,7 @@ public abstract class Message<T extends Message<T>> implements Serializable {
    *
    * @param <E> the enum class type
    */
-  public static <E extends Enum & ProtoEnum> E enumFromInt(Class<E> enumClass, int value) {
+  public static <E extends Enum & WireEnum> E enumFromInt(Class<E> enumClass, int value) {
     RuntimeEnumAdapter<E> adapter = WIRE.enumAdapter(enumClass);
     return adapter.fromInt(value);
   }

--- a/wire-runtime/src/main/java/com/squareup/wire/MessageSerializedForm.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MessageSerializedForm.java
@@ -33,7 +33,7 @@ final class MessageSerializedForm implements Serializable {
   }
 
   Object readResolve() throws ObjectStreamException {
-    WireAdapter<? extends Message> adapter = Message.WIRE.adapter(messageClass);
+    ProtoAdapter<? extends Message> adapter = Message.WIRE.adapter(messageClass);
     try {
       // Extensions will be decoded as unknown values.
       return adapter.decode(bytes);

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
@@ -40,7 +40,7 @@ import static com.squareup.wire.ProtoWriter.varint64Size;
 import static java.lang.Double.doubleToLongBits;
 import static java.lang.Float.floatToIntBits;
 
-public abstract class WireAdapter<E> {
+public abstract class ProtoAdapter<E> {
   static final int FIXED_BOOL_SIZE = 1;
   static final int FIXED_32_SIZE = 4;
   static final int FIXED_64_SIZE = 8;
@@ -48,14 +48,14 @@ public abstract class WireAdapter<E> {
   final FieldEncoding fieldEncoding;
   final Class<?> javaType;
 
-  public WireAdapter(FieldEncoding fieldEncoding, Class<?> javaType) {
+  public ProtoAdapter(FieldEncoding fieldEncoding, Class<?> javaType) {
     this.fieldEncoding = fieldEncoding;
     this.javaType = javaType;
   }
 
-  static WireAdapter<?> get(Wire wire, WireType type,
-      Class<? extends Message> messageType, Class<? extends ProtoEnum> enumType) {
-    WireAdapter<?> result = TYPE_TO_ADAPTER.get(type);
+  static ProtoAdapter<?> get(Wire wire, ProtoType type,
+      Class<? extends Message> messageType, Class<? extends WireEnum> enumType) {
+    ProtoAdapter<?> result = TYPE_TO_ADAPTER.get(type);
     if (result != null) return result;
     if (messageType != null) return wire.adapter(messageType);
     if (enumType != null) return wire.enumAdapter(enumType);
@@ -66,7 +66,7 @@ public abstract class WireAdapter<E> {
    * Returns an adapter for the same type but with knowledge of the extensions in
    * {@code extensionRegistry} when parsing. This only affects adapters for message types.
    */
-  public WireAdapter<E> withExtensions(ExtensionRegistry extensionRegistry) {
+  public ProtoAdapter<E> withExtensions(ExtensionRegistry extensionRegistry) {
     return this;
   }
 
@@ -159,7 +159,7 @@ public abstract class WireAdapter<E> {
     return value.toString();
   }
 
-  public static final WireAdapter<Boolean> BOOL = new WireAdapter<Boolean>(
+  public static final ProtoAdapter<Boolean> BOOL = new ProtoAdapter<Boolean>(
       FieldEncoding.VARINT, Boolean.class) {
     @Override public int encodedSize(Boolean value) {
       return FIXED_BOOL_SIZE;
@@ -176,7 +176,7 @@ public abstract class WireAdapter<E> {
       throw new IOException(String.format("Invalid boolean value 0x%02x", value));
     }
   };
-  public static final WireAdapter<Integer> INT32 = new WireAdapter<Integer>(
+  public static final ProtoAdapter<Integer> INT32 = new ProtoAdapter<Integer>(
       FieldEncoding.VARINT, Integer.class) {
     @Override public int encodedSize(Integer value) {
       return int32Size(value);
@@ -190,7 +190,7 @@ public abstract class WireAdapter<E> {
       return reader.readVarint32();
     }
   };
-  public static final WireAdapter<Integer> UINT32 = new WireAdapter<Integer>(
+  public static final ProtoAdapter<Integer> UINT32 = new ProtoAdapter<Integer>(
       FieldEncoding.VARINT, Integer.class) {
     @Override public int encodedSize(Integer value) {
       return varint32Size(value);
@@ -204,7 +204,7 @@ public abstract class WireAdapter<E> {
       return reader.readVarint32();
     }
   };
-  public static final WireAdapter<Integer> SINT32 = new WireAdapter<Integer>(
+  public static final ProtoAdapter<Integer> SINT32 = new ProtoAdapter<Integer>(
       FieldEncoding.VARINT, Integer.class) {
     @Override public int encodedSize(Integer value) {
       return varint32Size(encodeZigZag32(value));
@@ -218,7 +218,7 @@ public abstract class WireAdapter<E> {
       return decodeZigZag32(reader.readVarint32());
     }
   };
-  public static final WireAdapter<Integer> FIXED32 = new WireAdapter<Integer>(
+  public static final ProtoAdapter<Integer> FIXED32 = new ProtoAdapter<Integer>(
       FieldEncoding.FIXED32, Integer.class) {
     @Override public int encodedSize(Integer value) {
       return FIXED_32_SIZE;
@@ -232,8 +232,8 @@ public abstract class WireAdapter<E> {
       return reader.readFixed32();
     }
   };
-  public static final WireAdapter<Integer> SFIXED32 = FIXED32;
-  public static final WireAdapter<Long> INT64 = new WireAdapter<Long>(
+  public static final ProtoAdapter<Integer> SFIXED32 = FIXED32;
+  public static final ProtoAdapter<Long> INT64 = new ProtoAdapter<Long>(
       FieldEncoding.VARINT, Long.class) {
     @Override public int encodedSize(Long value) {
       return varint64Size(value);
@@ -247,8 +247,8 @@ public abstract class WireAdapter<E> {
       return reader.readVarint64();
     }
   };
-  public static final WireAdapter<Long> UINT64 = INT64;
-  public static final WireAdapter<Long> SINT64 = new WireAdapter<Long>(
+  public static final ProtoAdapter<Long> UINT64 = INT64;
+  public static final ProtoAdapter<Long> SINT64 = new ProtoAdapter<Long>(
       FieldEncoding.VARINT, Long.class) {
     @Override public int encodedSize(Long value) {
       return varint64Size(encodeZigZag64(value));
@@ -262,7 +262,7 @@ public abstract class WireAdapter<E> {
       return decodeZigZag64(reader.readVarint64());
     }
   };
-  public static final WireAdapter<Long> FIXED64 = new WireAdapter<Long>(
+  public static final ProtoAdapter<Long> FIXED64 = new ProtoAdapter<Long>(
       FieldEncoding.FIXED64, Long.class) {
     @Override public int encodedSize(Long value) {
       return FIXED_64_SIZE;
@@ -276,8 +276,8 @@ public abstract class WireAdapter<E> {
       return reader.readFixed64();
     }
   };
-  public static final WireAdapter<Long> SFIXED64 = FIXED64;
-  public static final WireAdapter<Float> FLOAT = new WireAdapter<Float>(
+  public static final ProtoAdapter<Long> SFIXED64 = FIXED64;
+  public static final ProtoAdapter<Float> FLOAT = new ProtoAdapter<Float>(
       FieldEncoding.FIXED32, Float.class) {
     @Override public int encodedSize(Float value) {
       return FIXED_32_SIZE;
@@ -291,7 +291,7 @@ public abstract class WireAdapter<E> {
       return Float.intBitsToFloat(reader.readFixed32());
     }
   };
-  public static final WireAdapter<Double> DOUBLE = new WireAdapter<Double>(
+  public static final ProtoAdapter<Double> DOUBLE = new ProtoAdapter<Double>(
       FieldEncoding.FIXED64, Double.class) {
     @Override public int encodedSize(Double value) {
       return FIXED_64_SIZE;
@@ -305,7 +305,7 @@ public abstract class WireAdapter<E> {
       return Double.longBitsToDouble(reader.readFixed64());
     }
   };
-  public static final WireAdapter<String> STRING = new WireAdapter<String>(
+  public static final ProtoAdapter<String> STRING = new ProtoAdapter<String>(
       FieldEncoding.LENGTH_DELIMITED, String.class) {
     @Override public int encodedSize(String value) {
       return utf8Length(value);
@@ -319,7 +319,7 @@ public abstract class WireAdapter<E> {
       return reader.readString();
     }
   };
-  public static final WireAdapter<ByteString> BYTES = new WireAdapter<ByteString>(
+  public static final ProtoAdapter<ByteString> BYTES = new ProtoAdapter<ByteString>(
       FieldEncoding.LENGTH_DELIMITED, ByteString.class) {
     @Override public int encodedSize(ByteString value) {
       return value.size();
@@ -334,28 +334,28 @@ public abstract class WireAdapter<E> {
     }
   };
 
-  private static final Map<WireType, WireAdapter<?>> TYPE_TO_ADAPTER;
+  private static final Map<ProtoType, ProtoAdapter<?>> TYPE_TO_ADAPTER;
   static {
-    Map<WireType, WireAdapter<?>> map = new LinkedHashMap<>();
-    map.put(WireType.BOOL, WireAdapter.BOOL);
-    map.put(WireType.BYTES, WireAdapter.BYTES);
-    map.put(WireType.DOUBLE, WireAdapter.DOUBLE);
-    map.put(WireType.FIXED32, WireAdapter.FIXED32);
-    map.put(WireType.FIXED64, WireAdapter.FIXED64);
-    map.put(WireType.FLOAT, WireAdapter.FLOAT);
-    map.put(WireType.INT32, WireAdapter.INT32);
-    map.put(WireType.INT64, WireAdapter.INT64);
-    map.put(WireType.SFIXED32, WireAdapter.SFIXED32);
-    map.put(WireType.SFIXED64, WireAdapter.SFIXED64);
-    map.put(WireType.SINT32, WireAdapter.SINT32);
-    map.put(WireType.SINT64, WireAdapter.SINT64);
-    map.put(WireType.STRING, WireAdapter.STRING);
-    map.put(WireType.UINT32, WireAdapter.UINT32);
-    map.put(WireType.UINT64, WireAdapter.UINT64);
+    Map<ProtoType, ProtoAdapter<?>> map = new LinkedHashMap<>();
+    map.put(ProtoType.BOOL, ProtoAdapter.BOOL);
+    map.put(ProtoType.BYTES, ProtoAdapter.BYTES);
+    map.put(ProtoType.DOUBLE, ProtoAdapter.DOUBLE);
+    map.put(ProtoType.FIXED32, ProtoAdapter.FIXED32);
+    map.put(ProtoType.FIXED64, ProtoAdapter.FIXED64);
+    map.put(ProtoType.FLOAT, ProtoAdapter.FLOAT);
+    map.put(ProtoType.INT32, ProtoAdapter.INT32);
+    map.put(ProtoType.INT64, ProtoAdapter.INT64);
+    map.put(ProtoType.SFIXED32, ProtoAdapter.SFIXED32);
+    map.put(ProtoType.SFIXED64, ProtoAdapter.SFIXED64);
+    map.put(ProtoType.SINT32, ProtoAdapter.SINT32);
+    map.put(ProtoType.SINT64, ProtoAdapter.SINT64);
+    map.put(ProtoType.STRING, ProtoAdapter.STRING);
+    map.put(ProtoType.UINT32, ProtoAdapter.UINT32);
+    map.put(ProtoType.UINT64, ProtoAdapter.UINT64);
     TYPE_TO_ADAPTER = Collections.unmodifiableMap(map);
   }
 
-  WireAdapter<?> withLabel(Message.Label label) {
+  ProtoAdapter<?> withLabel(Message.Label label) {
     if (label.isRepeated()) {
       return label.isPacked()
           ? createPacked(this)
@@ -364,11 +364,11 @@ public abstract class WireAdapter<E> {
     return this;
   }
 
-  private static <T> WireAdapter<List<T>> createPacked(final WireAdapter<T> adapter) {
+  private static <T> ProtoAdapter<List<T>> createPacked(final ProtoAdapter<T> adapter) {
     if (adapter.fieldEncoding == FieldEncoding.LENGTH_DELIMITED) {
       throw new IllegalArgumentException("Unable to pack a length-delimited type.");
     }
-    return new WireAdapter<List<T>>(FieldEncoding.LENGTH_DELIMITED, List.class) {
+    return new ProtoAdapter<List<T>>(FieldEncoding.LENGTH_DELIMITED, List.class) {
       @Override public int encodedSize(List<T> value) {
         int size = 0;
         for (int i = 0, count = value.size(); i < count; i++) {
@@ -393,8 +393,8 @@ public abstract class WireAdapter<E> {
     };
   }
 
-  private static <T> WireAdapter<List<T>> createRepeated(final WireAdapter<T> adapter) {
-    return new WireAdapter<List<T>>(adapter.fieldEncoding, List.class) {
+  private static <T> ProtoAdapter<List<T>> createRepeated(final ProtoAdapter<T> adapter) {
+    return new ProtoAdapter<List<T>>(adapter.fieldEncoding, List.class) {
       @Override public int encodedSize(List<T> value) {
         throw new UnsupportedOperationException();
       }

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoType.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoType.java
@@ -25,26 +25,26 @@ import static com.squareup.wire.Preconditions.checkNotNull;
  * Names a protocol buffer message, enumerated type, service, or a scalar. This class models a
  * fully-qualified name using the protocol buffer package.
  */
-public final class WireType {
-  public static final WireType BOOL = new WireType(true, "bool");
-  public static final WireType BYTES = new WireType(true, "bytes");
-  public static final WireType DOUBLE = new WireType(true, "double");
-  public static final WireType FLOAT = new WireType(true, "float");
-  public static final WireType FIXED32 = new WireType(true, "fixed32");
-  public static final WireType FIXED64 = new WireType(true, "fixed64");
-  public static final WireType INT32 = new WireType(true, "int32");
-  public static final WireType INT64 = new WireType(true, "int64");
-  public static final WireType SFIXED32 = new WireType(true, "sfixed32");
-  public static final WireType SFIXED64 = new WireType(true, "sfixed64");
-  public static final WireType SINT32 = new WireType(true, "sint32");
-  public static final WireType SINT64 = new WireType(true, "sint64");
-  public static final WireType STRING = new WireType(true, "string");
-  public static final WireType UINT32 = new WireType(true, "uint32");
-  public static final WireType UINT64 = new WireType(true, "uint64");
+public final class ProtoType {
+  public static final ProtoType BOOL = new ProtoType(true, "bool");
+  public static final ProtoType BYTES = new ProtoType(true, "bytes");
+  public static final ProtoType DOUBLE = new ProtoType(true, "double");
+  public static final ProtoType FLOAT = new ProtoType(true, "float");
+  public static final ProtoType FIXED32 = new ProtoType(true, "fixed32");
+  public static final ProtoType FIXED64 = new ProtoType(true, "fixed64");
+  public static final ProtoType INT32 = new ProtoType(true, "int32");
+  public static final ProtoType INT64 = new ProtoType(true, "int64");
+  public static final ProtoType SFIXED32 = new ProtoType(true, "sfixed32");
+  public static final ProtoType SFIXED64 = new ProtoType(true, "sfixed64");
+  public static final ProtoType SINT32 = new ProtoType(true, "sint32");
+  public static final ProtoType SINT64 = new ProtoType(true, "sint64");
+  public static final ProtoType STRING = new ProtoType(true, "string");
+  public static final ProtoType UINT32 = new ProtoType(true, "uint32");
+  public static final ProtoType UINT64 = new ProtoType(true, "uint64");
 
-  private static final Map<String, WireType> SCALAR_TYPES;
+  private static final Map<String, ProtoType> SCALAR_TYPES;
   static {
-    Map<String, WireType> scalarTypes = new LinkedHashMap<>();
+    Map<String, ProtoType> scalarTypes = new LinkedHashMap<>();
     scalarTypes.put(BOOL.string, BOOL);
     scalarTypes.put(BYTES.string, BYTES);
     scalarTypes.put(DOUBLE.string, DOUBLE);
@@ -66,7 +66,7 @@ public final class WireType {
   private final boolean isScalar;
   private final String string;
 
-  private WireType(boolean isScalar, String string) {
+  private ProtoType(boolean isScalar, String string) {
     checkNotNull(string, "string == null");
     this.isScalar = isScalar;
     this.string = string;
@@ -87,35 +87,35 @@ public final class WireType {
     return isScalar;
   }
 
-  public static WireType get(String enclosingTypeOrPackage, String typeName) {
+  public static ProtoType get(String enclosingTypeOrPackage, String typeName) {
     return enclosingTypeOrPackage != null
         ? get(enclosingTypeOrPackage + '.' + typeName)
         : get(typeName);
   }
 
-  public static WireType get(String name) {
-    WireType scalar = SCALAR_TYPES.get(name);
+  public static ProtoType get(String name) {
+    ProtoType scalar = SCALAR_TYPES.get(name);
     if (scalar != null) return scalar;
 
     if (name == null || name.isEmpty()) {
       throw new IllegalArgumentException("unexpected name: " + name);
     }
-    return new WireType(false, name);
+    return new ProtoType(false, name);
   }
 
-  public WireType nestedType(String name) {
+  public ProtoType nestedType(String name) {
     if (isScalar) {
       throw new UnsupportedOperationException("scalar cannot have a nested type");
     }
     if (name == null || name.contains(".") || name.isEmpty()) {
       throw new IllegalArgumentException("unexpected name: " + name);
     }
-    return new WireType(false, string + '.' + name);
+    return new ProtoType(false, string + '.' + name);
   }
 
   @Override public boolean equals(Object o) {
-    return o instanceof WireType
-        && string.equals(((WireType) o).string);
+    return o instanceof ProtoType
+        && string.equals(((ProtoType) o).string);
   }
 
   @Override public int hashCode() {

--- a/wire-runtime/src/main/java/com/squareup/wire/RegisteredExtension.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RegisteredExtension.java
@@ -21,9 +21,9 @@ final class RegisteredExtension {
   final Message.Label label;
   final String name;
   final int tag;
-  final WireAdapter<?> adapter;
+  final ProtoAdapter<?> adapter;
 
-  public RegisteredExtension(Extension<?, ?> extension, WireAdapter<?> singleAdapter) {
+  public RegisteredExtension(Extension<?, ?> extension, ProtoAdapter<?> singleAdapter) {
     this.label = extension.getLabel();
     this.name = extension.getName();
     this.tag = extension.getTag();

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeEnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeEnumAdapter.java
@@ -22,9 +22,9 @@ import java.util.Comparator;
 /**
  * Converts values of an enum to and from integers.
  */
-final class RuntimeEnumAdapter<E extends ProtoEnum> extends WireAdapter<E> {
-  private static final Comparator<ProtoEnum> COMPARATOR = new Comparator<ProtoEnum>() {
-    @Override public int compare(ProtoEnum o1, ProtoEnum o2) {
+final class RuntimeEnumAdapter<E extends WireEnum> extends ProtoAdapter<E> {
+  private static final Comparator<WireEnum> COMPARATOR = new Comparator<WireEnum>() {
+    @Override public int compare(WireEnum o1, WireEnum o2) {
       return o1.getValue() - o2.getValue();
     }
   };

--- a/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
@@ -118,7 +118,7 @@ final class TagMap {
     int result = 0;
     for (int i = 0; i < size;) {
       Extension<?, ?> extension = extensions[i];
-      WireAdapter<Object> adapter = adapter(extension);
+      ProtoAdapter<Object> adapter = adapter(extension);
 
       if (extension.getLabel().isPacked()) {
         int runSize = 0;
@@ -141,7 +141,7 @@ final class TagMap {
   public void encode(ProtoWriter output) throws IOException {
     for (int i = 0; i < size;) {
       Extension<?, ?> extension = extensions[i];
-      WireAdapter<Object> adapter = adapter(extension);
+      ProtoAdapter<Object> adapter = adapter(extension);
       if (extension.getLabel().isPacked()) {
         int runEnd = runEnd(i);
         int runSize = 0;
@@ -261,8 +261,8 @@ final class TagMap {
   }
 
   @SuppressWarnings("unchecked") // Caller beware! Assumes the extension and value match at runtime.
-  private WireAdapter<Object> adapter(Extension<?, ?> extension) {
-    return (WireAdapter<Object>) WireAdapter.get(Message.WIRE, extension.getType(),
+  private ProtoAdapter<Object> adapter(Extension<?, ?> extension) {
+    return (ProtoAdapter<Object>) ProtoAdapter.get(Message.WIRE, extension.getType(),
         extension.getMessageType(), extension.getEnumType());
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/Wire.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Wire.java
@@ -29,7 +29,7 @@ public final class Wire {
   private final LinkedHashMap<Class<? extends Message<?>>,
       RuntimeMessageAdapter<? extends Message<?>, ? extends Message.Builder<?, ?>>> messageAdapters
       = new LinkedHashMap<>();
-  private final Map<Class<? extends ProtoEnum>, RuntimeEnumAdapter<? extends ProtoEnum>>
+  private final Map<Class<? extends WireEnum>, RuntimeEnumAdapter<? extends WireEnum>>
       enumAdapters = new LinkedHashMap<>();
   private final ExtensionRegistry registry;
 
@@ -42,7 +42,7 @@ public final class Wire {
   }
 
   /** Returns an adapter for reading and writing {@code type}, creating it if necessary. */
-  public <M extends Message> WireAdapter<M> adapter(Class<M> type) {
+  public <M extends Message> ProtoAdapter<M> adapter(Class<M> type) {
     List<DeferredAdapter<?>> deferredAdapters = reentrantCalls.get();
     if (deferredAdapters == null) {
       deferredAdapters = new ArrayList<>();
@@ -52,7 +52,7 @@ public final class Wire {
       for (DeferredAdapter<?> deferredAdapter : deferredAdapters) {
         if (deferredAdapter.javaType.equals(type)) {
           //noinspection unchecked
-          return (WireAdapter<M>) deferredAdapter;
+          return (ProtoAdapter<M>) deferredAdapter;
         }
       }
     }
@@ -60,7 +60,7 @@ public final class Wire {
     DeferredAdapter<M> deferredAdapter = new DeferredAdapter<>(type);
     deferredAdapters.add(deferredAdapter);
     try {
-      WireAdapter<M> adapter = messageAdapter(type);
+      ProtoAdapter<M> adapter = messageAdapter(type);
       deferredAdapter.ready(adapter);
       return adapter;
     } finally {
@@ -90,7 +90,7 @@ public final class Wire {
    * Returns an enum adapter for {@code enumClass}.
    */
   @SuppressWarnings("unchecked")
-  synchronized <E extends ProtoEnum> RuntimeEnumAdapter<E> enumAdapter(Class<E> enumClass) {
+  synchronized <E extends WireEnum> RuntimeEnumAdapter<E> enumAdapter(Class<E> enumClass) {
     RuntimeEnumAdapter<E> adapter = (RuntimeEnumAdapter<E>) enumAdapters.get(enumClass);
     if (adapter == null) {
       adapter = new RuntimeEnumAdapter<>(enumClass);
@@ -126,14 +126,14 @@ public final class Wire {
    * <p>Typically this is necessary in self-referential object models, such as an {@code Employee}
    * class that has a {@code List<Employee>} field for an organization's management hierarchy.
    */
-  private static class DeferredAdapter<M extends Message> extends WireAdapter<M> {
-    private WireAdapter<M> delegate;
+  private static class DeferredAdapter<M extends Message> extends ProtoAdapter<M> {
+    private ProtoAdapter<M> delegate;
 
     DeferredAdapter(Class<M> type) {
       super(FieldEncoding.LENGTH_DELIMITED, type);
     }
 
-    public void ready(WireAdapter<M> delegate) {
+    public void ready(ProtoAdapter<M> delegate) {
       this.delegate = delegate;
     }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/WireEnum.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/WireEnum.java
@@ -19,7 +19,7 @@ package com.squareup.wire;
  * Interface for generated {@link Enum} values to help serialization and
  * deserialization.
  */
-public interface ProtoEnum {
+public interface WireEnum {
   /**
    * The tag value of an enum constant.
    */

--- a/wire-runtime/src/main/java/com/squareup/wire/WireField.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/WireField.java
@@ -28,7 +28,7 @@ import static com.squareup.wire.Message.Label;
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-public @interface ProtoField {
+public @interface WireField {
   /** The tag number used to store the field's value. */
   int tag();
 

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -21,7 +21,7 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
   public static final String DEFAULT_DOC = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
@@ -30,48 +30,48 @@ public final class DescriptorProto extends Message<DescriptorProto> {
   /**
    * Doc string for generated code.
    */
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "string"
   )
   public final String doc;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "google.protobuf.FieldDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> field;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "google.protobuf.FieldDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "google.protobuf.DescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<DescriptorProto> nested_type;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "google.protobuf.EnumDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "google.protobuf.DescriptorProto.ExtensionRange",
       label = Message.Label.REPEATED
   )
   public final List<ExtensionRange> extension_range;
 
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "google.protobuf.MessageOptions"
   )
@@ -214,13 +214,13 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
     public static final Integer DEFAULT_END = 0;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32"
     )
     public final Integer start;
 
-    @ProtoField(
+    @WireField(
         tag = 2,
         type = "int32"
     )

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -20,7 +20,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
 
   public static final String DEFAULT_DOC = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
@@ -29,20 +29,20 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   /**
    * Doc string for generated code.
    */
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "string"
   )
   public final String doc;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "google.protobuf.EnumValueDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<EnumValueDescriptorProto> value;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "google.protobuf.EnumOptions"
   )

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -15,7 +15,7 @@ public final class EnumOptions extends Message<EnumOptions> {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
-  @ProtoField(
+  @WireField(
       tag = 999,
       type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -21,7 +21,7 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
 
   public static final Integer DEFAULT_NUMBER = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
@@ -30,19 +30,19 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
   /**
    * Doc string for generated code.
    */
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "string"
   )
   public final String doc;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "int32"
   )
   public final Integer number;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "google.protobuf.EnumValueOptions"
   )

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -15,7 +15,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
-  @ProtoField(
+  @WireField(
       tag = 999,
       type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
@@ -3,8 +3,8 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -32,7 +32,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
 
   public static final String DEFAULT_DEFAULT_VALUE = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
@@ -41,19 +41,19 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
   /**
    * Doc string for generated code.
    */
-  @ProtoField(
+  @WireField(
       tag = 9,
       type = "string"
   )
   public final String doc;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "int32"
   )
   public final Integer number;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "google.protobuf.FieldDescriptorProto.Label"
   )
@@ -63,7 +63,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    * If type_name is set, this need not be set.  If both this and type_name
    * are set, this must be either TYPE_ENUM or TYPE_MESSAGE.
    */
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "google.protobuf.FieldDescriptorProto.Type"
   )
@@ -76,7 +76,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    * message are searched, then within the parent, on up to the root
    * namespace).
    */
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "string"
   )
@@ -86,7 +86,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    * For extensions, this is the name of the type being extended.  It is
    * resolved in the same manner as type_name.
    */
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )
@@ -99,13 +99,13 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    * For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
    * TODO(kenton):  Base-64 encode?
    */
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "string"
   )
   public final String default_value;
 
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "google.protobuf.FieldOptions"
   )
@@ -274,7 +274,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
     }
   }
 
-  public enum Type implements ProtoEnum {
+  public enum Type implements WireEnum {
     /**
      * 0 is reserved for errors.
      * Order is weird for historical reasons.
@@ -356,7 +356,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
     }
   }
 
-  public enum Label implements ProtoEnum {
+  public enum Label implements WireEnum {
     /**
      * 0 is reserved for errors
      */

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -3,8 +3,8 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
@@ -29,7 +29,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "google.protobuf.FieldOptions.CType"
   )
@@ -41,7 +41,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    * writing the tag and type for each element, the entire array is encoded as
    * a single length-delimited blob.
    */
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "bool"
   )
@@ -53,7 +53,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    * for accessors, or it will be completely ignored; in the very least, this
    * is a formalization for deprecating fields.
    */
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "bool"
   )
@@ -73,7 +73,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    * In this situation, the map key for Item will be set to "name".
    * TODO: Fully-implement this, then remove the "experimental_" prefix.
    */
-  @ProtoField(
+  @WireField(
       tag = 9,
       type = "string"
   )
@@ -82,7 +82,7 @@ public final class FieldOptions extends Message<FieldOptions> {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
-  @ProtoField(
+  @WireField(
       tag = 999,
       type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
@@ -220,7 +220,7 @@ public final class FieldOptions extends Message<FieldOptions> {
     }
   }
 
-  public enum CType implements ProtoEnum {
+  public enum CType implements WireEnum {
     /**
      * Default mode.
      */

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -23,7 +23,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
   /**
    * file name, relative to root of source tree
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
@@ -32,7 +32,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
   /**
    * e.g. "foo", "foo.bar", etc.
    */
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )
@@ -41,7 +41,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
   /**
    * Names of files imported by this file.
    */
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "string",
       label = Message.Label.REPEATED
@@ -51,35 +51,35 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
   /**
    * All top-level definitions in this file.
    */
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "google.protobuf.DescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<DescriptorProto> message_type;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "google.protobuf.EnumDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "google.protobuf.ServiceDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<ServiceDescriptorProto> service;
 
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "google.protobuf.FieldDescriptorProto",
       label = Message.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "google.protobuf.FileOptions"
   )
@@ -91,7 +91,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    * functionality of the descriptors -- the information is needed only by
    * development tools.
    */
-  @ProtoField(
+  @WireField(
       tag = 9,
       type = "google.protobuf.SourceCodeInfo"
   )

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -16,7 +16,7 @@ import java.util.List;
 public final class FileDescriptorSet extends Message<FileDescriptorSet> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "google.protobuf.FileDescriptorProto",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -3,8 +3,8 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
@@ -64,7 +64,7 @@ public final class FileOptions extends Message<FileOptions> {
    * inappropriate because proto packages do not normally start with backwards
    * domain names.
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
@@ -77,7 +77,7 @@ public final class FileOptions extends Message<FileOptions> {
    * a .proto always translates to a single class, but you may want to
    * explicitly choose the class name).
    */
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "string"
   )
@@ -91,7 +91,7 @@ public final class FileOptions extends Message<FileOptions> {
    * generated to contain the file's getDescriptor() method as well as any
    * top-level extensions defined in the file.
    */
-  @ProtoField(
+  @WireField(
       tag = 10,
       type = "bool"
   )
@@ -103,13 +103,13 @@ public final class FileOptions extends Message<FileOptions> {
    * purely a speed optimization, as the AbstractMessage base class includes
    * reflection-based implementations of these methods.
    */
-  @ProtoField(
+  @WireField(
       tag = 20,
       type = "bool"
   )
   public final Boolean java_generate_equals_and_hash;
 
-  @ProtoField(
+  @WireField(
       tag = 9,
       type = "google.protobuf.FileOptions.OptimizeMode"
   )
@@ -127,19 +127,19 @@ public final class FileOptions extends Message<FileOptions> {
    * these default to false.  Old code which depends on generic services should
    * explicitly set them to true.
    */
-  @ProtoField(
+  @WireField(
       tag = 16,
       type = "bool"
   )
   public final Boolean cc_generic_services;
 
-  @ProtoField(
+  @WireField(
       tag = 17,
       type = "bool"
   )
   public final Boolean java_generic_services;
 
-  @ProtoField(
+  @WireField(
       tag = 18,
       type = "bool"
   )
@@ -148,7 +148,7 @@ public final class FileOptions extends Message<FileOptions> {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
-  @ProtoField(
+  @WireField(
       tag = 999,
       type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED
@@ -340,7 +340,7 @@ public final class FileOptions extends Message<FileOptions> {
   /**
    * Generated classes can be optimized for speed or code size.
    */
-  public enum OptimizeMode implements ProtoEnum {
+  public enum OptimizeMode implements WireEnum {
     /**
      * Generate complete code for parsing, serialization,
      */

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
@@ -37,7 +37,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    * Because this is an option, the above two restrictions are not enforced by
    * the protocol compiler.
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bool"
   )
@@ -48,7 +48,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    * conflict with a field of the same name.  This is meant to make migration
    * from proto1 easier; new code should avoid fields named "descriptor".
    */
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "bool"
   )
@@ -57,7 +57,7 @@ public final class MessageOptions extends Message<MessageOptions> {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
-  @ProtoField(
+  @WireField(
       tag = 999,
       type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -22,7 +22,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
 
   public static final String DEFAULT_OUTPUT_TYPE = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
@@ -31,7 +31,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
   /**
    * Doc string for generated code.
    */
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "string"
   )
@@ -41,19 +41,19 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
    * Input and output type names.  These are resolved in the same way as
    * FieldDescriptorProto.type_name, but must refer to a message type.
    */
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )
   public final String input_type;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "string"
   )
   public final String output_type;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "google.protobuf.MethodOptions"
   )

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -19,7 +19,7 @@ public final class MethodOptions extends Message<MethodOptions> {
    *   Buffers.
    * The parser stores options it doesn't recognize here. See above.
    */
-  @ProtoField(
+  @WireField(
       tag = 999,
       type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -20,13 +20,13 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
 
   public static final String DEFAULT_DOC = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
   public final String name;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "google.protobuf.MethodDescriptorProto",
       label = Message.Label.REPEATED
@@ -36,13 +36,13 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
   /**
    * Doc string for generated code.
    */
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "string"
   )
   public final String doc;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "google.protobuf.ServiceOptions"
   )

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -19,7 +19,7 @@ public final class ServiceOptions extends Message<ServiceOptions> {
    *   Buffers.
    * The parser stores options it doesn't recognize here. See above.
    */
-  @ProtoField(
+  @WireField(
       tag = 999,
       type = "google.protobuf.UninterpretedOption",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -64,7 +64,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
    *   ignore those that it doesn't understand, as more types of locations could
    *   be recorded in the future.
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "google.protobuf.SourceCodeInfo.Location",
       label = Message.Label.REPEATED
@@ -189,7 +189,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
      * this path refers to the whole field declaration (from the beginning
      * of the label to the terminating semicolon).
      */
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32",
         label = Message.Label.PACKED
@@ -203,7 +203,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
      * and column numbers are zero-based -- typically you will want to add
      * 1 to each before displaying to a user.
      */
-    @ProtoField(
+    @WireField(
         tag = 2,
         type = "int32",
         label = Message.Label.PACKED

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -3,7 +3,7 @@
 package com.google.protobuf;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Long;
@@ -37,7 +37,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
   public static final String DEFAULT_AGGREGATE_VALUE = "";
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "google.protobuf.UninterpretedOption.NamePart",
       label = Message.Label.REPEATED
@@ -48,37 +48,37 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
    * The value of the uninterpreted option, in whatever type the tokenizer
    * identified it as during parsing. Exactly one of these should be set.
    */
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "string"
   )
   public final String identifier_value;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "uint64"
   )
   public final Long positive_int_value;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "int64"
   )
   public final Long negative_int_value;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "double"
   )
   public final Double double_value;
 
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "bytes"
   )
   public final ByteString string_value;
 
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "string"
   )
@@ -218,14 +218,14 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
     public static final Boolean DEFAULT_IS_EXTENSION = false;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "string",
         label = Message.Label.REQUIRED
     )
     public final String name_part;
 
-    @ProtoField(
+    @WireField(
         tag = 2,
         type = "bool",
         label = Message.Label.REQUIRED

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -3,7 +3,7 @@
 package com.squareup.differentpackage.protos.bar;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -81,7 +81,7 @@ public final class Bar extends Message<Bar> {
 
       public static final String DEFAULT_BOO = "";
 
-      @ProtoField(
+      @WireField(
           tag = 1,
           type = "string"
       )

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -4,14 +4,14 @@ package com.squareup.differentpackage.protos.foo;
 
 import com.squareup.differentpackage.protos.bar.Bar;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
 public final class Foo extends Message<Foo> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.differentpackage.bar.Bar.Baz.Moo"
   )

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
@@ -3,7 +3,7 @@
 package com.squareup.foobar.protos.bar;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -81,7 +81,7 @@ public final class Bar extends Message<Bar> {
 
       public static final String DEFAULT_BOO = "";
 
-      @ProtoField(
+      @WireField(
           tag = 1,
           type = "string"
       )

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
@@ -4,14 +4,14 @@ package com.squareup.foobar.protos.foo;
 
 import com.squareup.foobar.protos.bar.Bar;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
 public final class Foo extends Message<Foo> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.foobar.Bar.Baz.Moo"
   )

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
@@ -3,7 +3,7 @@
 package com.squareup.services;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -13,7 +13,7 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bytes"
   )

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
@@ -3,7 +3,7 @@
 package com.squareup.services;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -13,7 +13,7 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bytes"
   )

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
@@ -3,7 +3,7 @@
 package com.squareup.services;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -13,7 +13,7 @@ public final class LetsDataRequest extends Message<LetsDataRequest> {
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bytes"
   )

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
@@ -3,7 +3,7 @@
 package com.squareup.services;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -13,7 +13,7 @@ public final class LetsDataResponse extends Message<LetsDataResponse> {
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bytes"
   )

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -3,7 +3,7 @@
 package com.squareup.services.anotherpackage;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -13,7 +13,7 @@ public final class SendDataRequest extends Message<SendDataRequest> {
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bytes"
   )

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -3,7 +3,7 @@
 package com.squareup.services.anotherpackage;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -13,7 +13,7 @@ public final class SendDataResponse extends Message<SendDataResponse> {
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bytes"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
@@ -30,7 +30,7 @@ public class OneOfTest {
   private static final byte[] BAR_BYTES = { 26, 6, 'b', 'a', 'r', 'b', 'a', 'r'};
 
   private final Wire wire = new Wire();
-  private final WireAdapter<OneOfMessage> adapter = wire.adapter(OneOfMessage.class);
+  private final ProtoAdapter<OneOfMessage> adapter = wire.adapter(OneOfMessage.class);
 
   @Test
   public void testOneOf() throws Exception {

--- a/wire-runtime/src/test/java/com/squareup/wire/ProtoTypeTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/ProtoTypeTest.java
@@ -20,60 +20,60 @@ import org.junit.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
-public final class WireTypeTest {
+public final class ProtoTypeTest {
   @Test public void get() throws Exception {
-    assertThat(WireType.get("int32")).isSameAs(WireType.INT32);
-    assertThat(WireType.get("Person")).isEqualTo(WireType.get("Person"));
-    assertThat(WireType.get("squareup.protos.person", "Person"))
-        .isEqualTo(WireType.get("squareup.protos.person.Person"));
+    assertThat(ProtoType.get("int32")).isSameAs(ProtoType.INT32);
+    assertThat(ProtoType.get("Person")).isEqualTo(ProtoType.get("Person"));
+    assertThat(ProtoType.get("squareup.protos.person", "Person"))
+        .isEqualTo(ProtoType.get("squareup.protos.person.Person"));
   }
 
   @Test public void simpleName() throws Exception {
-    WireType person = WireType.get("squareup.protos.person.Person");
+    ProtoType person = ProtoType.get("squareup.protos.person.Person");
     assertThat(person.simpleName()).isEqualTo("Person");
   }
 
   @Test public void scalarToString() throws Exception {
-    assertThat(WireType.INT32.toString()).isEqualTo("int32");
-    assertThat(WireType.STRING.toString()).isEqualTo("string");
-    assertThat(WireType.BYTES.toString()).isEqualTo("bytes");
+    assertThat(ProtoType.INT32.toString()).isEqualTo("int32");
+    assertThat(ProtoType.STRING.toString()).isEqualTo("string");
+    assertThat(ProtoType.BYTES.toString()).isEqualTo("bytes");
   }
 
   @Test public void nestedType() throws Exception {
-    assertThat(WireType.get("squareup.protos.person.Person").nestedType("PhoneType"))
-        .isEqualTo(WireType.get("squareup.protos.person.Person.PhoneType"));
+    assertThat(ProtoType.get("squareup.protos.person.Person").nestedType("PhoneType"))
+        .isEqualTo(ProtoType.get("squareup.protos.person.Person.PhoneType"));
   }
 
   @Test public void primitivesCannotNest() throws Exception {
     try {
-      WireType.INT32.nestedType("PhoneType");
+      ProtoType.INT32.nestedType("PhoneType");
       fail();
     } catch (UnsupportedOperationException expected) {
     }
   }
 
   @Test public void messageToString() throws Exception {
-    WireType person = WireType.get("squareup.protos.person.Person");
+    ProtoType person = ProtoType.get("squareup.protos.person.Person");
     assertThat(person.toString()).isEqualTo("squareup.protos.person.Person");
 
-    WireType phoneType = person.nestedType("PhoneType");
+    ProtoType phoneType = person.nestedType("PhoneType");
     assertThat(phoneType.toString()).isEqualTo("squareup.protos.person.Person.PhoneType");
   }
 
   @Test public void enclosingTypeOrPackage() throws Exception {
-    assertThat(WireType.STRING.enclosingTypeOrPackage()).isNull();
+    assertThat(ProtoType.STRING.enclosingTypeOrPackage()).isNull();
 
-    WireType person = WireType.get("squareup.protos.person.Person");
+    ProtoType person = ProtoType.get("squareup.protos.person.Person");
     assertThat(person.enclosingTypeOrPackage()).isEqualTo("squareup.protos.person");
 
-    WireType phoneType = person.nestedType("PhoneType");
+    ProtoType phoneType = person.nestedType("PhoneType");
     assertThat(phoneType.enclosingTypeOrPackage()).isEqualTo("squareup.protos.person.Person");
   }
 
   @Test public void isScalar() throws Exception {
-    assertThat(WireType.INT32.isScalar()).isTrue();
-    assertThat(WireType.STRING.isScalar()).isTrue();
-    assertThat(WireType.BYTES.isScalar()).isTrue();
-    assertThat(WireType.get("squareup.protos.person.Person").isScalar()).isFalse();
+    assertThat(ProtoType.INT32.isScalar()).isTrue();
+    assertThat(ProtoType.STRING.isScalar()).isTrue();
+    assertThat(ProtoType.BYTES.isScalar()).isTrue();
+    assertThat(ProtoType.get("squareup.protos.person.Person").isScalar()).isFalse();
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/RuntimeMessageAdapterRedactTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/RuntimeMessageAdapterRedactTest.java
@@ -89,7 +89,7 @@ public class RuntimeMessageAdapterRedactTest {
   }
 
   @Test public void requiredRedactedFieldThrowsRedacting() {
-    WireAdapter<RedactedRequired> adapter = wire.adapter(RedactedRequired.class);
+    ProtoAdapter<RedactedRequired> adapter = wire.adapter(RedactedRequired.class);
     try {
       adapter.redact(new RedactedRequired("a"));
       fail();
@@ -100,7 +100,7 @@ public class RuntimeMessageAdapterRedactTest {
   }
 
   @Test public void requiredRedactedFieldToString() {
-    WireAdapter<RedactedRequired> adapter = wire.adapter(RedactedRequired.class);
+    ProtoAdapter<RedactedRequired> adapter = wire.adapter(RedactedRequired.class);
     assertThat(adapter.toString(new RedactedRequired("a"))).isEqualTo("RedactedRequired{a=██}");
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
@@ -26,8 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class UnknownFieldsTest {
 
   private final Wire wire = new Wire();
-  private final WireAdapter<VersionOne> v1Adapter = wire.adapter(VersionOne.class);
-  private final WireAdapter<VersionTwo> v2Adapter = wire.adapter(VersionTwo.class);
+  private final ProtoAdapter<VersionOne> v1Adapter = wire.adapter(VersionOne.class);
+  private final ProtoAdapter<VersionTwo> v2Adapter = wire.adapter(VersionTwo.class);
 
   @Test
   public void testUnknownFields() throws IOException {

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -103,7 +103,7 @@ public class WireTest {
     }
 
     Wire wire = new Wire();
-    WireAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
+    ProtoAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
 
     byte[] result = adapter.encode(msg);
     assertThat(result.length).isEqualTo(46);
@@ -147,7 +147,7 @@ public class WireTest {
         .build();
 
     Wire wire = new Wire();
-    WireAdapter<Person> adapter = wire.adapter(Person.class);
+    ProtoAdapter<Person> adapter = wire.adapter(Person.class);
 
     byte[] data = adapter.encode(person);
     adapter.decode(data);
@@ -177,7 +177,7 @@ public class WireTest {
         Ext_simple_message.nested_enum_ext)).isEqualTo(SimpleMessage.NestedEnum.BAZ);
 
     Wire wire = new Wire(new ExtensionRegistry(Ext_simple_message.class));
-    WireAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
+    ProtoAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
 
     byte[] result = adapter.encode(msg);
     assertThat(result.length).isEqualTo(29);
@@ -201,8 +201,8 @@ public class WireTest {
 
     Wire wireNoExt = new Wire();
     ExtensionRegistry simpleMessageExtensions = new ExtensionRegistry(Ext_simple_message.class);
-    WireAdapter<SimpleMessage> adapterNoExt = wireNoExt.adapter(SimpleMessage.class);
-    WireAdapter<SimpleMessage> adapterExt = adapterNoExt.withExtensions(simpleMessageExtensions);
+    ProtoAdapter<SimpleMessage> adapterNoExt = wireNoExt.adapter(SimpleMessage.class);
+    ProtoAdapter<SimpleMessage> adapterExt = adapterNoExt.withExtensions(simpleMessageExtensions);
 
     byte[] data = adapterNoExt.encode(msg);
 
@@ -257,7 +257,7 @@ public class WireTest {
     assertThat(msg.optional_external_msg.getExtension(bazext)).isEqualTo(new Integer(222));
 
     Wire wire = new Wire();
-    WireAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
+    ProtoAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
 
     byte[] result = adapter.encode(msg);
     assertThat(result.length).isEqualTo(21);
@@ -292,7 +292,7 @@ public class WireTest {
     assertThat(noListHashCode).isEqualTo(emptyListHashCode);
 
     Wire wire = new Wire();
-    WireAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
+    ProtoAdapter<SimpleMessage> adapter = wire.adapter(SimpleMessage.class);
 
     // Empty lists and null lists occupy 0 bytes in the wire encoding
     byte[] noListBytes = adapter.encode(noListMessage);
@@ -326,7 +326,7 @@ public class WireTest {
     assertThat(person.phone.get(0).type).isEqualTo(PhoneType.WORK);
 
     Wire wire = new Wire();
-    WireAdapter<Person> adapter = wire.adapter(Person.class);
+    ProtoAdapter<Person> adapter = wire.adapter(Person.class);
 
     byte[] data = adapter.encode(person);
     assertThat(data[27]).isEqualTo((byte) PhoneType.WORK.getValue());

--- a/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
@@ -19,7 +19,7 @@ import com.squareup.wire.Extension;
 import com.squareup.wire.ExtensionRegistry;
 import com.squareup.wire.Message;
 import com.squareup.wire.Wire;
-import com.squareup.wire.WireAdapter;
+import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.protos.alltypes.AllTypes;
 import com.squareup.wire.protos.alltypes.Ext_all_types;
 import java.io.ByteArrayInputStream;
@@ -137,7 +137,7 @@ public class TestAllTypes {
 
   private final AllTypes allTypes = createAllTypes();
   private final Wire wire = new Wire(new ExtensionRegistry(Ext_all_types.class));
-  private final WireAdapter<AllTypes> adapter = wire.adapter(AllTypes.class);
+  private final ProtoAdapter<AllTypes> adapter = wire.adapter(AllTypes.class);
 
   private AllTypes createAllTypes(int numRepeated) {
     return getBuilder(numRepeated).build();

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class ChildPackage extends Message<ChildPackage> {
 
   public static final ForeignEnum DEFAULT_INNER_FOREIGN_ENUM = ForeignEnum.BAV;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.foreign.ForeignEnum"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,14 +13,14 @@ import java.util.List;
 public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 201,
       type = "int32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 301,
       type = "int32",
       label = Message.Label.PACKED

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -3,8 +3,8 @@
 package com.squareup.wire.protos.alltypes;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -117,535 +117,535 @@ public final class AllTypes extends Message<AllTypes> {
 
   public static final NestedEnum DEFAULT_DEFAULT_NESTED_ENUM = NestedEnum.A;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
   public final Integer opt_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "uint32"
   )
   public final Integer opt_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "sint32"
   )
   public final Integer opt_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "fixed32"
   )
   public final Integer opt_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "sfixed32"
   )
   public final Integer opt_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "int64"
   )
   public final Long opt_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "uint64"
   )
   public final Long opt_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "sint64"
   )
   public final Long opt_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 9,
       type = "fixed64"
   )
   public final Long opt_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 10,
       type = "sfixed64"
   )
   public final Long opt_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 11,
       type = "bool"
   )
   public final Boolean opt_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 12,
       type = "float"
   )
   public final Float opt_float;
 
-  @ProtoField(
+  @WireField(
       tag = 13,
       type = "double"
   )
   public final Double opt_double;
 
-  @ProtoField(
+  @WireField(
       tag = 14,
       type = "string"
   )
   public final String opt_string;
 
-  @ProtoField(
+  @WireField(
       tag = 15,
       type = "bytes"
   )
   public final ByteString opt_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 16,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
   public final NestedEnum opt_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 17,
       type = "squareup.protos.alltypes.AllTypes.NestedMessage"
   )
   public final NestedMessage opt_nested_message;
 
-  @ProtoField(
+  @WireField(
       tag = 101,
       type = "int32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 102,
       type = "uint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 103,
       type = "sint32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 104,
       type = "fixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 105,
       type = "sfixed32",
       label = Message.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 106,
       type = "int64",
       label = Message.Label.REQUIRED
   )
   public final Long req_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 107,
       type = "uint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 108,
       type = "sint64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 109,
       type = "fixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 110,
       type = "sfixed64",
       label = Message.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 111,
       type = "bool",
       label = Message.Label.REQUIRED
   )
   public final Boolean req_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 112,
       type = "float",
       label = Message.Label.REQUIRED
   )
   public final Float req_float;
 
-  @ProtoField(
+  @WireField(
       tag = 113,
       type = "double",
       label = Message.Label.REQUIRED
   )
   public final Double req_double;
 
-  @ProtoField(
+  @WireField(
       tag = 114,
       type = "string",
       label = Message.Label.REQUIRED
   )
   public final String req_string;
 
-  @ProtoField(
+  @WireField(
       tag = 115,
       type = "bytes",
       label = Message.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 116,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 117,
       type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
-  @ProtoField(
+  @WireField(
       tag = 201,
       type = "int32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 202,
       type = "uint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 203,
       type = "sint32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 204,
       type = "fixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 205,
       type = "sfixed32",
       label = Message.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 206,
       type = "int64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 207,
       type = "uint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 208,
       type = "sint64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 209,
       type = "fixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 210,
       type = "sfixed64",
       label = Message.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 211,
       type = "bool",
       label = Message.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 212,
       type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> rep_float;
 
-  @ProtoField(
+  @WireField(
       tag = 213,
       type = "double",
       label = Message.Label.REPEATED
   )
   public final List<Double> rep_double;
 
-  @ProtoField(
+  @WireField(
       tag = 214,
       type = "string",
       label = Message.Label.REPEATED
   )
   public final List<String> rep_string;
 
-  @ProtoField(
+  @WireField(
       tag = 215,
       type = "bytes",
       label = Message.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 216,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 217,
       type = "squareup.protos.alltypes.AllTypes.NestedMessage",
       label = Message.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
-  @ProtoField(
+  @WireField(
       tag = 301,
       type = "int32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 302,
       type = "uint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 303,
       type = "sint32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 304,
       type = "fixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 305,
       type = "sfixed32",
       label = Message.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 306,
       type = "int64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 307,
       type = "uint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 308,
       type = "sint64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 309,
       type = "fixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 310,
       type = "sfixed64",
       label = Message.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 311,
       type = "bool",
       label = Message.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 312,
       type = "float",
       label = Message.Label.PACKED
   )
   public final List<Float> pack_float;
 
-  @ProtoField(
+  @WireField(
       tag = 313,
       type = "double",
       label = Message.Label.PACKED
   )
   public final List<Double> pack_double;
 
-  @ProtoField(
+  @WireField(
       tag = 316,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum",
       label = Message.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
-  @ProtoField(
+  @WireField(
       tag = 401,
       type = "int32"
   )
   public final Integer default_int32;
 
-  @ProtoField(
+  @WireField(
       tag = 402,
       type = "uint32"
   )
   public final Integer default_uint32;
 
-  @ProtoField(
+  @WireField(
       tag = 403,
       type = "sint32"
   )
   public final Integer default_sint32;
 
-  @ProtoField(
+  @WireField(
       tag = 404,
       type = "fixed32"
   )
   public final Integer default_fixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 405,
       type = "sfixed32"
   )
   public final Integer default_sfixed32;
 
-  @ProtoField(
+  @WireField(
       tag = 406,
       type = "int64"
   )
   public final Long default_int64;
 
-  @ProtoField(
+  @WireField(
       tag = 407,
       type = "uint64"
   )
   public final Long default_uint64;
 
-  @ProtoField(
+  @WireField(
       tag = 408,
       type = "sint64"
   )
   public final Long default_sint64;
 
-  @ProtoField(
+  @WireField(
       tag = 409,
       type = "fixed64"
   )
   public final Long default_fixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 410,
       type = "sfixed64"
   )
   public final Long default_sfixed64;
 
-  @ProtoField(
+  @WireField(
       tag = 411,
       type = "bool"
   )
   public final Boolean default_bool;
 
-  @ProtoField(
+  @WireField(
       tag = 412,
       type = "float"
   )
   public final Float default_float;
 
-  @ProtoField(
+  @WireField(
       tag = 413,
       type = "double"
   )
   public final Double default_double;
 
-  @ProtoField(
+  @WireField(
       tag = 414,
       type = "string"
   )
   public final String default_string;
 
-  @ProtoField(
+  @WireField(
       tag = 415,
       type = "bytes"
   )
   public final ByteString default_bytes;
 
-  @ProtoField(
+  @WireField(
       tag = 416,
       type = "squareup.protos.alltypes.AllTypes.NestedEnum"
   )
@@ -1618,7 +1618,7 @@ public final class AllTypes extends Message<AllTypes> {
     }
   }
 
-  public enum NestedEnum implements ProtoEnum {
+  public enum NestedEnum implements WireEnum {
     A(1);
 
     private final int value;
@@ -1638,7 +1638,7 @@ public final class AllTypes extends Message<AllTypes> {
 
     public static final Integer DEFAULT_A = 0;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32"
     )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -5,8 +5,8 @@ package com.squareup.wire.protos.custom_options;
 import com.google.protobuf.EnumOptions;
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -76,44 +76,44 @@ public final class FooBar extends Message<FooBar> {
 
   public static final Double DEFAULT_DAISY = 0.0d;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
   public final Integer foo;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )
   public final String bar;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "squareup.protos.custom_options.FooBar.Nested"
   )
   public final Nested baz;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "uint64"
   )
   public final Long qux;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> fred;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "double"
   )
   public final Double daisy;
 
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "squareup.protos.custom_options.FooBar",
       label = Message.Label.REPEATED
@@ -243,7 +243,7 @@ public final class FooBar extends Message<FooBar> {
 
     public static final FooBarBazEnum DEFAULT_VALUE = FooBarBazEnum.FOO;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "squareup.protos.custom_options.FooBar.FooBarBazEnum"
     )
@@ -298,7 +298,7 @@ public final class FooBar extends Message<FooBar> {
   public static final class More extends Message<More> {
     private static final long serialVersionUID = 0L;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32",
         label = Message.Label.REPEATED
@@ -351,7 +351,7 @@ public final class FooBar extends Message<FooBar> {
     }
   }
 
-  public enum FooBarBazEnum implements ProtoEnum {
+  public enum FooBarBazEnum implements WireEnum {
     FOO(1, 17, new More.Builder()
         .serial(Arrays.asList(
             99,

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -3,8 +3,8 @@
 package com.squareup.wire.protos.custom_options;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.Integer;
@@ -26,44 +26,44 @@ public final class FooBar extends Message<FooBar> {
 
   public static final Double DEFAULT_DAISY = 0.0d;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
   public final Integer foo;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )
   public final String bar;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "squareup.protos.custom_options.FooBar.Nested"
   )
   public final Nested baz;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "uint64"
   )
   public final Long qux;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "float",
       label = Message.Label.REPEATED
   )
   public final List<Float> fred;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "double"
   )
   public final Double daisy;
 
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "squareup.protos.custom_options.FooBar",
       label = Message.Label.REPEATED
@@ -193,7 +193,7 @@ public final class FooBar extends Message<FooBar> {
 
     public static final FooBarBazEnum DEFAULT_VALUE = FooBarBazEnum.FOO;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "squareup.protos.custom_options.FooBar.FooBarBazEnum"
     )
@@ -248,7 +248,7 @@ public final class FooBar extends Message<FooBar> {
   public static final class More extends Message<More> {
     private static final long serialVersionUID = 0L;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32",
         label = Message.Label.REPEATED
@@ -301,7 +301,7 @@ public final class FooBar extends Message<FooBar> {
     }
   }
 
-  public enum FooBarBazEnum implements ProtoEnum {
+  public enum FooBarBazEnum implements WireEnum {
     FOO(1, 17),
 
     BAR(2, null),

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -13,7 +13,7 @@ public final class OneBytesField extends Message<OneBytesField> {
 
   public static final ByteString DEFAULT_OPT_BYTES = ByteString.EMPTY;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "bytes"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class OneField extends Message<OneField> {
 
   public static final Integer DEFAULT_OPT_INT32 = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,13 +13,13 @@ public final class Recursive extends Message<Recursive> {
 
   public static final Integer DEFAULT_VALUE = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
   public final Integer value;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "squareup.protos.edgecases.Recursive"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignEnum.java
@@ -2,10 +2,10 @@
 // Source file: ../wire-runtime/src/test/proto/foreign.proto at 23:1
 package com.squareup.wire.protos.foreign;
 
-import com.squareup.wire.ProtoEnum;
+import com.squareup.wire.WireEnum;
 import java.lang.Override;
 
-public enum ForeignEnum implements ProtoEnum {
+public enum ForeignEnum implements WireEnum {
   BAV(0),
 
   BAX(1);

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.foreign;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class ForeignMessage extends Message<ForeignMessage> {
 
   public static final Integer DEFAULT_I = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.one_extension;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -13,7 +13,7 @@ public final class Foo extends Message<Foo> {
 
   public static final String DEFAULT_BAR = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.one_extension;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -13,7 +13,7 @@ public final class OneExtension extends Message<OneExtension> {
 
   public static final String DEFAULT_ID = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.oneof;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -19,7 +19,7 @@ public final class OneOfMessage extends Message<OneOfMessage> {
   /**
    * What foo.
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
@@ -28,7 +28,7 @@ public final class OneOfMessage extends Message<OneOfMessage> {
   /**
    * Such bar.
    */
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "string"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -3,8 +3,8 @@
 package com.squareup.wire.protos.person;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -24,7 +24,7 @@ public final class Person extends Message<Person> {
   /**
    * The customer's full name.
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string",
       label = Message.Label.REQUIRED
@@ -34,7 +34,7 @@ public final class Person extends Message<Person> {
   /**
    * The customer's ID number.
    */
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "int32",
       label = Message.Label.REQUIRED
@@ -44,7 +44,7 @@ public final class Person extends Message<Person> {
   /**
    * Email address for the customer.
    */
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "string"
   )
@@ -53,7 +53,7 @@ public final class Person extends Message<Person> {
   /**
    * A list of the customer's phone numbers.
    */
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "squareup.protos.person.Person.PhoneNumber",
       label = Message.Label.REPEATED
@@ -160,7 +160,7 @@ public final class Person extends Message<Person> {
     }
   }
 
-  public enum PhoneType implements ProtoEnum {
+  public enum PhoneType implements WireEnum {
     MOBILE(0),
 
     HOME(1),
@@ -192,7 +192,7 @@ public final class Person extends Message<Person> {
     /**
      * The customer's phone number.
      */
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "string",
         label = Message.Label.REQUIRED
@@ -202,7 +202,7 @@ public final class Person extends Message<Person> {
     /**
      * The type of phone stored here.
      */
-    @ProtoField(
+    @WireField(
         tag = 2,
         type = "squareup.protos.person.Person.PhoneType"
     )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -15,13 +15,13 @@ public final class NotRedacted extends Message<NotRedacted> {
 
   public static final String DEFAULT_B = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
   public final String a;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
@@ -4,7 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -26,20 +26,20 @@ public final class Redacted extends Message<Redacted> {
 
   public static final String DEFAULT_C = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string",
       redacted = true
   )
   public final String a;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )
   public final String b;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "string"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -13,19 +13,19 @@ public final class RedactedChild extends Message<RedactedChild> {
 
   public static final String DEFAULT_A = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string"
   )
   public final String a;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "squareup.protos.redacted_test.Redacted"
   )
   public final Redacted b;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "squareup.protos.redacted_test.NotRedacted"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -3,14 +3,14 @@
 package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
 public final class RedactedCycleA extends Message<RedactedCycleA> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.redacted_test.RedactedCycleB"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -3,14 +3,14 @@
 package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
 public final class RedactedCycleB extends Message<RedactedCycleB> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.redacted_test.RedactedCycleA"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -4,7 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -20,14 +20,14 @@ public final class RedactedExtension extends Message<RedactedExtension> {
 
   public static final String DEFAULT_E = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string",
       redacted = true
   )
   public final String d;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "string"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -4,7 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -18,7 +18,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
       .setExtension(Ext_redacted_test.redacted, true)
       .build();
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string",
       label = Message.Label.REPEATED,

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -4,7 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -18,7 +18,7 @@ public final class RedactedRequired extends Message<RedactedRequired> {
 
   public static final String DEFAULT_A = "";
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "string",
       label = Message.Label.REQUIRED,

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -25,13 +25,13 @@ import java.lang.Override;
 public final class A extends Message<A> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.roots.B"
   )
   public final B c;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "squareup.protos.roots.D"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
@@ -3,14 +3,14 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
 public final class B extends Message<B> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.roots.C",
       label = Message.Label.REQUIRED

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class C extends Message<C> {
 
   public static final Integer DEFAULT_I = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class D extends Message<D> {
 
   public static final Integer DEFAULT_I = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,13 +13,13 @@ public final class E extends Message<E> {
 
   public static final G DEFAULT_G = G.FOO;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.roots.E.F"
   )
   public final F f;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "squareup.protos.roots.G"
   )
@@ -91,7 +91,7 @@ public final class E extends Message<E> {
 
     public static final Integer DEFAULT_I = 0;
 
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32"
     )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/G.java
@@ -2,10 +2,10 @@
 // Source file: ../wire-runtime/src/test/proto/roots.proto at 60:1
 package com.squareup.wire.protos.roots;
 
-import com.squareup.wire.ProtoEnum;
+import com.squareup.wire.WireEnum;
 import java.lang.Override;
 
-public enum G implements ProtoEnum {
+public enum G implements WireEnum {
   FOO(1),
 
   BAR(2);

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
@@ -3,14 +3,14 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
 public final class H extends Message<H> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.roots.E.F"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class I extends Message<I> {
 
   public static final Integer DEFAULT_I = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
@@ -3,14 +3,14 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 
 public final class J extends Message<J> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "squareup.protos.roots.K"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class K extends Message<K> {
 
   public static final Integer DEFAULT_I = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.simple;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Float;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class ExternalMessage extends Message<ExternalMessage> {
 
   public static final Float DEFAULT_F = 20f;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "float"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -3,8 +3,8 @@
 package com.squareup.wire.protos.simple;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoEnum;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.lang.Deprecated;
 import java.lang.Double;
@@ -42,7 +42,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * An optional int32
    */
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
@@ -51,7 +51,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * An optional NestedMessage, deprecated
    */
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "squareup.protos.simple.SimpleMessage.NestedMessage",
       deprecated = true
@@ -62,13 +62,13 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * An optional ExternalMessage
    */
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "squareup.protos.simple.ExternalMessage"
   )
   public final ExternalMessage optional_external_msg;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "squareup.protos.simple.SimpleMessage.NestedEnum"
   )
@@ -77,7 +77,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * A required int32
    */
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "int32",
       label = Message.Label.REQUIRED
@@ -87,7 +87,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * A repeated double, deprecated
    */
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "double",
       label = Message.Label.REPEATED,
@@ -99,7 +99,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * enum from another package with an explicit default
    */
-  @ProtoField(
+  @WireField(
       tag = 7,
       type = "squareup.protos.foreign.ForeignEnum"
   )
@@ -108,7 +108,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * enum from another package without an explicit default
    */
-  @ProtoField(
+  @WireField(
       tag = 8,
       type = "squareup.protos.foreign.ForeignEnum"
   )
@@ -117,7 +117,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * field with the same name as a Java keyword
    */
-  @ProtoField(
+  @WireField(
       tag = 9,
       type = "string"
   )
@@ -126,7 +126,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * field with the name "result"
    */
-  @ProtoField(
+  @WireField(
       tag = 10,
       type = "string"
   )
@@ -135,7 +135,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * field with the name "other"
    */
-  @ProtoField(
+  @WireField(
       tag = 11,
       type = "string"
   )
@@ -144,7 +144,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   /**
    * field with the name "o"
    */
-  @ProtoField(
+  @WireField(
       tag = 12,
       type = "string"
   )
@@ -367,7 +367,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
     /**
      * An optional int32
      */
-    @ProtoField(
+    @WireField(
         tag = 1,
         type = "int32"
     )
@@ -422,7 +422,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
     }
   }
 
-  public enum NestedEnum implements ProtoEnum {
+  public enum NestedEnum implements WireEnum {
     FOO(1),
 
     BAR(2),

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class Bar extends Message<Bar> {
 
   public static final Integer DEFAULT_BAZ = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -12,7 +12,7 @@ import java.util.List;
 public final class Bars extends Message<Bars> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "single_level.Bar",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class Foo extends Message<Foo> {
 
   public static final Integer DEFAULT_BAR = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -12,7 +12,7 @@ import java.util.List;
 public final class Foos extends Message<Foos> {
   private static final long serialVersionUID = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "single_level.Foo",
       label = Message.Label.REPEATED

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.unknownfields;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -13,7 +13,7 @@ public final class VersionOne extends Message<VersionOne> {
 
   public static final Integer DEFAULT_I = 0;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -3,7 +3,7 @@
 package com.squareup.wire.protos.unknownfields;
 
 import com.squareup.wire.Message;
-import com.squareup.wire.ProtoField;
+import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Long;
 import java.lang.Object;
@@ -25,37 +25,37 @@ public final class VersionTwo extends Message<VersionTwo> {
 
   public static final Long DEFAULT_V2_F64 = 0L;
 
-  @ProtoField(
+  @WireField(
       tag = 1,
       type = "int32"
   )
   public final Integer i;
 
-  @ProtoField(
+  @WireField(
       tag = 2,
       type = "int32"
   )
   public final Integer v2_i;
 
-  @ProtoField(
+  @WireField(
       tag = 3,
       type = "string"
   )
   public final String v2_s;
 
-  @ProtoField(
+  @WireField(
       tag = 4,
       type = "fixed32"
   )
   public final Integer v2_f32;
 
-  @ProtoField(
+  @WireField(
       tag = 5,
       type = "fixed64"
   )
   public final Long v2_f64;
 
-  @ProtoField(
+  @WireField(
       tag = 6,
       type = "string",
       label = Message.Label.REPEATED

--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.java
@@ -18,21 +18,21 @@ package com.squareup.wire.schema;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.EnumElement;
 import java.util.Collection;
 import java.util.Map;
 import java.util.NavigableSet;
 
 public final class EnumType extends Type {
-  private final WireType wireType;
+  private final ProtoType protoType;
   private final EnumElement element;
   private final ImmutableList<EnumConstant> constants;
   private final Options options;
 
-  EnumType(WireType wireType, EnumElement element,
+  EnumType(ProtoType protoType, EnumElement element,
       ImmutableList<EnumConstant> constants, Options options) {
-    this.wireType = wireType;
+    this.protoType = protoType;
     this.element = element;
     this.constants = constants;
     this.options = options;
@@ -42,8 +42,8 @@ public final class EnumType extends Type {
     return element.location();
   }
 
-  @Override public WireType name() {
-    return wireType;
+  @Override public ProtoType name() {
+    return protoType;
   }
 
   @Override public String documentation() {
@@ -121,13 +121,13 @@ public final class EnumType extends Type {
   }
 
   @Override Type retainAll(NavigableSet<String> identifiers) {
-    String typeName = wireType.toString();
+    String typeName = protoType.toString();
 
     // If this type is not retained, prune it.
     if (!identifiers.contains(typeName)) return null;
 
     ImmutableList<EnumConstant> retainedConstants = constants;
-    if (Pruner.hasMarkedMember(identifiers, wireType)) {
+    if (Pruner.hasMarkedMember(identifiers, protoType)) {
       ImmutableList.Builder<EnumConstant> retainedConstantsBuilder = ImmutableList.builder();
       for (EnumConstant constant : constants) {
         if (identifiers.contains(typeName + '#' + constant.name())) {
@@ -137,6 +137,6 @@ public final class EnumType extends Type {
       retainedConstants = retainedConstantsBuilder.build();
     }
 
-    return new EnumType(wireType, element, retainedConstants, options);
+    return new EnumType(protoType, element, retainedConstants, options);
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
@@ -16,14 +16,14 @@
 package com.squareup.wire.schema;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.ExtendElement;
 import com.squareup.wire.schema.internal.parser.FieldElement;
 
 public final class Extend {
   private final ExtendElement element;
   private final ImmutableList<Field> fields;
-  private WireType wireType;
+  private ProtoType protoType;
 
   Extend(String packageName, ExtendElement element) {
     this.element = element;
@@ -39,8 +39,8 @@ public final class Extend {
     return element.location();
   }
 
-  public WireType type() {
-    return wireType;
+  public ProtoType type() {
+    return protoType;
   }
 
   public String documentation() {
@@ -53,7 +53,7 @@ public final class Extend {
 
   void link(Linker linker) {
     linker = linker.withContext(this);
-    wireType = linker.resolveNamedType(element.name());
+    protoType = linker.resolveNamedType(element.name());
     for (Field field : fields) {
       field.link(linker);
     }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
@@ -15,14 +15,14 @@
  */
 package com.squareup.wire.schema;
 
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.FieldElement;
 
 public final class Field {
   private final String packageName;
   private final FieldElement element;
   private final Options options;
-  private WireType type;
+  private ProtoType type;
 
   Field(String packageName, FieldElement element) {
     this.packageName = packageName;
@@ -54,7 +54,7 @@ public final class Field {
     return label() == Label.REQUIRED;
   }
 
-  public WireType type() {
+  public ProtoType type() {
     return type;
   }
 
@@ -111,9 +111,9 @@ public final class Field {
     linker.validateImport(location(), type);
   }
 
-  private boolean isPackable(Linker linker, WireType type) {
-    return !type.equals(WireType.STRING)
-        && !type.equals(WireType.BYTES)
+  private boolean isPackable(Linker linker, ProtoType type) {
+    return !type.equals(ProtoType.STRING)
+        && !type.equals(ProtoType.BYTES)
         && !(linker.get(type) instanceof MessageType);
   }
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Linker.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Linker.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.Util;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -33,7 +33,7 @@ import java.util.Map;
 final class Linker {
   private final ImmutableList<ProtoFile> protoFiles;
   private final Map<String, Type> protoTypeNames;
-  private final Map<WireType, Map<String, Field>> extensionsMap;
+  private final Map<ProtoType, Map<String, Field>> extensionsMap;
   private final Multimap<String, String> imports;
   private final List<String> errors;
   private final List<Object> contextStack;
@@ -160,17 +160,17 @@ final class Linker {
   }
 
   /** Returns the type name for the scalar, relative or fully-qualified name {@code name}. */
-  WireType resolveType(String name) {
+  ProtoType resolveType(String name) {
     return resolveType(name, false);
   }
 
   /** Returns the type name for the relative or fully-qualified name {@code name}. */
-  WireType resolveNamedType(String name) {
+  ProtoType resolveNamedType(String name) {
     return resolveType(name, true);
   }
 
-  private WireType resolveType(String name, boolean namedTypesOnly) {
-    WireType scalar = WireType.get(name);
+  private ProtoType resolveType(String name, boolean namedTypesOnly) {
+    ProtoType scalar = ProtoType.get(name);
     if (scalar.isScalar()) {
       if (namedTypesOnly) {
         addError("expected a message but was %s", name);
@@ -199,7 +199,7 @@ final class Linker {
     }
 
     addError("unable to resolve %s", name);
-    return WireType.BYTES; // Just return any placeholder.
+    return ProtoType.BYTES; // Just return any placeholder.
   }
 
   private String resolveContext() {
@@ -224,12 +224,12 @@ final class Linker {
   }
 
   /** Returns the type or null if it doesn't exist. */
-  public Type get(WireType wireType) {
-    return protoTypeNames.get(wireType.toString());
+  public Type get(ProtoType protoType) {
+    return protoTypeNames.get(protoType.toString());
   }
 
   /** Returns the map of known extensions for {@code extensionType}. */
-  public Map<String, Field> extensions(WireType extensionType) {
+  public Map<String, Field> extensions(ProtoType extensionType) {
     Map<String, Field> result = extensionsMap.get(extensionType);
     return result != null ? result : ImmutableMap.<String, Field>of();
   }
@@ -315,7 +315,7 @@ final class Linker {
     }
   }
 
-  void validateImport(Location location, WireType type) {
+  void validateImport(Location location, ProtoType type) {
     if (type.isScalar()) return;
     String path = location.path();
     String requiredImport = get(type).location().path();
@@ -343,7 +343,7 @@ final class Linker {
 
       } else if (context instanceof Extend) {
         Extend extend = (Extend) context;
-        WireType type = extend.type();
+        ProtoType type = extend.type();
         error.append(type != null
             ? String.format("%s extend %s (%s)", prefix, type, extend.location())
             : String.format("%s extend (%s)", prefix, extend.location()));

--- a/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
@@ -16,14 +16,14 @@
 package com.squareup.wire.schema;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.MessageElement;
 import java.util.NavigableSet;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
 public final class MessageType extends Type {
-  private final WireType wireType;
+  private final ProtoType protoType;
   private final MessageElement element;
   private final ImmutableList<Field> fields;
   private final ImmutableList<OneOf> oneOfs;
@@ -31,10 +31,10 @@ public final class MessageType extends Type {
   private final ImmutableList<Extensions> extensionsList;
   private final Options options;
 
-  MessageType(WireType wireType, MessageElement element,
+  MessageType(ProtoType protoType, MessageElement element,
       ImmutableList<Field> fields, ImmutableList<OneOf> oneOfs,
       ImmutableList<Type> nestedTypes, ImmutableList<Extensions> extensionsList, Options options) {
-    this.wireType = wireType;
+    this.protoType = protoType;
     this.element = element;
     this.fields = fields;
     this.oneOfs = oneOfs;
@@ -47,8 +47,8 @@ public final class MessageType extends Type {
     return element.location();
   }
 
-  @Override public WireType name() {
-    return wireType;
+  @Override public ProtoType name() {
+    return protoType;
   }
 
   @Override public String documentation() {
@@ -165,7 +165,7 @@ public final class MessageType extends Type {
       }
     }
 
-    String typeName = wireType.toString();
+    String typeName = protoType.toString();
 
     // If this type is not retained, and none of its nested types are retained, prune it.
     ImmutableList<Type> retainedNestedTypes = retainedNestedTypesBuilder.build();
@@ -175,7 +175,7 @@ public final class MessageType extends Type {
 
     // If any of our fields are specifically retained, retain only that set.
     ImmutableList<Field> retainedFields = fields;
-    if (Pruner.hasMarkedMember(identifiers, wireType)) {
+    if (Pruner.hasMarkedMember(identifiers, protoType)) {
       ImmutableList.Builder<Field> retainedFieldsBuilder = ImmutableList.builder();
       for (Field field : fields) {
         if (identifiers.contains(typeName + '#' + field.name())) {
@@ -185,7 +185,7 @@ public final class MessageType extends Type {
       retainedFields = retainedFieldsBuilder.build();
     }
 
-    return new MessageType(wireType, element, retainedFields, oneOfs, retainedNestedTypes,
+    return new MessageType(protoType, element, retainedFields, oneOfs, retainedNestedTypes,
         extensionsList, options);
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Options.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Options.java
@@ -18,7 +18,7 @@ package com.squareup.wire.schema;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.OptionElement;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -37,20 +37,20 @@ import static com.google.common.collect.Iterables.getOnlyElement;
  * messages.
  */
 public final class Options {
-  public static final WireType FILE_OPTIONS = WireType.get("google.protobuf.FileOptions");
-  public static final WireType MESSAGE_OPTIONS = WireType.get("google.protobuf.MessageOptions");
-  public static final WireType FIELD_OPTIONS = WireType.get("google.protobuf.FieldOptions");
-  public static final WireType ENUM_OPTIONS = WireType.get("google.protobuf.EnumOptions");
-  public static final WireType ENUM_VALUE_OPTIONS
-      = WireType.get("google.protobuf.EnumValueOptions");
-  public static final WireType SERVICE_OPTIONS = WireType.get("google.protobuf.ServiceOptions");
-  public static final WireType METHOD_OPTIONS = WireType.get("google.protobuf.MethodOptions");
+  public static final ProtoType FILE_OPTIONS = ProtoType.get("google.protobuf.FileOptions");
+  public static final ProtoType MESSAGE_OPTIONS = ProtoType.get("google.protobuf.MessageOptions");
+  public static final ProtoType FIELD_OPTIONS = ProtoType.get("google.protobuf.FieldOptions");
+  public static final ProtoType ENUM_OPTIONS = ProtoType.get("google.protobuf.EnumOptions");
+  public static final ProtoType ENUM_VALUE_OPTIONS
+      = ProtoType.get("google.protobuf.EnumValueOptions");
+  public static final ProtoType SERVICE_OPTIONS = ProtoType.get("google.protobuf.ServiceOptions");
+  public static final ProtoType METHOD_OPTIONS = ProtoType.get("google.protobuf.MethodOptions");
 
-  private final WireType optionType;
+  private final ProtoType optionType;
   private final ImmutableList<OptionElement> optionElements;
   private ImmutableMap<Field, Object> map;
 
-  public Options(WireType optionType, List<OptionElement> elements) {
+  public Options(ProtoType optionType, List<OptionElement> elements) {
     this.optionType = optionType;
     this.optionElements = ImmutableList.copyOf(elements);
   }
@@ -110,7 +110,7 @@ public final class Options {
   }
 
   Map<Field, Object> canonicalizeOption(
-      Linker linker, WireType extensionType, OptionElement option) {
+      Linker linker, ProtoType extensionType, OptionElement option) {
     Map<String, Field> extensionsForType = linker.extensions(extensionType);
     if (extensionsForType == null) {
       return null; // No known extensions for the given extension type.

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -16,7 +16,7 @@
 package com.squareup.wire.schema;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.ExtendElement;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ServiceElement;
@@ -44,14 +44,14 @@ public final class ProtoFile {
 
     ImmutableList.Builder<Type> types = ImmutableList.builder();
     for (TypeElement type : protoFileElement.types()) {
-      WireType wireType = WireType.get(packageName, type.name());
-      types.add(Type.get(packageName, wireType, type));
+      ProtoType protoType = ProtoType.get(packageName, type.name());
+      types.add(Type.get(packageName, protoType, type));
     }
 
     ImmutableList.Builder<Service> services = ImmutableList.builder();
     for (ServiceElement service : protoFileElement.services()) {
-      WireType wireType = WireType.get(packageName, service.name());
-      services.add(Service.get(wireType, service));
+      ProtoType protoType = ProtoType.get(packageName, service.name());
+      services.add(Service.get(protoType, service));
     }
 
     ImmutableList.Builder<Extend> wireExtends = ImmutableList.builder();

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
@@ -16,7 +16,7 @@
 package com.squareup.wire.schema;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Deque;
@@ -105,7 +105,7 @@ final class Pruner {
         throw new IllegalArgumentException("Unexpected member: " + root);
 
       } else {
-        if (WireType.get(root).isScalar()) {
+        if (ProtoType.get(root).isScalar()) {
           continue; // Skip scalar types.
         }
 
@@ -134,15 +134,15 @@ final class Pruner {
   }
 
   /** Returns true if any RPC, enum constant or field of {@code identifier} is in marks. */
-  static boolean hasMarkedMember(NavigableSet<String> marks, WireType typeName) {
+  static boolean hasMarkedMember(NavigableSet<String> marks, ProtoType typeName) {
     // If there's a member field, it will sort immediately after <Name># in the marks set.
     String prefix = typeName + "#";
     String ceiling = marks.ceiling(prefix);
     return ceiling != null && ceiling.startsWith(prefix);
   }
 
-  private void mark(WireType wireType) {
-    mark(wireType.toString());
+  private void mark(ProtoType protoType) {
+    mark(protoType.toString());
   }
 
   private void mark(String identifier) {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Rpc.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Rpc.java
@@ -15,14 +15,14 @@
  */
 package com.squareup.wire.schema;
 
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.RpcElement;
 
 public final class Rpc {
   private final RpcElement element;
   private final Options options;
-  private WireType requestType;
-  private WireType responseType;
+  private ProtoType requestType;
+  private ProtoType responseType;
 
   Rpc(RpcElement element) {
     this.element = element;
@@ -41,11 +41,11 @@ public final class Rpc {
     return element.documentation();
   }
 
-  public WireType requestType() {
+  public ProtoType requestType() {
     return requestType;
   }
 
-  public WireType responseType() {
+  public ProtoType responseType() {
     return responseType;
   }
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -17,8 +17,8 @@ package com.squareup.wire.schema;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.squareup.wire.WireAdapter;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.ProtoType;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -71,8 +71,8 @@ public final class Schema {
    * Returns the service with the fully qualified name {@code name}, or null if this schema defines
    * no such service.
    */
-  public Service getService(WireType wireType) {
-    return getService(wireType.toString());
+  public Service getService(ProtoType protoType) {
+    return getService(protoType.toString());
   }
 
   /**
@@ -87,8 +87,8 @@ public final class Schema {
    * Returns the type with the fully qualified name {@code name}, or null if this schema defines no
    * such type.
    */
-  public Type getType(WireType wireType) {
-    return getType(wireType.toString());
+  public Type getType(ProtoType protoType) {
+    return getType(protoType.toString());
   }
 
   private static ImmutableMap<String, Type> buildTypesIndex(Iterable<ProtoFile> protoFiles) {
@@ -133,9 +133,9 @@ public final class Schema {
    *     com.squareup.wire.FieldEncoding#FIXED32 FIXED32}, or {@linkplain
    *     com.squareup.wire.FieldEncoding#LENGTH_DELIMITED LENGTH_DELIMITED} respectively.
    */
-  public WireAdapter<Object> wireAdapter(String typeName, boolean includeUnknown) {
+  public ProtoAdapter<Object> protoAdapter(String typeName, boolean includeUnknown) {
     Type type = getType(typeName);
     if (type == null) throw new IllegalArgumentException("unexpected type " + typeName);
-    return new SchemaWireAdapterFactory(this, includeUnknown).get(type.name());
+    return new SchemaProtoAdapterFactory(this, includeUnknown).get(type.name());
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/SchemaProtoAdapterFactory.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/SchemaProtoAdapterFactory.java
@@ -18,8 +18,8 @@ package com.squareup.wire.schema;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
-import com.squareup.wire.WireAdapter;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.ProtoType;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -30,53 +30,53 @@ import java.util.Map;
  * Creates type adapters to read and write protocol buffer data from a schema model. This doesn't
  * require an intermediate code gen step.
  */
-final class SchemaWireAdapterFactory {
+final class SchemaProtoAdapterFactory {
   final Schema schema;
   final boolean includeUnknown;
-  final Map<WireType, WireAdapter<?>> adapterMap = new LinkedHashMap<>();
+  final Map<ProtoType, ProtoAdapter<?>> adapterMap = new LinkedHashMap<>();
 
-  public SchemaWireAdapterFactory(Schema schema, boolean includeUnknown) {
+  public SchemaProtoAdapterFactory(Schema schema, boolean includeUnknown) {
     this.schema = schema;
     this.includeUnknown = includeUnknown;
 
-    adapterMap.put(WireType.BOOL, WireAdapter.BOOL);
-    adapterMap.put(WireType.BYTES, WireAdapter.BYTES);
-    adapterMap.put(WireType.DOUBLE, WireAdapter.DOUBLE);
-    adapterMap.put(WireType.FLOAT, WireAdapter.FLOAT);
-    adapterMap.put(WireType.FIXED32, WireAdapter.FIXED32);
-    adapterMap.put(WireType.FIXED64, WireAdapter.FIXED64);
-    adapterMap.put(WireType.INT32, WireAdapter.INT32);
-    adapterMap.put(WireType.INT64, WireAdapter.INT64);
-    adapterMap.put(WireType.SFIXED32, WireAdapter.SFIXED32);
-    adapterMap.put(WireType.SFIXED64, WireAdapter.SFIXED64);
-    adapterMap.put(WireType.SINT32, WireAdapter.SINT32);
-    adapterMap.put(WireType.SINT64, WireAdapter.SINT64);
-    adapterMap.put(WireType.STRING, WireAdapter.STRING);
-    adapterMap.put(WireType.UINT32, WireAdapter.UINT32);
-    adapterMap.put(WireType.UINT64, WireAdapter.UINT64);
+    adapterMap.put(ProtoType.BOOL, ProtoAdapter.BOOL);
+    adapterMap.put(ProtoType.BYTES, ProtoAdapter.BYTES);
+    adapterMap.put(ProtoType.DOUBLE, ProtoAdapter.DOUBLE);
+    adapterMap.put(ProtoType.FLOAT, ProtoAdapter.FLOAT);
+    adapterMap.put(ProtoType.FIXED32, ProtoAdapter.FIXED32);
+    adapterMap.put(ProtoType.FIXED64, ProtoAdapter.FIXED64);
+    adapterMap.put(ProtoType.INT32, ProtoAdapter.INT32);
+    adapterMap.put(ProtoType.INT64, ProtoAdapter.INT64);
+    adapterMap.put(ProtoType.SFIXED32, ProtoAdapter.SFIXED32);
+    adapterMap.put(ProtoType.SFIXED64, ProtoAdapter.SFIXED64);
+    adapterMap.put(ProtoType.SINT32, ProtoAdapter.SINT32);
+    adapterMap.put(ProtoType.SINT64, ProtoAdapter.SINT64);
+    adapterMap.put(ProtoType.STRING, ProtoAdapter.STRING);
+    adapterMap.put(ProtoType.UINT32, ProtoAdapter.UINT32);
+    adapterMap.put(ProtoType.UINT64, ProtoAdapter.UINT64);
   }
 
-  public WireAdapter<Object> get(WireType wireType) {
-    WireAdapter<?> result = adapterMap.get(wireType);
+  public ProtoAdapter<Object> get(ProtoType protoType) {
+    ProtoAdapter<?> result = adapterMap.get(protoType);
     if (result != null) {
-      return (WireAdapter<Object>) result;
+      return (ProtoAdapter<Object>) result;
     }
 
-    Type type = schema.getType(wireType);
+    Type type = schema.getType(protoType);
     if (type == null) {
-      throw new IllegalArgumentException("unknown type: " + wireType);
+      throw new IllegalArgumentException("unknown type: " + protoType);
     }
 
     if (type instanceof EnumType) {
       EnumAdapter enumAdapter = new EnumAdapter((EnumType) type);
-      adapterMap.put(wireType, enumAdapter);
+      adapterMap.put(protoType, enumAdapter);
       return enumAdapter;
     }
 
     if (type instanceof MessageType) {
       MessageAdapter messageAdapter = new MessageAdapter(includeUnknown);
       // Put the adapter in the map early to mitigate the recursive calls to get() made below.
-      adapterMap.put(wireType, messageAdapter);
+      adapterMap.put(protoType, messageAdapter);
 
       for (com.squareup.wire.schema.Field field : ((MessageType) type).fields()) {
         Field fieldAdapter = new Field(
@@ -84,13 +84,13 @@ final class SchemaWireAdapterFactory {
         messageAdapter.fieldsByName.put(field.name(), fieldAdapter);
         messageAdapter.fieldsByTag.put(field.tag(), fieldAdapter);
       }
-      return (WireAdapter) messageAdapter;
+      return (ProtoAdapter) messageAdapter;
     }
 
-    throw new IllegalArgumentException("unexpected type: " + wireType);
+    throw new IllegalArgumentException("unexpected type: " + protoType);
   }
 
-  static final class EnumAdapter extends WireAdapter<Object> {
+  static final class EnumAdapter extends ProtoAdapter<Object> {
     final EnumType enumType;
 
     public EnumAdapter(EnumType enumType) {
@@ -114,13 +114,13 @@ final class SchemaWireAdapterFactory {
     }
 
     @Override public Object decode(ProtoReader reader) throws IOException {
-      Integer value = WireAdapter.UINT32.decode(reader);
+      Integer value = ProtoAdapter.UINT32.decode(reader);
       EnumConstant constant = enumType.constant(value);
       return constant != null ? constant.name() : value;
     }
   }
 
-  static final class MessageAdapter extends WireAdapter<Map<String, Object>> {
+  static final class MessageAdapter extends ProtoAdapter<Map<String, Object>> {
     final Map<Integer, Field> fieldsByTag = new LinkedHashMap<>();
     final Map<String, Field> fieldsByName = new LinkedHashMap<>();
     final boolean includeUnknown;
@@ -140,13 +140,13 @@ final class SchemaWireAdapterFactory {
         Field field = fieldsByName.get(entry.getKey());
         if (field == null) continue; // Ignore unknown values!
 
-        WireAdapter<Object> wireAdapter = (WireAdapter<Object>) field.wireAdapter;
+        ProtoAdapter<Object> protoAdapter = (ProtoAdapter<Object>) field.protoAdapter;
         if (field.repeated) {
           for (Object o : (List<?>) entry.getValue()) {
-            size += wireAdapter.encodedSize(field.tag, o);
+            size += protoAdapter.encodedSize(field.tag, o);
           }
         } else {
-          size += wireAdapter.encodedSize(field.tag, entry.getValue());
+          size += protoAdapter.encodedSize(field.tag, entry.getValue());
         }
       }
       return size;
@@ -157,13 +157,13 @@ final class SchemaWireAdapterFactory {
         Field field = fieldsByName.get(entry.getKey());
         if (field == null) continue; // Ignore unknown values!
 
-        WireAdapter<Object> wireAdapter = (WireAdapter<Object>) field.wireAdapter;
+        ProtoAdapter<Object> protoAdapter = (ProtoAdapter<Object>) field.protoAdapter;
         if (field.repeated) {
           for (Object o : (List<?>) entry.getValue()) {
-            wireAdapter.encodeTagged(writer, field.tag, o);
+            protoAdapter.encodeTagged(writer, field.tag, o);
           }
         } else {
-          wireAdapter.encodeTagged(writer, field.tag, entry.getValue());
+          protoAdapter.encodeTagged(writer, field.tag, entry.getValue());
         }
       }
     }
@@ -177,14 +177,14 @@ final class SchemaWireAdapterFactory {
         if (field == null) {
           if (includeUnknown) {
             String name = Integer.toString(tag);
-            field = new Field(name, tag, true, reader.peekFieldEncoding().rawWireAdapter());
+            field = new Field(name, tag, true, reader.peekFieldEncoding().rawProtoAdapter());
           } else {
             reader.skip();
             continue;
           }
         }
 
-        Object value = field.wireAdapter.decode(reader);
+        Object value = field.protoAdapter.decode(reader);
         if (field.repeated) {
           List<Object> values = (List<Object>) result.get(field.name);
           if (values == null) {
@@ -209,13 +209,13 @@ final class SchemaWireAdapterFactory {
     final String name;
     final int tag;
     final boolean repeated;
-    final WireAdapter<?> wireAdapter;
+    final ProtoAdapter<?> protoAdapter;
 
-    public Field(String name, int tag, boolean repeated, WireAdapter<?> wireAdapter) {
+    public Field(String name, int tag, boolean repeated, ProtoAdapter<?> protoAdapter) {
       this.name = name;
       this.tag = tag;
       this.repeated = repeated;
-      this.wireAdapter = wireAdapter;
+      this.protoAdapter = protoAdapter;
     }
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Service.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Service.java
@@ -16,26 +16,26 @@
 package com.squareup.wire.schema;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.RpcElement;
 import com.squareup.wire.schema.internal.parser.ServiceElement;
 import java.util.NavigableSet;
 
 public final class Service {
-  private final WireType wireType;
+  private final ProtoType protoType;
   private final ServiceElement element;
   private final ImmutableList<Rpc> rpcs;
   private final Options options;
 
-  private Service(WireType wireType, ServiceElement element,
+  private Service(ProtoType protoType, ServiceElement element,
       ImmutableList<Rpc> rpcs, Options options) {
-    this.wireType = wireType;
+    this.protoType = protoType;
     this.element = element;
     this.rpcs = rpcs;
     this.options = options;
   }
 
-  public static Service get(WireType wireType, ServiceElement element) {
+  public static Service get(ProtoType protoType, ServiceElement element) {
     ImmutableList.Builder<Rpc> rpcs = ImmutableList.builder();
     for (RpcElement rpc : element.rpcs()) {
       rpcs.add(new Rpc(rpc));
@@ -43,15 +43,15 @@ public final class Service {
 
     Options options = new Options(Options.SERVICE_OPTIONS, element.options());
 
-    return new Service(wireType, element, rpcs.build(), options);
+    return new Service(protoType, element, rpcs.build(), options);
   }
 
   public Location location() {
     return element.location();
   }
 
-  public WireType type() {
-    return wireType;
+  public ProtoType type() {
+    return protoType;
   }
 
   public String documentation() {
@@ -99,7 +99,7 @@ public final class Service {
   }
 
   Service retainAll(NavigableSet<String> identifiers) {
-    String serviceName = wireType.toString();
+    String serviceName = protoType.toString();
 
     // If this service is not retained, prune it.
     if (!identifiers.contains(serviceName)) {
@@ -109,7 +109,7 @@ public final class Service {
     ImmutableList<Rpc> retainedRpcs = rpcs;
 
     // If any of our RPCs are specifically retained, retain only that set.
-    if (Pruner.hasMarkedMember(identifiers, wireType)) {
+    if (Pruner.hasMarkedMember(identifiers, protoType)) {
       ImmutableList.Builder<Rpc> retainedRpcsBuilder = ImmutableList.builder();
       for (Rpc rpc : rpcs) {
         if (identifiers.contains(serviceName + '#' + rpc.name())) {
@@ -119,6 +119,6 @@ public final class Service {
       retainedRpcs = retainedRpcsBuilder.build();
     }
 
-    return new Service(wireType, element, retainedRpcs, options);
+    return new Service(protoType, element, retainedRpcs, options);
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
@@ -16,7 +16,7 @@
 package com.squareup.wire.schema;
 
 import com.google.common.collect.ImmutableList;
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.parser.EnumConstantElement;
 import com.squareup.wire.schema.internal.parser.EnumElement;
 import com.squareup.wire.schema.internal.parser.ExtensionsElement;
@@ -28,7 +28,7 @@ import java.util.NavigableSet;
 
 public abstract class Type {
   public abstract Location location();
-  public abstract WireType name();
+  public abstract ProtoType name();
   public abstract String documentation();
   public abstract Options options();
   public abstract ImmutableList<Type> nestedTypes();
@@ -37,7 +37,7 @@ public abstract class Type {
   abstract void linkOptions(Linker linker);
   abstract Type retainAll(NavigableSet<String> identifiers);
 
-  static Type get(String packageName, WireType wireType, TypeElement type) {
+  static Type get(String packageName, ProtoType protoType, TypeElement type) {
     if (type instanceof EnumElement) {
       EnumElement enumElement = (EnumElement) type;
 
@@ -48,7 +48,7 @@ public abstract class Type {
 
       Options options = new Options(Options.ENUM_OPTIONS, enumElement.options());
 
-      return new EnumType(wireType, enumElement, constants.build(), options);
+      return new EnumType(protoType, enumElement, constants.build(), options);
 
     } else if (type instanceof MessageElement) {
       MessageElement messageElement = (MessageElement) type;
@@ -65,7 +65,7 @@ public abstract class Type {
 
       ImmutableList.Builder<Type> nestedTypes = ImmutableList.builder();
       for (TypeElement nestedType : messageElement.nestedTypes()) {
-        nestedTypes.add(Type.get(packageName, wireType.nestedType(nestedType.name()), nestedType));
+        nestedTypes.add(Type.get(packageName, protoType.nestedType(nestedType.name()), nestedType));
       }
 
       ImmutableList.Builder<Extensions> extensionsList = ImmutableList.builder();
@@ -75,7 +75,7 @@ public abstract class Type {
 
       Options options = new Options(Options.MESSAGE_OPTIONS, messageElement.options());
 
-      return new MessageType(wireType, messageElement, fields.build(), oneOfs.build(),
+      return new MessageType(protoType, messageElement, fields.build(), oneOfs.build(),
           nestedTypes.build(), extensionsList.build(), options);
 
     } else {

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaBuilder.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaBuilder.java
@@ -17,7 +17,7 @@ package com.squareup.wire.schema;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
-import com.squareup.wire.WireAdapter;
+import com.squareup.wire.ProtoAdapter;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;
@@ -65,8 +65,8 @@ class SchemaBuilder {
     }
   }
 
-  public WireAdapter<Object> buildWireAdapter(String messageTypeName) {
+  public ProtoAdapter<Object> buildProtoAdapter(String messageTypeName) {
     Schema schema = build();
-    return schema.wireAdapter(messageTypeName, true);
+    return schema.protoAdapter(messageTypeName, true);
   }
 }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.wire.schema;
 
-import com.squareup.wire.WireType;
+import com.squareup.wire.ProtoType;
 import com.squareup.wire.schema.internal.Util;
 import org.junit.Test;
 
@@ -821,10 +821,10 @@ public final class SchemaTest {
             + "}\n")
         .build();
     MessageType messageC = (MessageType) schema.getType("a.b.MessageB");
-    assertThat(messageC.field("c1").type()).isEqualTo(WireType.get("a.b.MessageC"));
-    assertThat(messageC.field("c2").type()).isEqualTo(WireType.get("a.b.MessageC"));
-    assertThat(messageC.field("c3").type()).isEqualTo(WireType.get("a.b.MessageC"));
-    assertThat(messageC.field("c4").type()).isEqualTo(WireType.get("a.b.MessageC"));
+    assertThat(messageC.field("c1").type()).isEqualTo(ProtoType.get("a.b.MessageC"));
+    assertThat(messageC.field("c2").type()).isEqualTo(ProtoType.get("a.b.MessageC"));
+    assertThat(messageC.field("c3").type()).isEqualTo(ProtoType.get("a.b.MessageC"));
+    assertThat(messageC.field("c4").type()).isEqualTo(ProtoType.get("a.b.MessageC"));
   }
 
   @Test public void importResolvesEnclosingPackageSuffix() throws Exception {
@@ -844,7 +844,7 @@ public final class SchemaTest {
             + "}\n")
         .build();
     MessageType messageC = (MessageType) schema.getType("a.b.c.MessageC");
-    assertThat(messageC.field("message_b").type()).isEqualTo(WireType.get("a.b.MessageB"));
+    assertThat(messageC.field("message_b").type()).isEqualTo(ProtoType.get("a.b.MessageB"));
   }
 
   @Test public void importResolvesNestedPackageSuffix() throws Exception {
@@ -864,7 +864,7 @@ public final class SchemaTest {
             + "}\n")
         .build();
     MessageType messageC = (MessageType) schema.getType("a.b.MessageB");
-    assertThat(messageC.field("message_c").type()).isEqualTo(WireType.get("a.b.c.MessageC"));
+    assertThat(messageC.field("message_c").type()).isEqualTo(ProtoType.get("a.b.c.MessageC"));
   }
 
   @Test public void nestedPackagePreferredOverEnclosingPackage() throws Exception {
@@ -890,7 +890,7 @@ public final class SchemaTest {
             + "}\n")
         .build();
     MessageType messageC = (MessageType) schema.getType("a.b.MessageB");
-    assertThat(messageC.field("message_a").type()).isEqualTo(WireType.get("a.b.a.MessageA"));
+    assertThat(messageC.field("message_a").type()).isEqualTo(ProtoType.get("a.b.a.MessageA"));
   }
 
   @Test public void dotPrefixRefersToRootPackage() throws Exception {
@@ -916,7 +916,7 @@ public final class SchemaTest {
             + "}\n")
         .build();
     MessageType messageC = (MessageType) schema.getType("a.b.MessageB");
-    assertThat(messageC.field("message_a").type()).isEqualTo(WireType.get("a.MessageA"));
+    assertThat(messageC.field("message_a").type()).isEqualTo(ProtoType.get("a.MessageA"));
   }
 
   @Test public void dotPrefixMustBeRoot() throws Exception {


### PR DESCRIPTION
Our new policy is simple. Use the Wire prefix for everything that is a part
of our beautiful API. Use the Proto prefix for everything that's a part of
Google's efficient schema language and encoded form.