### PR TITLE
Rename FieldEncoding to ProtoEncoding to match convention.

### DIFF
--- a/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
+++ b/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
@@ -31,10 +31,10 @@ import java.util.List;
 import java.util.Map;
 import okio.ByteString;
 
-import static com.squareup.wire.FieldEncoding.FIXED32;
-import static com.squareup.wire.FieldEncoding.FIXED64;
-import static com.squareup.wire.FieldEncoding.LENGTH_DELIMITED;
-import static com.squareup.wire.FieldEncoding.VARINT;
+import static com.squareup.wire.ProtoEncoding.FIXED32;
+import static com.squareup.wire.ProtoEncoding.FIXED64;
+import static com.squareup.wire.ProtoEncoding.LENGTH_DELIMITED;
+import static com.squareup.wire.ProtoEncoding.VARINT;
 import static com.squareup.wire.Message.Label;
 import static java.util.Collections.unmodifiableMap;
 

--- a/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
@@ -279,11 +279,11 @@ public class GsonTest {
     Gson gson = createGson();
 
     AllTypes.Builder builder = createBuilder();
-    builder.setExtension(Extension.unknown(AllTypes.class, 9000, FieldEncoding.FIXED32), 9000);
-    builder.setExtension(Extension.unknown(AllTypes.class, 9001, FieldEncoding.FIXED64), 9001L);
-    builder.setExtension(Extension.unknown(AllTypes.class, 9002, FieldEncoding.LENGTH_DELIMITED),
+    builder.setExtension(Extension.unknown(AllTypes.class, 9000, ProtoEncoding.FIXED32), 9000);
+    builder.setExtension(Extension.unknown(AllTypes.class, 9001, ProtoEncoding.FIXED64), 9001L);
+    builder.setExtension(Extension.unknown(AllTypes.class, 9002, ProtoEncoding.LENGTH_DELIMITED),
         ByteString.of((byte) '9', (byte) '0', (byte) '0', (byte) '2'));
-    builder.setExtension(Extension.unknown(AllTypes.class, 9003, FieldEncoding.VARINT), 9003L);
+    builder.setExtension(Extension.unknown(AllTypes.class, 9003, ProtoEncoding.VARINT), 9003L);
 
     AllTypes allTypes = builder.build();
     String json = gson.toJson(allTypes);
@@ -299,11 +299,11 @@ public class GsonTest {
     Gson gson = createGson();
 
     AllTypes.Builder builder = createBuilder();
-    builder.setExtension(Extension.unknown(AllTypes.class, 9000, FieldEncoding.FIXED32), 9000);
-    builder.setExtension(Extension.unknown(AllTypes.class, 9001, FieldEncoding.FIXED64), 9001L);
-    builder.setExtension(Extension.unknown(AllTypes.class, 9002, FieldEncoding.LENGTH_DELIMITED),
+    builder.setExtension(Extension.unknown(AllTypes.class, 9000, ProtoEncoding.FIXED32), 9000);
+    builder.setExtension(Extension.unknown(AllTypes.class, 9001, ProtoEncoding.FIXED64), 9001L);
+    builder.setExtension(Extension.unknown(AllTypes.class, 9002, ProtoEncoding.LENGTH_DELIMITED),
         ByteString.of((byte) '9', (byte) '0', (byte) '0', (byte) '2'));
-    builder.setExtension(Extension.unknown(AllTypes.class, 9003, FieldEncoding.VARINT), 9003L);
+    builder.setExtension(Extension.unknown(AllTypes.class, 9003, ProtoEncoding.VARINT), 9003L);
 
     AllTypes allTypes = setExtensions(builder).build();
     String json = gson.toJson(allTypes);

--- a/wire-runtime/src/main/java/com/squareup/wire/Extension.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Extension.java
@@ -219,8 +219,8 @@ public final class Extension<T extends Message<T>, E> implements Comparable<Exte
    * prepared with an older schema (if a field was added), or if an extension is not registered.
    */
   public static <T extends Message<T>, E> Extension<T, E> unknown(
-      Class<T> messageType, int tag, FieldEncoding fieldEncoding) {
-    return new Extension<>(messageType, fieldEncoding.javaType(), fieldEncoding.protoType(),
+      Class<T> messageType, int tag, ProtoEncoding protoEncoding) {
+    return new Extension<>(messageType, protoEncoding.javaType(), protoEncoding.protoType(),
         null, tag, Label.REPEATED);
   }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoEncoding.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoEncoding.java
@@ -19,16 +19,17 @@ import java.io.IOException;
 import java.net.ProtocolException;
 import okio.ByteString;
 
-public enum FieldEncoding {
+/** The byte format of an encoded proto object (message or field value). */
+public enum ProtoEncoding {
   VARINT(0), FIXED64(1), LENGTH_DELIMITED(2), FIXED32(5);
 
   final int value;
 
-  FieldEncoding(int value) {
+  ProtoEncoding(int value) {
     this.value = value;
   }
 
-  static FieldEncoding get(int value) throws IOException {
+  static ProtoEncoding get(int value) throws IOException {
     switch (value) {
       case 0: return VARINT;
       case 1: return FIXED64;

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoReader.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoReader.java
@@ -75,7 +75,7 @@ public final class ProtoReader {
   /** Limit once we complete the current length-delimited value. */
   private long pushedLimit = -1;
   /** The encoding of the next value to be read. */
-  private FieldEncoding nextFieldEncoding;
+  private ProtoEncoding nextEncoding;
 
   public ProtoReader(BufferedSource source, ExtensionRegistry extensionRegistry) {
     this.source = source;
@@ -127,7 +127,7 @@ public final class ProtoReader {
 
   /**
    * Reads and returns the next tag of the message, or -1 if there are no further tags. Use {@link
-   * #peekFieldEncoding()} after calling this method to query its encoding. This silently skips
+   * #peekEncoding()} after calling this method to query its encoding. This silently skips
    * groups.
    */
   public int nextTag() throws IOException {
@@ -153,7 +153,7 @@ public final class ProtoReader {
           throw new ProtocolException("Unexpected end group");
 
         case STATE_LENGTH_DELIMITED:
-          nextFieldEncoding = FieldEncoding.LENGTH_DELIMITED;
+          nextEncoding = ProtoEncoding.LENGTH_DELIMITED;
           state = STATE_LENGTH_DELIMITED;
           int length = internalReadVarint32();
           if (length < 0) throw new ProtocolException("Negative length: " + length);
@@ -165,17 +165,17 @@ public final class ProtoReader {
           return tag;
 
         case STATE_VARINT:
-          nextFieldEncoding = FieldEncoding.VARINT;
+          nextEncoding = ProtoEncoding.VARINT;
           state = STATE_VARINT;
           return tag;
 
         case STATE_FIXED64:
-          nextFieldEncoding = FieldEncoding.FIXED64;
+          nextEncoding = ProtoEncoding.FIXED64;
           state = STATE_FIXED64;
           return tag;
 
         case STATE_FIXED32:
-          nextFieldEncoding = FieldEncoding.FIXED32;
+          nextEncoding = ProtoEncoding.FIXED32;
           state = STATE_FIXED32;
           return tag;
 
@@ -191,15 +191,15 @@ public final class ProtoReader {
     Extension<T, ?> extension = extensionRegistry.get(messageType, tag);
     return extension != null
         ? extension
-        : Extension.unknown(messageType, tag, peekFieldEncoding());
+        : Extension.unknown(messageType, tag, peekEncoding());
   }
 
   /**
    * Returns the encoding of the next field value. {@link #nextTag()} must be called before
    * this method.
    */
-  public FieldEncoding peekFieldEncoding() throws IOException {
-    return nextFieldEncoding;
+  public ProtoEncoding peekEncoding() throws IOException {
+    return nextEncoding;
   }
 
   /**

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoWriter.java
@@ -59,13 +59,13 @@ import okio.ByteString;
 public final class ProtoWriter {
 
   /** Makes a tag value given a field number and wire type. */
-  private static int makeTag(int fieldNumber, FieldEncoding fieldEncoding) {
-    return (fieldNumber << ProtoReader.TAG_FIELD_ENCODING_BITS) | fieldEncoding.value;
+  private static int makeTag(int fieldNumber, ProtoEncoding protoEncoding) {
+    return (fieldNumber << ProtoReader.TAG_FIELD_ENCODING_BITS) | protoEncoding.value;
   }
 
   /** Compute the number of bytes that would be needed to encode a tag. */
   static int tagSize(int tag) {
-    return varint32Size(makeTag(tag, FieldEncoding.VARINT));
+    return varint32Size(makeTag(tag, ProtoEncoding.VARINT));
   }
 
   static int utf8Length(String s) {
@@ -199,8 +199,8 @@ public final class ProtoWriter {
   }
 
   /** Encode and write a tag. */
-  public void writeTag(int fieldNumber, FieldEncoding fieldEncoding) throws IOException {
-    writeVarint32(makeTag(fieldNumber, fieldEncoding));
+  public void writeTag(int fieldNumber, ProtoEncoding protoEncoding) throws IOException {
+    writeVarint32(makeTag(fieldNumber, protoEncoding));
   }
 
   /** Write an {@code int32} field to the stream. */

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeEnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeEnumAdapter.java
@@ -36,7 +36,7 @@ final class RuntimeEnumAdapter<E extends WireEnum> extends ProtoAdapter<E> {
   private final boolean isDense;
 
   RuntimeEnumAdapter(Class<E> type) {
-    super(FieldEncoding.VARINT, type);
+    super(ProtoEncoding.VARINT, type);
     this.type = type;
 
     constants = type.getEnumConstants();

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -53,7 +53,7 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
 
   RuntimeMessageAdapter(Class<M> messageType, Class<B> builderType,
       Constructor<B> builderCopyConstructor, Map<Integer, FieldBinding<M, B>> fieldBindings) {
-    super(FieldEncoding.LENGTH_DELIMITED, messageType);
+    super(ProtoEncoding.LENGTH_DELIMITED, messageType);
     this.messageType = messageType;
     this.builderType = builderType;
     this.builderCopyConstructor = builderCopyConstructor;
@@ -211,7 +211,7 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
         }
       } catch (RuntimeEnumAdapter.EnumConstantNotFoundException e) {
         // An unknown Enum value was encountered, store it as an unknown field
-        builder.setExtension(Extension.unknown(messageType, tag, FieldEncoding.VARINT), e.value);
+        builder.setExtension(Extension.unknown(messageType, tag, ProtoEncoding.VARINT), e.value);
       }
     }
     reader.endMessage(token);

--- a/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
@@ -108,7 +108,7 @@ public final class TagMap {
         for (int j = i; j < runEnd; j += 2) {
           runSize += adapter.encodedSize(array[j + 1]);
         }
-        writer.writeTag(extension.getTag(), FieldEncoding.LENGTH_DELIMITED);
+        writer.writeTag(extension.getTag(), ProtoEncoding.LENGTH_DELIMITED);
         writer.writeVarint32(runSize);
         for (int j = i; j < runEnd; j += 2) {
           adapter.encode(writer, array[j + 1]);

--- a/wire-runtime/src/test/java/com/squareup/wire/TagMapTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/TagMapTest.java
@@ -28,21 +28,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public final class TagMapTest {
   final Extension<FileOptions, Object> unknownA
-      = Extension.unknown(FileOptions.class, 1, FieldEncoding.FIXED64);
+      = Extension.unknown(FileOptions.class, 1, ProtoEncoding.FIXED64);
   final Extension<FileOptions, Double> extensionA
       = Extension.doubleExtending(FileOptions.class)
       .setName("a")
       .setTag(1)
       .buildOptional();
   final Extension<FileOptions, Object> unknownB
-      = Extension.unknown(FileOptions.class, 2, FieldEncoding.LENGTH_DELIMITED);
+      = Extension.unknown(FileOptions.class, 2, ProtoEncoding.LENGTH_DELIMITED);
   final Extension<FileOptions, String> extensionB
       = Extension.stringExtending(FileOptions.class)
       .setName("b")
       .setTag(2)
       .buildOptional();
   final Extension<FileOptions, Object> unknownC
-      = Extension.unknown(FileOptions.class, 3, FieldEncoding.VARINT);
+      = Extension.unknown(FileOptions.class, 3, ProtoEncoding.VARINT);
   final Extension<FileOptions, Type> extensionC
       = Extension.enumExtending("google.protobuf.FileOptions", Type.class, FileOptions.class)
       .setName("c")
@@ -308,7 +308,7 @@ public final class TagMapTest {
 
   @Test public void encodeUnknownEncodesAsRepeated() throws IOException {
     Extension<FileOptions, Object> unknown
-        = Extension.unknown(FileOptions.class, 90, FieldEncoding.VARINT);
+        = Extension.unknown(FileOptions.class, 90, ProtoEncoding.VARINT);
     TagMap map = new TagMap.Builder()
         .add(unknown, 601L)
         .add(unknown, 701L)
@@ -332,7 +332,7 @@ public final class TagMapTest {
         .buildPacked();
 
     Extension<FileOptions, Object> unknown
-        = Extension.unknown(FileOptions.class, 90, FieldEncoding.VARINT);
+        = Extension.unknown(FileOptions.class, 90, ProtoEncoding.VARINT);
     TagMap map = new TagMap.Builder()
         .add(extension, 601)
         .add(extension, 602)
@@ -355,7 +355,7 @@ public final class TagMapTest {
         .buildPacked();
 
     Extension<FileOptions, Object> unknown
-        = Extension.unknown(FileOptions.class, 90, FieldEncoding.LENGTH_DELIMITED);
+        = Extension.unknown(FileOptions.class, 90, ProtoEncoding.LENGTH_DELIMITED);
     TagMap map = new TagMap.Builder()
         .add(unknown, ByteString.decodeHex("d904da04"))
         .build();

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -332,7 +332,7 @@ public class WireTest {
     // The value 17 will be stored as an unknown varint with tag number 2
     TagMap tagMap = ((Message) result.phone.get(0)).tagMap;
     assertThat(tagMap.size()).isEqualTo(1);
-    assertThat(tagMap.get(Extension.unknown(PhoneNumber.class, 2, FieldEncoding.VARINT)))
+    assertThat(tagMap.get(Extension.unknown(PhoneNumber.class, 2, ProtoEncoding.VARINT)))
         .isEqualTo(Arrays.asList(17L));
 
     // Serialize again, value is preserved

--- a/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protobuf/TestAllTypes.java
@@ -17,7 +17,7 @@ package com.squareup.wire.protobuf;
 
 import com.squareup.wire.Extension;
 import com.squareup.wire.ExtensionRegistry;
-import com.squareup.wire.FieldEncoding;
+import com.squareup.wire.ProtoEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.protos.alltypes.AllTypes;
@@ -556,7 +556,7 @@ public class TestAllTypes {
   @Test
   public void testUnknownFields() {
     AllTypes.Builder builder = getBuilder();
-    builder.setExtension(Extension.unknown(AllTypes.class, 10000, FieldEncoding.VARINT), 1L);
+    builder.setExtension(Extension.unknown(AllTypes.class, 10000, ProtoEncoding.VARINT), 1L);
     AllTypes withUnknownField = builder.build();
     byte[] data = adapter.encode(withUnknownField);
     int count = TestAllTypesData.expectedOutput.size();
@@ -570,10 +570,10 @@ public class TestAllTypes {
   @Test @Ignore("we no longer enforce this constraint")
   public void testUnknownFieldsTypeMismatch() {
     AllTypes.Builder builder = getBuilder();
-    builder.setExtension(Extension.unknown(AllTypes.class, 10000, FieldEncoding.VARINT), 1);
+    builder.setExtension(Extension.unknown(AllTypes.class, 10000, ProtoEncoding.VARINT), 1);
     try {
       // Don't allow heterogeneous types for the same tag
-      builder.setExtension(Extension.unknown(AllTypes.class, 10000, FieldEncoding.FIXED32), 2);
+      builder.setExtension(Extension.unknown(AllTypes.class, 10000, ProtoEncoding.FIXED32), 2);
       fail();
     } catch (IllegalArgumentException expected) {
       assertThat(expected).hasMessage(

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -128,10 +128,10 @@ public final class Schema {
    * @param includeUnknown true to include values for unknown tags in the returned model. Map keys
    *     for such values is the unknown value's tag name as a string. Unknown values are decoded to
    *     {@linkplain Long}, {@linkplain Long}, {@linkplain Integer}, or {@linkplain okio.ByteString
-   *     ByteString} for {@linkplain com.squareup.wire.FieldEncoding#VARINT VARINT}, {@linkplain
-   *     com.squareup.wire.FieldEncoding#FIXED64 FIXED64}, {@linkplain
-   *     com.squareup.wire.FieldEncoding#FIXED32 FIXED32}, or {@linkplain
-   *     com.squareup.wire.FieldEncoding#LENGTH_DELIMITED LENGTH_DELIMITED} respectively.
+   *     ByteString} for {@linkplain com.squareup.wire.ProtoEncoding#VARINT VARINT}, {@linkplain
+   *     com.squareup.wire.ProtoEncoding#FIXED64 FIXED64}, {@linkplain
+   *     com.squareup.wire.ProtoEncoding#FIXED32 FIXED32}, or {@linkplain
+   *     com.squareup.wire.ProtoEncoding#LENGTH_DELIMITED LENGTH_DELIMITED} respectively.
    */
   public ProtoAdapter<Object> protoAdapter(String typeName, boolean includeUnknown) {
     Type type = getType(typeName);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/SchemaProtoAdapterFactory.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/SchemaProtoAdapterFactory.java
@@ -15,7 +15,7 @@
  */
 package com.squareup.wire.schema;
 
-import com.squareup.wire.FieldEncoding;
+import com.squareup.wire.ProtoEncoding;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.ProtoAdapter;
@@ -94,7 +94,7 @@ final class SchemaProtoAdapterFactory {
     final EnumType enumType;
 
     public EnumAdapter(EnumType enumType) {
-      super(FieldEncoding.VARINT, Object.class);
+      super(ProtoEncoding.VARINT, Object.class);
       this.enumType = enumType;
     }
 
@@ -126,7 +126,7 @@ final class SchemaProtoAdapterFactory {
     final boolean includeUnknown;
 
     public MessageAdapter(boolean includeUnknown) {
-      super(FieldEncoding.LENGTH_DELIMITED, Map.class);
+      super(ProtoEncoding.LENGTH_DELIMITED, Map.class);
       this.includeUnknown = includeUnknown;
     }
 
@@ -177,7 +177,7 @@ final class SchemaProtoAdapterFactory {
         if (field == null) {
           if (includeUnknown) {
             String name = Integer.toString(tag);
-            field = new Field(name, tag, true, reader.peekFieldEncoding().rawProtoAdapter());
+            field = new Field(name, tag, true, reader.peekEncoding().rawProtoAdapter());
           } else {
             reader.skip();
             continue;


### PR DESCRIPTION
This represents an encoded format in protocol buffers and thus should be prefixed with 'Proto'.