### PR TITLE
Expose TagMap in the public API.

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.alltypes;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Boolean;
@@ -655,6 +656,11 @@ public final class AllTypes extends Message<AllTypes> {
   public final NestedEnum default_nested_enum;
 
   public AllTypes(Integer opt_int32, Integer opt_uint32, Integer opt_sint32, Integer opt_fixed32, Integer opt_sfixed32, Long opt_int64, Long opt_uint64, Long opt_sint64, Long opt_fixed64, Long opt_sfixed64, Boolean opt_bool, Float opt_float, Double opt_double, String opt_string, ByteString opt_bytes, NestedEnum opt_nested_enum, NestedMessage opt_nested_message, Integer req_int32, Integer req_uint32, Integer req_sint32, Integer req_fixed32, Integer req_sfixed32, Long req_int64, Long req_uint64, Long req_sint64, Long req_fixed64, Long req_sfixed64, Boolean req_bool, Float req_float, Double req_double, String req_string, ByteString req_bytes, NestedEnum req_nested_enum, NestedMessage req_nested_message, List<Integer> rep_int32, List<Integer> rep_uint32, List<Integer> rep_sint32, List<Integer> rep_fixed32, List<Integer> rep_sfixed32, List<Long> rep_int64, List<Long> rep_uint64, List<Long> rep_sint64, List<Long> rep_fixed64, List<Long> rep_sfixed64, List<Boolean> rep_bool, List<Float> rep_float, List<Double> rep_double, List<String> rep_string, List<ByteString> rep_bytes, List<NestedEnum> rep_nested_enum, List<NestedMessage> rep_nested_message, List<Integer> pack_int32, List<Integer> pack_uint32, List<Integer> pack_sint32, List<Integer> pack_fixed32, List<Integer> pack_sfixed32, List<Long> pack_int64, List<Long> pack_uint64, List<Long> pack_sint64, List<Long> pack_fixed64, List<Long> pack_sfixed64, List<Boolean> pack_bool, List<Float> pack_float, List<Double> pack_double, List<NestedEnum> pack_nested_enum, Integer default_int32, Integer default_uint32, Integer default_sint32, Integer default_fixed32, Integer default_sfixed32, Long default_int64, Long default_uint64, Long default_sint64, Long default_fixed64, Long default_sfixed64, Boolean default_bool, Float default_float, Double default_double, String default_string, ByteString default_bytes, NestedEnum default_nested_enum) {
+    this(opt_int32, opt_uint32, opt_sint32, opt_fixed32, opt_sfixed32, opt_int64, opt_uint64, opt_sint64, opt_fixed64, opt_sfixed64, opt_bool, opt_float, opt_double, opt_string, opt_bytes, opt_nested_enum, opt_nested_message, req_int32, req_uint32, req_sint32, req_fixed32, req_sfixed32, req_int64, req_uint64, req_sint64, req_fixed64, req_sfixed64, req_bool, req_float, req_double, req_string, req_bytes, req_nested_enum, req_nested_message, rep_int32, rep_uint32, rep_sint32, rep_fixed32, rep_sfixed32, rep_int64, rep_uint64, rep_sint64, rep_fixed64, rep_sfixed64, rep_bool, rep_float, rep_double, rep_string, rep_bytes, rep_nested_enum, rep_nested_message, pack_int32, pack_uint32, pack_sint32, pack_fixed32, pack_sfixed32, pack_int64, pack_uint64, pack_sint64, pack_fixed64, pack_sfixed64, pack_bool, pack_float, pack_double, pack_nested_enum, default_int32, default_uint32, default_sint32, default_fixed32, default_sfixed32, default_int64, default_uint64, default_sint64, default_fixed64, default_sfixed64, default_bool, default_float, default_double, default_string, default_bytes, default_nested_enum, null);
+  }
+
+  public AllTypes(Integer opt_int32, Integer opt_uint32, Integer opt_sint32, Integer opt_fixed32, Integer opt_sfixed32, Long opt_int64, Long opt_uint64, Long opt_sint64, Long opt_fixed64, Long opt_sfixed64, Boolean opt_bool, Float opt_float, Double opt_double, String opt_string, ByteString opt_bytes, NestedEnum opt_nested_enum, NestedMessage opt_nested_message, Integer req_int32, Integer req_uint32, Integer req_sint32, Integer req_fixed32, Integer req_sfixed32, Long req_int64, Long req_uint64, Long req_sint64, Long req_fixed64, Long req_sfixed64, Boolean req_bool, Float req_float, Double req_double, String req_string, ByteString req_bytes, NestedEnum req_nested_enum, NestedMessage req_nested_message, List<Integer> rep_int32, List<Integer> rep_uint32, List<Integer> rep_sint32, List<Integer> rep_fixed32, List<Integer> rep_sfixed32, List<Long> rep_int64, List<Long> rep_uint64, List<Long> rep_sint64, List<Long> rep_fixed64, List<Long> rep_sfixed64, List<Boolean> rep_bool, List<Float> rep_float, List<Double> rep_double, List<String> rep_string, List<ByteString> rep_bytes, List<NestedEnum> rep_nested_enum, List<NestedMessage> rep_nested_message, List<Integer> pack_int32, List<Integer> pack_uint32, List<Integer> pack_sint32, List<Integer> pack_fixed32, List<Integer> pack_sfixed32, List<Long> pack_int64, List<Long> pack_uint64, List<Long> pack_sint64, List<Long> pack_fixed64, List<Long> pack_sfixed64, List<Boolean> pack_bool, List<Float> pack_float, List<Double> pack_double, List<NestedEnum> pack_nested_enum, Integer default_int32, Integer default_uint32, Integer default_sint32, Integer default_fixed32, Integer default_sfixed32, Long default_int64, Long default_uint64, Long default_sint64, Long default_fixed64, Long default_sfixed64, Boolean default_bool, Float default_float, Double default_double, String default_string, ByteString default_bytes, NestedEnum default_nested_enum, TagMap tagMap) {
+    super(tagMap);
     this.opt_int32 = opt_int32;
     this.opt_uint32 = opt_uint32;
     this.opt_sint32 = opt_sint32;
@@ -738,18 +744,13 @@ public final class AllTypes extends Message<AllTypes> {
     this.default_nested_enum = default_nested_enum;
   }
 
-  private AllTypes(Builder builder) {
-    this(builder.opt_int32, builder.opt_uint32, builder.opt_sint32, builder.opt_fixed32, builder.opt_sfixed32, builder.opt_int64, builder.opt_uint64, builder.opt_sint64, builder.opt_fixed64, builder.opt_sfixed64, builder.opt_bool, builder.opt_float, builder.opt_double, builder.opt_string, builder.opt_bytes, builder.opt_nested_enum, builder.opt_nested_message, builder.req_int32, builder.req_uint32, builder.req_sint32, builder.req_fixed32, builder.req_sfixed32, builder.req_int64, builder.req_uint64, builder.req_sint64, builder.req_fixed64, builder.req_sfixed64, builder.req_bool, builder.req_float, builder.req_double, builder.req_string, builder.req_bytes, builder.req_nested_enum, builder.req_nested_message, builder.rep_int32, builder.rep_uint32, builder.rep_sint32, builder.rep_fixed32, builder.rep_sfixed32, builder.rep_int64, builder.rep_uint64, builder.rep_sint64, builder.rep_fixed64, builder.rep_sfixed64, builder.rep_bool, builder.rep_float, builder.rep_double, builder.rep_string, builder.rep_bytes, builder.rep_nested_enum, builder.rep_nested_message, builder.pack_int32, builder.pack_uint32, builder.pack_sint32, builder.pack_fixed32, builder.pack_sfixed32, builder.pack_int64, builder.pack_uint64, builder.pack_sint64, builder.pack_fixed64, builder.pack_sfixed64, builder.pack_bool, builder.pack_float, builder.pack_double, builder.pack_nested_enum, builder.default_int32, builder.default_uint32, builder.default_sint32, builder.default_fixed32, builder.default_sfixed32, builder.default_int64, builder.default_uint64, builder.default_sint64, builder.default_fixed64, builder.default_sfixed64, builder.default_bool, builder.default_float, builder.default_double, builder.default_string, builder.default_bytes, builder.default_nested_enum);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(opt_int32, o.opt_int32)
+    return equals(tagMap(), o.tagMap())
+        && equals(opt_int32, o.opt_int32)
         && equals(opt_uint32, o.opt_uint32)
         && equals(opt_sint32, o.opt_sint32)
         && equals(opt_fixed32, o.opt_fixed32)
@@ -836,7 +837,7 @@ public final class AllTypes extends Message<AllTypes> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (opt_int32 != null ? opt_int32.hashCode() : 0);
       result = result * 37 + (opt_uint32 != null ? opt_uint32.hashCode() : 0);
       result = result * 37 + (opt_sint32 != null ? opt_sint32.hashCode() : 0);
@@ -1617,7 +1618,7 @@ public final class AllTypes extends Message<AllTypes> {
             req_nested_enum, "req_nested_enum",
             req_nested_message, "req_nested_message");
       }
-      return new AllTypes(this);
+      return new AllTypes(opt_int32, opt_uint32, opt_sint32, opt_fixed32, opt_sfixed32, opt_int64, opt_uint64, opt_sint64, opt_fixed64, opt_sfixed64, opt_bool, opt_float, opt_double, opt_string, opt_bytes, opt_nested_enum, opt_nested_message, req_int32, req_uint32, req_sint32, req_fixed32, req_sfixed32, req_int64, req_uint64, req_sint64, req_fixed64, req_sfixed64, req_bool, req_float, req_double, req_string, req_bytes, req_nested_enum, req_nested_message, rep_int32, rep_uint32, rep_sint32, rep_fixed32, rep_sfixed32, rep_int64, rep_uint64, rep_sint64, rep_fixed64, rep_sfixed64, rep_bool, rep_float, rep_double, rep_string, rep_bytes, rep_nested_enum, rep_nested_message, pack_int32, pack_uint32, pack_sint32, pack_fixed32, pack_sfixed32, pack_int64, pack_uint64, pack_sint64, pack_fixed64, pack_sfixed64, pack_bool, pack_float, pack_double, pack_nested_enum, default_int32, default_uint32, default_sint32, default_fixed32, default_sfixed32, default_int64, default_uint64, default_sint64, default_fixed64, default_sfixed64, default_bool, default_float, default_double, default_string, default_bytes, default_nested_enum, buildTagMap());
     }
   }
 
