### PR TITLE
Remove needless transient modifier.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -28,13 +28,13 @@ import java.util.Set;
 public abstract class Message<T extends Message<T>> implements Serializable {
   private static final long serialVersionUID = 0L;
 
-  final transient TagMap tagMap;
+  final TagMap tagMap;
 
   /** If not {@code 0} then the serialized size of this message. */
-  transient int cachedSerializedSize = 0;
+  int cachedSerializedSize = 0;
 
   /** If non-zero, the hash code of this message. Accessed by generated code. */
-  protected transient int hashCode = 0;
+  protected int hashCode = 0;
 
   protected Message(TagMap tagMap) {
     if (tagMap == null) {


### PR DESCRIPTION
Not needed now that we are correctly using a serialization delegate.