### PR TITLE
Actually use serialization delegate and test serialization output.

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -924,6 +925,10 @@ public final class AllTypes extends Message<AllTypes> {
     return result;
   }
 
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
+  }
+
   public static final class Builder extends com.squareup.wire.Message.Builder<AllTypes, Builder> {
     public Integer opt_int32;
 
@@ -1679,6 +1684,10 @@ public final class AllTypes extends Message<AllTypes> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage, Builder> {

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -48,6 +48,7 @@ import com.squareup.wire.schema.ProtoFile;
 import com.squareup.wire.schema.Schema;
 import com.squareup.wire.schema.Service;
 import com.squareup.wire.schema.Type;
+import java.io.ObjectStreamException;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collection;
@@ -409,6 +410,7 @@ public final class JavaGenerator {
     builder.addMethod(messageFieldsAndTagMapConstructor(type));
     builder.addMethod(messageEquals(type));
     builder.addMethod(messageHashCode(type));
+    builder.addMethod(messageWriteReplace(type));
     builder.addType(builder(type, javaType, builderJavaType));
 
     for (Type nestedType : type.nestedTypes()) {
@@ -421,6 +423,20 @@ public final class JavaGenerator {
     return builder.build();
   }
 
+  // Example:
+  //
+  // private Object writeReplace() throws ObjectStreamException {
+  //   return super.createSerializedForm();
+  // }
+  //
+  private MethodSpec messageWriteReplace(MessageType type) {
+    return MethodSpec.methodBuilder("writeReplace")
+        .addModifiers(PRIVATE)
+        .returns(Object.class)
+        .addException(ObjectStreamException.class)
+        .addStatement("return super.createSerializedForm()")
+        .build();
+  }
 
   // Example:
   //

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -28,13 +28,13 @@ import java.util.Set;
 public abstract class Message<T extends Message<T>> implements Serializable {
   private static final long serialVersionUID = 0L;
 
-  final transient TagMap tagMap;
+  final TagMap tagMap;
 
   /** If not {@code 0} then the serialized size of this message. */
-  transient int cachedSerializedSize = 0;
+  int cachedSerializedSize = 0;
 
   /** If non-zero, the hash code of this message. Accessed by generated code. */
-  protected transient int hashCode = 0;
+  protected int hashCode = 0;
 
   protected Message(TagMap tagMap) {
     this.tagMap = tagMap;
@@ -101,7 +101,7 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     return ProtoAdapter.newMessageAdapter((Class<Message>) getClass()).toString(this);
   }
 
-  private Object writeReplace() throws ObjectStreamException {
+  protected final Object createSerializedForm() throws ObjectStreamException {
     return new MessageSerializedForm(this, getClass());
   }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -129,6 +130,10 @@ public final class DescriptorProto extends Message<DescriptorProto> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<DescriptorProto, Builder> {
@@ -264,6 +269,10 @@ public final class DescriptorProto extends Message<DescriptorProto> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<ExtensionRange, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -88,6 +89,10 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<EnumDescriptorProto, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -53,6 +54,10 @@ public final class EnumOptions extends Message<EnumOptions> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<EnumOptions, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -88,6 +89,10 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<EnumValueDescriptorProto, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -53,6 +54,10 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<EnumValueOptions, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldDescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -166,6 +167,10 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FieldDescriptorProto, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
@@ -132,6 +133,10 @@ public final class FieldOptions extends Message<FieldOptions> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FieldOptions, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -152,6 +153,10 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FileDescriptorProto, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -54,6 +55,10 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FileDescriptorSet, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
@@ -210,6 +211,10 @@ public final class FileOptions extends Message<FileOptions> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FileOptions, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
@@ -101,6 +102,10 @@ public final class MessageOptions extends Message<MessageOptions> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MessageOptions, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodDescriptorProto.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -102,6 +103,10 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto> 
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MethodDescriptorProto, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -57,6 +58,10 @@ public final class MethodOptions extends Message<MethodOptions> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MethodOptions, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -88,6 +89,10 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<ServiceDescriptorProto, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -57,6 +58,10 @@ public final class ServiceOptions extends Message<ServiceOptions> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<ServiceOptions, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -102,6 +103,10 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<SourceCodeInfo, Builder> {
@@ -253,6 +258,10 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Location, Builder> {

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Long;
@@ -133,6 +134,10 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<UninterpretedOption, Builder> {
@@ -270,6 +275,10 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<NamePart, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -31,6 +32,10 @@ public final class Bar extends Message<Bar> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bar, Builder> {
@@ -68,6 +73,10 @@ public final class Bar extends Message<Bar> {
     @Override
     public int hashCode() {
       return tagMap() != null ? tagMap().hashCode() : 0;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Baz, Builder> {
@@ -124,6 +133,10 @@ public final class Bar extends Message<Bar> {
           hashCode = result;
         }
         return result;
+      }
+
+      private Object writeReplace() throws ObjectStreamException {
+        return super.createSerializedForm();
       }
 
       public static final class Builder extends com.squareup.wire.Message.Builder<Moo, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -48,6 +49,10 @@ public final class Foo extends Message<Foo> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/bar/Bar.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -31,6 +32,10 @@ public final class Bar extends Message<Bar> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bar, Builder> {
@@ -68,6 +73,10 @@ public final class Bar extends Message<Bar> {
     @Override
     public int hashCode() {
       return tagMap() != null ? tagMap().hashCode() : 0;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Baz, Builder> {
@@ -124,6 +133,10 @@ public final class Bar extends Message<Bar> {
           hashCode = result;
         }
         return result;
+      }
+
+      private Object writeReplace() throws ObjectStreamException {
+        return super.createSerializedForm();
       }
 
       public static final class Builder extends com.squareup.wire.Message.Builder<Moo, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/foobar/protos/foo/Foo.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -48,6 +49,10 @@ public final class Foo extends Message<Foo> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataRequest.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -50,6 +51,10 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<HeresAllTheDataRequest, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/HeresAllTheDataResponse.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -50,6 +51,10 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<HeresAllTheDataResponse, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataRequest.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -50,6 +51,10 @@ public final class LetsDataRequest extends Message<LetsDataRequest> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<LetsDataRequest, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/LetsDataResponse.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -50,6 +51,10 @@ public final class LetsDataResponse extends Message<LetsDataResponse> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<LetsDataResponse, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -50,6 +51,10 @@ public final class SendDataRequest extends Message<SendDataRequest> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<SendDataRequest, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -50,6 +51,10 @@ public final class SendDataResponse extends Message<SendDataResponse> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<SendDataResponse, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/SerializableTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/SerializableTest.java
@@ -31,7 +31,7 @@ public class SerializableTest {
 
   @Test public void testSimpleSerializable() throws Exception {
     SimpleMessage message = new SimpleMessage.Builder().required_int32(42).build();
-    assertThat(serializeDeserialize(message)).isEqualTo(message);
+    assertThat(deserialize(serialize(message))).isEqualTo(message);
   }
 
   @Test public void testNestedMessageSerializable() throws Exception {
@@ -44,12 +44,12 @@ public class SerializableTest {
             .type(Person.PhoneType.MOBILE)
             .build()))
         .build();
-    assertThat(serializeDeserialize(person)).isEqualTo(person);
+    assertThat(deserialize(serialize(person))).isEqualTo(person);
   }
 
   @Test public void testNoFieldsSerializable() throws Exception {
     NoFields noFields = new NoFields();
-    assertThat(serializeDeserialize(noFields)).isEqualTo(noFields);
+    assertThat(deserialize(serialize(noFields))).isEqualTo(noFields);
   }
 
   @Test public void decodeGolden() throws Exception {
@@ -70,14 +70,21 @@ public class SerializableTest {
         + "YWdlO0wABW90aGVycQB+AAdMAA9yZXBlYXRlZF9kb3VibGV0ABBMamF2YS91dGlsL0xpc3Q7TAAOcmVxdWlyZWRf"
         + "aW50MzJxAH4AC0wABnJlc3VsdHEAfgAHeHIAGWNvbS5zcXVhcmV1cC53aXJlLk1lc3NhZ2UAAAAAAAAAAAIAAHhw"
     );
-    Buffer buffer = new Buffer();
-    buffer.write(goldenSerialized);
-    assertThat(new ObjectInputStream(buffer.inputStream()).readObject()).isEqualTo(goldenValue);
+    assertThat(deserialize(goldenSerialized)).isEqualTo(goldenValue);
+    assertThat(serialize(goldenValue)).isEqualTo(goldenSerialized);
   }
 
-  private static Object serializeDeserialize(Message message) throws Exception {
+  private static ByteString serialize(Message message) throws Exception {
     Buffer buffer = new Buffer();
-    new ObjectOutputStream(buffer.outputStream()).writeObject(message);
-    return new ObjectInputStream(buffer.inputStream()).readObject();
+    ObjectOutputStream stream = new ObjectOutputStream(buffer.outputStream());
+    stream.writeObject(message);
+    stream.flush();
+    return buffer.readByteString();
+  }
+
+  public static Object deserialize(ByteString data) throws Exception {
+    Buffer buffer = new Buffer().write(data);
+    ObjectInputStream stream = new ObjectInputStream(buffer.inputStream());
+    return stream.readObject();
   }
 }

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/ChildPackage.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -50,6 +51,10 @@ public final class ChildPackage extends Message<ChildPackage> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<ChildPackage, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -61,6 +62,10 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RepeatedAndPacked, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -924,6 +925,10 @@ public final class AllTypes extends Message<AllTypes> {
     return result;
   }
 
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
+  }
+
   public static final class Builder extends com.squareup.wire.Message.Builder<AllTypes, Builder> {
     public Integer opt_int32;
 
@@ -1679,6 +1684,10 @@ public final class AllTypes extends Message<AllTypes> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -171,6 +172,10 @@ public final class FooBar extends Message<FooBar> {
     return result;
   }
 
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
+  }
+
   public static final class Builder extends com.squareup.wire.Message.Builder<FooBar, Builder> {
     public Integer foo;
 
@@ -284,6 +289,10 @@ public final class FooBar extends Message<FooBar> {
       return result;
     }
 
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
+    }
+
     public static final class Builder extends com.squareup.wire.Message.Builder<Nested, Builder> {
       public FooBarBazEnum value;
 
@@ -347,6 +356,10 @@ public final class FooBar extends Message<FooBar> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<More, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.Integer;
@@ -119,6 +120,10 @@ public final class FooBar extends Message<FooBar> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FooBar, Builder> {
@@ -234,6 +239,10 @@ public final class FooBar extends Message<FooBar> {
       return result;
     }
 
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
+    }
+
     public static final class Builder extends com.squareup.wire.Message.Builder<Nested, Builder> {
       public FooBarBazEnum value;
 
@@ -297,6 +306,10 @@ public final class FooBar extends Message<FooBar> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<More, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.protos.foreign.Ext_foreign;
 import com.squareup.wire.protos.foreign.ForeignMessage;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Arrays;
@@ -89,6 +90,10 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MessageWithOptions, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/MessageWithOptions.java.noOptions
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.custom_options;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -29,6 +30,10 @@ public final class MessageWithOptions extends Message<MessageWithOptions> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MessageWithOptions, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/NoFields.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/NoFields.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.edgecases;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -29,6 +30,10 @@ public final class NoFields extends Message<NoFields> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<NoFields, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import okio.ByteString;
@@ -50,6 +51,10 @@ public final class OneBytesField extends Message<OneBytesField> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<OneBytesField, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/OneField.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class OneField extends Message<OneField> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<OneField, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -59,6 +60,10 @@ public final class Recursive extends Message<Recursive> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Recursive, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class ForeignMessage extends Message<ForeignMessage> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<ForeignMessage, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/Foo.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -50,6 +51,10 @@ public final class Foo extends Message<Foo> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -50,6 +51,10 @@ public final class OneExtension extends Message<OneExtension> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<OneExtension, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -68,6 +69,10 @@ public final class OneOfMessage extends Message<OneOfMessage> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<OneOfMessage, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -100,6 +101,10 @@ public final class Person extends Message<Person> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Person, Builder> {
@@ -248,6 +253,10 @@ public final class Person extends Message<Person> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<PhoneNumber, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -61,6 +62,10 @@ public final class NotRedacted extends Message<NotRedacted> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<NotRedacted, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/Redacted.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -82,6 +83,10 @@ public final class Redacted extends Message<Redacted> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Redacted, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -68,6 +69,10 @@ public final class RedactedChild extends Message<RedactedChild> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedChild, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -47,6 +48,10 @@ public final class RedactedCycleA extends Message<RedactedCycleA> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedCycleA, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -47,6 +48,10 @@ public final class RedactedCycleB extends Message<RedactedCycleB> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedCycleB, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -67,6 +68,10 @@ public final class RedactedExtension extends Message<RedactedExtension> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedExtension, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -57,6 +58,10 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedRepeated, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
@@ -57,6 +58,10 @@ public final class RedactedRequired extends Message<RedactedRequired> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedRequired, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/A.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -71,6 +72,10 @@ public final class A extends Message<A> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<A, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/B.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -48,6 +49,10 @@ public final class B extends Message<B> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<B, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/C.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class C extends Message<C> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<C, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/D.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class D extends Message<D> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<D, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/E.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -59,6 +60,10 @@ public final class E extends Message<E> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<E, Builder> {
@@ -132,6 +137,10 @@ public final class E extends Message<E> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<F, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/H.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -47,6 +48,10 @@ public final class H extends Message<H> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<H, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/I.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class I extends Message<I> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<I, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/J.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -47,6 +48,10 @@ public final class J extends Message<J> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<J, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/K.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class K extends Message<K> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<K, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheRequest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheRequest.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.roots;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -29,6 +30,10 @@ public final class TheRequest extends Message<TheRequest> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<TheRequest, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/TheResponse.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.roots;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -29,6 +30,10 @@ public final class TheResponse extends Message<TheResponse> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<TheResponse, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.roots;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 
@@ -29,6 +30,10 @@ public final class UnnecessaryResponse extends Message<UnnecessaryResponse> {
   @Override
   public int hashCode() {
     return tagMap() != null ? tagMap().hashCode() : 0;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<UnnecessaryResponse, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Float;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class ExternalMessage extends Message<ExternalMessage> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<ExternalMessage, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -8,6 +8,7 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
+import java.io.ObjectStreamException;
 import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Integer;
@@ -216,6 +217,10 @@ public final class SimpleMessage extends Message<SimpleMessage> {
     return result;
   }
 
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
+  }
+
   public static final class Builder extends com.squareup.wire.Message.Builder<SimpleMessage, Builder> {
     public Integer optional_int32;
 
@@ -408,6 +413,10 @@ public final class SimpleMessage extends Message<SimpleMessage> {
         hashCode = result;
       }
       return result;
+    }
+
+    private Object writeReplace() throws ObjectStreamException {
+      return super.createSerializedForm();
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<NestedMessage, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bar.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class Bar extends Message<Bar> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bar, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -50,6 +51,10 @@ public final class Bars extends Message<Bars> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bars, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foo.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class Foo extends Message<Foo> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foo, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Object;
 import java.lang.Override;
 import java.util.Collections;
@@ -50,6 +51,10 @@ public final class Foos extends Message<Foos> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foos, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,6 +51,10 @@ public final class VersionOne extends Message<VersionOne> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<VersionOne, Builder> {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
+import java.io.ObjectStreamException;
 import java.lang.Integer;
 import java.lang.Long;
 import java.lang.Object;
@@ -108,6 +109,10 @@ public final class VersionTwo extends Message<VersionTwo> {
       hashCode = result;
     }
     return result;
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return super.createSerializedForm();
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<VersionTwo, Builder> {


### PR DESCRIPTION
The tests never asserted that the serialized output matched any golden value. As a result, all serialized classes from v1 are in the normal, gross Java object format.