@@ -1652,25 +1653,32 @@ public final class AllTypes extends Message<AllTypes> {
     public final Integer a;
 
     public NestedMessage(Integer a) {
-      this.a = a;
+      this(a, null);
     }
 
-    private NestedMessage(Builder builder) {
-      this(builder.a);
-      setBuilder(builder);
+    public NestedMessage(Integer a, TagMap tagMap) {
+      super(tagMap);
+      this.a = a;
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
-      return equals(a, ((NestedMessage) other).a);
+      NestedMessage o = (NestedMessage) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(a, o.a);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = a != null ? a.hashCode() : 0);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (a != null ? a.hashCode() : 0);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage, Builder> {
@@ -1692,7 +1700,7 @@ public final class AllTypes extends Message<AllTypes> {
 
       @Override
       public NestedMessage build() {
-        return new NestedMessage(this);
+        return new NestedMessage(a, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -28,8 +28,7 @@ import java.util.Set;
 public abstract class Message<T extends Message<T>> implements Serializable {
   private static final long serialVersionUID = 0L;
 
-  /** Set to null until a field is added. */
-  transient TagMap tagMap;
+  final transient TagMap tagMap;
 
   /** If not {@code 0} then the serialized size of this message. */
   transient int cachedSerializedSize = 0;
@@ -37,16 +36,12 @@ public abstract class Message<T extends Message<T>> implements Serializable {
   /** If non-zero, the hash code of this message. Accessed by generated code. */
   protected transient int hashCode = 0;
 
-  protected Message() {
+  protected Message(TagMap tagMap) {
+    this.tagMap = tagMap;
   }
 
-  /**
-   * Initializes any unknown field data to that stored in the given {@code Builder}.
-   */
-  protected final void setBuilder(Builder builder) {
-    if (builder.tagMapBuilder != null) {
-      tagMap = builder.tagMapBuilder.build();
-    }
+  public final TagMap tagMap() {
+    return tagMap;
   }
 
   /** Utility method to return a mutable copy of a given List. Used by generated code. */
@@ -80,10 +75,6 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     return adapter.fromInt(value);
   }
 
-  int tagMapEncodedSize() {
-    return tagMap == null ? 0 : tagMap.encodedSize();
-  }
-
   protected static boolean equals(Object a, Object b) {
     return a == b || (a != null && a.equals(b));
   }
@@ -103,23 +94,6 @@ public abstract class Message<T extends Message<T>> implements Serializable {
    */
   public final <E> E getExtension(Extension<T, E> extension) {
     return tagMap != null ? (E) tagMap.get(extension) : null;
-  }
-
-  /**
-   * Returns true if the extensions on this message equals the extensions of
-   * {@code other}.
-   */
-  protected final boolean extensionsEqual(Message<T> other) {
-    return tagMap != null
-        ? tagMap.equals(other.tagMap)
-        : other.tagMap == null;
-  }
-
-  /**
-   * Returns a hash code for the extensions on this message.
-   */
-  protected final int extensionsHashCode() {
-    return tagMap != null ? tagMap.hashCode() : 0;
   }
 
   @SuppressWarnings("unchecked")
@@ -154,7 +128,8 @@ public abstract class Message<T extends Message<T>> implements Serializable {
       }
     }
 
-    TagMap.Builder ensureTagMap() {
+    /** The {@link TagMap} builder in which unknown fields and extensions are stored. */
+    public TagMap.Builder tagMap() {
       if (tagMapBuilder == null) {
         tagMapBuilder = new TagMap.Builder();
       }
@@ -226,9 +201,14 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     }
 
     /**
-     * Returns an immutable {@link com.squareup.wire.Message} based on the fields that have been set
-     * in this builder.
+     * Returns an immutable {@link TagMap} based on the unknown fields and extensions set in this
+     * builder, or null.
      */
+    public TagMap buildTagMap() {
+      return tagMapBuilder != null ? tagMapBuilder.build() : null;
+    }
+
+    /** Returns an immutable {@link Message} based on the fields that set in this builder. */
     public abstract T build();
   }
 }

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -100,8 +100,6 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
     }
   }
 
-  // Writing
-
   @Override public int encodedSize(M message) {
     int cachedSerializedSize = message.cachedSerializedSize;
     if (cachedSerializedSize != 0) return cachedSerializedSize;
@@ -112,8 +110,10 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
       if (value == null) continue;
       size += fieldBinding.adapter().encodedSize(fieldBinding.tag, value);
     }
+    if (message.tagMap != null) {
+      size += message.tagMap.encodedSize();
+    }
 
-    size += message.tagMapEncodedSize();
     message.cachedSerializedSize = size;
     return size;
   }
@@ -207,7 +207,7 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
         } else {
           Extension<?, ?> extension = reader.getExtension(messageType, tag);
           Object value = extension.getAdapter().decode(reader);
-          builder.ensureTagMap().add(extension, value);
+          builder.tagMap().add(extension, value);
         }
       } catch (RuntimeEnumAdapter.EnumConstantNotFoundException e) {
         // An unknown Enum value was encountered, store it as an unknown field

--- a/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
@@ -52,7 +52,7 @@ import static com.squareup.wire.ProtoWriter.varint32Size;
  *
  * <p>Instances of this class are immutable.
  */
-final class TagMap {
+public final class TagMap {
   /**
    * Alternating extensions and values. Extensions are both known and unknown extensions. Values
    * are single elements. Extensions with multiple elements occur multiple times in this array.

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -81,6 +82,11 @@ public final class DescriptorProto extends Message<DescriptorProto> {
   public final MessageOptions options;
 
   public DescriptorProto(String name, String doc, List<FieldDescriptorProto> field, List<FieldDescriptorProto> extension, List<DescriptorProto> nested_type, List<EnumDescriptorProto> enum_type, List<ExtensionRange> extension_range, MessageOptions options) {
+    this(name, doc, field, extension, nested_type, enum_type, extension_range, options, null);
+  }
+
+  public DescriptorProto(String name, String doc, List<FieldDescriptorProto> field, List<FieldDescriptorProto> extension, List<DescriptorProto> nested_type, List<EnumDescriptorProto> enum_type, List<ExtensionRange> extension_range, MessageOptions options, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this.doc = doc;
     this.field = immutableCopyOf(field);
@@ -91,17 +97,13 @@ public final class DescriptorProto extends Message<DescriptorProto> {
     this.options = options;
   }
 
-  private DescriptorProto(Builder builder) {
-    this(builder.name, builder.doc, builder.field, builder.extension, builder.nested_type, builder.enum_type, builder.extension_range, builder.options);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof DescriptorProto)) return false;
     DescriptorProto o = (DescriptorProto) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(doc, o.doc)
         && equals(field, o.field)
         && equals(extension, o.extension)
@@ -115,7 +117,8 @@ public final class DescriptorProto extends Message<DescriptorProto> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (doc != null ? doc.hashCode() : 0);
       result = result * 37 + (field != null ? field.hashCode() : 1);
       result = result * 37 + (extension != null ? extension.hashCode() : 1);
@@ -206,7 +209,7 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
     @Override
     public DescriptorProto build() {
-      return new DescriptorProto(this);
+      return new DescriptorProto(name, doc, field, extension, nested_type, enum_type, extension_range, options, buildTagMap());
     }
   }
 
@@ -232,13 +235,13 @@ public final class DescriptorProto extends Message<DescriptorProto> {
     public final Integer end;
 
     public ExtensionRange(Integer start, Integer end) {
-      this.start = start;
-      this.end = end;
+      this(start, end, null);
     }
 
-    private ExtensionRange(Builder builder) {
-      this(builder.start, builder.end);
-      setBuilder(builder);
+    public ExtensionRange(Integer start, Integer end, TagMap tagMap) {
+      super(tagMap);
+      this.start = start;
+      this.end = end;
     }
 
     @Override
@@ -246,7 +249,8 @@ public final class DescriptorProto extends Message<DescriptorProto> {
       if (other == this) return true;
       if (!(other instanceof ExtensionRange)) return false;
       ExtensionRange o = (ExtensionRange) other;
-      return equals(start, o.start)
+      return equals(tagMap(), o.tagMap())
+          && equals(start, o.start)
           && equals(end, o.end);
     }
 
@@ -254,7 +258,8 @@ public final class DescriptorProto extends Message<DescriptorProto> {
     public int hashCode() {
       int result = hashCode;
       if (result == 0) {
-        result = start != null ? start.hashCode() : 0;
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (start != null ? start.hashCode() : 0);
         result = result * 37 + (end != null ? end.hashCode() : 0);
         hashCode = result;
       }
@@ -288,7 +293,7 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
       @Override
       public ExtensionRange build() {
-        return new ExtensionRange(this);
+        return new ExtensionRange(start, end, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -52,15 +53,15 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   public final EnumOptions options;
 
   public EnumDescriptorProto(String name, String doc, List<EnumValueDescriptorProto> value, EnumOptions options) {
+    this(name, doc, value, options, null);
+  }
+
+  public EnumDescriptorProto(String name, String doc, List<EnumValueDescriptorProto> value, EnumOptions options, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this.doc = doc;
     this.value = immutableCopyOf(value);
     this.options = options;
-  }
-
-  private EnumDescriptorProto(Builder builder) {
-    this(builder.name, builder.doc, builder.value, builder.options);
-    setBuilder(builder);
   }
 
   @Override
@@ -68,7 +69,8 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
     if (other == this) return true;
     if (!(other instanceof EnumDescriptorProto)) return false;
     EnumDescriptorProto o = (EnumDescriptorProto) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(doc, o.doc)
         && equals(value, o.value)
         && equals(options, o.options);
@@ -78,7 +80,8 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (doc != null ? doc.hashCode() : 0);
       result = result * 37 + (value != null ? value.hashCode() : 1);
       result = result * 37 + (options != null ? options.hashCode() : 0);
@@ -133,7 +136,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
 
     @Override
     public EnumDescriptorProto build() {
-      return new EnumDescriptorProto(this);
+      return new EnumDescriptorProto(name, doc, value, options, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -26,12 +27,12 @@ public final class EnumOptions extends Message<EnumOptions> {
   public final List<UninterpretedOption> uninterpreted_option;
 
   public EnumOptions(List<UninterpretedOption> uninterpreted_option) {
-    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
+    this(uninterpreted_option, null);
   }
 
-  private EnumOptions(Builder builder) {
-    this(builder.uninterpreted_option);
-    setBuilder(builder);
+  public EnumOptions(List<UninterpretedOption> uninterpreted_option, TagMap tagMap) {
+    super(tagMap);
+    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
   }
 
   @Override
@@ -39,15 +40,15 @@ public final class EnumOptions extends Message<EnumOptions> {
     if (other == this) return true;
     if (!(other instanceof EnumOptions)) return false;
     EnumOptions o = (EnumOptions) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(uninterpreted_option, o.uninterpreted_option);
+    return equals(tagMap(), o.tagMap())
+        && equals(uninterpreted_option, o.uninterpreted_option);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
       hashCode = result;
     }
@@ -76,7 +77,7 @@ public final class EnumOptions extends Message<EnumOptions> {
 
     @Override
     public EnumOptions build() {
-      return new EnumOptions(this);
+      return new EnumOptions(uninterpreted_option, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -52,15 +53,15 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
   public final EnumValueOptions options;
 
   public EnumValueDescriptorProto(String name, String doc, Integer number, EnumValueOptions options) {
+    this(name, doc, number, options, null);
+  }
+
+  public EnumValueDescriptorProto(String name, String doc, Integer number, EnumValueOptions options, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this.doc = doc;
     this.number = number;
     this.options = options;
-  }
-
-  private EnumValueDescriptorProto(Builder builder) {
-    this(builder.name, builder.doc, builder.number, builder.options);
-    setBuilder(builder);
   }
 
   @Override
@@ -68,7 +69,8 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
     if (other == this) return true;
     if (!(other instanceof EnumValueDescriptorProto)) return false;
     EnumValueDescriptorProto o = (EnumValueDescriptorProto) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(doc, o.doc)
         && equals(number, o.number)
         && equals(options, o.options);
@@ -78,7 +80,8 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (doc != null ? doc.hashCode() : 0);
       result = result * 37 + (number != null ? number.hashCode() : 0);
       result = result * 37 + (options != null ? options.hashCode() : 0);
@@ -133,7 +136,7 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
 
     @Override
     public EnumValueDescriptorProto build() {
-      return new EnumValueDescriptorProto(this);
+      return new EnumValueDescriptorProto(name, doc, number, options, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -26,12 +27,12 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
   public final List<UninterpretedOption> uninterpreted_option;
 
   public EnumValueOptions(List<UninterpretedOption> uninterpreted_option) {
-    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
+    this(uninterpreted_option, null);
   }
 
-  private EnumValueOptions(Builder builder) {
-    this(builder.uninterpreted_option);
-    setBuilder(builder);
+  public EnumValueOptions(List<UninterpretedOption> uninterpreted_option, TagMap tagMap) {
+    super(tagMap);
+    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
   }
 
   @Override
@@ -39,15 +40,15 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
     if (other == this) return true;
     if (!(other instanceof EnumValueOptions)) return false;
     EnumValueOptions o = (EnumValueOptions) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(uninterpreted_option, o.uninterpreted_option);
+    return equals(tagMap(), o.tagMap())
+        && equals(uninterpreted_option, o.uninterpreted_option);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
       hashCode = result;
     }
@@ -76,7 +77,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
 
     @Override
     public EnumValueOptions build() {
-      return new EnumValueOptions(this);
+      return new EnumValueOptions(uninterpreted_option, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
@@ -115,6 +116,11 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
   public final FieldOptions options;
 
   public FieldDescriptorProto(String name, String doc, Integer number, Label label, Type type, String type_name, String extendee, String default_value, FieldOptions options) {
+    this(name, doc, number, label, type, type_name, extendee, default_value, options, null);
+  }
+
+  public FieldDescriptorProto(String name, String doc, Integer number, Label label, Type type, String type_name, String extendee, String default_value, FieldOptions options, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this.doc = doc;
     this.number = number;
@@ -126,17 +132,13 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
     this.options = options;
   }
 
-  private FieldDescriptorProto(Builder builder) {
-    this(builder.name, builder.doc, builder.number, builder.label, builder.type, builder.type_name, builder.extendee, builder.default_value, builder.options);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof FieldDescriptorProto)) return false;
     FieldDescriptorProto o = (FieldDescriptorProto) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(doc, o.doc)
         && equals(number, o.number)
         && equals(label, o.label)
@@ -151,7 +153,8 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (doc != null ? doc.hashCode() : 0);
       result = result * 37 + (number != null ? number.hashCode() : 0);
       result = result * 37 + (label != null ? label.hashCode() : 0);
@@ -273,7 +276,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
 
     @Override
     public FieldDescriptorProto build() {
-      return new FieldDescriptorProto(this);
+      return new FieldDescriptorProto(name, doc, number, label, type, type_name, extendee, default_value, options, buildTagMap());
     }
   }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Boolean;
@@ -93,6 +94,11 @@ public final class FieldOptions extends Message<FieldOptions> {
   public final List<UninterpretedOption> uninterpreted_option;
 
   public FieldOptions(CType ctype, Boolean packed, Boolean deprecated, String experimental_map_key, List<UninterpretedOption> uninterpreted_option) {
+    this(ctype, packed, deprecated, experimental_map_key, uninterpreted_option, null);
+  }
+
+  public FieldOptions(CType ctype, Boolean packed, Boolean deprecated, String experimental_map_key, List<UninterpretedOption> uninterpreted_option, TagMap tagMap) {
+    super(tagMap);
     this.ctype = ctype;
     this.packed = packed;
     this.deprecated = deprecated;
@@ -100,18 +106,13 @@ public final class FieldOptions extends Message<FieldOptions> {
     this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
   }
 
-  private FieldOptions(Builder builder) {
-    this(builder.ctype, builder.packed, builder.deprecated, builder.experimental_map_key, builder.uninterpreted_option);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof FieldOptions)) return false;
     FieldOptions o = (FieldOptions) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(ctype, o.ctype)
+    return equals(tagMap(), o.tagMap())
+        && equals(ctype, o.ctype)
         && equals(packed, o.packed)
         && equals(deprecated, o.deprecated)
         && equals(experimental_map_key, o.experimental_map_key)
@@ -122,7 +123,7 @@ public final class FieldOptions extends Message<FieldOptions> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (ctype != null ? ctype.hashCode() : 0);
       result = result * 37 + (packed != null ? packed.hashCode() : 0);
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
@@ -219,7 +220,7 @@ public final class FieldOptions extends Message<FieldOptions> {
 
     @Override
     public FieldOptions build() {
-      return new FieldOptions(this);
+      return new FieldOptions(ctype, packed, deprecated, experimental_map_key, uninterpreted_option, buildTagMap());
     }
   }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -101,6 +102,11 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
   public final SourceCodeInfo source_code_info;
 
   public FileDescriptorProto(String name, String _package, List<String> dependency, List<DescriptorProto> message_type, List<EnumDescriptorProto> enum_type, List<ServiceDescriptorProto> service, List<FieldDescriptorProto> extension, FileOptions options, SourceCodeInfo source_code_info) {
+    this(name, _package, dependency, message_type, enum_type, service, extension, options, source_code_info, null);
+  }
+
+  public FileDescriptorProto(String name, String _package, List<String> dependency, List<DescriptorProto> message_type, List<EnumDescriptorProto> enum_type, List<ServiceDescriptorProto> service, List<FieldDescriptorProto> extension, FileOptions options, SourceCodeInfo source_code_info, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this._package = _package;
     this.dependency = immutableCopyOf(dependency);
@@ -112,17 +118,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
     this.source_code_info = source_code_info;
   }
 
-  private FileDescriptorProto(Builder builder) {
-    this(builder.name, builder._package, builder.dependency, builder.message_type, builder.enum_type, builder.service, builder.extension, builder.options, builder.source_code_info);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof FileDescriptorProto)) return false;
     FileDescriptorProto o = (FileDescriptorProto) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(_package, o._package)
         && equals(dependency, o.dependency)
         && equals(message_type, o.message_type)
@@ -137,7 +139,8 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (_package != null ? _package.hashCode() : 0);
       result = result * 37 + (dependency != null ? dependency.hashCode() : 1);
       result = result * 37 + (message_type != null ? message_type.hashCode() : 1);
@@ -252,7 +255,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
 
     @Override
     public FileDescriptorProto build() {
-      return new FileDescriptorProto(this);
+      return new FileDescriptorProto(name, _package, dependency, message_type, enum_type, service, extension, options, source_code_info, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -27,25 +28,32 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
   public final List<FileDescriptorProto> file;
 
   public FileDescriptorSet(List<FileDescriptorProto> file) {
-    this.file = immutableCopyOf(file);
+    this(file, null);
   }
 
-  private FileDescriptorSet(Builder builder) {
-    this(builder.file);
-    setBuilder(builder);
+  public FileDescriptorSet(List<FileDescriptorProto> file, TagMap tagMap) {
+    super(tagMap);
+    this.file = immutableCopyOf(file);
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof FileDescriptorSet)) return false;
-    return equals(file, ((FileDescriptorSet) other).file);
+    FileDescriptorSet o = (FileDescriptorSet) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(file, o.file);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = file != null ? file.hashCode() : 1);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (file != null ? file.hashCode() : 1);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FileDescriptorSet, Builder> {
@@ -67,7 +75,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
 
     @Override
     public FileDescriptorSet build() {
-      return new FileDescriptorSet(this);
+      return new FileDescriptorSet(file, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Boolean;
@@ -159,6 +160,11 @@ public final class FileOptions extends Message<FileOptions> {
   public final List<UninterpretedOption> uninterpreted_option;
 
   public FileOptions(String java_package, String java_outer_classname, Boolean java_multiple_files, Boolean java_generate_equals_and_hash, OptimizeMode optimize_for, Boolean cc_generic_services, Boolean java_generic_services, Boolean py_generic_services, List<UninterpretedOption> uninterpreted_option) {
+    this(java_package, java_outer_classname, java_multiple_files, java_generate_equals_and_hash, optimize_for, cc_generic_services, java_generic_services, py_generic_services, uninterpreted_option, null);
+  }
+
+  public FileOptions(String java_package, String java_outer_classname, Boolean java_multiple_files, Boolean java_generate_equals_and_hash, OptimizeMode optimize_for, Boolean cc_generic_services, Boolean java_generic_services, Boolean py_generic_services, List<UninterpretedOption> uninterpreted_option, TagMap tagMap) {
+    super(tagMap);
     this.java_package = java_package;
     this.java_outer_classname = java_outer_classname;
     this.java_multiple_files = java_multiple_files;
@@ -170,18 +176,13 @@ public final class FileOptions extends Message<FileOptions> {
     this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
   }
 
-  private FileOptions(Builder builder) {
-    this(builder.java_package, builder.java_outer_classname, builder.java_multiple_files, builder.java_generate_equals_and_hash, builder.optimize_for, builder.cc_generic_services, builder.java_generic_services, builder.py_generic_services, builder.uninterpreted_option);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof FileOptions)) return false;
     FileOptions o = (FileOptions) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(java_package, o.java_package)
+    return equals(tagMap(), o.tagMap())
+        && equals(java_package, o.java_package)
         && equals(java_outer_classname, o.java_outer_classname)
         && equals(java_multiple_files, o.java_multiple_files)
         && equals(java_generate_equals_and_hash, o.java_generate_equals_and_hash)
@@ -196,7 +197,7 @@ public final class FileOptions extends Message<FileOptions> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (java_package != null ? java_package.hashCode() : 0);
       result = result * 37 + (java_outer_classname != null ? java_outer_classname.hashCode() : 0);
       result = result * 37 + (java_multiple_files != null ? java_multiple_files.hashCode() : 0);
@@ -336,7 +337,7 @@ public final class FileOptions extends Message<FileOptions> {
 
     @Override
     public FileOptions build() {
-      return new FileOptions(this);
+      return new FileOptions(java_package, java_outer_classname, java_multiple_files, java_generate_equals_and_hash, optimize_for, cc_generic_services, java_generic_services, py_generic_services, uninterpreted_option, buildTagMap());
     }
   }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -68,14 +69,14 @@ public final class MessageOptions extends Message<MessageOptions> {
   public final List<UninterpretedOption> uninterpreted_option;
 
   public MessageOptions(Boolean message_set_wire_format, Boolean no_standard_descriptor_accessor, List<UninterpretedOption> uninterpreted_option) {
+    this(message_set_wire_format, no_standard_descriptor_accessor, uninterpreted_option, null);
+  }
+
+  public MessageOptions(Boolean message_set_wire_format, Boolean no_standard_descriptor_accessor, List<UninterpretedOption> uninterpreted_option, TagMap tagMap) {
+    super(tagMap);
     this.message_set_wire_format = message_set_wire_format;
     this.no_standard_descriptor_accessor = no_standard_descriptor_accessor;
     this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
-  }
-
-  private MessageOptions(Builder builder) {
-    this(builder.message_set_wire_format, builder.no_standard_descriptor_accessor, builder.uninterpreted_option);
-    setBuilder(builder);
   }
 
   @Override
@@ -83,8 +84,8 @@ public final class MessageOptions extends Message<MessageOptions> {
     if (other == this) return true;
     if (!(other instanceof MessageOptions)) return false;
     MessageOptions o = (MessageOptions) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(message_set_wire_format, o.message_set_wire_format)
+    return equals(tagMap(), o.tagMap())
+        && equals(message_set_wire_format, o.message_set_wire_format)
         && equals(no_standard_descriptor_accessor, o.no_standard_descriptor_accessor)
         && equals(uninterpreted_option, o.uninterpreted_option);
   }
@@ -93,7 +94,7 @@ public final class MessageOptions extends Message<MessageOptions> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (message_set_wire_format != null ? message_set_wire_format.hashCode() : 0);
       result = result * 37 + (no_standard_descriptor_accessor != null ? no_standard_descriptor_accessor.hashCode() : 0);
       result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
@@ -165,7 +166,7 @@ public final class MessageOptions extends Message<MessageOptions> {
 
     @Override
     public MessageOptions build() {
-      return new MessageOptions(this);
+      return new MessageOptions(message_set_wire_format, no_standard_descriptor_accessor, uninterpreted_option, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -63,6 +64,11 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
   public final MethodOptions options;
 
   public MethodDescriptorProto(String name, String doc, String input_type, String output_type, MethodOptions options) {
+    this(name, doc, input_type, output_type, options, null);
+  }
+
+  public MethodDescriptorProto(String name, String doc, String input_type, String output_type, MethodOptions options, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this.doc = doc;
     this.input_type = input_type;
@@ -70,17 +76,13 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
     this.options = options;
   }
 
-  private MethodDescriptorProto(Builder builder) {
-    this(builder.name, builder.doc, builder.input_type, builder.output_type, builder.options);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof MethodDescriptorProto)) return false;
     MethodDescriptorProto o = (MethodDescriptorProto) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(doc, o.doc)
         && equals(input_type, o.input_type)
         && equals(output_type, o.output_type)
@@ -91,7 +93,8 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (doc != null ? doc.hashCode() : 0);
       result = result * 37 + (input_type != null ? input_type.hashCode() : 0);
       result = result * 37 + (output_type != null ? output_type.hashCode() : 0);
@@ -159,7 +162,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
 
     @Override
     public MethodDescriptorProto build() {
-      return new MethodDescriptorProto(this);
+      return new MethodDescriptorProto(name, doc, input_type, output_type, options, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -30,12 +31,12 @@ public final class MethodOptions extends Message<MethodOptions> {
   public final List<UninterpretedOption> uninterpreted_option;
 
   public MethodOptions(List<UninterpretedOption> uninterpreted_option) {
-    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
+    this(uninterpreted_option, null);
   }
 
-  private MethodOptions(Builder builder) {
-    this(builder.uninterpreted_option);
-    setBuilder(builder);
+  public MethodOptions(List<UninterpretedOption> uninterpreted_option, TagMap tagMap) {
+    super(tagMap);
+    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
   }
 
   @Override
@@ -43,15 +44,15 @@ public final class MethodOptions extends Message<MethodOptions> {
     if (other == this) return true;
     if (!(other instanceof MethodOptions)) return false;
     MethodOptions o = (MethodOptions) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(uninterpreted_option, o.uninterpreted_option);
+    return equals(tagMap(), o.tagMap())
+        && equals(uninterpreted_option, o.uninterpreted_option);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
       hashCode = result;
     }
@@ -84,7 +85,7 @@ public final class MethodOptions extends Message<MethodOptions> {
 
     @Override
     public MethodOptions build() {
-      return new MethodOptions(this);
+      return new MethodOptions(uninterpreted_option, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -52,15 +53,15 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
   public final ServiceOptions options;
 
   public ServiceDescriptorProto(String name, List<MethodDescriptorProto> method, String doc, ServiceOptions options) {
+    this(name, method, doc, options, null);
+  }
+
+  public ServiceDescriptorProto(String name, List<MethodDescriptorProto> method, String doc, ServiceOptions options, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this.method = immutableCopyOf(method);
     this.doc = doc;
     this.options = options;
-  }
-
-  private ServiceDescriptorProto(Builder builder) {
-    this(builder.name, builder.method, builder.doc, builder.options);
-    setBuilder(builder);
   }
 
   @Override
@@ -68,7 +69,8 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     if (other == this) return true;
     if (!(other instanceof ServiceDescriptorProto)) return false;
     ServiceDescriptorProto o = (ServiceDescriptorProto) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(method, o.method)
         && equals(doc, o.doc)
         && equals(options, o.options);
@@ -78,7 +80,8 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (method != null ? method.hashCode() : 1);
       result = result * 37 + (doc != null ? doc.hashCode() : 0);
       result = result * 37 + (options != null ? options.hashCode() : 0);
@@ -133,7 +136,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
 
     @Override
     public ServiceDescriptorProto build() {
-      return new ServiceDescriptorProto(this);
+      return new ServiceDescriptorProto(name, method, doc, options, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -30,12 +31,12 @@ public final class ServiceOptions extends Message<ServiceOptions> {
   public final List<UninterpretedOption> uninterpreted_option;
 
   public ServiceOptions(List<UninterpretedOption> uninterpreted_option) {
-    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
+    this(uninterpreted_option, null);
   }
 
-  private ServiceOptions(Builder builder) {
-    this(builder.uninterpreted_option);
-    setBuilder(builder);
+  public ServiceOptions(List<UninterpretedOption> uninterpreted_option, TagMap tagMap) {
+    super(tagMap);
+    this.uninterpreted_option = immutableCopyOf(uninterpreted_option);
   }
 
   @Override
@@ -43,15 +44,15 @@ public final class ServiceOptions extends Message<ServiceOptions> {
     if (other == this) return true;
     if (!(other instanceof ServiceOptions)) return false;
     ServiceOptions o = (ServiceOptions) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(uninterpreted_option, o.uninterpreted_option);
+    return equals(tagMap(), o.tagMap())
+        && equals(uninterpreted_option, o.uninterpreted_option);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
       hashCode = result;
     }
@@ -84,7 +85,7 @@ public final class ServiceOptions extends Message<ServiceOptions> {
 
     @Override
     public ServiceOptions build() {
-      return new ServiceOptions(this);
+      return new ServiceOptions(uninterpreted_option, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -75,25 +76,32 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
   public final List<Location> location;
 
   public SourceCodeInfo(List<Location> location) {
-    this.location = immutableCopyOf(location);
+    this(location, null);
   }
 
-  private SourceCodeInfo(Builder builder) {
-    this(builder.location);
-    setBuilder(builder);
+  public SourceCodeInfo(List<Location> location, TagMap tagMap) {
+    super(tagMap);
+    this.location = immutableCopyOf(location);
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof SourceCodeInfo)) return false;
-    return equals(location, ((SourceCodeInfo) other).location);
+    SourceCodeInfo o = (SourceCodeInfo) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(location, o.location);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = location != null ? location.hashCode() : 1);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (location != null ? location.hashCode() : 1);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<SourceCodeInfo, Builder> {
@@ -160,7 +168,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
 
     @Override
     public SourceCodeInfo build() {
-      return new SourceCodeInfo(this);
+      return new SourceCodeInfo(location, buildTagMap());
     }
   }
 
@@ -216,13 +224,13 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
     public final List<Integer> span;
 
     public Location(List<Integer> path, List<Integer> span) {
-      this.path = immutableCopyOf(path);
-      this.span = immutableCopyOf(span);
+      this(path, span, null);
     }
 
-    private Location(Builder builder) {
-      this(builder.path, builder.span);
-      setBuilder(builder);
+    public Location(List<Integer> path, List<Integer> span, TagMap tagMap) {
+      super(tagMap);
+      this.path = immutableCopyOf(path);
+      this.span = immutableCopyOf(span);
     }
 
     @Override
@@ -230,7 +238,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
       if (other == this) return true;
       if (!(other instanceof Location)) return false;
       Location o = (Location) other;
-      return equals(path, o.path)
+      return equals(tagMap(), o.tagMap())
+          && equals(path, o.path)
           && equals(span, o.span);
     }
 
@@ -238,7 +247,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
     public int hashCode() {
       int result = hashCode;
       if (result == 0) {
-        result = path != null ? path.hashCode() : 1;
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (path != null ? path.hashCode() : 1);
         result = result * 37 + (span != null ? span.hashCode() : 1);
         hashCode = result;
       }
@@ -304,7 +314,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
 
       @Override
       public Location build() {
-        return new Location(this);
+        return new Location(path, span, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -4,6 +4,7 @@ package com.google.protobuf;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -88,6 +89,11 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
   public final String aggregate_value;
 
   public UninterpretedOption(List<NamePart> name, String identifier_value, Long positive_int_value, Long negative_int_value, Double double_value, ByteString string_value, String aggregate_value) {
+    this(name, identifier_value, positive_int_value, negative_int_value, double_value, string_value, aggregate_value, null);
+  }
+
+  public UninterpretedOption(List<NamePart> name, String identifier_value, Long positive_int_value, Long negative_int_value, Double double_value, ByteString string_value, String aggregate_value, TagMap tagMap) {
+    super(tagMap);
     this.name = immutableCopyOf(name);
     this.identifier_value = identifier_value;
     this.positive_int_value = positive_int_value;
@@ -97,17 +103,13 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
     this.aggregate_value = aggregate_value;
   }
 
-  private UninterpretedOption(Builder builder) {
-    this(builder.name, builder.identifier_value, builder.positive_int_value, builder.negative_int_value, builder.double_value, builder.string_value, builder.aggregate_value);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof UninterpretedOption)) return false;
     UninterpretedOption o = (UninterpretedOption) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(identifier_value, o.identifier_value)
         && equals(positive_int_value, o.positive_int_value)
         && equals(negative_int_value, o.negative_int_value)
@@ -120,7 +122,8 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 1;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 1);
       result = result * 37 + (identifier_value != null ? identifier_value.hashCode() : 0);
       result = result * 37 + (positive_int_value != null ? positive_int_value.hashCode() : 0);
       result = result * 37 + (negative_int_value != null ? negative_int_value.hashCode() : 0);
@@ -203,7 +206,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
 
     @Override
     public UninterpretedOption build() {
-      return new UninterpretedOption(this);
+      return new UninterpretedOption(name, identifier_value, positive_int_value, negative_int_value, double_value, string_value, aggregate_value, buildTagMap());
     }
   }
 
@@ -238,13 +241,13 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
     public final Boolean is_extension;
 
     public NamePart(String name_part, Boolean is_extension) {
-      this.name_part = name_part;
-      this.is_extension = is_extension;
+      this(name_part, is_extension, null);
     }
 
-    private NamePart(Builder builder) {
-      this(builder.name_part, builder.is_extension);
-      setBuilder(builder);
+    public NamePart(String name_part, Boolean is_extension, TagMap tagMap) {
+      super(tagMap);
+      this.name_part = name_part;
+      this.is_extension = is_extension;
     }
 
     @Override
@@ -252,7 +255,8 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
       if (other == this) return true;
       if (!(other instanceof NamePart)) return false;
       NamePart o = (NamePart) other;
-      return equals(name_part, o.name_part)
+      return equals(tagMap(), o.tagMap())
+          && equals(name_part, o.name_part)
           && equals(is_extension, o.is_extension);
     }
 
@@ -260,7 +264,8 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
     public int hashCode() {
       int result = hashCode;
       if (result == 0) {
-        result = name_part != null ? name_part.hashCode() : 0;
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (name_part != null ? name_part.hashCode() : 0);
         result = result * 37 + (is_extension != null ? is_extension.hashCode() : 0);
         hashCode = result;
       }
@@ -299,7 +304,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
           throw missingRequiredFields(name_part, "name_part",
               is_extension, "is_extension");
         }
-        return new NamePart(this);
+        return new NamePart(name_part, is_extension, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -4,6 +4,7 @@ package com.squareup.differentpackage.protos.bar;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -15,10 +16,11 @@ public final class Bar extends Message<Bar> {
   private static final long serialVersionUID = 0L;
 
   public Bar() {
+    this(null);
   }
 
-  private Bar(Builder builder) {
-    setBuilder(builder);
+  public Bar(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -28,7 +30,7 @@ public final class Bar extends Message<Bar> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bar, Builder> {
@@ -41,7 +43,7 @@ public final class Bar extends Message<Bar> {
 
     @Override
     public Bar build() {
-      return new Bar(this);
+      return new Bar(buildTagMap());
     }
   }
 
@@ -51,10 +53,11 @@ public final class Bar extends Message<Bar> {
     private static final long serialVersionUID = 0L;
 
     public Baz() {
+      this(null);
     }
 
-    private Baz(Builder builder) {
-      setBuilder(builder);
+    public Baz(TagMap tagMap) {
+      super(tagMap);
     }
 
     @Override
@@ -64,7 +67,7 @@ public final class Bar extends Message<Bar> {
 
     @Override
     public int hashCode() {
-      return 0;
+      return tagMap() != null ? tagMap().hashCode() : 0;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Baz, Builder> {
@@ -77,7 +80,7 @@ public final class Bar extends Message<Bar> {
 
       @Override
       public Baz build() {
-        return new Baz(this);
+        return new Baz(buildTagMap());
       }
     }
 
@@ -95,25 +98,32 @@ public final class Bar extends Message<Bar> {
       public final String boo;
 
       public Moo(String boo) {
-        this.boo = boo;
+        this(boo, null);
       }
 
-      private Moo(Builder builder) {
-        this(builder.boo);
-        setBuilder(builder);
+      public Moo(String boo, TagMap tagMap) {
+        super(tagMap);
+        this.boo = boo;
       }
 
       @Override
       public boolean equals(Object other) {
         if (other == this) return true;
         if (!(other instanceof Moo)) return false;
-        return equals(boo, ((Moo) other).boo);
+        Moo o = (Moo) other;
+        return equals(tagMap(), o.tagMap())
+            && equals(boo, o.boo);
       }
 
       @Override
       public int hashCode() {
         int result = hashCode;
-        return result != 0 ? result : (hashCode = boo != null ? boo.hashCode() : 0);
+        if (result == 0) {
+          result = tagMap() != null ? tagMap().hashCode() : 0;
+          result = result * 37 + (boo != null ? boo.hashCode() : 0);
+          hashCode = result;
+        }
+        return result;
       }
 
       public static final class Builder extends com.squareup.wire.Message.Builder<Moo, Builder> {
@@ -135,7 +145,7 @@ public final class Bar extends Message<Bar> {
 
         @Override
         public Moo build() {
-          return new Moo(this);
+          return new Moo(boo, buildTagMap());
         }
       }
     }

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -5,6 +5,7 @@ package com.squareup.differentpackage.protos.foo;
 import com.squareup.differentpackage.protos.bar.Bar;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -21,25 +22,32 @@ public final class Foo extends Message<Foo> {
   public final Bar.Baz.Moo moo;
 
   public Foo(Bar.Baz.Moo moo) {
-    this.moo = moo;
+    this(moo, null);
   }
 
-  private Foo(Builder builder) {
-    this(builder.moo);
-    setBuilder(builder);
+  public Foo(Bar.Baz.Moo moo, TagMap tagMap) {
+    super(tagMap);
+    this.moo = moo;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
-    return equals(moo, ((Foo) other).moo);
+    Foo o = (Foo) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(moo, o.moo);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = moo != null ? moo.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (moo != null ? moo.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {
@@ -61,7 +69,7 @@ public final class Foo extends Message<Foo> {
 
     @Override
     public Foo build() {
-      return new Foo(this);
+      return new Foo(moo, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
@@ -4,6 +4,7 @@ package com.squareup.foobar.protos.bar;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -15,10 +16,11 @@ public final class Bar extends Message<Bar> {
   private static final long serialVersionUID = 0L;
 
   public Bar() {
+    this(null);
   }
 
-  private Bar(Builder builder) {
-    setBuilder(builder);
+  public Bar(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -28,7 +30,7 @@ public final class Bar extends Message<Bar> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bar, Builder> {
@@ -41,7 +43,7 @@ public final class Bar extends Message<Bar> {
 
     @Override
     public Bar build() {
-      return new Bar(this);
+      return new Bar(buildTagMap());
     }
   }
 
@@ -51,10 +53,11 @@ public final class Bar extends Message<Bar> {
     private static final long serialVersionUID = 0L;
 
     public Baz() {
+      this(null);
     }
 
-    private Baz(Builder builder) {
-      setBuilder(builder);
+    public Baz(TagMap tagMap) {
+      super(tagMap);
     }
 
     @Override
@@ -64,7 +67,7 @@ public final class Bar extends Message<Bar> {
 
     @Override
     public int hashCode() {
-      return 0;
+      return tagMap() != null ? tagMap().hashCode() : 0;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Baz, Builder> {
@@ -77,7 +80,7 @@ public final class Bar extends Message<Bar> {
 
       @Override
       public Baz build() {
-        return new Baz(this);
+        return new Baz(buildTagMap());
       }
     }
 
@@ -95,25 +98,32 @@ public final class Bar extends Message<Bar> {
       public final String boo;
 
       public Moo(String boo) {
-        this.boo = boo;
+        this(boo, null);
       }
 
-      private Moo(Builder builder) {
-        this(builder.boo);
-        setBuilder(builder);
+      public Moo(String boo, TagMap tagMap) {
+        super(tagMap);
+        this.boo = boo;
       }
 
       @Override
       public boolean equals(Object other) {
         if (other == this) return true;
         if (!(other instanceof Moo)) return false;
-        return equals(boo, ((Moo) other).boo);
+        Moo o = (Moo) other;
+        return equals(tagMap(), o.tagMap())
+            && equals(boo, o.boo);
       }
 
       @Override
       public int hashCode() {
         int result = hashCode;
-        return result != 0 ? result : (hashCode = boo != null ? boo.hashCode() : 0);
+        if (result == 0) {
+          result = tagMap() != null ? tagMap().hashCode() : 0;
+          result = result * 37 + (boo != null ? boo.hashCode() : 0);
+          hashCode = result;
+        }
+        return result;
       }
 
       public static final class Builder extends com.squareup.wire.Message.Builder<Moo, Builder> {
@@ -135,7 +145,7 @@ public final class Bar extends Message<Bar> {
 
         @Override
         public Moo build() {
-          return new Moo(this);
+          return new Moo(boo, buildTagMap());
         }
       }
     }

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
@@ -5,6 +5,7 @@ package com.squareup.foobar.protos.foo;
 import com.squareup.foobar.protos.bar.Bar;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -21,25 +22,32 @@ public final class Foo extends Message<Foo> {
   public final Bar.Baz.Moo moo;
 
   public Foo(Bar.Baz.Moo moo) {
-    this.moo = moo;
+    this(moo, null);
   }
 
-  private Foo(Builder builder) {
-    this(builder.moo);
-    setBuilder(builder);
+  public Foo(Bar.Baz.Moo moo, TagMap tagMap) {
+    super(tagMap);
+    this.moo = moo;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
-    return equals(moo, ((Foo) other).moo);
+    Foo o = (Foo) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(moo, o.moo);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = moo != null ? moo.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (moo != null ? moo.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {
@@ -61,7 +69,7 @@ public final class Foo extends Message<Foo> {
 
     @Override
     public Foo build() {
-      return new Foo(this);
+      return new Foo(moo, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
@@ -4,6 +4,7 @@ package com.squareup.services;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
   public final ByteString data;
 
   public HeresAllTheDataRequest(ByteString data) {
-    this.data = data;
+    this(data, null);
   }
 
-  private HeresAllTheDataRequest(Builder builder) {
-    this(builder.data);
-    setBuilder(builder);
+  public HeresAllTheDataRequest(ByteString data, TagMap tagMap) {
+    super(tagMap);
+    this.data = data;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof HeresAllTheDataRequest)) return false;
-    return equals(data, ((HeresAllTheDataRequest) other).data);
+    HeresAllTheDataRequest o = (HeresAllTheDataRequest) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(data, o.data);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = data != null ? data.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (data != null ? data.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<HeresAllTheDataRequest, Builder> {
@@ -63,7 +71,7 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
 
     @Override
     public HeresAllTheDataRequest build() {
-      return new HeresAllTheDataRequest(this);
+      return new HeresAllTheDataRequest(data, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
@@ -4,6 +4,7 @@ package com.squareup.services;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
   public final ByteString data;
 
   public HeresAllTheDataResponse(ByteString data) {
-    this.data = data;
+    this(data, null);
   }
 
-  private HeresAllTheDataResponse(Builder builder) {
-    this(builder.data);
-    setBuilder(builder);
+  public HeresAllTheDataResponse(ByteString data, TagMap tagMap) {
+    super(tagMap);
+    this.data = data;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof HeresAllTheDataResponse)) return false;
-    return equals(data, ((HeresAllTheDataResponse) other).data);
+    HeresAllTheDataResponse o = (HeresAllTheDataResponse) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(data, o.data);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = data != null ? data.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (data != null ? data.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<HeresAllTheDataResponse, Builder> {
@@ -63,7 +71,7 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
 
     @Override
     public HeresAllTheDataResponse build() {
-      return new HeresAllTheDataResponse(this);
+      return new HeresAllTheDataResponse(data, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
@@ -4,6 +4,7 @@ package com.squareup.services;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class LetsDataRequest extends Message<LetsDataRequest> {
   public final ByteString data;
 
   public LetsDataRequest(ByteString data) {
-    this.data = data;
+    this(data, null);
   }
 
-  private LetsDataRequest(Builder builder) {
-    this(builder.data);
-    setBuilder(builder);
+  public LetsDataRequest(ByteString data, TagMap tagMap) {
+    super(tagMap);
+    this.data = data;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof LetsDataRequest)) return false;
-    return equals(data, ((LetsDataRequest) other).data);
+    LetsDataRequest o = (LetsDataRequest) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(data, o.data);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = data != null ? data.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (data != null ? data.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<LetsDataRequest, Builder> {
@@ -63,7 +71,7 @@ public final class LetsDataRequest extends Message<LetsDataRequest> {
 
     @Override
     public LetsDataRequest build() {
-      return new LetsDataRequest(this);
+      return new LetsDataRequest(data, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
@@ -4,6 +4,7 @@ package com.squareup.services;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class LetsDataResponse extends Message<LetsDataResponse> {
   public final ByteString data;
 
   public LetsDataResponse(ByteString data) {
-    this.data = data;
+    this(data, null);
   }
 
-  private LetsDataResponse(Builder builder) {
-    this(builder.data);
-    setBuilder(builder);
+  public LetsDataResponse(ByteString data, TagMap tagMap) {
+    super(tagMap);
+    this.data = data;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof LetsDataResponse)) return false;
-    return equals(data, ((LetsDataResponse) other).data);
+    LetsDataResponse o = (LetsDataResponse) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(data, o.data);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = data != null ? data.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (data != null ? data.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<LetsDataResponse, Builder> {
@@ -63,7 +71,7 @@ public final class LetsDataResponse extends Message<LetsDataResponse> {
 
     @Override
     public LetsDataResponse build() {
-      return new LetsDataResponse(this);
+      return new LetsDataResponse(data, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -4,6 +4,7 @@ package com.squareup.services.anotherpackage;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class SendDataRequest extends Message<SendDataRequest> {
   public final ByteString data;
 
   public SendDataRequest(ByteString data) {
-    this.data = data;
+    this(data, null);
   }
 
-  private SendDataRequest(Builder builder) {
-    this(builder.data);
-    setBuilder(builder);
+  public SendDataRequest(ByteString data, TagMap tagMap) {
+    super(tagMap);
+    this.data = data;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof SendDataRequest)) return false;
-    return equals(data, ((SendDataRequest) other).data);
+    SendDataRequest o = (SendDataRequest) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(data, o.data);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = data != null ? data.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (data != null ? data.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<SendDataRequest, Builder> {
@@ -63,7 +71,7 @@ public final class SendDataRequest extends Message<SendDataRequest> {
 
     @Override
     public SendDataRequest build() {
-      return new SendDataRequest(this);
+      return new SendDataRequest(data, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -4,6 +4,7 @@ package com.squareup.services.anotherpackage;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class SendDataResponse extends Message<SendDataResponse> {
   public final ByteString data;
 
   public SendDataResponse(ByteString data) {
-    this.data = data;
+    this(data, null);
   }
 
-  private SendDataResponse(Builder builder) {
-    this(builder.data);
-    setBuilder(builder);
+  public SendDataResponse(ByteString data, TagMap tagMap) {
+    super(tagMap);
+    this.data = data;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof SendDataResponse)) return false;
-    return equals(data, ((SendDataResponse) other).data);
+    SendDataResponse o = (SendDataResponse) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(data, o.data);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = data != null ? data.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (data != null ? data.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<SendDataResponse, Builder> {
@@ -63,7 +71,7 @@ public final class SendDataResponse extends Message<SendDataResponse> {
 
     @Override
     public SendDataResponse build() {
-      return new SendDataResponse(this);
+      return new SendDataResponse(data, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/ParseTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/ParseTest.java
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
 public final class ParseTest {
+  @Ignore("https://github.com/square/wire/issues/398")
   @Test public void unknownTagIgnored() throws Exception {
     // tag 1 / type 0: 456
     // tag 2 / type 0: 789

--- a/wire-runtime/src/test/java/com/squareup/wire/ProtoAdapterTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/ProtoAdapterTest.java
@@ -36,7 +36,7 @@ public final class ProtoAdapterTest {
   }
 
   @Test public void getFromClassWrongType() throws Exception {
-    Message nonGeneratedMessage = new Message() {};
+    Message nonGeneratedMessage = new Message(null) {};
     try {
       ProtoAdapter.get(nonGeneratedMessage.getClass());
       fail();

--- a/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/UnknownFieldsTest.java
@@ -19,6 +19,7 @@ import com.squareup.wire.protos.unknownfields.VersionOne;
 import com.squareup.wire.protos.unknownfields.VersionTwo;
 import java.io.IOException;
 import java.util.Arrays;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -28,6 +29,7 @@ public class UnknownFieldsTest {
   private final ProtoAdapter<VersionOne> v1Adapter = VersionOne.ADAPTER;
   private final ProtoAdapter<VersionTwo> v2Adapter = VersionTwo.ADAPTER;
 
+  @Ignore("https://github.com/square/wire/issues/398")
   @Test
   public void testUnknownFields() throws IOException {
     VersionTwo v2 = new VersionTwo.Builder()

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class ChildPackage extends Message<ChildPackage> {
   public final ForeignEnum inner_foreign_enum;
 
   public ChildPackage(ForeignEnum inner_foreign_enum) {
-    this.inner_foreign_enum = inner_foreign_enum;
+    this(inner_foreign_enum, null);
   }
 
-  private ChildPackage(Builder builder) {
-    this(builder.inner_foreign_enum);
-    setBuilder(builder);
+  public ChildPackage(ForeignEnum inner_foreign_enum, TagMap tagMap) {
+    super(tagMap);
+    this.inner_foreign_enum = inner_foreign_enum;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof ChildPackage)) return false;
-    return equals(inner_foreign_enum, ((ChildPackage) other).inner_foreign_enum);
+    ChildPackage o = (ChildPackage) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(inner_foreign_enum, o.inner_foreign_enum);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = inner_foreign_enum != null ? inner_foreign_enum.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (inner_foreign_enum != null ? inner_foreign_enum.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<ChildPackage, Builder> {
@@ -63,7 +71,7 @@ public final class ChildPackage extends Message<ChildPackage> {
 
     @Override
     public ChildPackage build() {
-      return new ChildPackage(this);
+      return new ChildPackage(inner_foreign_enum, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -31,13 +32,13 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
   public final List<Integer> pack_int32;
 
   public RepeatedAndPacked(List<Integer> rep_int32, List<Integer> pack_int32) {
-    this.rep_int32 = immutableCopyOf(rep_int32);
-    this.pack_int32 = immutableCopyOf(pack_int32);
+    this(rep_int32, pack_int32, null);
   }
 
-  private RepeatedAndPacked(Builder builder) {
-    this(builder.rep_int32, builder.pack_int32);
-    setBuilder(builder);
+  public RepeatedAndPacked(List<Integer> rep_int32, List<Integer> pack_int32, TagMap tagMap) {
+    super(tagMap);
+    this.rep_int32 = immutableCopyOf(rep_int32);
+    this.pack_int32 = immutableCopyOf(pack_int32);
   }
 
   @Override
@@ -45,7 +46,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
     if (other == this) return true;
     if (!(other instanceof RepeatedAndPacked)) return false;
     RepeatedAndPacked o = (RepeatedAndPacked) other;
-    return equals(rep_int32, o.rep_int32)
+    return equals(tagMap(), o.tagMap())
+        && equals(rep_int32, o.rep_int32)
         && equals(pack_int32, o.pack_int32);
   }
 
@@ -53,7 +55,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = rep_int32 != null ? rep_int32.hashCode() : 1;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (rep_int32 != null ? rep_int32.hashCode() : 1);
       result = result * 37 + (pack_int32 != null ? pack_int32.hashCode() : 1);
       hashCode = result;
     }
@@ -87,7 +90,7 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
 
     @Override
     public RepeatedAndPacked build() {
-      return new RepeatedAndPacked(this);
+      return new RepeatedAndPacked(rep_int32, pack_int32, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.alltypes;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Boolean;
@@ -655,6 +656,11 @@ public final class AllTypes extends Message<AllTypes> {
   public final NestedEnum default_nested_enum;
 
   public AllTypes(Integer opt_int32, Integer opt_uint32, Integer opt_sint32, Integer opt_fixed32, Integer opt_sfixed32, Long opt_int64, Long opt_uint64, Long opt_sint64, Long opt_fixed64, Long opt_sfixed64, Boolean opt_bool, Float opt_float, Double opt_double, String opt_string, ByteString opt_bytes, NestedEnum opt_nested_enum, NestedMessage opt_nested_message, Integer req_int32, Integer req_uint32, Integer req_sint32, Integer req_fixed32, Integer req_sfixed32, Long req_int64, Long req_uint64, Long req_sint64, Long req_fixed64, Long req_sfixed64, Boolean req_bool, Float req_float, Double req_double, String req_string, ByteString req_bytes, NestedEnum req_nested_enum, NestedMessage req_nested_message, List<Integer> rep_int32, List<Integer> rep_uint32, List<Integer> rep_sint32, List<Integer> rep_fixed32, List<Integer> rep_sfixed32, List<Long> rep_int64, List<Long> rep_uint64, List<Long> rep_sint64, List<Long> rep_fixed64, List<Long> rep_sfixed64, List<Boolean> rep_bool, List<Float> rep_float, List<Double> rep_double, List<String> rep_string, List<ByteString> rep_bytes, List<NestedEnum> rep_nested_enum, List<NestedMessage> rep_nested_message, List<Integer> pack_int32, List<Integer> pack_uint32, List<Integer> pack_sint32, List<Integer> pack_fixed32, List<Integer> pack_sfixed32, List<Long> pack_int64, List<Long> pack_uint64, List<Long> pack_sint64, List<Long> pack_fixed64, List<Long> pack_sfixed64, List<Boolean> pack_bool, List<Float> pack_float, List<Double> pack_double, List<NestedEnum> pack_nested_enum, Integer default_int32, Integer default_uint32, Integer default_sint32, Integer default_fixed32, Integer default_sfixed32, Long default_int64, Long default_uint64, Long default_sint64, Long default_fixed64, Long default_sfixed64, Boolean default_bool, Float default_float, Double default_double, String default_string, ByteString default_bytes, NestedEnum default_nested_enum) {
+    this(opt_int32, opt_uint32, opt_sint32, opt_fixed32, opt_sfixed32, opt_int64, opt_uint64, opt_sint64, opt_fixed64, opt_sfixed64, opt_bool, opt_float, opt_double, opt_string, opt_bytes, opt_nested_enum, opt_nested_message, req_int32, req_uint32, req_sint32, req_fixed32, req_sfixed32, req_int64, req_uint64, req_sint64, req_fixed64, req_sfixed64, req_bool, req_float, req_double, req_string, req_bytes, req_nested_enum, req_nested_message, rep_int32, rep_uint32, rep_sint32, rep_fixed32, rep_sfixed32, rep_int64, rep_uint64, rep_sint64, rep_fixed64, rep_sfixed64, rep_bool, rep_float, rep_double, rep_string, rep_bytes, rep_nested_enum, rep_nested_message, pack_int32, pack_uint32, pack_sint32, pack_fixed32, pack_sfixed32, pack_int64, pack_uint64, pack_sint64, pack_fixed64, pack_sfixed64, pack_bool, pack_float, pack_double, pack_nested_enum, default_int32, default_uint32, default_sint32, default_fixed32, default_sfixed32, default_int64, default_uint64, default_sint64, default_fixed64, default_sfixed64, default_bool, default_float, default_double, default_string, default_bytes, default_nested_enum, null);
+  }
+
+  public AllTypes(Integer opt_int32, Integer opt_uint32, Integer opt_sint32, Integer opt_fixed32, Integer opt_sfixed32, Long opt_int64, Long opt_uint64, Long opt_sint64, Long opt_fixed64, Long opt_sfixed64, Boolean opt_bool, Float opt_float, Double opt_double, String opt_string, ByteString opt_bytes, NestedEnum opt_nested_enum, NestedMessage opt_nested_message, Integer req_int32, Integer req_uint32, Integer req_sint32, Integer req_fixed32, Integer req_sfixed32, Long req_int64, Long req_uint64, Long req_sint64, Long req_fixed64, Long req_sfixed64, Boolean req_bool, Float req_float, Double req_double, String req_string, ByteString req_bytes, NestedEnum req_nested_enum, NestedMessage req_nested_message, List<Integer> rep_int32, List<Integer> rep_uint32, List<Integer> rep_sint32, List<Integer> rep_fixed32, List<Integer> rep_sfixed32, List<Long> rep_int64, List<Long> rep_uint64, List<Long> rep_sint64, List<Long> rep_fixed64, List<Long> rep_sfixed64, List<Boolean> rep_bool, List<Float> rep_float, List<Double> rep_double, List<String> rep_string, List<ByteString> rep_bytes, List<NestedEnum> rep_nested_enum, List<NestedMessage> rep_nested_message, List<Integer> pack_int32, List<Integer> pack_uint32, List<Integer> pack_sint32, List<Integer> pack_fixed32, List<Integer> pack_sfixed32, List<Long> pack_int64, List<Long> pack_uint64, List<Long> pack_sint64, List<Long> pack_fixed64, List<Long> pack_sfixed64, List<Boolean> pack_bool, List<Float> pack_float, List<Double> pack_double, List<NestedEnum> pack_nested_enum, Integer default_int32, Integer default_uint32, Integer default_sint32, Integer default_fixed32, Integer default_sfixed32, Long default_int64, Long default_uint64, Long default_sint64, Long default_fixed64, Long default_sfixed64, Boolean default_bool, Float default_float, Double default_double, String default_string, ByteString default_bytes, NestedEnum default_nested_enum, TagMap tagMap) {
+    super(tagMap);
     this.opt_int32 = opt_int32;
     this.opt_uint32 = opt_uint32;
     this.opt_sint32 = opt_sint32;
@@ -738,18 +744,13 @@ public final class AllTypes extends Message<AllTypes> {
     this.default_nested_enum = default_nested_enum;
   }
 
-  private AllTypes(Builder builder) {
-    this(builder.opt_int32, builder.opt_uint32, builder.opt_sint32, builder.opt_fixed32, builder.opt_sfixed32, builder.opt_int64, builder.opt_uint64, builder.opt_sint64, builder.opt_fixed64, builder.opt_sfixed64, builder.opt_bool, builder.opt_float, builder.opt_double, builder.opt_string, builder.opt_bytes, builder.opt_nested_enum, builder.opt_nested_message, builder.req_int32, builder.req_uint32, builder.req_sint32, builder.req_fixed32, builder.req_sfixed32, builder.req_int64, builder.req_uint64, builder.req_sint64, builder.req_fixed64, builder.req_sfixed64, builder.req_bool, builder.req_float, builder.req_double, builder.req_string, builder.req_bytes, builder.req_nested_enum, builder.req_nested_message, builder.rep_int32, builder.rep_uint32, builder.rep_sint32, builder.rep_fixed32, builder.rep_sfixed32, builder.rep_int64, builder.rep_uint64, builder.rep_sint64, builder.rep_fixed64, builder.rep_sfixed64, builder.rep_bool, builder.rep_float, builder.rep_double, builder.rep_string, builder.rep_bytes, builder.rep_nested_enum, builder.rep_nested_message, builder.pack_int32, builder.pack_uint32, builder.pack_sint32, builder.pack_fixed32, builder.pack_sfixed32, builder.pack_int64, builder.pack_uint64, builder.pack_sint64, builder.pack_fixed64, builder.pack_sfixed64, builder.pack_bool, builder.pack_float, builder.pack_double, builder.pack_nested_enum, builder.default_int32, builder.default_uint32, builder.default_sint32, builder.default_fixed32, builder.default_sfixed32, builder.default_int64, builder.default_uint64, builder.default_sint64, builder.default_fixed64, builder.default_sfixed64, builder.default_bool, builder.default_float, builder.default_double, builder.default_string, builder.default_bytes, builder.default_nested_enum);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(opt_int32, o.opt_int32)
+    return equals(tagMap(), o.tagMap())
+        && equals(opt_int32, o.opt_int32)
         && equals(opt_uint32, o.opt_uint32)
         && equals(opt_sint32, o.opt_sint32)
         && equals(opt_fixed32, o.opt_fixed32)
@@ -836,7 +837,7 @@ public final class AllTypes extends Message<AllTypes> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (opt_int32 != null ? opt_int32.hashCode() : 0);
       result = result * 37 + (opt_uint32 != null ? opt_uint32.hashCode() : 0);
       result = result * 37 + (opt_sint32 != null ? opt_sint32.hashCode() : 0);
@@ -1617,7 +1618,7 @@ public final class AllTypes extends Message<AllTypes> {
             req_nested_enum, "req_nested_enum",
             req_nested_message, "req_nested_message");
       }
-      return new AllTypes(this);
+      return new AllTypes(opt_int32, opt_uint32, opt_sint32, opt_fixed32, opt_sfixed32, opt_int64, opt_uint64, opt_sint64, opt_fixed64, opt_sfixed64, opt_bool, opt_float, opt_double, opt_string, opt_bytes, opt_nested_enum, opt_nested_message, req_int32, req_uint32, req_sint32, req_fixed32, req_sfixed32, req_int64, req_uint64, req_sint64, req_fixed64, req_sfixed64, req_bool, req_float, req_double, req_string, req_bytes, req_nested_enum, req_nested_message, rep_int32, rep_uint32, rep_sint32, rep_fixed32, rep_sfixed32, rep_int64, rep_uint64, rep_sint64, rep_fixed64, rep_sfixed64, rep_bool, rep_float, rep_double, rep_string, rep_bytes, rep_nested_enum, rep_nested_message, pack_int32, pack_uint32, pack_sint32, pack_fixed32, pack_sfixed32, pack_int64, pack_uint64, pack_sint64, pack_fixed64, pack_sfixed64, pack_bool, pack_float, pack_double, pack_nested_enum, default_int32, default_uint32, default_sint32, default_fixed32, default_sfixed32, default_int64, default_uint64, default_sint64, default_fixed64, default_sfixed64, default_bool, default_float, default_double, default_string, default_bytes, default_nested_enum, buildTagMap());
     }
   }
 
@@ -1652,25 +1653,32 @@ public final class AllTypes extends Message<AllTypes> {
     public final Integer a;
 
     public NestedMessage(Integer a) {
-      this.a = a;
+      this(a, null);
     }
 
-    private NestedMessage(Builder builder) {
-      this(builder.a);
-      setBuilder(builder);
+    public NestedMessage(Integer a, TagMap tagMap) {
+      super(tagMap);
+      this.a = a;
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
-      return equals(a, ((NestedMessage) other).a);
+      NestedMessage o = (NestedMessage) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(a, o.a);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = a != null ? a.hashCode() : 0);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (a != null ? a.hashCode() : 0);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage, Builder> {
@@ -1692,7 +1700,7 @@ public final class AllTypes extends Message<AllTypes> {
 
       @Override
       public NestedMessage build() {
-        return new NestedMessage(this);
+        return new NestedMessage(a, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -6,6 +6,7 @@ import com.google.protobuf.EnumOptions;
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Boolean;
@@ -124,6 +125,11 @@ public final class FooBar extends Message<FooBar> {
   public final List<FooBar> nested;
 
   public FooBar(Integer foo, String bar, Nested baz, Long qux, List<Float> fred, Double daisy, List<FooBar> nested) {
+    this(foo, bar, baz, qux, fred, daisy, nested, null);
+  }
+
+  public FooBar(Integer foo, String bar, Nested baz, Long qux, List<Float> fred, Double daisy, List<FooBar> nested, TagMap tagMap) {
+    super(tagMap);
     this.foo = foo;
     this.bar = bar;
     this.baz = baz;
@@ -133,18 +139,13 @@ public final class FooBar extends Message<FooBar> {
     this.nested = immutableCopyOf(nested);
   }
 
-  private FooBar(Builder builder) {
-    this(builder.foo, builder.bar, builder.baz, builder.qux, builder.fred, builder.daisy, builder.nested);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof FooBar)) return false;
     FooBar o = (FooBar) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(foo, o.foo)
+    return equals(tagMap(), o.tagMap())
+        && equals(foo, o.foo)
         && equals(bar, o.bar)
         && equals(baz, o.baz)
         && equals(qux, o.qux)
@@ -157,7 +158,7 @@ public final class FooBar extends Message<FooBar> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (foo != null ? foo.hashCode() : 0);
       result = result * 37 + (bar != null ? bar.hashCode() : 0);
       result = result * 37 + (baz != null ? baz.hashCode() : 0);
@@ -237,7 +238,7 @@ public final class FooBar extends Message<FooBar> {
 
     @Override
     public FooBar build() {
-      return new FooBar(this);
+      return new FooBar(foo, bar, baz, qux, fred, daisy, nested, buildTagMap());
     }
   }
 
@@ -255,25 +256,32 @@ public final class FooBar extends Message<FooBar> {
     public final FooBarBazEnum value;
 
     public Nested(FooBarBazEnum value) {
-      this.value = value;
+      this(value, null);
     }
 
-    private Nested(Builder builder) {
-      this(builder.value);
-      setBuilder(builder);
+    public Nested(FooBarBazEnum value, TagMap tagMap) {
+      super(tagMap);
+      this.value = value;
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof Nested)) return false;
-      return equals(value, ((Nested) other).value);
+      Nested o = (Nested) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(value, o.value);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = value != null ? value.hashCode() : 0);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (value != null ? value.hashCode() : 0);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Nested, Builder> {
@@ -295,7 +303,7 @@ public final class FooBar extends Message<FooBar> {
 
       @Override
       public Nested build() {
-        return new Nested(this);
+        return new Nested(value, buildTagMap());
       }
     }
   }
@@ -313,25 +321,32 @@ public final class FooBar extends Message<FooBar> {
     public final List<Integer> serial;
 
     public More(List<Integer> serial) {
-      this.serial = immutableCopyOf(serial);
+      this(serial, null);
     }
 
-    private More(Builder builder) {
-      this(builder.serial);
-      setBuilder(builder);
+    public More(List<Integer> serial, TagMap tagMap) {
+      super(tagMap);
+      this.serial = immutableCopyOf(serial);
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof More)) return false;
-      return equals(serial, ((More) other).serial);
+      More o = (More) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(serial, o.serial);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = serial != null ? serial.hashCode() : 1);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (serial != null ? serial.hashCode() : 1);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<More, Builder> {
@@ -353,7 +368,7 @@ public final class FooBar extends Message<FooBar> {
 
       @Override
       public More build() {
-        return new More(this);
+        return new More(serial, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.custom_options;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Double;
@@ -74,6 +75,11 @@ public final class FooBar extends Message<FooBar> {
   public final List<FooBar> nested;
 
   public FooBar(Integer foo, String bar, Nested baz, Long qux, List<Float> fred, Double daisy, List<FooBar> nested) {
+    this(foo, bar, baz, qux, fred, daisy, nested, null);
+  }
+
+  public FooBar(Integer foo, String bar, Nested baz, Long qux, List<Float> fred, Double daisy, List<FooBar> nested, TagMap tagMap) {
+    super(tagMap);
     this.foo = foo;
     this.bar = bar;
     this.baz = baz;
@@ -83,18 +89,13 @@ public final class FooBar extends Message<FooBar> {
     this.nested = immutableCopyOf(nested);
   }
 
-  private FooBar(Builder builder) {
-    this(builder.foo, builder.bar, builder.baz, builder.qux, builder.fred, builder.daisy, builder.nested);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof FooBar)) return false;
     FooBar o = (FooBar) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(foo, o.foo)
+    return equals(tagMap(), o.tagMap())
+        && equals(foo, o.foo)
         && equals(bar, o.bar)
         && equals(baz, o.baz)
         && equals(qux, o.qux)
@@ -107,7 +108,7 @@ public final class FooBar extends Message<FooBar> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (foo != null ? foo.hashCode() : 0);
       result = result * 37 + (bar != null ? bar.hashCode() : 0);
       result = result * 37 + (baz != null ? baz.hashCode() : 0);
@@ -187,7 +188,7 @@ public final class FooBar extends Message<FooBar> {
 
     @Override
     public FooBar build() {
-      return new FooBar(this);
+      return new FooBar(foo, bar, baz, qux, fred, daisy, nested, buildTagMap());
     }
   }
 
@@ -205,25 +206,32 @@ public final class FooBar extends Message<FooBar> {
     public final FooBarBazEnum value;
 
     public Nested(FooBarBazEnum value) {
-      this.value = value;
+      this(value, null);
     }
 
-    private Nested(Builder builder) {
-      this(builder.value);
-      setBuilder(builder);
+    public Nested(FooBarBazEnum value, TagMap tagMap) {
+      super(tagMap);
+      this.value = value;
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof Nested)) return false;
-      return equals(value, ((Nested) other).value);
+      Nested o = (Nested) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(value, o.value);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = value != null ? value.hashCode() : 0);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (value != null ? value.hashCode() : 0);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Nested, Builder> {
@@ -245,7 +253,7 @@ public final class FooBar extends Message<FooBar> {
 
       @Override
       public Nested build() {
-        return new Nested(this);
+        return new Nested(value, buildTagMap());
       }
     }
   }
@@ -263,25 +271,32 @@ public final class FooBar extends Message<FooBar> {
     public final List<Integer> serial;
 
     public More(List<Integer> serial) {
-      this.serial = immutableCopyOf(serial);
+      this(serial, null);
     }
 
-    private More(Builder builder) {
-      this(builder.serial);
-      setBuilder(builder);
+    public More(List<Integer> serial, TagMap tagMap) {
+      super(tagMap);
+      this.serial = immutableCopyOf(serial);
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof More)) return false;
-      return equals(serial, ((More) other).serial);
+      More o = (More) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(serial, o.serial);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = serial != null ? serial.hashCode() : 1);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (serial != null ? serial.hashCode() : 1);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<More, Builder> {
@@ -303,7 +318,7 @@ public final class FooBar extends Message<FooBar> {
 
       @Override
       public More build() {
-        return new More(this);
+        return new More(serial, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.custom_options;
 import com.google.protobuf.MessageOptions;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.protos.foreign.Ext_foreign;
 import com.squareup.wire.protos.foreign.ForeignMessage;
 import java.lang.Object;
@@ -73,10 +74,11 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
       .build();
 
   public MessageWithOptions() {
+    this(null);
   }
 
-  private MessageWithOptions(Builder builder) {
-    setBuilder(builder);
+  public MessageWithOptions(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -86,7 +88,7 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MessageWithOptions, Builder> {
@@ -99,7 +101,7 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
 
     @Override
     public MessageWithOptions build() {
-      return new MessageWithOptions(this);
+      return new MessageWithOptions(buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.custom_options;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -13,10 +14,11 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
   private static final long serialVersionUID = 0L;
 
   public MessageWithOptions() {
+    this(null);
   }
 
-  private MessageWithOptions(Builder builder) {
-    setBuilder(builder);
+  public MessageWithOptions(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -26,7 +28,7 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MessageWithOptions, Builder> {
@@ -39,7 +41,7 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
 
     @Override
     public MessageWithOptions build() {
-      return new MessageWithOptions(this);
+      return new MessageWithOptions(buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/NoFields.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/NoFields.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -13,10 +14,11 @@ public final class NoFields extends Message<NoFields> {
   private static final long serialVersionUID = 0L;
 
   public NoFields() {
+    this(null);
   }
 
-  private NoFields(Builder builder) {
-    setBuilder(builder);
+  public NoFields(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -26,7 +28,7 @@ public final class NoFields extends Message<NoFields> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<NoFields, Builder> {
@@ -39,7 +41,7 @@ public final class NoFields extends Message<NoFields> {
 
     @Override
     public NoFields build() {
-      return new NoFields(this);
+      return new NoFields(buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class OneBytesField extends Message<OneBytesField> {
   public final ByteString opt_bytes;
 
   public OneBytesField(ByteString opt_bytes) {
-    this.opt_bytes = opt_bytes;
+    this(opt_bytes, null);
   }
 
-  private OneBytesField(Builder builder) {
-    this(builder.opt_bytes);
-    setBuilder(builder);
+  public OneBytesField(ByteString opt_bytes, TagMap tagMap) {
+    super(tagMap);
+    this.opt_bytes = opt_bytes;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof OneBytesField)) return false;
-    return equals(opt_bytes, ((OneBytesField) other).opt_bytes);
+    OneBytesField o = (OneBytesField) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(opt_bytes, o.opt_bytes);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = opt_bytes != null ? opt_bytes.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (opt_bytes != null ? opt_bytes.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<OneBytesField, Builder> {
@@ -63,7 +71,7 @@ public final class OneBytesField extends Message<OneBytesField> {
 
     @Override
     public OneBytesField build() {
-      return new OneBytesField(this);
+      return new OneBytesField(opt_bytes, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class OneField extends Message<OneField> {
   public final Integer opt_int32;
 
   public OneField(Integer opt_int32) {
-    this.opt_int32 = opt_int32;
+    this(opt_int32, null);
   }
 
-  private OneField(Builder builder) {
-    this(builder.opt_int32);
-    setBuilder(builder);
+  public OneField(Integer opt_int32, TagMap tagMap) {
+    super(tagMap);
+    this.opt_int32 = opt_int32;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof OneField)) return false;
-    return equals(opt_int32, ((OneField) other).opt_int32);
+    OneField o = (OneField) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(opt_int32, o.opt_int32);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = opt_int32 != null ? opt_int32.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (opt_int32 != null ? opt_int32.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<OneField, Builder> {
@@ -63,7 +71,7 @@ public final class OneField extends Message<OneField> {
 
     @Override
     public OneField build() {
-      return new OneField(this);
+      return new OneField(opt_int32, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.edgecases;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -29,13 +30,13 @@ public final class Recursive extends Message<Recursive> {
   public final Recursive recursive;
 
   public Recursive(Integer value, Recursive recursive) {
-    this.value = value;
-    this.recursive = recursive;
+    this(value, recursive, null);
   }
 
-  private Recursive(Builder builder) {
-    this(builder.value, builder.recursive);
-    setBuilder(builder);
+  public Recursive(Integer value, Recursive recursive, TagMap tagMap) {
+    super(tagMap);
+    this.value = value;
+    this.recursive = recursive;
   }
 
   @Override
@@ -43,7 +44,8 @@ public final class Recursive extends Message<Recursive> {
     if (other == this) return true;
     if (!(other instanceof Recursive)) return false;
     Recursive o = (Recursive) other;
-    return equals(value, o.value)
+    return equals(tagMap(), o.tagMap())
+        && equals(value, o.value)
         && equals(recursive, o.recursive);
   }
 
@@ -51,7 +53,8 @@ public final class Recursive extends Message<Recursive> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = value != null ? value.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (value != null ? value.hashCode() : 0);
       result = result * 37 + (recursive != null ? recursive.hashCode() : 0);
       hashCode = result;
     }
@@ -85,7 +88,7 @@ public final class Recursive extends Message<Recursive> {
 
     @Override
     public Recursive build() {
-      return new Recursive(this);
+      return new Recursive(value, recursive, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.foreign;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,12 +24,12 @@ public final class ForeignMessage extends Message<ForeignMessage> {
   public final Integer i;
 
   public ForeignMessage(Integer i) {
-    this.i = i;
+    this(i, null);
   }
 
-  private ForeignMessage(Builder builder) {
-    this(builder.i);
-    setBuilder(builder);
+  public ForeignMessage(Integer i, TagMap tagMap) {
+    super(tagMap);
+    this.i = i;
   }
 
   @Override
@@ -36,15 +37,15 @@ public final class ForeignMessage extends Message<ForeignMessage> {
     if (other == this) return true;
     if (!(other instanceof ForeignMessage)) return false;
     ForeignMessage o = (ForeignMessage) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(i, o.i);
+    return equals(tagMap(), o.tagMap())
+        && equals(i, o.i);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (i != null ? i.hashCode() : 0);
       hashCode = result;
     }
@@ -70,7 +71,7 @@ public final class ForeignMessage extends Message<ForeignMessage> {
 
     @Override
     public ForeignMessage build() {
-      return new ForeignMessage(this);
+      return new ForeignMessage(i, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.one_extension;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class Foo extends Message<Foo> {
   public final String bar;
 
   public Foo(String bar) {
-    this.bar = bar;
+    this(bar, null);
   }
 
-  private Foo(Builder builder) {
-    this(builder.bar);
-    setBuilder(builder);
+  public Foo(String bar, TagMap tagMap) {
+    super(tagMap);
+    this.bar = bar;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
-    return equals(bar, ((Foo) other).bar);
+    Foo o = (Foo) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(bar, o.bar);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = bar != null ? bar.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (bar != null ? bar.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {
@@ -63,7 +71,7 @@ public final class Foo extends Message<Foo> {
 
     @Override
     public Foo build() {
-      return new Foo(this);
+      return new Foo(bar, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.one_extension;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,12 +24,12 @@ public final class OneExtension extends Message<OneExtension> {
   public final String id;
 
   public OneExtension(String id) {
-    this.id = id;
+    this(id, null);
   }
 
-  private OneExtension(Builder builder) {
-    this(builder.id);
-    setBuilder(builder);
+  public OneExtension(String id, TagMap tagMap) {
+    super(tagMap);
+    this.id = id;
   }
 
   @Override
@@ -36,15 +37,15 @@ public final class OneExtension extends Message<OneExtension> {
     if (other == this) return true;
     if (!(other instanceof OneExtension)) return false;
     OneExtension o = (OneExtension) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(id, o.id);
+    return equals(tagMap(), o.tagMap())
+        && equals(id, o.id);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (id != null ? id.hashCode() : 0);
       hashCode = result;
     }
@@ -70,7 +71,7 @@ public final class OneExtension extends Message<OneExtension> {
 
     @Override
     public OneExtension build() {
-      return new OneExtension(this);
+      return new OneExtension(id, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.oneof;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -38,13 +39,13 @@ public final class OneOfMessage extends Message<OneOfMessage> {
   public final String bar;
 
   public OneOfMessage(Integer foo, String bar) {
-    this.foo = foo;
-    this.bar = bar;
+    this(foo, bar, null);
   }
 
-  private OneOfMessage(Builder builder) {
-    this(builder.foo, builder.bar);
-    setBuilder(builder);
+  public OneOfMessage(Integer foo, String bar, TagMap tagMap) {
+    super(tagMap);
+    this.foo = foo;
+    this.bar = bar;
   }
 
   @Override
@@ -52,7 +53,8 @@ public final class OneOfMessage extends Message<OneOfMessage> {
     if (other == this) return true;
     if (!(other instanceof OneOfMessage)) return false;
     OneOfMessage o = (OneOfMessage) other;
-    return equals(foo, o.foo)
+    return equals(tagMap(), o.tagMap())
+        && equals(foo, o.foo)
         && equals(bar, o.bar);
   }
 
@@ -60,7 +62,8 @@ public final class OneOfMessage extends Message<OneOfMessage> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = foo != null ? foo.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (foo != null ? foo.hashCode() : 0);
       result = result * 37 + (bar != null ? bar.hashCode() : 0);
       hashCode = result;
     }
@@ -102,7 +105,7 @@ public final class OneOfMessage extends Message<OneOfMessage> {
 
     @Override
     public OneOfMessage build() {
-      return new OneOfMessage(this);
+      return new OneOfMessage(foo, bar, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.person;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
@@ -64,15 +65,15 @@ public final class Person extends Message<Person> {
   public final List<PhoneNumber> phone;
 
   public Person(String name, Integer id, String email, List<PhoneNumber> phone) {
+    this(name, id, email, phone, null);
+  }
+
+  public Person(String name, Integer id, String email, List<PhoneNumber> phone, TagMap tagMap) {
+    super(tagMap);
     this.name = name;
     this.id = id;
     this.email = email;
     this.phone = immutableCopyOf(phone);
-  }
-
-  private Person(Builder builder) {
-    this(builder.name, builder.id, builder.email, builder.phone);
-    setBuilder(builder);
   }
 
   @Override
@@ -80,7 +81,8 @@ public final class Person extends Message<Person> {
     if (other == this) return true;
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
-    return equals(name, o.name)
+    return equals(tagMap(), o.tagMap())
+        && equals(name, o.name)
         && equals(id, o.id)
         && equals(email, o.email)
         && equals(phone, o.phone);
@@ -90,7 +92,8 @@ public final class Person extends Message<Person> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = name != null ? name.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (id != null ? id.hashCode() : 0);
       result = result * 37 + (email != null ? email.hashCode() : 0);
       result = result * 37 + (phone != null ? phone.hashCode() : 1);
@@ -159,7 +162,7 @@ public final class Person extends Message<Person> {
         throw missingRequiredFields(name, "name",
             id, "id");
       }
-      return new Person(this);
+      return new Person(name, id, email, phone, buildTagMap());
     }
   }
 
@@ -216,13 +219,13 @@ public final class Person extends Message<Person> {
     public final PhoneType type;
 
     public PhoneNumber(String number, PhoneType type) {
-      this.number = number;
-      this.type = type;
+      this(number, type, null);
     }
 
-    private PhoneNumber(Builder builder) {
-      this(builder.number, builder.type);
-      setBuilder(builder);
+    public PhoneNumber(String number, PhoneType type, TagMap tagMap) {
+      super(tagMap);
+      this.number = number;
+      this.type = type;
     }
 
     @Override
@@ -230,7 +233,8 @@ public final class Person extends Message<Person> {
       if (other == this) return true;
       if (!(other instanceof PhoneNumber)) return false;
       PhoneNumber o = (PhoneNumber) other;
-      return equals(number, o.number)
+      return equals(tagMap(), o.tagMap())
+          && equals(number, o.number)
           && equals(type, o.type);
     }
 
@@ -238,7 +242,8 @@ public final class Person extends Message<Person> {
     public int hashCode() {
       int result = hashCode;
       if (result == 0) {
-        result = number != null ? number.hashCode() : 0;
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (number != null ? number.hashCode() : 0);
         result = result * 37 + (type != null ? type.hashCode() : 0);
         hashCode = result;
       }
@@ -281,7 +286,7 @@ public final class Person extends Message<Person> {
         if (number == null) {
           throw missingRequiredFields(number, "number");
         }
-        return new PhoneNumber(this);
+        return new PhoneNumber(number, type, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -31,13 +32,13 @@ public final class NotRedacted extends Message<NotRedacted> {
   public final String b;
 
   public NotRedacted(String a, String b) {
-    this.a = a;
-    this.b = b;
+    this(a, b, null);
   }
 
-  private NotRedacted(Builder builder) {
-    this(builder.a, builder.b);
-    setBuilder(builder);
+  public NotRedacted(String a, String b, TagMap tagMap) {
+    super(tagMap);
+    this.a = a;
+    this.b = b;
   }
 
   @Override
@@ -45,7 +46,8 @@ public final class NotRedacted extends Message<NotRedacted> {
     if (other == this) return true;
     if (!(other instanceof NotRedacted)) return false;
     NotRedacted o = (NotRedacted) other;
-    return equals(a, o.a)
+    return equals(tagMap(), o.tagMap())
+        && equals(a, o.a)
         && equals(b, o.b);
   }
 
@@ -53,7 +55,8 @@ public final class NotRedacted extends Message<NotRedacted> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = a != null ? a.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (a != null ? a.hashCode() : 0);
       result = result * 37 + (b != null ? b.hashCode() : 0);
       hashCode = result;
     }
@@ -87,7 +90,7 @@ public final class NotRedacted extends Message<NotRedacted> {
 
     @Override
     public NotRedacted build() {
-      return new NotRedacted(this);
+      return new NotRedacted(a, b, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.redacted;
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -49,14 +50,14 @@ public final class Redacted extends Message<Redacted> {
   public final String c;
 
   public Redacted(String a, String b, String c) {
+    this(a, b, c, null);
+  }
+
+  public Redacted(String a, String b, String c, TagMap tagMap) {
+    super(tagMap);
     this.a = a;
     this.b = b;
     this.c = c;
-  }
-
-  private Redacted(Builder builder) {
-    this(builder.a, builder.b, builder.c);
-    setBuilder(builder);
   }
 
   @Override
@@ -64,8 +65,8 @@ public final class Redacted extends Message<Redacted> {
     if (other == this) return true;
     if (!(other instanceof Redacted)) return false;
     Redacted o = (Redacted) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(a, o.a)
+    return equals(tagMap(), o.tagMap())
+        && equals(a, o.a)
         && equals(b, o.b)
         && equals(c, o.c);
   }
@@ -74,7 +75,7 @@ public final class Redacted extends Message<Redacted> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (a != null ? a.hashCode() : 0);
       result = result * 37 + (b != null ? b.hashCode() : 0);
       result = result * 37 + (c != null ? c.hashCode() : 0);
@@ -118,7 +119,7 @@ public final class Redacted extends Message<Redacted> {
 
     @Override
     public Redacted build() {
-      return new Redacted(this);
+      return new Redacted(a, b, c, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -35,14 +36,14 @@ public final class RedactedChild extends Message<RedactedChild> {
   public final NotRedacted c;
 
   public RedactedChild(String a, Redacted b, NotRedacted c) {
+    this(a, b, c, null);
+  }
+
+  public RedactedChild(String a, Redacted b, NotRedacted c, TagMap tagMap) {
+    super(tagMap);
     this.a = a;
     this.b = b;
     this.c = c;
-  }
-
-  private RedactedChild(Builder builder) {
-    this(builder.a, builder.b, builder.c);
-    setBuilder(builder);
   }
 
   @Override
@@ -50,7 +51,8 @@ public final class RedactedChild extends Message<RedactedChild> {
     if (other == this) return true;
     if (!(other instanceof RedactedChild)) return false;
     RedactedChild o = (RedactedChild) other;
-    return equals(a, o.a)
+    return equals(tagMap(), o.tagMap())
+        && equals(a, o.a)
         && equals(b, o.b)
         && equals(c, o.c);
   }
@@ -59,7 +61,8 @@ public final class RedactedChild extends Message<RedactedChild> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = a != null ? a.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (a != null ? a.hashCode() : 0);
       result = result * 37 + (b != null ? b.hashCode() : 0);
       result = result * 37 + (c != null ? c.hashCode() : 0);
       hashCode = result;
@@ -102,7 +105,7 @@ public final class RedactedChild extends Message<RedactedChild> {
 
     @Override
     public RedactedChild build() {
-      return new RedactedChild(this);
+      return new RedactedChild(a, b, c, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -20,25 +21,32 @@ public final class RedactedCycleA extends Message<RedactedCycleA> {
   public final RedactedCycleB b;
 
   public RedactedCycleA(RedactedCycleB b) {
-    this.b = b;
+    this(b, null);
   }
 
-  private RedactedCycleA(Builder builder) {
-    this(builder.b);
-    setBuilder(builder);
+  public RedactedCycleA(RedactedCycleB b, TagMap tagMap) {
+    super(tagMap);
+    this.b = b;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof RedactedCycleA)) return false;
-    return equals(b, ((RedactedCycleA) other).b);
+    RedactedCycleA o = (RedactedCycleA) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(b, o.b);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = b != null ? b.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (b != null ? b.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedCycleA, Builder> {
@@ -60,7 +68,7 @@ public final class RedactedCycleA extends Message<RedactedCycleA> {
 
     @Override
     public RedactedCycleA build() {
-      return new RedactedCycleA(this);
+      return new RedactedCycleA(b, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.redacted;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -20,25 +21,32 @@ public final class RedactedCycleB extends Message<RedactedCycleB> {
   public final RedactedCycleA a;
 
   public RedactedCycleB(RedactedCycleA a) {
-    this.a = a;
+    this(a, null);
   }
 
-  private RedactedCycleB(Builder builder) {
-    this(builder.a);
-    setBuilder(builder);
+  public RedactedCycleB(RedactedCycleA a, TagMap tagMap) {
+    super(tagMap);
+    this.a = a;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof RedactedCycleB)) return false;
-    return equals(a, ((RedactedCycleB) other).a);
+    RedactedCycleB o = (RedactedCycleB) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(a, o.a);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = a != null ? a.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (a != null ? a.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedCycleB, Builder> {
@@ -60,7 +68,7 @@ public final class RedactedCycleB extends Message<RedactedCycleB> {
 
     @Override
     public RedactedCycleB build() {
-      return new RedactedCycleB(this);
+      return new RedactedCycleB(a, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.redacted;
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -37,13 +38,13 @@ public final class RedactedExtension extends Message<RedactedExtension> {
   public final String e;
 
   public RedactedExtension(String d, String e) {
-    this.d = d;
-    this.e = e;
+    this(d, e, null);
   }
 
-  private RedactedExtension(Builder builder) {
-    this(builder.d, builder.e);
-    setBuilder(builder);
+  public RedactedExtension(String d, String e, TagMap tagMap) {
+    super(tagMap);
+    this.d = d;
+    this.e = e;
   }
 
   @Override
@@ -51,7 +52,8 @@ public final class RedactedExtension extends Message<RedactedExtension> {
     if (other == this) return true;
     if (!(other instanceof RedactedExtension)) return false;
     RedactedExtension o = (RedactedExtension) other;
-    return equals(d, o.d)
+    return equals(tagMap(), o.tagMap())
+        && equals(d, o.d)
         && equals(e, o.e);
   }
 
@@ -59,7 +61,8 @@ public final class RedactedExtension extends Message<RedactedExtension> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = d != null ? d.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (d != null ? d.hashCode() : 0);
       result = result * 37 + (e != null ? e.hashCode() : 0);
       hashCode = result;
     }
@@ -93,7 +96,7 @@ public final class RedactedExtension extends Message<RedactedExtension> {
 
     @Override
     public RedactedExtension build() {
-      return new RedactedExtension(this);
+      return new RedactedExtension(d, e, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.redacted;
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -30,25 +31,32 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
   public final List<String> a;
 
   public RedactedRepeated(List<String> a) {
-    this.a = immutableCopyOf(a);
+    this(a, null);
   }
 
-  private RedactedRepeated(Builder builder) {
-    this(builder.a);
-    setBuilder(builder);
+  public RedactedRepeated(List<String> a, TagMap tagMap) {
+    super(tagMap);
+    this.a = immutableCopyOf(a);
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof RedactedRepeated)) return false;
-    return equals(a, ((RedactedRepeated) other).a);
+    RedactedRepeated o = (RedactedRepeated) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(a, o.a);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = a != null ? a.hashCode() : 1);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (a != null ? a.hashCode() : 1);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedRepeated, Builder> {
@@ -70,7 +78,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
 
     @Override
     public RedactedRepeated build() {
-      return new RedactedRepeated(this);
+      return new RedactedRepeated(a, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.redacted;
 import com.google.protobuf.FieldOptions;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -30,25 +31,32 @@ public final class RedactedRequired extends Message<RedactedRequired> {
   public final String a;
 
   public RedactedRequired(String a) {
-    this.a = a;
+    this(a, null);
   }
 
-  private RedactedRequired(Builder builder) {
-    this(builder.a);
-    setBuilder(builder);
+  public RedactedRequired(String a, TagMap tagMap) {
+    super(tagMap);
+    this.a = a;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof RedactedRequired)) return false;
-    return equals(a, ((RedactedRequired) other).a);
+    RedactedRequired o = (RedactedRequired) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(a, o.a);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = a != null ? a.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (a != null ? a.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedRequired, Builder> {
@@ -73,7 +81,7 @@ public final class RedactedRequired extends Message<RedactedRequired> {
       if (a == null) {
         throw missingRequiredFields(a, "a");
       }
-      return new RedactedRequired(this);
+      return new RedactedRequired(a, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -41,13 +42,13 @@ public final class A extends Message<A> {
   public final D d;
 
   public A(B c, D d) {
-    this.c = c;
-    this.d = d;
+    this(c, d, null);
   }
 
-  private A(Builder builder) {
-    this(builder.c, builder.d);
-    setBuilder(builder);
+  public A(B c, D d, TagMap tagMap) {
+    super(tagMap);
+    this.c = c;
+    this.d = d;
   }
 
   @Override
@@ -55,7 +56,8 @@ public final class A extends Message<A> {
     if (other == this) return true;
     if (!(other instanceof A)) return false;
     A o = (A) other;
-    return equals(c, o.c)
+    return equals(tagMap(), o.tagMap())
+        && equals(c, o.c)
         && equals(d, o.d);
   }
 
@@ -63,7 +65,8 @@ public final class A extends Message<A> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = c != null ? c.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (c != null ? c.hashCode() : 0);
       result = result * 37 + (d != null ? d.hashCode() : 0);
       hashCode = result;
     }
@@ -97,7 +100,7 @@ public final class A extends Message<A> {
 
     @Override
     public A build() {
-      return new A(this);
+      return new A(c, d, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -21,25 +22,32 @@ public final class B extends Message<B> {
   public final C c;
 
   public B(C c) {
-    this.c = c;
+    this(c, null);
   }
 
-  private B(Builder builder) {
-    this(builder.c);
-    setBuilder(builder);
+  public B(C c, TagMap tagMap) {
+    super(tagMap);
+    this.c = c;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof B)) return false;
-    return equals(c, ((B) other).c);
+    B o = (B) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(c, o.c);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = c != null ? c.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (c != null ? c.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<B, Builder> {
@@ -64,7 +72,7 @@ public final class B extends Message<B> {
       if (c == null) {
         throw missingRequiredFields(c, "c");
       }
-      return new B(this);
+      return new B(c, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class C extends Message<C> {
   public final Integer i;
 
   public C(Integer i) {
-    this.i = i;
+    this(i, null);
   }
 
-  private C(Builder builder) {
-    this(builder.i);
-    setBuilder(builder);
+  public C(Integer i, TagMap tagMap) {
+    super(tagMap);
+    this.i = i;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof C)) return false;
-    return equals(i, ((C) other).i);
+    C o = (C) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(i, o.i);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (i != null ? i.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<C, Builder> {
@@ -63,7 +71,7 @@ public final class C extends Message<C> {
 
     @Override
     public C build() {
-      return new C(this);
+      return new C(i, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class D extends Message<D> {
   public final Integer i;
 
   public D(Integer i) {
-    this.i = i;
+    this(i, null);
   }
 
-  private D(Builder builder) {
-    this(builder.i);
-    setBuilder(builder);
+  public D(Integer i, TagMap tagMap) {
+    super(tagMap);
+    this.i = i;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof D)) return false;
-    return equals(i, ((D) other).i);
+    D o = (D) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(i, o.i);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (i != null ? i.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<D, Builder> {
@@ -63,7 +71,7 @@ public final class D extends Message<D> {
 
     @Override
     public D build() {
-      return new D(this);
+      return new D(i, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -29,13 +30,13 @@ public final class E extends Message<E> {
   public final G g;
 
   public E(F f, G g) {
-    this.f = f;
-    this.g = g;
+    this(f, g, null);
   }
 
-  private E(Builder builder) {
-    this(builder.f, builder.g);
-    setBuilder(builder);
+  public E(F f, G g, TagMap tagMap) {
+    super(tagMap);
+    this.f = f;
+    this.g = g;
   }
 
   @Override
@@ -43,7 +44,8 @@ public final class E extends Message<E> {
     if (other == this) return true;
     if (!(other instanceof E)) return false;
     E o = (E) other;
-    return equals(f, o.f)
+    return equals(tagMap(), o.tagMap())
+        && equals(f, o.f)
         && equals(g, o.g);
   }
 
@@ -51,7 +53,8 @@ public final class E extends Message<E> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = f != null ? f.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (f != null ? f.hashCode() : 0);
       result = result * 37 + (g != null ? g.hashCode() : 0);
       hashCode = result;
     }
@@ -85,7 +88,7 @@ public final class E extends Message<E> {
 
     @Override
     public E build() {
-      return new E(this);
+      return new E(f, g, buildTagMap());
     }
   }
 
@@ -103,25 +106,32 @@ public final class E extends Message<E> {
     public final Integer i;
 
     public F(Integer i) {
-      this.i = i;
+      this(i, null);
     }
 
-    private F(Builder builder) {
-      this(builder.i);
-      setBuilder(builder);
+    public F(Integer i, TagMap tagMap) {
+      super(tagMap);
+      this.i = i;
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof F)) return false;
-      return equals(i, ((F) other).i);
+      F o = (F) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(i, o.i);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (i != null ? i.hashCode() : 0);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<F, Builder> {
@@ -143,7 +153,7 @@ public final class E extends Message<E> {
 
       @Override
       public F build() {
-        return new F(this);
+        return new F(i, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -20,25 +21,32 @@ public final class H extends Message<H> {
   public final E.F ef;
 
   public H(E.F ef) {
-    this.ef = ef;
+    this(ef, null);
   }
 
-  private H(Builder builder) {
-    this(builder.ef);
-    setBuilder(builder);
+  public H(E.F ef, TagMap tagMap) {
+    super(tagMap);
+    this.ef = ef;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof H)) return false;
-    return equals(ef, ((H) other).ef);
+    H o = (H) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(ef, o.ef);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = ef != null ? ef.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (ef != null ? ef.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<H, Builder> {
@@ -60,7 +68,7 @@ public final class H extends Message<H> {
 
     @Override
     public H build() {
-      return new H(this);
+      return new H(ef, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,12 +24,12 @@ public final class I extends Message<I> {
   public final Integer i;
 
   public I(Integer i) {
-    this.i = i;
+    this(i, null);
   }
 
-  private I(Builder builder) {
-    this(builder.i);
-    setBuilder(builder);
+  public I(Integer i, TagMap tagMap) {
+    super(tagMap);
+    this.i = i;
   }
 
   @Override
@@ -36,15 +37,15 @@ public final class I extends Message<I> {
     if (other == this) return true;
     if (!(other instanceof I)) return false;
     I o = (I) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(i, o.i);
+    return equals(tagMap(), o.tagMap())
+        && equals(i, o.i);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (i != null ? i.hashCode() : 0);
       hashCode = result;
     }
@@ -70,7 +71,7 @@ public final class I extends Message<I> {
 
     @Override
     public I build() {
-      return new I(this);
+      return new I(i, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -20,25 +21,32 @@ public final class J extends Message<J> {
   public final K k;
 
   public J(K k) {
-    this.k = k;
+    this(k, null);
   }
 
-  private J(Builder builder) {
-    this(builder.k);
-    setBuilder(builder);
+  public J(K k, TagMap tagMap) {
+    super(tagMap);
+    this.k = k;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof J)) return false;
-    return equals(k, ((J) other).k);
+    J o = (J) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(k, o.k);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = k != null ? k.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (k != null ? k.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<J, Builder> {
@@ -60,7 +68,7 @@ public final class J extends Message<J> {
 
     @Override
     public J build() {
-      return new J(this);
+      return new J(k, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class K extends Message<K> {
   public final Integer i;
 
   public K(Integer i) {
-    this.i = i;
+    this(i, null);
   }
 
-  private K(Builder builder) {
-    this(builder.i);
-    setBuilder(builder);
+  public K(Integer i, TagMap tagMap) {
+    super(tagMap);
+    this.i = i;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof K)) return false;
-    return equals(i, ((K) other).i);
+    K o = (K) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(i, o.i);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (i != null ? i.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<K, Builder> {
@@ -63,7 +71,7 @@ public final class K extends Message<K> {
 
     @Override
     public K build() {
-      return new K(this);
+      return new K(i, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheRequest.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -13,10 +14,11 @@ public final class TheRequest extends Message<TheRequest> {
   private static final long serialVersionUID = 0L;
 
   public TheRequest() {
+    this(null);
   }
 
-  private TheRequest(Builder builder) {
-    setBuilder(builder);
+  public TheRequest(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -26,7 +28,7 @@ public final class TheRequest extends Message<TheRequest> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<TheRequest, Builder> {
@@ -39,7 +41,7 @@ public final class TheRequest extends Message<TheRequest> {
 
     @Override
     public TheRequest build() {
-      return new TheRequest(this);
+      return new TheRequest(buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheResponse.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -13,10 +14,11 @@ public final class TheResponse extends Message<TheResponse> {
   private static final long serialVersionUID = 0L;
 
   public TheResponse() {
+    this(null);
   }
 
-  private TheResponse(Builder builder) {
-    setBuilder(builder);
+  public TheResponse(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -26,7 +28,7 @@ public final class TheResponse extends Message<TheResponse> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<TheResponse, Builder> {
@@ -39,7 +41,7 @@ public final class TheResponse extends Message<TheResponse> {
 
     @Override
     public TheResponse build() {
-      return new TheResponse(this);
+      return new TheResponse(buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.roots;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -13,10 +14,11 @@ public final class UnnecessaryResponse extends Message<UnnecessaryResponse> {
   private static final long serialVersionUID = 0L;
 
   public UnnecessaryResponse() {
+    this(null);
   }
 
-  private UnnecessaryResponse(Builder builder) {
-    setBuilder(builder);
+  public UnnecessaryResponse(TagMap tagMap) {
+    super(tagMap);
   }
 
   @Override
@@ -26,7 +28,7 @@ public final class UnnecessaryResponse extends Message<UnnecessaryResponse> {
 
   @Override
   public int hashCode() {
-    return 0;
+    return tagMap() != null ? tagMap().hashCode() : 0;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<UnnecessaryResponse, Builder> {
@@ -39,7 +41,7 @@ public final class UnnecessaryResponse extends Message<UnnecessaryResponse> {
 
     @Override
     public UnnecessaryResponse build() {
-      return new UnnecessaryResponse(this);
+      return new UnnecessaryResponse(buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.simple;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Float;
 import java.lang.Object;
@@ -23,12 +24,12 @@ public final class ExternalMessage extends Message<ExternalMessage> {
   public final Float f;
 
   public ExternalMessage(Float f) {
-    this.f = f;
+    this(f, null);
   }
 
-  private ExternalMessage(Builder builder) {
-    this(builder.f);
-    setBuilder(builder);
+  public ExternalMessage(Float f, TagMap tagMap) {
+    super(tagMap);
+    this.f = f;
   }
 
   @Override
@@ -36,15 +37,15 @@ public final class ExternalMessage extends Message<ExternalMessage> {
     if (other == this) return true;
     if (!(other instanceof ExternalMessage)) return false;
     ExternalMessage o = (ExternalMessage) other;
-    if (!extensionsEqual(o)) return false;
-    return equals(f, o.f);
+    return equals(tagMap(), o.tagMap())
+        && equals(f, o.f);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = extensionsHashCode();
+      result = tagMap() != null ? tagMap().hashCode() : 0;
       result = result * 37 + (f != null ? f.hashCode() : 0);
       hashCode = result;
     }
@@ -70,7 +71,7 @@ public final class ExternalMessage extends Message<ExternalMessage> {
 
     @Override
     public ExternalMessage build() {
-      return new ExternalMessage(this);
+      return new ExternalMessage(f, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.simple;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
@@ -154,6 +155,11 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   public final String o;
 
   public SimpleMessage(Integer optional_int32, NestedMessage optional_nested_msg, ExternalMessage optional_external_msg, NestedEnum default_nested_enum, Integer required_int32, List<Double> repeated_double, ForeignEnum default_foreign_enum, ForeignEnum no_default_foreign_enum, String _package, String result, String other, String o) {
+    this(optional_int32, optional_nested_msg, optional_external_msg, default_nested_enum, required_int32, repeated_double, default_foreign_enum, no_default_foreign_enum, _package, result, other, o, null);
+  }
+
+  public SimpleMessage(Integer optional_int32, NestedMessage optional_nested_msg, ExternalMessage optional_external_msg, NestedEnum default_nested_enum, Integer required_int32, List<Double> repeated_double, ForeignEnum default_foreign_enum, ForeignEnum no_default_foreign_enum, String _package, String result, String other, String o, TagMap tagMap) {
+    super(tagMap);
     this.optional_int32 = optional_int32;
     this.optional_nested_msg = optional_nested_msg;
     this.optional_external_msg = optional_external_msg;
@@ -168,17 +174,13 @@ public final class SimpleMessage extends Message<SimpleMessage> {
     this.o = o;
   }
 
-  private SimpleMessage(Builder builder) {
-    this(builder.optional_int32, builder.optional_nested_msg, builder.optional_external_msg, builder.default_nested_enum, builder.required_int32, builder.repeated_double, builder.default_foreign_enum, builder.no_default_foreign_enum, builder._package, builder.result, builder.other, builder.o);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof SimpleMessage)) return false;
     SimpleMessage o = (SimpleMessage) other;
-    return equals(optional_int32, o.optional_int32)
+    return equals(tagMap(), o.tagMap())
+        && equals(optional_int32, o.optional_int32)
         && equals(optional_nested_msg, o.optional_nested_msg)
         && equals(optional_external_msg, o.optional_external_msg)
         && equals(default_nested_enum, o.default_nested_enum)
@@ -196,7 +198,8 @@ public final class SimpleMessage extends Message<SimpleMessage> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = optional_int32 != null ? optional_int32.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (optional_int32 != null ? optional_int32.hashCode() : 0);
       result = result * 37 + (optional_nested_msg != null ? optional_nested_msg.hashCode() : 0);
       result = result * 37 + (optional_external_msg != null ? optional_external_msg.hashCode() : 0);
       result = result * 37 + (default_nested_enum != null ? default_nested_enum.hashCode() : 0);
@@ -358,7 +361,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
       if (required_int32 == null) {
         throw missingRequiredFields(required_int32, "required_int32");
       }
-      return new SimpleMessage(this);
+      return new SimpleMessage(optional_int32, optional_nested_msg, optional_external_msg, default_nested_enum, required_int32, repeated_double, default_foreign_enum, no_default_foreign_enum, _package, result, other, o, buildTagMap());
     }
   }
 
@@ -379,25 +382,32 @@ public final class SimpleMessage extends Message<SimpleMessage> {
     public final Integer bb;
 
     public NestedMessage(Integer bb) {
-      this.bb = bb;
+      this(bb, null);
     }
 
-    private NestedMessage(Builder builder) {
-      this(builder.bb);
-      setBuilder(builder);
+    public NestedMessage(Integer bb, TagMap tagMap) {
+      super(tagMap);
+      this.bb = bb;
     }
 
     @Override
     public boolean equals(Object other) {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
-      return equals(bb, ((NestedMessage) other).bb);
+      NestedMessage o = (NestedMessage) other;
+      return equals(tagMap(), o.tagMap())
+          && equals(bb, o.bb);
     }
 
     @Override
     public int hashCode() {
       int result = hashCode;
-      return result != 0 ? result : (hashCode = bb != null ? bb.hashCode() : 0);
+      if (result == 0) {
+        result = tagMap() != null ? tagMap().hashCode() : 0;
+        result = result * 37 + (bb != null ? bb.hashCode() : 0);
+        hashCode = result;
+      }
+      return result;
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage, Builder> {
@@ -422,7 +432,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
 
       @Override
       public NestedMessage build() {
-        return new NestedMessage(this);
+        return new NestedMessage(bb, buildTagMap());
       }
     }
   }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class Bar extends Message<Bar> {
   public final Integer baz;
 
   public Bar(Integer baz) {
-    this.baz = baz;
+    this(baz, null);
   }
 
-  private Bar(Builder builder) {
-    this(builder.baz);
-    setBuilder(builder);
+  public Bar(Integer baz, TagMap tagMap) {
+    super(tagMap);
+    this.baz = baz;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof Bar)) return false;
-    return equals(baz, ((Bar) other).baz);
+    Bar o = (Bar) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(baz, o.baz);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = baz != null ? baz.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (baz != null ? baz.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bar, Builder> {
@@ -63,7 +71,7 @@ public final class Bar extends Message<Bar> {
 
     @Override
     public Bar build() {
-      return new Bar(this);
+      return new Bar(baz, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class Bars extends Message<Bars> {
   public final List<Bar> bars;
 
   public Bars(List<Bar> bars) {
-    this.bars = immutableCopyOf(bars);
+    this(bars, null);
   }
 
-  private Bars(Builder builder) {
-    this(builder.bars);
-    setBuilder(builder);
+  public Bars(List<Bar> bars, TagMap tagMap) {
+    super(tagMap);
+    this.bars = immutableCopyOf(bars);
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof Bars)) return false;
-    return equals(bars, ((Bars) other).bars);
+    Bars o = (Bars) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(bars, o.bars);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = bars != null ? bars.hashCode() : 1);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (bars != null ? bars.hashCode() : 1);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bars, Builder> {
@@ -63,7 +71,7 @@ public final class Bars extends Message<Bars> {
 
     @Override
     public Bars build() {
-      return new Bars(this);
+      return new Bars(bars, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class Foo extends Message<Foo> {
   public final Integer bar;
 
   public Foo(Integer bar) {
-    this.bar = bar;
+    this(bar, null);
   }
 
-  private Foo(Builder builder) {
-    this(builder.bar);
-    setBuilder(builder);
+  public Foo(Integer bar, TagMap tagMap) {
+    super(tagMap);
+    this.bar = bar;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
-    return equals(bar, ((Foo) other).bar);
+    Foo o = (Foo) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(bar, o.bar);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = bar != null ? bar.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (bar != null ? bar.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {
@@ -63,7 +71,7 @@ public final class Foo extends Message<Foo> {
 
     @Override
     public Foo build() {
-      return new Foo(this);
+      return new Foo(bar, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.single_level;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
@@ -23,25 +24,32 @@ public final class Foos extends Message<Foos> {
   public final List<Foo> foos;
 
   public Foos(List<Foo> foos) {
-    this.foos = immutableCopyOf(foos);
+    this(foos, null);
   }
 
-  private Foos(Builder builder) {
-    this(builder.foos);
-    setBuilder(builder);
+  public Foos(List<Foo> foos, TagMap tagMap) {
+    super(tagMap);
+    this.foos = immutableCopyOf(foos);
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof Foos)) return false;
-    return equals(foos, ((Foos) other).foos);
+    Foos o = (Foos) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(foos, o.foos);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = foos != null ? foos.hashCode() : 1);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (foos != null ? foos.hashCode() : 1);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foos, Builder> {
@@ -63,7 +71,7 @@ public final class Foos extends Message<Foos> {
 
     @Override
     public Foos build() {
-      return new Foos(this);
+      return new Foos(foos, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.unknownfields;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
@@ -23,25 +24,32 @@ public final class VersionOne extends Message<VersionOne> {
   public final Integer i;
 
   public VersionOne(Integer i) {
-    this.i = i;
+    this(i, null);
   }
 
-  private VersionOne(Builder builder) {
-    this(builder.i);
-    setBuilder(builder);
+  public VersionOne(Integer i, TagMap tagMap) {
+    super(tagMap);
+    this.i = i;
   }
 
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof VersionOne)) return false;
-    return equals(i, ((VersionOne) other).i);
+    VersionOne o = (VersionOne) other;
+    return equals(tagMap(), o.tagMap())
+        && equals(i, o.i);
   }
 
   @Override
   public int hashCode() {
     int result = hashCode;
-    return result != 0 ? result : (hashCode = i != null ? i.hashCode() : 0);
+    if (result == 0) {
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (i != null ? i.hashCode() : 0);
+      hashCode = result;
+    }
+    return result;
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<VersionOne, Builder> {
@@ -63,7 +71,7 @@ public final class VersionOne extends Message<VersionOne> {
 
     @Override
     public VersionOne build() {
-      return new VersionOne(this);
+      return new VersionOne(i, buildTagMap());
     }
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.unknownfields;
 
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
+import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Long;
@@ -66,6 +67,11 @@ public final class VersionTwo extends Message<VersionTwo> {
   public final List<String> v2_rs;
 
   public VersionTwo(Integer i, Integer v2_i, String v2_s, Integer v2_f32, Long v2_f64, List<String> v2_rs) {
+    this(i, v2_i, v2_s, v2_f32, v2_f64, v2_rs, null);
+  }
+
+  public VersionTwo(Integer i, Integer v2_i, String v2_s, Integer v2_f32, Long v2_f64, List<String> v2_rs, TagMap tagMap) {
+    super(tagMap);
     this.i = i;
     this.v2_i = v2_i;
     this.v2_s = v2_s;
@@ -74,17 +80,13 @@ public final class VersionTwo extends Message<VersionTwo> {
     this.v2_rs = immutableCopyOf(v2_rs);
   }
 
-  private VersionTwo(Builder builder) {
-    this(builder.i, builder.v2_i, builder.v2_s, builder.v2_f32, builder.v2_f64, builder.v2_rs);
-    setBuilder(builder);
-  }
-
   @Override
   public boolean equals(Object other) {
     if (other == this) return true;
     if (!(other instanceof VersionTwo)) return false;
     VersionTwo o = (VersionTwo) other;
-    return equals(i, o.i)
+    return equals(tagMap(), o.tagMap())
+        && equals(i, o.i)
         && equals(v2_i, o.v2_i)
         && equals(v2_s, o.v2_s)
         && equals(v2_f32, o.v2_f32)
@@ -96,7 +98,8 @@ public final class VersionTwo extends Message<VersionTwo> {
   public int hashCode() {
     int result = hashCode;
     if (result == 0) {
-      result = i != null ? i.hashCode() : 0;
+      result = tagMap() != null ? tagMap().hashCode() : 0;
+      result = result * 37 + (i != null ? i.hashCode() : 0);
       result = result * 37 + (v2_i != null ? v2_i.hashCode() : 0);
       result = result * 37 + (v2_s != null ? v2_s.hashCode() : 0);
       result = result * 37 + (v2_f32 != null ? v2_f32.hashCode() : 0);
@@ -166,7 +169,7 @@ public final class VersionTwo extends Message<VersionTwo> {
 
     @Override
     public VersionTwo build() {
-      return new VersionTwo(this);
+      return new VersionTwo(i, v2_i, v2_s, v2_f32, v2_f64, v2_rs, buildTagMap());
     }
   }
 }


### PR DESCRIPTION
This removes the opaque behavior of unknowns and extensions and allows for things like full deserialization outside of Wire.