### PR TITLE
Add unknown decoding helper to TagMap.Builder.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -205,9 +205,7 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
           Object value = fieldBinding.singleAdapter().decode(reader);
           fieldBinding.value(builder, value);
         } else {
-          Extension<?, ?> extension = reader.getExtension(messageType, tag);
-          Object value = extension.getAdapter().decode(reader);
-          builder.tagMap().add(extension, value);
+          builder.tagMap().decodeUnknown(reader, tag, messageType);
         }
       } catch (RuntimeEnumAdapter.EnumConstantNotFoundException e) {
         // An unknown Enum value was encountered, store it as an unknown field

--- a/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
@@ -244,6 +244,14 @@ public final class TagMap {
       this.limit = tagMap.array.length;
     }
 
+    /** Decode a value for an unknown {@code tag} in {@code messageType}. */
+    public Builder decodeUnknown(ProtoReader reader, int tag,
+        Class<? extends Message> messageType) throws IOException {
+      Extension<?, ?> extension = reader.getExtension(messageType, tag);
+      Object value = extension.getAdapter().decode(reader);
+      return add(extension, value);
+    }
+
     public Builder add(Extension<?, ?> extension, Object value) {
       if (extension == null) throw new NullPointerException("extension == null");
       if (value == null) throw new NullPointerException("value == null");


### PR DESCRIPTION
Also useful for `default` case in code gen:
```java
@Override public Person decode(ProtoReader reader) throws IOException {
  Person.Builder builder = new Person.Builder();
  long token = reader.beginMessage();
  for (int tag; (tag = reader.nextTag()) != -1;) {
    switch (tag) {
      case 1: builder.name(nameAdapter.decode(reader)); break;
      case 2: builder.id(idAdapter.decode(reader)); break;
      case 3: builder.email(emailAdapter.decode(reader)); break;
      default: builder.tagMap().decodeUnknown(reader, tag, Person.class); break;
  }
  reader.endMessage(token);
  return builder.build();
}
```