### PR TITLE
Remove last uses of method indirection.

### DIFF
--- a/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
+++ b/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
@@ -99,7 +99,7 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
       emitJson(out, value, tagBinding.type, tagBinding.label);
     }
 
-    TagMap tagMap = message.tagMap();
+    TagMap tagMap = message.tagMap;
     if (tagMap != null) {
       for (Extension<?, ?> extension : tagMap.extensions(true)) {
         if (extension.isUnknown()) {

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -68,11 +68,6 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     }
   }
 
-  // Increase visibility for testing
-  TagMap tagMap() {
-    return tagMap;
-  }
-
   /** Utility method to return a mutable copy of a given List. Used by generated code. */
   protected static <T> List<T> copyOf(List<T> list) {
     if (list == null) {

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -337,7 +337,7 @@ public class WireTest {
     assertThat(result.phone.get(0).type).isNull();
 
     // The value 17 will be stored as an unknown varint with tag number 2
-    TagMap tagMap = ((Message) result.phone.get(0)).tagMap();
+    TagMap tagMap = ((Message) result.phone.get(0)).tagMap;
     assertThat(tagMap.size()).isEqualTo(1);
     assertThat(tagMap.get(Extension.unknown(PhoneNumber.class, 2, FieldEncoding.VARINT)))
         .isEqualTo(Arrays.asList(17L));


### PR DESCRIPTION
Most accesses were already directly to the package-private field.