### PR TITLE
Consolidate generated code static helper methods to bottom of file.

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1347,157 +1347,188 @@ public final class AllTypes extends Message<AllTypes> {
     }
 
     public Builder rep_int32(List<Integer> rep_int32) {
-      this.rep_int32 = canonicalizeList(rep_int32);
+      checkElementsNotNull(rep_int32);
+      this.rep_int32 = rep_int32;
       return this;
     }
 
     public Builder rep_uint32(List<Integer> rep_uint32) {
-      this.rep_uint32 = canonicalizeList(rep_uint32);
+      checkElementsNotNull(rep_uint32);
+      this.rep_uint32 = rep_uint32;
       return this;
     }
 
     public Builder rep_sint32(List<Integer> rep_sint32) {
-      this.rep_sint32 = canonicalizeList(rep_sint32);
+      checkElementsNotNull(rep_sint32);
+      this.rep_sint32 = rep_sint32;
       return this;
     }
 
     public Builder rep_fixed32(List<Integer> rep_fixed32) {
-      this.rep_fixed32 = canonicalizeList(rep_fixed32);
+      checkElementsNotNull(rep_fixed32);
+      this.rep_fixed32 = rep_fixed32;
       return this;
     }
 
     public Builder rep_sfixed32(List<Integer> rep_sfixed32) {
-      this.rep_sfixed32 = canonicalizeList(rep_sfixed32);
+      checkElementsNotNull(rep_sfixed32);
+      this.rep_sfixed32 = rep_sfixed32;
       return this;
     }
 
     public Builder rep_int64(List<Long> rep_int64) {
-      this.rep_int64 = canonicalizeList(rep_int64);
+      checkElementsNotNull(rep_int64);
+      this.rep_int64 = rep_int64;
       return this;
     }
 
     public Builder rep_uint64(List<Long> rep_uint64) {
-      this.rep_uint64 = canonicalizeList(rep_uint64);
+      checkElementsNotNull(rep_uint64);
+      this.rep_uint64 = rep_uint64;
       return this;
     }
 
     public Builder rep_sint64(List<Long> rep_sint64) {
-      this.rep_sint64 = canonicalizeList(rep_sint64);
+      checkElementsNotNull(rep_sint64);
+      this.rep_sint64 = rep_sint64;
       return this;
     }
 
     public Builder rep_fixed64(List<Long> rep_fixed64) {
-      this.rep_fixed64 = canonicalizeList(rep_fixed64);
+      checkElementsNotNull(rep_fixed64);
+      this.rep_fixed64 = rep_fixed64;
       return this;
     }
 
     public Builder rep_sfixed64(List<Long> rep_sfixed64) {
-      this.rep_sfixed64 = canonicalizeList(rep_sfixed64);
+      checkElementsNotNull(rep_sfixed64);
+      this.rep_sfixed64 = rep_sfixed64;
       return this;
     }
 
     public Builder rep_bool(List<Boolean> rep_bool) {
-      this.rep_bool = canonicalizeList(rep_bool);
+      checkElementsNotNull(rep_bool);
+      this.rep_bool = rep_bool;
       return this;
     }
 
     public Builder rep_float(List<Float> rep_float) {
-      this.rep_float = canonicalizeList(rep_float);
+      checkElementsNotNull(rep_float);
+      this.rep_float = rep_float;
       return this;
     }
 
     public Builder rep_double(List<Double> rep_double) {
-      this.rep_double = canonicalizeList(rep_double);
+      checkElementsNotNull(rep_double);
+      this.rep_double = rep_double;
       return this;
     }
 
     public Builder rep_string(List<String> rep_string) {
-      this.rep_string = canonicalizeList(rep_string);
+      checkElementsNotNull(rep_string);
+      this.rep_string = rep_string;
       return this;
     }
 
     public Builder rep_bytes(List<ByteString> rep_bytes) {
-      this.rep_bytes = canonicalizeList(rep_bytes);
+      checkElementsNotNull(rep_bytes);
+      this.rep_bytes = rep_bytes;
       return this;
     }
 
     public Builder rep_nested_enum(List<NestedEnum> rep_nested_enum) {
-      this.rep_nested_enum = canonicalizeList(rep_nested_enum);
+      checkElementsNotNull(rep_nested_enum);
+      this.rep_nested_enum = rep_nested_enum;
       return this;
     }
 
     public Builder rep_nested_message(List<NestedMessage> rep_nested_message) {
-      this.rep_nested_message = canonicalizeList(rep_nested_message);
+      checkElementsNotNull(rep_nested_message);
+      this.rep_nested_message = rep_nested_message;
       return this;
     }
 
     public Builder pack_int32(List<Integer> pack_int32) {
-      this.pack_int32 = canonicalizeList(pack_int32);
+      checkElementsNotNull(pack_int32);
+      this.pack_int32 = pack_int32;
       return this;
     }
 
     public Builder pack_uint32(List<Integer> pack_uint32) {
-      this.pack_uint32 = canonicalizeList(pack_uint32);
+      checkElementsNotNull(pack_uint32);
+      this.pack_uint32 = pack_uint32;
       return this;
     }
 
     public Builder pack_sint32(List<Integer> pack_sint32) {
-      this.pack_sint32 = canonicalizeList(pack_sint32);
+      checkElementsNotNull(pack_sint32);
+      this.pack_sint32 = pack_sint32;
       return this;
     }
 
     public Builder pack_fixed32(List<Integer> pack_fixed32) {
-      this.pack_fixed32 = canonicalizeList(pack_fixed32);
+      checkElementsNotNull(pack_fixed32);
+      this.pack_fixed32 = pack_fixed32;
       return this;
     }
 
     public Builder pack_sfixed32(List<Integer> pack_sfixed32) {
-      this.pack_sfixed32 = canonicalizeList(pack_sfixed32);
+      checkElementsNotNull(pack_sfixed32);
+      this.pack_sfixed32 = pack_sfixed32;
       return this;
     }
 
     public Builder pack_int64(List<Long> pack_int64) {
-      this.pack_int64 = canonicalizeList(pack_int64);
+      checkElementsNotNull(pack_int64);
+      this.pack_int64 = pack_int64;
       return this;
     }
 
     public Builder pack_uint64(List<Long> pack_uint64) {
-      this.pack_uint64 = canonicalizeList(pack_uint64);
+      checkElementsNotNull(pack_uint64);
+      this.pack_uint64 = pack_uint64;
       return this;
     }
 
     public Builder pack_sint64(List<Long> pack_sint64) {
-      this.pack_sint64 = canonicalizeList(pack_sint64);
+      checkElementsNotNull(pack_sint64);
+      this.pack_sint64 = pack_sint64;
       return this;
     }
 
     public Builder pack_fixed64(List<Long> pack_fixed64) {
-      this.pack_fixed64 = canonicalizeList(pack_fixed64);
+      checkElementsNotNull(pack_fixed64);
+      this.pack_fixed64 = pack_fixed64;
       return this;
     }
 
     public Builder pack_sfixed64(List<Long> pack_sfixed64) {
-      this.pack_sfixed64 = canonicalizeList(pack_sfixed64);
+      checkElementsNotNull(pack_sfixed64);
+      this.pack_sfixed64 = pack_sfixed64;
       return this;
     }
 
     public Builder pack_bool(List<Boolean> pack_bool) {
-      this.pack_bool = canonicalizeList(pack_bool);
+      checkElementsNotNull(pack_bool);
+      this.pack_bool = pack_bool;
       return this;
     }
 
     public Builder pack_float(List<Float> pack_float) {
-      this.pack_float = canonicalizeList(pack_float);
+      checkElementsNotNull(pack_float);
+      this.pack_float = pack_float;
       return this;
     }
 
     public Builder pack_double(List<Double> pack_double) {
-      this.pack_double = canonicalizeList(pack_double);
+      checkElementsNotNull(pack_double);
+      this.pack_double = pack_double;
       return this;
     }
 
     public Builder pack_nested_enum(List<NestedEnum> pack_nested_enum) {
-      this.pack_nested_enum = canonicalizeList(pack_nested_enum);
+      checkElementsNotNull(pack_nested_enum);
+      this.pack_nested_enum = pack_nested_enum;
       return this;
     }
 

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -741,15 +741,14 @@ public final class JavaGenerator {
     }
 
     if (field.isRepeated()) {
-      result.addStatement("this.$L = canonicalizeList($L)", fieldName, fieldName);
-    } else {
-      result.addStatement("this.$L = $L", fieldName, fieldName);
+      result.addStatement("checkElementsNotNull($L)", fieldName);
+    }
+    result.addStatement("this.$L = $L", fieldName, fieldName);
 
