### PR TITLE
Try to lookup adapter before creating.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/Wire.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Wire.java
@@ -46,7 +46,12 @@ public final class Wire {
    * @param <E> the enum class type
    */
   public static <E extends Enum & WireEnum> E enumFromInt(Class<E> enumClass, int value) {
-    RuntimeEnumAdapter<E> adapter = ProtoAdapter.newEnumAdapter(enumClass);
+    RuntimeEnumAdapter<E> adapter;
+    try {
+      adapter = (RuntimeEnumAdapter<E>) enumClass.getField("ADAPTER").get(null);
+    } catch (IllegalAccessException | NoSuchFieldException | ClassCastException e) {
+      adapter = ProtoAdapter.newEnumAdapter(enumClass);
+    }
     return adapter.fromInt(value);
   }
 }


### PR DESCRIPTION
This avoids the costly recomputation of the constant cache on every call.