### PR TITLE
Only initialize repeated builder fields for new instances.

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -993,67 +993,67 @@ public final class AllTypes extends Message<AllTypes> {
 
     public NestedMessage req_nested_message;
 
-    public List<Integer> rep_int32 = Collections.emptyList();
+    public List<Integer> rep_int32;
 
-    public List<Integer> rep_uint32 = Collections.emptyList();
+    public List<Integer> rep_uint32;
 
-    public List<Integer> rep_sint32 = Collections.emptyList();
+    public List<Integer> rep_sint32;
 
-    public List<Integer> rep_fixed32 = Collections.emptyList();
+    public List<Integer> rep_fixed32;
 
-    public List<Integer> rep_sfixed32 = Collections.emptyList();
+    public List<Integer> rep_sfixed32;
 
-    public List<Long> rep_int64 = Collections.emptyList();
+    public List<Long> rep_int64;
 
-    public List<Long> rep_uint64 = Collections.emptyList();
+    public List<Long> rep_uint64;
 
-    public List<Long> rep_sint64 = Collections.emptyList();
+    public List<Long> rep_sint64;
 
-    public List<Long> rep_fixed64 = Collections.emptyList();
+    public List<Long> rep_fixed64;
 
-    public List<Long> rep_sfixed64 = Collections.emptyList();
+    public List<Long> rep_sfixed64;
 
-    public List<Boolean> rep_bool = Collections.emptyList();
+    public List<Boolean> rep_bool;
 
-    public List<Float> rep_float = Collections.emptyList();
+    public List<Float> rep_float;
 
-    public List<Double> rep_double = Collections.emptyList();
+    public List<Double> rep_double;
 
-    public List<String> rep_string = Collections.emptyList();
+    public List<String> rep_string;
 
-    public List<ByteString> rep_bytes = Collections.emptyList();
+    public List<ByteString> rep_bytes;
 
-    public List<NestedEnum> rep_nested_enum = Collections.emptyList();
+    public List<NestedEnum> rep_nested_enum;
 
-    public List<NestedMessage> rep_nested_message = Collections.emptyList();
+    public List<NestedMessage> rep_nested_message;
 
-    public List<Integer> pack_int32 = Collections.emptyList();
+    public List<Integer> pack_int32;
 
-    public List<Integer> pack_uint32 = Collections.emptyList();
+    public List<Integer> pack_uint32;
 
-    public List<Integer> pack_sint32 = Collections.emptyList();
+    public List<Integer> pack_sint32;
 
-    public List<Integer> pack_fixed32 = Collections.emptyList();
+    public List<Integer> pack_fixed32;
 
-    public List<Integer> pack_sfixed32 = Collections.emptyList();
+    public List<Integer> pack_sfixed32;
 
-    public List<Long> pack_int64 = Collections.emptyList();
+    public List<Long> pack_int64;
 
-    public List<Long> pack_uint64 = Collections.emptyList();
+    public List<Long> pack_uint64;
 
-    public List<Long> pack_sint64 = Collections.emptyList();
+    public List<Long> pack_sint64;
 
-    public List<Long> pack_fixed64 = Collections.emptyList();
+    public List<Long> pack_fixed64;
 
-    public List<Long> pack_sfixed64 = Collections.emptyList();
+    public List<Long> pack_sfixed64;
 
-    public List<Boolean> pack_bool = Collections.emptyList();
+    public List<Boolean> pack_bool;
 
-    public List<Float> pack_float = Collections.emptyList();
+    public List<Float> pack_float;
 
-    public List<Double> pack_double = Collections.emptyList();
+    public List<Double> pack_double;
 
-    public List<NestedEnum> pack_nested_enum = Collections.emptyList();
+    public List<NestedEnum> pack_nested_enum;
 
     public Integer default_int32;
 
@@ -1088,6 +1088,37 @@ public final class AllTypes extends Message<AllTypes> {
     public NestedEnum default_nested_enum;
 
     public Builder() {
+      rep_int32 = Collections.emptyList();
+      rep_uint32 = Collections.emptyList();
+      rep_sint32 = Collections.emptyList();
+      rep_fixed32 = Collections.emptyList();
+      rep_sfixed32 = Collections.emptyList();
+      rep_int64 = Collections.emptyList();
+      rep_uint64 = Collections.emptyList();
+      rep_sint64 = Collections.emptyList();
+      rep_fixed64 = Collections.emptyList();
+      rep_sfixed64 = Collections.emptyList();
+      rep_bool = Collections.emptyList();
+      rep_float = Collections.emptyList();
+      rep_double = Collections.emptyList();
+      rep_string = Collections.emptyList();
+      rep_bytes = Collections.emptyList();
+      rep_nested_enum = Collections.emptyList();
+      rep_nested_message = Collections.emptyList();
+      pack_int32 = Collections.emptyList();
+      pack_uint32 = Collections.emptyList();
+      pack_sint32 = Collections.emptyList();
+      pack_fixed32 = Collections.emptyList();
+      pack_sfixed32 = Collections.emptyList();
+      pack_int64 = Collections.emptyList();
+      pack_uint64 = Collections.emptyList();
+      pack_sint64 = Collections.emptyList();
+      pack_fixed64 = Collections.emptyList();
+      pack_sfixed64 = Collections.emptyList();
+      pack_bool = Collections.emptyList();
+      pack_float = Collections.emptyList();
+      pack_double = Collections.emptyList();
+      pack_nested_enum = Collections.emptyList();
     }
 
     public Builder(AllTypes message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -136,19 +136,24 @@ public final class DescriptorProto extends Message<DescriptorProto> {
 
     public String doc;
 
-    public List<FieldDescriptorProto> field = Collections.emptyList();
+    public List<FieldDescriptorProto> field;
 
-    public List<FieldDescriptorProto> extension = Collections.emptyList();
+    public List<FieldDescriptorProto> extension;
 
-    public List<DescriptorProto> nested_type = Collections.emptyList();
+    public List<DescriptorProto> nested_type;
 
-    public List<EnumDescriptorProto> enum_type = Collections.emptyList();
+    public List<EnumDescriptorProto> enum_type;
 
-    public List<ExtensionRange> extension_range = Collections.emptyList();
+    public List<ExtensionRange> extension_range;
 
     public MessageOptions options;
 
     public Builder() {
+      field = Collections.emptyList();
+      extension = Collections.emptyList();
+      nested_type = Collections.emptyList();
+      enum_type = Collections.emptyList();
+      extension_range = Collections.emptyList();
     }
 
     public Builder(DescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -95,11 +95,12 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
 
     public String doc;
 
-    public List<EnumValueDescriptorProto> value = Collections.emptyList();
+    public List<EnumValueDescriptorProto> value;
 
     public EnumOptions options;
 
     public Builder() {
+      value = Collections.emptyList();
     }
 
     public Builder(EnumDescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -56,9 +56,10 @@ public final class EnumOptions extends Message<EnumOptions> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<EnumOptions, Builder> {
-    public List<UninterpretedOption> uninterpreted_option = Collections.emptyList();
+    public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
+      uninterpreted_option = Collections.emptyList();
     }
 
     public Builder(EnumOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -56,9 +56,10 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<EnumValueOptions, Builder> {
-    public List<UninterpretedOption> uninterpreted_option = Collections.emptyList();
+    public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
+      uninterpreted_option = Collections.emptyList();
     }
 
     public Builder(EnumValueOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -143,9 +143,10 @@ public final class FieldOptions extends Message<FieldOptions> {
 
     public String experimental_map_key;
 
-    public List<UninterpretedOption> uninterpreted_option = Collections.emptyList();
+    public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
+      uninterpreted_option = Collections.emptyList();
     }
 
     public Builder(FieldOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -159,21 +159,26 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
 
     public String _package;
 
-    public List<String> dependency = Collections.emptyList();
+    public List<String> dependency;
 
-    public List<DescriptorProto> message_type = Collections.emptyList();
+    public List<DescriptorProto> message_type;
 
-    public List<EnumDescriptorProto> enum_type = Collections.emptyList();
+    public List<EnumDescriptorProto> enum_type;
 
-    public List<ServiceDescriptorProto> service = Collections.emptyList();
+    public List<ServiceDescriptorProto> service;
 
-    public List<FieldDescriptorProto> extension = Collections.emptyList();
+    public List<FieldDescriptorProto> extension;
 
     public FileOptions options;
 
     public SourceCodeInfo source_code_info;
 
     public Builder() {
+      dependency = Collections.emptyList();
+      message_type = Collections.emptyList();
+      enum_type = Collections.emptyList();
+      service = Collections.emptyList();
+      extension = Collections.emptyList();
     }
 
     public Builder(FileDescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -57,9 +57,10 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<FileDescriptorSet, Builder> {
-    public List<FileDescriptorProto> file = Collections.emptyList();
+    public List<FileDescriptorProto> file;
 
     public Builder() {
+      file = Collections.emptyList();
     }
 
     public Builder(FileDescriptorSet message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -229,9 +229,10 @@ public final class FileOptions extends Message<FileOptions> {
 
     public Boolean py_generic_services;
 
-    public List<UninterpretedOption> uninterpreted_option = Collections.emptyList();
+    public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
+      uninterpreted_option = Collections.emptyList();
     }
 
     public Builder(FileOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -108,9 +108,10 @@ public final class MessageOptions extends Message<MessageOptions> {
 
     public Boolean no_standard_descriptor_accessor;
 
-    public List<UninterpretedOption> uninterpreted_option = Collections.emptyList();
+    public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
+      uninterpreted_option = Collections.emptyList();
     }
 
     public Builder(MessageOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -60,9 +60,10 @@ public final class MethodOptions extends Message<MethodOptions> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<MethodOptions, Builder> {
-    public List<UninterpretedOption> uninterpreted_option = Collections.emptyList();
+    public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
+      uninterpreted_option = Collections.emptyList();
     }
 
     public Builder(MethodOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -93,13 +93,14 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
   public static final class Builder extends com.squareup.wire.Message.Builder<ServiceDescriptorProto, Builder> {
     public String name;
 
-    public List<MethodDescriptorProto> method = Collections.emptyList();
+    public List<MethodDescriptorProto> method;
 
     public String doc;
 
     public ServiceOptions options;
 
     public Builder() {
+      method = Collections.emptyList();
     }
 
     public Builder(ServiceDescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -60,9 +60,10 @@ public final class ServiceOptions extends Message<ServiceOptions> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<ServiceOptions, Builder> {
-    public List<UninterpretedOption> uninterpreted_option = Collections.emptyList();
+    public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
+      uninterpreted_option = Collections.emptyList();
     }
 
     public Builder(ServiceOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -105,9 +105,10 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<SourceCodeInfo, Builder> {
-    public List<Location> location = Collections.emptyList();
+    public List<Location> location;
 
     public Builder() {
+      location = Collections.emptyList();
     }
 
     public Builder(SourceCodeInfo message) {
@@ -256,11 +257,13 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<Location, Builder> {
-      public List<Integer> path = Collections.emptyList();
+      public List<Integer> path;
 
-      public List<Integer> span = Collections.emptyList();
+      public List<Integer> span;
 
       public Builder() {
+        path = Collections.emptyList();
+        span = Collections.emptyList();
       }
 
       public Builder(Location message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -136,7 +136,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<UninterpretedOption, Builder> {
-    public List<NamePart> name = Collections.emptyList();
+    public List<NamePart> name;
 
     public String identifier_value;
 
@@ -151,6 +151,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
     public String aggregate_value;
 
     public Builder() {
+      name = Collections.emptyList();
     }
 
     public Builder(UninterpretedOption message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -64,11 +64,13 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RepeatedAndPacked, Builder> {
-    public List<Integer> rep_int32 = Collections.emptyList();
+    public List<Integer> rep_int32;
 
-    public List<Integer> pack_int32 = Collections.emptyList();
+    public List<Integer> pack_int32;
 
     public Builder() {
+      rep_int32 = Collections.emptyList();
+      pack_int32 = Collections.emptyList();
     }
 
     public Builder(RepeatedAndPacked message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -993,67 +993,67 @@ public final class AllTypes extends Message<AllTypes> {
 
     public NestedMessage req_nested_message;
 
-    public List<Integer> rep_int32 = Collections.emptyList();
+    public List<Integer> rep_int32;
 
-    public List<Integer> rep_uint32 = Collections.emptyList();
+    public List<Integer> rep_uint32;
 
-    public List<Integer> rep_sint32 = Collections.emptyList();
+    public List<Integer> rep_sint32;
 
-    public List<Integer> rep_fixed32 = Collections.emptyList();
+    public List<Integer> rep_fixed32;
 
-    public List<Integer> rep_sfixed32 = Collections.emptyList();
+    public List<Integer> rep_sfixed32;
 
-    public List<Long> rep_int64 = Collections.emptyList();
+    public List<Long> rep_int64;
 
-    public List<Long> rep_uint64 = Collections.emptyList();
+    public List<Long> rep_uint64;
 
-    public List<Long> rep_sint64 = Collections.emptyList();
+    public List<Long> rep_sint64;
 
-    public List<Long> rep_fixed64 = Collections.emptyList();
+    public List<Long> rep_fixed64;
 
-    public List<Long> rep_sfixed64 = Collections.emptyList();
+    public List<Long> rep_sfixed64;
 
-    public List<Boolean> rep_bool = Collections.emptyList();
+    public List<Boolean> rep_bool;
 
-    public List<Float> rep_float = Collections.emptyList();
+    public List<Float> rep_float;
 
-    public List<Double> rep_double = Collections.emptyList();
+    public List<Double> rep_double;
 
-    public List<String> rep_string = Collections.emptyList();
+    public List<String> rep_string;
 
-    public List<ByteString> rep_bytes = Collections.emptyList();
+    public List<ByteString> rep_bytes;
 
-    public List<NestedEnum> rep_nested_enum = Collections.emptyList();
+    public List<NestedEnum> rep_nested_enum;
 
-    public List<NestedMessage> rep_nested_message = Collections.emptyList();
+    public List<NestedMessage> rep_nested_message;
 
-    public List<Integer> pack_int32 = Collections.emptyList();
+    public List<Integer> pack_int32;
 
-    public List<Integer> pack_uint32 = Collections.emptyList();
+    public List<Integer> pack_uint32;
 
-    public List<Integer> pack_sint32 = Collections.emptyList();
+    public List<Integer> pack_sint32;
 
-    public List<Integer> pack_fixed32 = Collections.emptyList();
+    public List<Integer> pack_fixed32;
 
-    public List<Integer> pack_sfixed32 = Collections.emptyList();
+    public List<Integer> pack_sfixed32;
 
-    public List<Long> pack_int64 = Collections.emptyList();
+    public List<Long> pack_int64;
 
-    public List<Long> pack_uint64 = Collections.emptyList();
+    public List<Long> pack_uint64;
 
-    public List<Long> pack_sint64 = Collections.emptyList();
+    public List<Long> pack_sint64;
 
-    public List<Long> pack_fixed64 = Collections.emptyList();
+    public List<Long> pack_fixed64;
 
-    public List<Long> pack_sfixed64 = Collections.emptyList();
+    public List<Long> pack_sfixed64;
 
-    public List<Boolean> pack_bool = Collections.emptyList();
+    public List<Boolean> pack_bool;
 
-    public List<Float> pack_float = Collections.emptyList();
+    public List<Float> pack_float;
 
-    public List<Double> pack_double = Collections.emptyList();
+    public List<Double> pack_double;
 
-    public List<NestedEnum> pack_nested_enum = Collections.emptyList();
+    public List<NestedEnum> pack_nested_enum;
 
     public Integer default_int32;
 
@@ -1088,6 +1088,37 @@ public final class AllTypes extends Message<AllTypes> {
     public NestedEnum default_nested_enum;
 
     public Builder() {
+      rep_int32 = Collections.emptyList();
+      rep_uint32 = Collections.emptyList();
+      rep_sint32 = Collections.emptyList();
+      rep_fixed32 = Collections.emptyList();
+      rep_sfixed32 = Collections.emptyList();
+      rep_int64 = Collections.emptyList();
+      rep_uint64 = Collections.emptyList();
+      rep_sint64 = Collections.emptyList();
+      rep_fixed64 = Collections.emptyList();
+      rep_sfixed64 = Collections.emptyList();
+      rep_bool = Collections.emptyList();
+      rep_float = Collections.emptyList();
+      rep_double = Collections.emptyList();
+      rep_string = Collections.emptyList();
+      rep_bytes = Collections.emptyList();
+      rep_nested_enum = Collections.emptyList();
+      rep_nested_message = Collections.emptyList();
+      pack_int32 = Collections.emptyList();
+      pack_uint32 = Collections.emptyList();
+      pack_sint32 = Collections.emptyList();
+      pack_fixed32 = Collections.emptyList();
+      pack_sfixed32 = Collections.emptyList();
+      pack_int64 = Collections.emptyList();
+      pack_uint64 = Collections.emptyList();
+      pack_sint64 = Collections.emptyList();
+      pack_fixed64 = Collections.emptyList();
+      pack_sfixed64 = Collections.emptyList();
+      pack_bool = Collections.emptyList();
+      pack_float = Collections.emptyList();
+      pack_double = Collections.emptyList();
+      pack_nested_enum = Collections.emptyList();
     }
 
     public Builder(AllTypes message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -180,13 +180,15 @@ public final class FooBar extends Message<FooBar> {
 
     public Long qux;
 
-    public List<Float> fred = Collections.emptyList();
+    public List<Float> fred;
 
     public Double daisy;
 
-    public List<FooBar> nested = Collections.emptyList();
+    public List<FooBar> nested;
 
     public Builder() {
+      fred = Collections.emptyList();
+      nested = Collections.emptyList();
     }
 
     public Builder(FooBar message) {
@@ -350,9 +352,10 @@ public final class FooBar extends Message<FooBar> {
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<More, Builder> {
-      public List<Integer> serial = Collections.emptyList();
+      public List<Integer> serial;
 
       public Builder() {
+        serial = Collections.emptyList();
       }
 
       public Builder(More message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -130,13 +130,15 @@ public final class FooBar extends Message<FooBar> {
 
     public Long qux;
 
-    public List<Float> fred = Collections.emptyList();
+    public List<Float> fred;
 
     public Double daisy;
 
-    public List<FooBar> nested = Collections.emptyList();
+    public List<FooBar> nested;
 
     public Builder() {
+      fred = Collections.emptyList();
+      nested = Collections.emptyList();
     }
 
     public Builder(FooBar message) {
@@ -300,9 +302,10 @@ public final class FooBar extends Message<FooBar> {
     }
 
     public static final class Builder extends com.squareup.wire.Message.Builder<More, Builder> {
-      public List<Integer> serial = Collections.emptyList();
+      public List<Integer> serial;
 
       public Builder() {
+        serial = Collections.emptyList();
       }
 
       public Builder(More message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -109,9 +109,10 @@ public final class Person extends Message<Person> {
 
     public String email;
 
-    public List<PhoneNumber> phone = Collections.emptyList();
+    public List<PhoneNumber> phone;
 
     public Builder() {
+      phone = Collections.emptyList();
     }
 
     public Builder(Person message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -60,9 +60,10 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<RedactedRepeated, Builder> {
-    public List<String> a = Collections.emptyList();
+    public List<String> a;
 
     public Builder() {
+      a = Collections.emptyList();
     }
 
     public Builder(RedactedRepeated message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -227,7 +227,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
 
     public Integer required_int32;
 
-    public List<Double> repeated_double = Collections.emptyList();
+    public List<Double> repeated_double;
 
     public ForeignEnum default_foreign_enum;
 
@@ -242,6 +242,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
     public String o;
 
     public Builder() {
+      repeated_double = Collections.emptyList();
     }
 
     public Builder(SimpleMessage message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -53,9 +53,10 @@ public final class Bars extends Message<Bars> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Bars, Builder> {
-    public List<Bar> bars = Collections.emptyList();
+    public List<Bar> bars;
 
     public Builder() {
+      bars = Collections.emptyList();
     }
 
     public Builder(Bars message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -53,9 +53,10 @@ public final class Foos extends Message<Foos> {
   }
 
   public static final class Builder extends com.squareup.wire.Message.Builder<Foos, Builder> {
-    public List<Foo> foos = Collections.emptyList();
+    public List<Foo> foos;
 
     public Builder() {
+      foos = Collections.emptyList();
     }
 
     public Builder(Foos message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -121,9 +121,10 @@ public final class VersionTwo extends Message<VersionTwo> {
 
     public Long v2_f64;
 
-    public List<String> v2_rs = Collections.emptyList();
+    public List<String> v2_rs;
 
     public Builder() {
+      v2_rs = Collections.emptyList();
     }
 
     public Builder(VersionTwo message) {


### PR DESCRIPTION
The copy constructor will initialize to the value from the source instance.