-      if (oneOf != null) {
-        for (Field other : oneOf.fields()) {
-          if (field != other) {
-            result.addStatement("this.$L = null", sanitize(other.name()));
-          }
+    if (oneOf != null) {
+      for (Field other : oneOf.fields()) {
+        if (field != other) {
+          result.addStatement("this.$L = null", sanitize(other.name()));
         }
       }
     }

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -22,9 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-/**
- * Superclass for protocol buffer messages.
- */
+/** A protocol buffer message. */
 public abstract class Message<T extends Message<T>> implements Serializable {
   private static final long serialVersionUID = 0L;
 
@@ -45,29 +43,6 @@ public abstract class Message<T extends Message<T>> implements Serializable {
 
   public final TagMap tagMap() {
     return tagMap;
-  }
-
-  /** Utility method to return a mutable copy of a given List. Used by generated code. */
-  protected static <T> List<T> copyOf(List<T> list) {
-    if (list == null) {
-      throw new NullPointerException("list == null");
-    }
-    return new ArrayList<>(list);
-  }
-
-  /** Utility method to return an immutable copy of a given List. Used by generated code. */
-  protected static <T> List<T> immutableCopyOf(List<T> list) {
-    if (list == null) {
-      throw new NullPointerException("list == null");
-    }
-    if (list == Collections.emptyList() || list instanceof ImmutableList) {
-      return list;
-    }
-    return Collections.unmodifiableList(new ArrayList<>(list));
-  }
-
-  protected static boolean equals(Object a, Object b) {
-    return a == b || (a != null && a.equals(b));
   }
 
   /**
@@ -126,43 +101,6 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     }
 
     /**
-     * Create an exception for missing required fields.
-     *
-     * @param args Alternating field value and field name pairs.
-     */
-    protected static IllegalStateException missingRequiredFields(Object... args) {
-      StringBuilder sb = new StringBuilder();
-      String plural = "";
-      for (int i = 0, size = args.length; i < size; i += 2) {
-        if (args[i] == null) {
-          if (sb.length() > 0) {
-            plural = "s"; // Found more than one missing field
-          }
-          sb.append("\n  ");
-          sb.append(args[i + 1]);
-        }
-      }
-      throw new IllegalStateException("Required field" + plural + " not set:" + sb);
-    }
-
-    /**
-     * If {@code list} is null it will be replaced with {@link Collections#emptyList()}.
-     * Otherwise look for null items and throw {@link NullPointerException} if one is found.
-     */
-    protected static <T> List<T> canonicalizeList(List<T> list) {
-      if (list == null) {
-        throw new NullPointerException("list == null");
-      }
-      for (int i = 0, size = list.size(); i < size; i++) {
-        T element = list.get(i);
-        if (element == null) {
-          throw new NullPointerException("Element at index " + i + " is null");
-        }
-      }
-      return list;
-    }
-
-    /**
      * Returns the value for {@code extension} on this message, or null if no
      * value is set.
      */
@@ -199,5 +137,59 @@ public abstract class Message<T extends Message<T>> implements Serializable {
 
     /** Returns an immutable {@link Message} based on the fields that set in this builder. */
     public abstract T build();
+  }
+
+  /** <b>For generated code only.</b> Utility method to return a mutable copy of {@code list}. */
+  protected static <T> List<T> copyOf(List<T> list) {
+    if (list == null) throw new NullPointerException("list == null");
+    return new ArrayList<>(list);
+  }
+
+  /** <b>For generated code only.</b> Utility method to return an immutable copy of {@code list}. */
+  protected static <T> List<T> immutableCopyOf(List<T> list) {
+    if (list == null) throw new NullPointerException("list == null");
+    if (list == Collections.emptyList() || list instanceof ImmutableList) {
+      return list;
+    }
+    return Collections.unmodifiableList(new ArrayList<>(list));
+  }
+
+  /** <b>For generated code only.</b> */
+  protected static boolean equals(Object a, Object b) {
+    return a == b || (a != null && a.equals(b));
+  }
+
+  /**
+   * <b>For generated code only.</b> Create an exception for missing required fields.
+   *
+   * @param args Alternating field value and field name pairs.
+   */
+  protected static IllegalStateException missingRequiredFields(Object... args) {
+    StringBuilder sb = new StringBuilder();
+    String plural = "";
+    for (int i = 0, size = args.length; i < size; i += 2) {
+      if (args[i] == null) {
+        if (sb.length() > 0) {
+          plural = "s"; // Found more than one missing field
+        }
+        sb.append("\n  ");
+        sb.append(args[i + 1]);
+      }
+    }
+    throw new IllegalStateException("Required field" + plural + " not set:" + sb);
+  }
+
+  /**
+   * <b>For generated code only.</b> Throw {@link NullPointerException} if {@code list} or one of
+   * its items are null.
+   */
+  protected static void checkElementsNotNull(List<?> list) {
+    if (list == null) throw new NullPointerException("list == null");
+    for (int i = 0, size = list.size(); i < size; i++) {
+      Object element = list.get(i);
+      if (element == null) {
+        throw new NullPointerException("Element at index " + i + " is null");
+      }
+    }
   }
 }

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -178,27 +178,32 @@ public final class DescriptorProto extends Message<DescriptorProto> {
     }
 
     public Builder field(List<FieldDescriptorProto> field) {
-      this.field = canonicalizeList(field);
+      checkElementsNotNull(field);
+      this.field = field;
       return this;
     }
 
     public Builder extension(List<FieldDescriptorProto> extension) {
-      this.extension = canonicalizeList(extension);
+      checkElementsNotNull(extension);
+      this.extension = extension;
       return this;
     }
 
     public Builder nested_type(List<DescriptorProto> nested_type) {
-      this.nested_type = canonicalizeList(nested_type);
+      checkElementsNotNull(nested_type);
+      this.nested_type = nested_type;
       return this;
     }
 
     public Builder enum_type(List<EnumDescriptorProto> enum_type) {
-      this.enum_type = canonicalizeList(enum_type);
+      checkElementsNotNull(enum_type);
+      this.enum_type = enum_type;
       return this;
     }
 
     public Builder extension_range(List<ExtensionRange> extension_range) {
-      this.extension_range = canonicalizeList(extension_range);
+      checkElementsNotNull(extension_range);
+      this.extension_range = extension_range;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -125,7 +125,8 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
     }
 
     public Builder value(List<EnumValueDescriptorProto> value) {
-      this.value = canonicalizeList(value);
+      checkElementsNotNull(value);
+      this.value = value;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -71,7 +71,8 @@ public final class EnumOptions extends Message<EnumOptions> {
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      this.uninterpreted_option = canonicalizeList(uninterpreted_option);
+      checkElementsNotNull(uninterpreted_option);
+      this.uninterpreted_option = uninterpreted_option;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -71,7 +71,8 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      this.uninterpreted_option = canonicalizeList(uninterpreted_option);
+      checkElementsNotNull(uninterpreted_option);
+      this.uninterpreted_option = uninterpreted_option;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -214,7 +214,8 @@ public final class FieldOptions extends Message<FieldOptions> {
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      this.uninterpreted_option = canonicalizeList(uninterpreted_option);
+      checkElementsNotNull(uninterpreted_option);
+      this.uninterpreted_option = uninterpreted_option;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -210,7 +210,8 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
      * Names of files imported by this file.
      */
     public Builder dependency(List<String> dependency) {
-      this.dependency = canonicalizeList(dependency);
+      checkElementsNotNull(dependency);
+      this.dependency = dependency;
       return this;
     }
 
@@ -218,22 +219,26 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
      * All top-level definitions in this file.
      */
     public Builder message_type(List<DescriptorProto> message_type) {
-      this.message_type = canonicalizeList(message_type);
+      checkElementsNotNull(message_type);
+      this.message_type = message_type;
       return this;
     }
 
     public Builder enum_type(List<EnumDescriptorProto> enum_type) {
-      this.enum_type = canonicalizeList(enum_type);
+      checkElementsNotNull(enum_type);
+      this.enum_type = enum_type;
       return this;
     }
 
     public Builder service(List<ServiceDescriptorProto> service) {
-      this.service = canonicalizeList(service);
+      checkElementsNotNull(service);
+      this.service = service;
       return this;
     }
 
     public Builder extension(List<FieldDescriptorProto> extension) {
-      this.extension = canonicalizeList(extension);
+      checkElementsNotNull(extension);
+      this.extension = extension;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -69,7 +69,8 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
     }
 
     public Builder file(List<FileDescriptorProto> file) {
-      this.file = canonicalizeList(file);
+      checkElementsNotNull(file);
+      this.file = file;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -331,7 +331,8 @@ public final class FileOptions extends Message<FileOptions> {
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      this.uninterpreted_option = canonicalizeList(uninterpreted_option);
+      checkElementsNotNull(uninterpreted_option);
+      this.uninterpreted_option = uninterpreted_option;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -160,7 +160,8 @@ public final class MessageOptions extends Message<MessageOptions> {
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      this.uninterpreted_option = canonicalizeList(uninterpreted_option);
+      checkElementsNotNull(uninterpreted_option);
+      this.uninterpreted_option = uninterpreted_option;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -79,7 +79,8 @@ public final class MethodOptions extends Message<MethodOptions> {
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      this.uninterpreted_option = canonicalizeList(uninterpreted_option);
+      checkElementsNotNull(uninterpreted_option);
+      this.uninterpreted_option = uninterpreted_option;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -117,7 +117,8 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     }
 
     public Builder method(List<MethodDescriptorProto> method) {
-      this.method = canonicalizeList(method);
+      checkElementsNotNull(method);
+      this.method = method;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -79,7 +79,8 @@ public final class ServiceOptions extends Message<ServiceOptions> {
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      this.uninterpreted_option = canonicalizeList(uninterpreted_option);
+      checkElementsNotNull(uninterpreted_option);
+      this.uninterpreted_option = uninterpreted_option;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -162,7 +162,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
      *   be recorded in the future.
      */
     public Builder location(List<Location> location) {
-      this.location = canonicalizeList(location);
+      checkElementsNotNull(location);
+      this.location = location;
       return this;
     }
 
@@ -296,7 +297,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
        * of the label to the terminating semicolon).
        */
       public Builder path(List<Integer> path) {
-        this.path = canonicalizeList(path);
+        checkElementsNotNull(path);
+        this.path = path;
         return this;
       }
 
@@ -308,7 +310,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
        * 1 to each before displaying to a user.
        */
       public Builder span(List<Integer> span) {
-        this.span = canonicalizeList(span);
+        checkElementsNotNull(span);
+        this.span = span;
         return this;
       }
 

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -166,7 +166,8 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
     }
 
     public Builder name(List<NamePart> name) {
-      this.name = canonicalizeList(name);
+      checkElementsNotNull(name);
+      this.name = name;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -79,12 +79,14 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
     }
 
     public Builder rep_int32(List<Integer> rep_int32) {
-      this.rep_int32 = canonicalizeList(rep_int32);
+      checkElementsNotNull(rep_int32);
+      this.rep_int32 = rep_int32;
       return this;
     }
 
     public Builder pack_int32(List<Integer> pack_int32) {
-      this.pack_int32 = canonicalizeList(pack_int32);
+      checkElementsNotNull(pack_int32);
+      this.pack_int32 = pack_int32;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1347,157 +1347,188 @@ public final class AllTypes extends Message<AllTypes> {
     }
 
     public Builder rep_int32(List<Integer> rep_int32) {
-      this.rep_int32 = canonicalizeList(rep_int32);
+      checkElementsNotNull(rep_int32);
+      this.rep_int32 = rep_int32;
       return this;
     }
 
     public Builder rep_uint32(List<Integer> rep_uint32) {
-      this.rep_uint32 = canonicalizeList(rep_uint32);
+      checkElementsNotNull(rep_uint32);
+      this.rep_uint32 = rep_uint32;
       return this;
     }
 
     public Builder rep_sint32(List<Integer> rep_sint32) {
-      this.rep_sint32 = canonicalizeList(rep_sint32);
+      checkElementsNotNull(rep_sint32);
+      this.rep_sint32 = rep_sint32;
       return this;
     }
 
     public Builder rep_fixed32(List<Integer> rep_fixed32) {
-      this.rep_fixed32 = canonicalizeList(rep_fixed32);
+      checkElementsNotNull(rep_fixed32);
+      this.rep_fixed32 = rep_fixed32;
       return this;
     }
 
     public Builder rep_sfixed32(List<Integer> rep_sfixed32) {
-      this.rep_sfixed32 = canonicalizeList(rep_sfixed32);
+      checkElementsNotNull(rep_sfixed32);
+      this.rep_sfixed32 = rep_sfixed32;
       return this;
     }
 
     public Builder rep_int64(List<Long> rep_int64) {
-      this.rep_int64 = canonicalizeList(rep_int64);
+      checkElementsNotNull(rep_int64);
+      this.rep_int64 = rep_int64;
       return this;
     }
 
     public Builder rep_uint64(List<Long> rep_uint64) {
-      this.rep_uint64 = canonicalizeList(rep_uint64);
+      checkElementsNotNull(rep_uint64);
+      this.rep_uint64 = rep_uint64;
       return this;
     }
 
     public Builder rep_sint64(List<Long> rep_sint64) {
-      this.rep_sint64 = canonicalizeList(rep_sint64);
+      checkElementsNotNull(rep_sint64);
+      this.rep_sint64 = rep_sint64;
       return this;
     }
 
     public Builder rep_fixed64(List<Long> rep_fixed64) {
-      this.rep_fixed64 = canonicalizeList(rep_fixed64);
+      checkElementsNotNull(rep_fixed64);
+      this.rep_fixed64 = rep_fixed64;
       return this;
     }
 
     public Builder rep_sfixed64(List<Long> rep_sfixed64) {
-      this.rep_sfixed64 = canonicalizeList(rep_sfixed64);
+      checkElementsNotNull(rep_sfixed64);
+      this.rep_sfixed64 = rep_sfixed64;
       return this;
     }
 
     public Builder rep_bool(List<Boolean> rep_bool) {
-      this.rep_bool = canonicalizeList(rep_bool);
+      checkElementsNotNull(rep_bool);
+      this.rep_bool = rep_bool;
       return this;
     }
 
     public Builder rep_float(List<Float> rep_float) {
-      this.rep_float = canonicalizeList(rep_float);
+      checkElementsNotNull(rep_float);
+      this.rep_float = rep_float;
       return this;
     }
 
     public Builder rep_double(List<Double> rep_double) {
-      this.rep_double = canonicalizeList(rep_double);
+      checkElementsNotNull(rep_double);
+      this.rep_double = rep_double;
       return this;
     }
 
     public Builder rep_string(List<String> rep_string) {
-      this.rep_string = canonicalizeList(rep_string);
+      checkElementsNotNull(rep_string);
+      this.rep_string = rep_string;
       return this;
     }
 
     public Builder rep_bytes(List<ByteString> rep_bytes) {
-      this.rep_bytes = canonicalizeList(rep_bytes);
+      checkElementsNotNull(rep_bytes);
+      this.rep_bytes = rep_bytes;
       return this;
     }
 
     public Builder rep_nested_enum(List<NestedEnum> rep_nested_enum) {
-      this.rep_nested_enum = canonicalizeList(rep_nested_enum);
+      checkElementsNotNull(rep_nested_enum);
+      this.rep_nested_enum = rep_nested_enum;
       return this;
     }
 
     public Builder rep_nested_message(List<NestedMessage> rep_nested_message) {
-      this.rep_nested_message = canonicalizeList(rep_nested_message);
+      checkElementsNotNull(rep_nested_message);
+      this.rep_nested_message = rep_nested_message;
       return this;
     }
 
     public Builder pack_int32(List<Integer> pack_int32) {
-      this.pack_int32 = canonicalizeList(pack_int32);
+      checkElementsNotNull(pack_int32);
+      this.pack_int32 = pack_int32;
       return this;
     }
 
     public Builder pack_uint32(List<Integer> pack_uint32) {
-      this.pack_uint32 = canonicalizeList(pack_uint32);
+      checkElementsNotNull(pack_uint32);
+      this.pack_uint32 = pack_uint32;
       return this;
     }
 
     public Builder pack_sint32(List<Integer> pack_sint32) {
-      this.pack_sint32 = canonicalizeList(pack_sint32);
+      checkElementsNotNull(pack_sint32);
+      this.pack_sint32 = pack_sint32;
       return this;
     }
 
     public Builder pack_fixed32(List<Integer> pack_fixed32) {
-      this.pack_fixed32 = canonicalizeList(pack_fixed32);
+      checkElementsNotNull(pack_fixed32);
+      this.pack_fixed32 = pack_fixed32;
       return this;
     }
 
     public Builder pack_sfixed32(List<Integer> pack_sfixed32) {
-      this.pack_sfixed32 = canonicalizeList(pack_sfixed32);
+      checkElementsNotNull(pack_sfixed32);
+      this.pack_sfixed32 = pack_sfixed32;
       return this;
     }
 
     public Builder pack_int64(List<Long> pack_int64) {
-      this.pack_int64 = canonicalizeList(pack_int64);
+      checkElementsNotNull(pack_int64);
+      this.pack_int64 = pack_int64;
       return this;
     }
 
     public Builder pack_uint64(List<Long> pack_uint64) {
-      this.pack_uint64 = canonicalizeList(pack_uint64);
+      checkElementsNotNull(pack_uint64);
+      this.pack_uint64 = pack_uint64;
       return this;
     }
 
     public Builder pack_sint64(List<Long> pack_sint64) {
-      this.pack_sint64 = canonicalizeList(pack_sint64);
+      checkElementsNotNull(pack_sint64);
+      this.pack_sint64 = pack_sint64;
       return this;
     }
 
     public Builder pack_fixed64(List<Long> pack_fixed64) {
-      this.pack_fixed64 = canonicalizeList(pack_fixed64);
+      checkElementsNotNull(pack_fixed64);
+      this.pack_fixed64 = pack_fixed64;
       return this;
     }
 
     public Builder pack_sfixed64(List<Long> pack_sfixed64) {
-      this.pack_sfixed64 = canonicalizeList(pack_sfixed64);
+      checkElementsNotNull(pack_sfixed64);
+      this.pack_sfixed64 = pack_sfixed64;
       return this;
     }
 
     public Builder pack_bool(List<Boolean> pack_bool) {
-      this.pack_bool = canonicalizeList(pack_bool);
+      checkElementsNotNull(pack_bool);
+      this.pack_bool = pack_bool;
       return this;
     }
 
     public Builder pack_float(List<Float> pack_float) {
-      this.pack_float = canonicalizeList(pack_float);
+      checkElementsNotNull(pack_float);
+      this.pack_float = pack_float;
       return this;
     }
 
     public Builder pack_double(List<Double> pack_double) {
-      this.pack_double = canonicalizeList(pack_double);
+      checkElementsNotNull(pack_double);
+      this.pack_double = pack_double;
       return this;
     }
 
     public Builder pack_nested_enum(List<NestedEnum> pack_nested_enum) {
-      this.pack_nested_enum = canonicalizeList(pack_nested_enum);
+      checkElementsNotNull(pack_nested_enum);
+      this.pack_nested_enum = pack_nested_enum;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -222,7 +222,8 @@ public final class FooBar extends Message<FooBar> {
     }
 
     public Builder fred(List<Float> fred) {
-      this.fred = canonicalizeList(fred);
+      checkElementsNotNull(fred);
+      this.fred = fred;
       return this;
     }
 
@@ -232,7 +233,8 @@ public final class FooBar extends Message<FooBar> {
     }
 
     public Builder nested(List<FooBar> nested) {
-      this.nested = canonicalizeList(nested);
+      checkElementsNotNull(nested);
+      this.nested = nested;
       return this;
     }
 
@@ -362,7 +364,8 @@ public final class FooBar extends Message<FooBar> {
       }
 
       public Builder serial(List<Integer> serial) {
-        this.serial = canonicalizeList(serial);
+        checkElementsNotNull(serial);
+        this.serial = serial;
         return this;
       }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -172,7 +172,8 @@ public final class FooBar extends Message<FooBar> {
     }
 
     public Builder fred(List<Float> fred) {
-      this.fred = canonicalizeList(fred);
+      checkElementsNotNull(fred);
+      this.fred = fred;
       return this;
     }
 
@@ -182,7 +183,8 @@ public final class FooBar extends Message<FooBar> {
     }
 
     public Builder nested(List<FooBar> nested) {
-      this.nested = canonicalizeList(nested);
+      checkElementsNotNull(nested);
+      this.nested = nested;
       return this;
     }
 
@@ -312,7 +314,8 @@ public final class FooBar extends Message<FooBar> {
       }
 
       public Builder serial(List<Integer> serial) {
-        this.serial = canonicalizeList(serial);
+        checkElementsNotNull(serial);
+        this.serial = serial;
         return this;
       }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -151,7 +151,8 @@ public final class Person extends Message<Person> {
      * A list of the customer's phone numbers.
      */
     public Builder phone(List<PhoneNumber> phone) {
-      this.phone = canonicalizeList(phone);
+      checkElementsNotNull(phone);
+      this.phone = phone;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -72,7 +72,8 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
     }
 
     public Builder a(List<String> a) {
-      this.a = canonicalizeList(a);
+      checkElementsNotNull(a);
+      this.a = a;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -304,7 +304,8 @@ public final class SimpleMessage extends Message<SimpleMessage> {
      */
     @Deprecated
     public Builder repeated_double(List<Double> repeated_double) {
-      this.repeated_double = canonicalizeList(repeated_double);
+      checkElementsNotNull(repeated_double);
+      this.repeated_double = repeated_double;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -65,7 +65,8 @@ public final class Bars extends Message<Bars> {
     }
 
     public Builder bars(List<Bar> bars) {
-      this.bars = canonicalizeList(bars);
+      checkElementsNotNull(bars);
+      this.bars = bars;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -65,7 +65,8 @@ public final class Foos extends Message<Foos> {
     }
 
     public Builder foos(List<Foo> foos) {
-      this.foos = canonicalizeList(foos);
+      checkElementsNotNull(foos);
+      this.foos = foos;
       return this;
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -163,7 +163,8 @@ public final class VersionTwo extends Message<VersionTwo> {
     }
 
     public Builder v2_rs(List<String> v2_rs) {
-      this.v2_rs = canonicalizeList(v2_rs);
+      checkElementsNotNull(v2_rs);
+      this.v2_rs = v2_rs;
       return this;
     }
 


### PR DESCRIPTION
This also adds a standard warning to all their Javadoc and cleans up a few things about their implementation.