### PR TITLE
Change WireField to use the adapter, not the proto type.

### DIFF
--- a/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
+++ b/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.java
@@ -96,7 +96,7 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
         continue;
       }
       out.name(tagBinding.name);
-      emitJson(out, value, tagBinding.type, tagBinding.label);
+      emitJson(out, value, tagBinding.singleAdapter(), tagBinding.label);
     }
 
     TagMap tagMap = message.tagMap;
@@ -135,7 +135,7 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
         } else {
           Object value = tagMap.get(extension);
           out.name(extension.getName());
-          emitJson(out, value, extension.getProtoType(), extension.getLabel());
+          emitJson(out, value, extension.getAdapter(), extension.getLabel());
         }
       }
     }
@@ -144,9 +144,9 @@ class MessageTypeAdapter<M extends Message<M>, B extends Message.Builder<M, B>>
   }
 
   @SuppressWarnings("unchecked")
-  private void emitJson(JsonWriter out, Object value, ProtoType type, Label label)
+  private void emitJson(JsonWriter out, Object value, ProtoAdapter<?> adapter, Label label)
       throws IOException {
-    if (type == ProtoType.UINT64) {
+    if (adapter == ProtoAdapter.UINT64) {
       if (label.isRepeated()) {
         List<Long> longs = (List<Long>) value;
         out.beginArray();

--- a/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
@@ -98,7 +98,7 @@ public class GsonTest {
 
   private static final String JSON_EXTENSIONS =
       ",\"squareup.protos.alltypes.ext_opt_int32\":2147483647,"
-          + "\"squareup.protos.alltypes.ext_opt_int64\":4611686018427388081,"
+          + "\"squareup.protos.alltypes.ext_opt_int64\":-4611686018427387726,"
           + "\"squareup.protos.alltypes.ext_opt_uint64\":13835058055282163890,"
           + "\"squareup.protos.alltypes.ext_opt_sint64\":-4611686018427387726,"
           + "\"squareup.protos.alltypes.ext_opt_bool\":true,"
@@ -210,7 +210,7 @@ public class GsonTest {
   private AllTypes.Builder setExtensions(AllTypes.Builder builder) {
     AllTypes.NestedMessage nestedMessage = new AllTypes.NestedMessage.Builder().a(999).build();
     builder.setExtension(Ext_all_types.ext_opt_int32, Integer.MAX_VALUE)
-        .setExtension(Ext_all_types.ext_opt_int64, Long.MAX_VALUE / 2 + 178)
+        .setExtension(Ext_all_types.ext_opt_int64, Long.MIN_VALUE / 2 + 178)
         .setExtension(Ext_all_types.ext_opt_uint64, Long.MIN_VALUE / 2 + 178)
         .setExtension(Ext_all_types.ext_opt_sint64, Long.MIN_VALUE / 2 + 178)
         .setExtension(Ext_all_types.ext_opt_bool, true)

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -122,535 +122,535 @@ public final class AllTypes extends Message<AllTypes> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      type = "uint32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      type = "sint32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      type = "fixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      type = "sfixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      type = "int64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      type = "uint64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      type = "sint64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      type = "fixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      type = "sfixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      type = "float"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      type = "double"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      type = "squareup.protos.alltypes.AllTypes.NestedMessage"
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
-      type = "uint32",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
-      type = "sint32",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
-      type = "fixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
-      type = "sfixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
-      type = "int64",
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
-      type = "uint64",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
-      type = "sint64",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
-      type = "fixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
-      type = "sfixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
-      type = "bool",
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
       label = WireField.Label.REQUIRED
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.REQUIRED
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
-      type = "double",
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
       label = WireField.Label.REQUIRED
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
-      type = "bytes",
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
       label = WireField.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
       label = WireField.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
-      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER",
       label = WireField.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
-      type = "uint32",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
-      type = "sint32",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
-      type = "fixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
-      type = "sfixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
-      type = "int64",
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
-      type = "uint64",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
-      type = "sint64",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
-      type = "fixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
-      type = "sfixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
-      type = "bool",
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
       label = WireField.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.REPEATED
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
-      type = "double",
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
       label = WireField.Label.REPEATED
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REPEATED
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
-      type = "bytes",
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
       label = WireField.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
-      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
-      type = "uint32",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
-      type = "sint32",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
-      type = "fixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
-      type = "sfixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
-      type = "int64",
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
-      type = "uint64",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
-      type = "sint64",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
-      type = "fixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
-      type = "sfixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
-      type = "bool",
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
       label = WireField.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.PACKED
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
-      type = "double",
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
       label = WireField.Label.PACKED
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
       label = WireField.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      type = "uint32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      type = "sint32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      type = "fixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      type = "sfixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      type = "int64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      type = "uint64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      type = "sint64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      type = "fixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      type = "sfixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      type = "float"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      type = "double"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum default_nested_enum;
 
@@ -1647,7 +1647,7 @@ public final class AllTypes extends Message<AllTypes> {
 
     @WireField(
         tag = 1,
-        type = "int32"
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
     )
     public final Integer a;
 

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
@@ -272,7 +272,24 @@ public abstract class ProtoAdapter<E> {
       return reader.readVarint64();
     }
   };
-  public static final ProtoAdapter<Long> UINT64 = INT64;
+  /**
+   * Like INT64, but negative longs are interpreted as large positive values, and encoded that way
+   * in JSON.
+   */
+  public static final ProtoAdapter<Long> UINT64 = new ProtoAdapter<Long>(
+      FieldEncoding.VARINT, Long.class) {
+    @Override public int encodedSize(Long value) {
+      return varint64Size(value);
+    }
+
+    @Override public void encode(ProtoWriter writer, Long value) throws IOException {
+      writer.writeVarint64(value);
+    }
+
+    @Override public Long decode(ProtoReader reader) throws IOException {
+      return reader.readVarint64();
+    }
+  };
   public static final ProtoAdapter<Long> SINT64 = new ProtoAdapter<Long>(
       FieldEncoding.VARINT, Long.class) {
     @Override public int encodedSize(Long value) {

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -132,8 +132,8 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
   @Override public M redact(M message) {
     B builder = newBuilder(message);
     for (FieldBinding<M, B> fieldBinding : fieldBindings.values()) {
-      if (!fieldBinding.redacted && (fieldBinding.type.isScalar()
-          || fieldBinding.getFromBuilder(builder) instanceof WireEnum)) {
+      if (!fieldBinding.redacted
+          && !Message.class.isAssignableFrom(fieldBinding.singleAdapter().javaType)) {
         continue;
       }
       if (fieldBinding.redacted && fieldBinding.label == WireField.Label.REQUIRED) {

--- a/wire-runtime/src/main/java/com/squareup/wire/WireField.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/WireField.java
@@ -31,11 +31,11 @@ public @interface WireField {
   int tag();
 
   /**
-   * The field's protocol buffer data type. This is either a scalar (like {@code int32} or {@code
-   * string}), a message type (like {@code squareup.protos.Person}), or an enum type (like {@code
-   * squareup.protos.CurrencyCode}).
+   * Reference to the static field that holds a {@link ProtoAdapter} that can encode and decode this
+   * field. The reference is a string like {@code com.squareup.wire.protos.person.Person#ADAPTER}
+   * and contains a fully-qualified class name followed by a hash symbol and a field name.
    */
-  String type();
+  String adapter();
 
   /**
    * The field's protocol buffer label, one of {@link Label#OPTIONAL},

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -26,7 +26,7 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String name;
 
@@ -35,48 +35,48 @@ public final class DescriptorProto extends Message<DescriptorProto> {
    */
   @WireField(
       tag = 8,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String doc;
 
   @WireField(
       tag = 2,
-      type = "google.protobuf.FieldDescriptorProto",
+      adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<FieldDescriptorProto> field;
 
   @WireField(
       tag = 6,
-      type = "google.protobuf.FieldDescriptorProto",
+      adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 
   @WireField(
       tag = 3,
-      type = "google.protobuf.DescriptorProto",
+      adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<DescriptorProto> nested_type;
 
   @WireField(
       tag = 4,
-      type = "google.protobuf.EnumDescriptorProto",
+      adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
   @WireField(
       tag = 5,
-      type = "google.protobuf.DescriptorProto.ExtensionRange",
+      adapter = "com.google.protobuf.DescriptorProto$ExtensionRange#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<ExtensionRange> extension_range;
 
   @WireField(
       tag = 7,
-      type = "google.protobuf.MessageOptions"
+      adapter = "com.google.protobuf.MessageOptions#ADAPTER"
   )
   public final MessageOptions options;
 
@@ -221,13 +221,13 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
     @WireField(
         tag = 1,
-        type = "int32"
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
     )
     public final Integer start;
 
     @WireField(
         tag = 2,
-        type = "int32"
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
     )
     public final Integer end;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -25,7 +25,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String name;
 
@@ -34,20 +34,20 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
    */
   @WireField(
       tag = 4,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String doc;
 
   @WireField(
       tag = 2,
-      type = "google.protobuf.EnumValueDescriptorProto",
+      adapter = "com.google.protobuf.EnumValueDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<EnumValueDescriptorProto> value;
 
   @WireField(
       tag = 3,
-      type = "google.protobuf.EnumOptions"
+      adapter = "com.google.protobuf.EnumOptions#ADAPTER"
   )
   public final EnumOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -20,7 +20,7 @@ public final class EnumOptions extends Message<EnumOptions> {
    */
   @WireField(
       tag = 999,
-      type = "google.protobuf.UninterpretedOption",
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -26,7 +26,7 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String name;
 
@@ -35,19 +35,19 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
    */
   @WireField(
       tag = 4,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String doc;
 
   @WireField(
       tag = 2,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer number;
 
   @WireField(
       tag = 3,
-      type = "google.protobuf.EnumValueOptions"
+      adapter = "com.google.protobuf.EnumValueOptions#ADAPTER"
   )
   public final EnumValueOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -20,7 +20,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
    */
   @WireField(
       tag = 999,
-      type = "google.protobuf.UninterpretedOption",
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
@@ -37,7 +37,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String name;
 
@@ -46,19 +46,19 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @WireField(
       tag = 9,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String doc;
 
   @WireField(
       tag = 3,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer number;
 
   @WireField(
       tag = 4,
-      type = "google.protobuf.FieldDescriptorProto.Label"
+      adapter = "com.google.protobuf.FieldDescriptorProto$Label#ADAPTER"
   )
   public final Label label;
 
@@ -68,7 +68,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @WireField(
       tag = 5,
-      type = "google.protobuf.FieldDescriptorProto.Type"
+      adapter = "com.google.protobuf.FieldDescriptorProto$Type#ADAPTER"
   )
   public final Type type;
 
@@ -81,7 +81,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @WireField(
       tag = 6,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String type_name;
 
@@ -91,7 +91,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String extendee;
 
@@ -104,13 +104,13 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
    */
   @WireField(
       tag = 7,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String default_value;
 
   @WireField(
       tag = 8,
-      type = "google.protobuf.FieldOptions"
+      adapter = "com.google.protobuf.FieldOptions#ADAPTER"
   )
   public final FieldOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -34,7 +34,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @WireField(
       tag = 1,
-      type = "google.protobuf.FieldOptions.CType"
+      adapter = "com.google.protobuf.FieldOptions$CType#ADAPTER"
   )
   public final CType ctype;
 
@@ -46,7 +46,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @WireField(
       tag = 2,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean packed;
 
@@ -58,7 +58,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @WireField(
       tag = 3,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean deprecated;
 
@@ -78,7 +78,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @WireField(
       tag = 9,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String experimental_map_key;
 
@@ -87,7 +87,7 @@ public final class FieldOptions extends Message<FieldOptions> {
    */
   @WireField(
       tag = 999,
-      type = "google.protobuf.UninterpretedOption",
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -28,7 +28,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String name;
 
@@ -37,7 +37,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String _package;
 
@@ -46,7 +46,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @WireField(
       tag = 3,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REPEATED
   )
   public final List<String> dependency;
@@ -56,35 +56,35 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @WireField(
       tag = 4,
-      type = "google.protobuf.DescriptorProto",
+      adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<DescriptorProto> message_type;
 
   @WireField(
       tag = 5,
-      type = "google.protobuf.EnumDescriptorProto",
+      adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<EnumDescriptorProto> enum_type;
 
   @WireField(
       tag = 6,
-      type = "google.protobuf.ServiceDescriptorProto",
+      adapter = "com.google.protobuf.ServiceDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<ServiceDescriptorProto> service;
 
   @WireField(
       tag = 7,
-      type = "google.protobuf.FieldDescriptorProto",
+      adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<FieldDescriptorProto> extension;
 
   @WireField(
       tag = 8,
-      type = "google.protobuf.FileOptions"
+      adapter = "com.google.protobuf.FileOptions#ADAPTER"
   )
   public final FileOptions options;
 
@@ -96,7 +96,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
    */
   @WireField(
       tag = 9,
-      type = "google.protobuf.SourceCodeInfo"
+      adapter = "com.google.protobuf.SourceCodeInfo#ADAPTER"
   )
   public final SourceCodeInfo source_code_info;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -21,7 +21,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
 
   @WireField(
       tag = 1,
-      type = "google.protobuf.FileDescriptorProto",
+      adapter = "com.google.protobuf.FileDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<FileDescriptorProto> file;

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -69,7 +69,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String java_package;
 
@@ -82,7 +82,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @WireField(
       tag = 8,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String java_outer_classname;
 
@@ -96,7 +96,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @WireField(
       tag = 10,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean java_multiple_files;
 
@@ -108,13 +108,13 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @WireField(
       tag = 20,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean java_generate_equals_and_hash;
 
   @WireField(
       tag = 9,
-      type = "google.protobuf.FileOptions.OptimizeMode"
+      adapter = "com.google.protobuf.FileOptions$OptimizeMode#ADAPTER"
   )
   public final OptimizeMode optimize_for;
 
@@ -132,19 +132,19 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @WireField(
       tag = 16,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean cc_generic_services;
 
   @WireField(
       tag = 17,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean java_generic_services;
 
   @WireField(
       tag = 18,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean py_generic_services;
 
@@ -153,7 +153,7 @@ public final class FileOptions extends Message<FileOptions> {
    */
   @WireField(
       tag = 999,
-      type = "google.protobuf.UninterpretedOption",
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -42,7 +42,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    */
   @WireField(
       tag = 1,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean message_set_wire_format;
 
@@ -53,7 +53,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    */
   @WireField(
       tag = 2,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean no_standard_descriptor_accessor;
 
@@ -62,7 +62,7 @@ public final class MessageOptions extends Message<MessageOptions> {
    */
   @WireField(
       tag = 999,
-      type = "google.protobuf.UninterpretedOption",
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
@@ -27,7 +27,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String name;
 
@@ -36,7 +36,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
    */
   @WireField(
       tag = 5,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String doc;
 
@@ -46,19 +46,19 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
    */
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String input_type;
 
   @WireField(
       tag = 3,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String output_type;
 
   @WireField(
       tag = 4,
-      type = "google.protobuf.MethodOptions"
+      adapter = "com.google.protobuf.MethodOptions#ADAPTER"
   )
   public final MethodOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -24,7 +24,7 @@ public final class MethodOptions extends Message<MethodOptions> {
    */
   @WireField(
       tag = 999,
-      type = "google.protobuf.UninterpretedOption",
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -25,13 +25,13 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String name;
 
   @WireField(
       tag = 2,
-      type = "google.protobuf.MethodDescriptorProto",
+      adapter = "com.google.protobuf.MethodDescriptorProto#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<MethodDescriptorProto> method;
@@ -41,13 +41,13 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
    */
   @WireField(
       tag = 4,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String doc;
 
   @WireField(
       tag = 3,
-      type = "google.protobuf.ServiceOptions"
+      adapter = "com.google.protobuf.ServiceOptions#ADAPTER"
   )
   public final ServiceOptions options;
 

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -24,7 +24,7 @@ public final class ServiceOptions extends Message<ServiceOptions> {
    */
   @WireField(
       tag = 999,
-      type = "google.protobuf.UninterpretedOption",
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<UninterpretedOption> uninterpreted_option;

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -69,7 +69,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
    */
   @WireField(
       tag = 1,
-      type = "google.protobuf.SourceCodeInfo.Location",
+      adapter = "com.google.protobuf.SourceCodeInfo$Location#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<Location> location;
@@ -196,7 +196,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
      */
     @WireField(
         tag = 1,
-        type = "int32",
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
         label = WireField.Label.PACKED
     )
     public final List<Integer> path;
@@ -210,7 +210,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
      */
     @WireField(
         tag = 2,
-        type = "int32",
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
         label = WireField.Label.PACKED
     )
     public final List<Integer> span;

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -42,7 +42,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
   @WireField(
       tag = 2,
-      type = "google.protobuf.UninterpretedOption.NamePart",
+      adapter = "com.google.protobuf.UninterpretedOption$NamePart#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<NamePart> name;
@@ -53,37 +53,37 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
    */
   @WireField(
       tag = 3,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String identifier_value;
 
   @WireField(
       tag = 4,
-      type = "uint64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long positive_int_value;
 
   @WireField(
       tag = 5,
-      type = "int64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long negative_int_value;
 
   @WireField(
       tag = 6,
-      type = "double"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double double_value;
 
   @WireField(
       tag = 7,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString string_value;
 
   @WireField(
       tag = 8,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String aggregate_value;
 
@@ -225,14 +225,14 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
     @WireField(
         tag = 1,
-        type = "string",
+        adapter = "com.squareup.wire.ProtoAdapter#STRING",
         label = WireField.Label.REQUIRED
     )
     public final String name_part;
 
     @WireField(
         tag = 2,
-        type = "bool",
+        adapter = "com.squareup.wire.ProtoAdapter#BOOL",
         label = WireField.Label.REQUIRED
     )
     public final Boolean is_extension;

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -90,7 +90,7 @@ public final class Bar extends Message<Bar> {
 
       @WireField(
           tag = 1,
-          type = "string"
+          adapter = "com.squareup.wire.ProtoAdapter#STRING"
       )
       public final String boo;
 

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -16,7 +16,7 @@ public final class Foo extends Message<Foo> {
 
   @WireField(
       tag = 1,
-      type = "squareup.differentpackage.bar.Bar.Baz.Moo"
+      adapter = "com.squareup.differentpackage.protos.bar.Bar$Baz$Moo#ADAPTER"
   )
   public final Bar.Baz.Moo moo;
 

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
@@ -90,7 +90,7 @@ public final class Bar extends Message<Bar> {
 
       @WireField(
           tag = 1,
-          type = "string"
+          adapter = "com.squareup.wire.ProtoAdapter#STRING"
       )
       public final String boo;
 

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
@@ -16,7 +16,7 @@ public final class Foo extends Message<Foo> {
 
   @WireField(
       tag = 1,
-      type = "squareup.foobar.Bar.Baz.Moo"
+      adapter = "com.squareup.foobar.protos.bar.Bar$Baz$Moo#ADAPTER"
   )
   public final Bar.Baz.Moo moo;
 

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
@@ -18,7 +18,7 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
 
   @WireField(
       tag = 1,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
@@ -18,7 +18,7 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
 
   @WireField(
       tag = 1,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
@@ -18,7 +18,7 @@ public final class LetsDataRequest extends Message<LetsDataRequest> {
 
   @WireField(
       tag = 1,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
@@ -18,7 +18,7 @@ public final class LetsDataResponse extends Message<LetsDataResponse> {
 
   @WireField(
       tag = 1,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -18,7 +18,7 @@ public final class SendDataRequest extends Message<SendDataRequest> {
 
   @WireField(
       tag = 1,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -18,7 +18,7 @@ public final class SendDataResponse extends Message<SendDataResponse> {
 
   @WireField(
       tag = 1,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString data;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
@@ -18,7 +18,7 @@ public final class ChildPackage extends Message<ChildPackage> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.foreign.ForeignEnum"
+      adapter = "com.squareup.wire.protos.foreign.ForeignEnum#ADAPTER"
   )
   public final ForeignEnum inner_foreign_enum;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -18,14 +18,14 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
 
   @WireField(
       tag = 201,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 301,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_int32;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -122,535 +122,535 @@ public final class AllTypes extends Message<AllTypes> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      type = "uint32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      type = "sint32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      type = "fixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      type = "sfixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      type = "int64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      type = "uint64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      type = "sint64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      type = "fixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      type = "sfixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      type = "float"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      type = "double"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      type = "squareup.protos.alltypes.AllTypes.NestedMessage"
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
-      type = "uint32",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
-      type = "sint32",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
-      type = "fixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
-      type = "sfixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
-      type = "int64",
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
-      type = "uint64",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
-      type = "sint64",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
-      type = "fixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
-      type = "sfixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
-      type = "bool",
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
       label = WireField.Label.REQUIRED
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.REQUIRED
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
-      type = "double",
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
       label = WireField.Label.REQUIRED
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
-      type = "bytes",
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
       label = WireField.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
       label = WireField.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
-      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER",
       label = WireField.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
-      type = "uint32",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
-      type = "sint32",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
-      type = "fixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
-      type = "sfixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
-      type = "int64",
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
-      type = "uint64",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
-      type = "sint64",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
-      type = "fixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
-      type = "sfixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
-      type = "bool",
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
       label = WireField.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.REPEATED
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
-      type = "double",
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
       label = WireField.Label.REPEATED
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REPEATED
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
-      type = "bytes",
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
       label = WireField.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
-      type = "squareup.protos.alltypes.AllTypes.NestedMessage",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
-      type = "uint32",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
-      type = "sint32",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
-      type = "fixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
-      type = "sfixed32",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
-      type = "int64",
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
-      type = "uint64",
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
-      type = "sint64",
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
-      type = "fixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
-      type = "sfixed64",
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
-      type = "bool",
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
       label = WireField.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.PACKED
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
-      type = "double",
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
       label = WireField.Label.PACKED
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum",
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
       label = WireField.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      type = "uint32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      type = "sint32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      type = "fixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      type = "sfixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      type = "int64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      type = "uint64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      type = "sint64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      type = "fixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      type = "sfixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      type = "bool"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      type = "float"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      type = "double"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      type = "squareup.protos.alltypes.AllTypes.NestedEnum"
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum default_nested_enum;
 
@@ -1647,7 +1647,7 @@ public final class AllTypes extends Message<AllTypes> {
 
     @WireField(
         tag = 1,
-        type = "int32"
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
     )
     public final Integer a;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -81,44 +81,44 @@ public final class FooBar extends Message<FooBar> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer foo;
 
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String bar;
 
   @WireField(
       tag = 3,
-      type = "squareup.protos.custom_options.FooBar.Nested"
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$Nested#ADAPTER"
   )
   public final Nested baz;
 
   @WireField(
       tag = 4,
-      type = "uint64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long qux;
 
   @WireField(
       tag = 5,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.REPEATED
   )
   public final List<Float> fred;
 
   @WireField(
       tag = 6,
-      type = "double"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double daisy;
 
   @WireField(
       tag = 7,
-      type = "squareup.protos.custom_options.FooBar",
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<FooBar> nested;
@@ -250,7 +250,7 @@ public final class FooBar extends Message<FooBar> {
 
     @WireField(
         tag = 1,
-        type = "squareup.protos.custom_options.FooBar.FooBarBazEnum"
+        adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
     )
     public final FooBarBazEnum value;
 
@@ -307,7 +307,7 @@ public final class FooBar extends Message<FooBar> {
 
     @WireField(
         tag = 1,
-        type = "int32",
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
         label = WireField.Label.REPEATED
     )
     public final List<Integer> serial;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -31,44 +31,44 @@ public final class FooBar extends Message<FooBar> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer foo;
 
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String bar;
 
   @WireField(
       tag = 3,
-      type = "squareup.protos.custom_options.FooBar.Nested"
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$Nested#ADAPTER"
   )
   public final Nested baz;
 
   @WireField(
       tag = 4,
-      type = "uint64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long qux;
 
   @WireField(
       tag = 5,
-      type = "float",
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
       label = WireField.Label.REPEATED
   )
   public final List<Float> fred;
 
   @WireField(
       tag = 6,
-      type = "double"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double daisy;
 
   @WireField(
       tag = 7,
-      type = "squareup.protos.custom_options.FooBar",
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<FooBar> nested;
@@ -200,7 +200,7 @@ public final class FooBar extends Message<FooBar> {
 
     @WireField(
         tag = 1,
-        type = "squareup.protos.custom_options.FooBar.FooBarBazEnum"
+        adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
     )
     public final FooBarBazEnum value;
 
@@ -257,7 +257,7 @@ public final class FooBar extends Message<FooBar> {
 
     @WireField(
         tag = 1,
-        type = "int32",
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
         label = WireField.Label.REPEATED
     )
     public final List<Integer> serial;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -18,7 +18,7 @@ public final class OneBytesField extends Message<OneBytesField> {
 
   @WireField(
       tag = 1,
-      type = "bytes"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString opt_bytes;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
@@ -18,7 +18,7 @@ public final class OneField extends Message<OneField> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer opt_int32;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -18,13 +18,13 @@ public final class Recursive extends Message<Recursive> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer value;
 
   @WireField(
       tag = 2,
-      type = "squareup.protos.edgecases.Recursive"
+      adapter = "com.squareup.wire.protos.edgecases.Recursive#ADAPTER"
   )
   public final Recursive recursive;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -18,7 +18,7 @@ public final class ForeignMessage extends Message<ForeignMessage> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
@@ -18,7 +18,7 @@ public final class Foo extends Message<Foo> {
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String bar;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -18,7 +18,7 @@ public final class OneExtension extends Message<OneExtension> {
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String id;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -24,7 +24,7 @@ public final class OneOfMessage extends Message<OneOfMessage> {
    */
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer foo;
 
@@ -33,7 +33,7 @@ public final class OneOfMessage extends Message<OneOfMessage> {
    */
   @WireField(
       tag = 3,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String bar;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -29,7 +29,7 @@ public final class Person extends Message<Person> {
    */
   @WireField(
       tag = 1,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED
   )
   public final String name;
@@ -39,7 +39,7 @@ public final class Person extends Message<Person> {
    */
   @WireField(
       tag = 2,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer id;
@@ -49,7 +49,7 @@ public final class Person extends Message<Person> {
    */
   @WireField(
       tag = 3,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String email;
 
@@ -58,7 +58,7 @@ public final class Person extends Message<Person> {
    */
   @WireField(
       tag = 4,
-      type = "squareup.protos.person.Person.PhoneNumber",
+      adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<PhoneNumber> phone;
@@ -201,7 +201,7 @@ public final class Person extends Message<Person> {
      */
     @WireField(
         tag = 1,
-        type = "string",
+        adapter = "com.squareup.wire.ProtoAdapter#STRING",
         label = WireField.Label.REQUIRED
     )
     public final String number;
@@ -211,7 +211,7 @@ public final class Person extends Message<Person> {
      */
     @WireField(
         tag = 2,
-        type = "squareup.protos.person.Person.PhoneType"
+        adapter = "com.squareup.wire.protos.person.Person$PhoneType#ADAPTER"
     )
     public final PhoneType type;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -20,13 +20,13 @@ public final class NotRedacted extends Message<NotRedacted> {
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String a;
 
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String b;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
@@ -31,20 +31,20 @@ public final class Redacted extends Message<Redacted> {
 
   @WireField(
       tag = 1,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       redacted = true
   )
   public final String a;
 
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String b;
 
   @WireField(
       tag = 3,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String c;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -18,19 +18,19 @@ public final class RedactedChild extends Message<RedactedChild> {
 
   @WireField(
       tag = 1,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String a;
 
   @WireField(
       tag = 2,
-      type = "squareup.protos.redacted_test.Redacted"
+      adapter = "com.squareup.wire.protos.redacted.Redacted#ADAPTER"
   )
   public final Redacted b;
 
   @WireField(
       tag = 3,
-      type = "squareup.protos.redacted_test.NotRedacted"
+      adapter = "com.squareup.wire.protos.redacted.NotRedacted#ADAPTER"
   )
   public final NotRedacted c;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -15,7 +15,7 @@ public final class RedactedCycleA extends Message<RedactedCycleA> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.redacted_test.RedactedCycleB"
+      adapter = "com.squareup.wire.protos.redacted.RedactedCycleB#ADAPTER"
   )
   public final RedactedCycleB b;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -15,7 +15,7 @@ public final class RedactedCycleB extends Message<RedactedCycleB> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.redacted_test.RedactedCycleA"
+      adapter = "com.squareup.wire.protos.redacted.RedactedCycleA#ADAPTER"
   )
   public final RedactedCycleA a;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -25,14 +25,14 @@ public final class RedactedExtension extends Message<RedactedExtension> {
 
   @WireField(
       tag = 1,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       redacted = true
   )
   public final String d;
 
   @WireField(
       tag = 2,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String e;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -23,7 +23,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
 
   @WireField(
       tag = 1,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REPEATED,
       redacted = true
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -23,7 +23,7 @@ public final class RedactedRequired extends Message<RedactedRequired> {
 
   @WireField(
       tag = 1,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED,
       redacted = true
   )

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
@@ -30,13 +30,13 @@ public final class A extends Message<A> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.roots.B"
+      adapter = "com.squareup.wire.protos.roots.B#ADAPTER"
   )
   public final B c;
 
   @WireField(
       tag = 2,
-      type = "squareup.protos.roots.D"
+      adapter = "com.squareup.wire.protos.roots.D#ADAPTER"
   )
   public final D d;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
@@ -15,7 +15,7 @@ public final class B extends Message<B> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.roots.C",
+      adapter = "com.squareup.wire.protos.roots.C#ADAPTER",
       label = WireField.Label.REQUIRED
   )
   public final C c;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
@@ -18,7 +18,7 @@ public final class C extends Message<C> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
@@ -18,7 +18,7 @@ public final class D extends Message<D> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
@@ -18,13 +18,13 @@ public final class E extends Message<E> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.roots.E.F"
+      adapter = "com.squareup.wire.protos.roots.E$F#ADAPTER"
   )
   public final F f;
 
   @WireField(
       tag = 2,
-      type = "squareup.protos.roots.G"
+      adapter = "com.squareup.wire.protos.roots.G#ADAPTER"
   )
   public final G g;
 
@@ -98,7 +98,7 @@ public final class E extends Message<E> {
 
     @WireField(
         tag = 1,
-        type = "int32"
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
     )
     public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
@@ -15,7 +15,7 @@ public final class H extends Message<H> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.roots.E.F"
+      adapter = "com.squareup.wire.protos.roots.E$F#ADAPTER"
   )
   public final E.F ef;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
@@ -18,7 +18,7 @@ public final class I extends Message<I> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
@@ -15,7 +15,7 @@ public final class J extends Message<J> {
 
   @WireField(
       tag = 1,
-      type = "squareup.protos.roots.K"
+      adapter = "com.squareup.wire.protos.roots.K#ADAPTER"
   )
   public final K k;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
@@ -18,7 +18,7 @@ public final class K extends Message<K> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -18,7 +18,7 @@ public final class ExternalMessage extends Message<ExternalMessage> {
 
   @WireField(
       tag = 1,
-      type = "float"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float f;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -47,7 +47,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer optional_int32;
 
@@ -56,7 +56,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 2,
-      type = "squareup.protos.simple.SimpleMessage.NestedMessage",
+      adapter = "com.squareup.wire.protos.simple.SimpleMessage$NestedMessage#ADAPTER",
       deprecated = true
   )
   @Deprecated
@@ -67,13 +67,13 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 3,
-      type = "squareup.protos.simple.ExternalMessage"
+      adapter = "com.squareup.wire.protos.simple.ExternalMessage#ADAPTER"
   )
   public final ExternalMessage optional_external_msg;
 
   @WireField(
       tag = 4,
-      type = "squareup.protos.simple.SimpleMessage.NestedEnum"
+      adapter = "com.squareup.wire.protos.simple.SimpleMessage$NestedEnum#ADAPTER"
   )
   public final NestedEnum default_nested_enum;
 
@@ -82,7 +82,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 5,
-      type = "int32",
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REQUIRED
   )
   public final Integer required_int32;
@@ -92,7 +92,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 6,
-      type = "double",
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
       label = WireField.Label.REPEATED,
       deprecated = true
   )
@@ -104,7 +104,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 7,
-      type = "squareup.protos.foreign.ForeignEnum"
+      adapter = "com.squareup.wire.protos.foreign.ForeignEnum#ADAPTER"
   )
   public final ForeignEnum default_foreign_enum;
 
@@ -113,7 +113,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 8,
-      type = "squareup.protos.foreign.ForeignEnum"
+      adapter = "com.squareup.wire.protos.foreign.ForeignEnum#ADAPTER"
   )
   public final ForeignEnum no_default_foreign_enum;
 
@@ -122,7 +122,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 9,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String _package;
 
@@ -131,7 +131,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 10,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String result;
 
@@ -140,7 +140,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 11,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String other;
 
@@ -149,7 +149,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
    */
   @WireField(
       tag = 12,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String o;
 
@@ -374,7 +374,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
      */
     @WireField(
         tag = 1,
-        type = "int32"
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
     )
     public final Integer bb;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
@@ -18,7 +18,7 @@ public final class Bar extends Message<Bar> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer baz;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -17,7 +17,7 @@ public final class Bars extends Message<Bars> {
 
   @WireField(
       tag = 1,
-      type = "single_level.Bar",
+      adapter = "com.squareup.wire.protos.single_level.Bar#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<Bar> bars;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
@@ -18,7 +18,7 @@ public final class Foo extends Message<Foo> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer bar;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -17,7 +17,7 @@ public final class Foos extends Message<Foos> {
 
   @WireField(
       tag = 1,
-      type = "single_level.Foo",
+      adapter = "com.squareup.wire.protos.single_level.Foo#ADAPTER",
       label = WireField.Label.REPEATED
   )
   public final List<Foo> foos;

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -18,7 +18,7 @@ public final class VersionOne extends Message<VersionOne> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer i;
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -30,37 +30,37 @@ public final class VersionTwo extends Message<VersionTwo> {
 
   @WireField(
       tag = 1,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer i;
 
   @WireField(
       tag = 2,
-      type = "int32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer v2_i;
 
   @WireField(
       tag = 3,
-      type = "string"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String v2_s;
 
   @WireField(
       tag = 4,
-      type = "fixed32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer v2_f32;
 
   @WireField(
       tag = 5,
-      type = "fixed64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long v2_f64;
 
   @WireField(
       tag = 6,
-      type = "string",
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REPEATED
   )
   public final List<String> v2_rs;


### PR DESCRIPTION
This opens the door to later generating custom adapters in other files,
or writing custom binding code to mix protos with built-in types.