### PR TITLE
Optimize list movement for repeated fields.

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -15,7 +15,6 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 import okio.ByteString;
 
@@ -1088,37 +1087,37 @@ public final class AllTypes extends Message<AllTypes> {
     public NestedEnum default_nested_enum;
 
     public Builder() {
-      rep_int32 = Collections.emptyList();
-      rep_uint32 = Collections.emptyList();
-      rep_sint32 = Collections.emptyList();
-      rep_fixed32 = Collections.emptyList();
-      rep_sfixed32 = Collections.emptyList();
-      rep_int64 = Collections.emptyList();
-      rep_uint64 = Collections.emptyList();
-      rep_sint64 = Collections.emptyList();
-      rep_fixed64 = Collections.emptyList();
-      rep_sfixed64 = Collections.emptyList();
-      rep_bool = Collections.emptyList();
-      rep_float = Collections.emptyList();
-      rep_double = Collections.emptyList();
-      rep_string = Collections.emptyList();
-      rep_bytes = Collections.emptyList();
-      rep_nested_enum = Collections.emptyList();
-      rep_nested_message = Collections.emptyList();
-      pack_int32 = Collections.emptyList();
-      pack_uint32 = Collections.emptyList();
-      pack_sint32 = Collections.emptyList();
-      pack_fixed32 = Collections.emptyList();
-      pack_sfixed32 = Collections.emptyList();
-      pack_int64 = Collections.emptyList();
-      pack_uint64 = Collections.emptyList();
-      pack_sint64 = Collections.emptyList();
-      pack_fixed64 = Collections.emptyList();
-      pack_sfixed64 = Collections.emptyList();
-      pack_bool = Collections.emptyList();
-      pack_float = Collections.emptyList();
-      pack_double = Collections.emptyList();
-      pack_nested_enum = Collections.emptyList();
+      rep_int32 = newMutableList();
+      rep_uint32 = newMutableList();
+      rep_sint32 = newMutableList();
+      rep_fixed32 = newMutableList();
+      rep_sfixed32 = newMutableList();
+      rep_int64 = newMutableList();
+      rep_uint64 = newMutableList();
+      rep_sint64 = newMutableList();
+      rep_fixed64 = newMutableList();
+      rep_sfixed64 = newMutableList();
+      rep_bool = newMutableList();
+      rep_float = newMutableList();
+      rep_double = newMutableList();
+      rep_string = newMutableList();
+      rep_bytes = newMutableList();
+      rep_nested_enum = newMutableList();
+      rep_nested_message = newMutableList();
+      pack_int32 = newMutableList();
+      pack_uint32 = newMutableList();
+      pack_sint32 = newMutableList();
+      pack_fixed32 = newMutableList();
+      pack_sfixed32 = newMutableList();
+      pack_int64 = newMutableList();
+      pack_uint64 = newMutableList();
+      pack_sint64 = newMutableList();
+      pack_fixed64 = newMutableList();
+      pack_sfixed64 = newMutableList();
+      pack_bool = newMutableList();
+      pack_float = newMutableList();
+      pack_double = newMutableList();
+      pack_nested_enum = newMutableList();
     }
 
     public Builder(AllTypes message) {

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -669,14 +669,14 @@ public final class JavaGenerator {
   // Example:
   //
   // public Builder() {
-  //   names = Collections.emptyList();
+  //   names = newMutableList();
   // }
   //
   private MethodSpec builderNoArgsConstructor(MessageType type) {
     MethodSpec.Builder result = MethodSpec.constructorBuilder().addModifiers(PUBLIC);
     for (Field field : type.fieldsAndOneOfFields()) {
       if (field.isPacked() || field.isRepeated()) {
-        result.addStatement("$L = $T.emptyList()", sanitize(field.name()), Collections.class);
+        result.addStatement("$L = newMutableList()", sanitize(field.name()));
       }
     }
     return result.build();

--- a/wire-runtime/src/main/java/com/squareup/wire/FieldBinding.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/FieldBinding.java
@@ -18,7 +18,6 @@ package com.squareup.wire;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -83,12 +82,8 @@ final class FieldBinding<M extends Message<M>, B extends Message.Builder<M, B>> 
   void value(B builder, Object value) {
     if (label.isRepeated()) {
       try {
-        List<?> list = (List<?>) builderField.get(builder);
-        if (list == Collections.emptyList()) {
-          list = new ImmutableList();
-          builderField.set(builder, list);
-        }
-        ((ImmutableList<Object>) list).list.add(value);
+        List<Object> list = (List<Object>) builderField.get(builder);
+        list.add(value);
       } catch (IllegalAccessException e) {
         throw new AssertionError(e);
       }

--- a/wire-runtime/src/main/java/com/squareup/wire/ImmutableList.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ImmutableList.java
@@ -23,13 +23,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.RandomAccess;
 
-/** An immutable list that avoids copies during decoding. */
-final class ImmutableList<T> extends AbstractList<T>
-    implements Cloneable, RandomAccess, Serializable {
-  final List<T> list = new ArrayList<>();
+final class ImmutableList<T> extends AbstractList<T> implements RandomAccess, Serializable {
+  final List<T> list;
 
-  @Override public Object clone() {
-    return this;
+  ImmutableList(List<T> list) {
+    this.list = new ArrayList<>(list);
   }
 
   @Override public int size() {

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -139,19 +139,30 @@ public abstract class Message<T extends Message<T>> implements Serializable {
     public abstract T build();
   }
 
+  /** <b>For generated code only.</b> */
+  protected static <T> List<T> newMutableList() {
+    return new MutableOnWriteList<>(Collections.<T>emptyList());
+  }
+
   /** <b>For generated code only.</b> Utility method to return a mutable copy of {@code list}. */
   protected static <T> List<T> copyOf(List<T> list) {
     if (list == null) throw new NullPointerException("list == null");
+    if (list == Collections.emptyList() || list instanceof ImmutableList) {
+      return new MutableOnWriteList<>(list);
+    }
     return new ArrayList<>(list);
   }
 
   /** <b>For generated code only.</b> Utility method to return an immutable copy of {@code list}. */
   protected static <T> List<T> immutableCopyOf(List<T> list) {
     if (list == null) throw new NullPointerException("list == null");
+    if (list instanceof MutableOnWriteList) {
+      list = ((MutableOnWriteList<T>) list).mutableList;
+    }
     if (list == Collections.emptyList() || list instanceof ImmutableList) {
       return list;
     }
-    return Collections.unmodifiableList(new ArrayList<>(list));
+    return new ImmutableList<>(list);
   }
 
   /** <b>For generated code only.</b> */

--- a/wire-runtime/src/main/java/com/squareup/wire/MutableOnWriteList.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/MutableOnWriteList.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2015 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+import java.io.ObjectStreamException;
+import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.RandomAccess;
+
+/** A wrapper around an empty/immutable list which only switches to mutable on first mutation. */
+final class MutableOnWriteList<T> extends AbstractList<T> implements RandomAccess, Serializable {
+  private final List<T> immutableList;
+  List<T> mutableList;
+
+  MutableOnWriteList(List<T> immutableList) {
+    this.immutableList = immutableList;
+    this.mutableList = immutableList;
+  }
+
+  @Override public T get(int index) {
+    return mutableList.get(index);
+  }
+
+  @Override public int size() {
+    return mutableList.size();
+  }
+
+  @Override public T set(int index, T element) {
+    if (mutableList == immutableList) {
+      mutableList = new ArrayList<>(immutableList);
+    }
+    return mutableList.set(index, element);
+  }
+
+  @Override public void add(int index, T element) {
+    if (mutableList == immutableList) {
+      mutableList = new ArrayList<>(immutableList);
+    }
+    mutableList.add(index, element);
+  }
+
+  @Override public T remove(int index) {
+    if (mutableList == immutableList) {
+      mutableList = new ArrayList<>(immutableList);
+    }
+    return mutableList.remove(index);
+  }
+
+  private Object writeReplace() throws ObjectStreamException {
+    return new ArrayList<>(mutableList);
+  }
+}

--- a/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/DescriptorProto.java
@@ -10,7 +10,6 @@ import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -149,11 +148,11 @@ public final class DescriptorProto extends Message<DescriptorProto> {
     public MessageOptions options;
 
     public Builder() {
-      field = Collections.emptyList();
-      extension = Collections.emptyList();
-      nested_type = Collections.emptyList();
-      enum_type = Collections.emptyList();
-      extension_range = Collections.emptyList();
+      field = newMutableList();
+      extension = newMutableList();
+      nested_type = newMutableList();
+      enum_type = newMutableList();
+      extension_range = newMutableList();
     }
 
     public Builder(DescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumDescriptorProto.java
@@ -9,7 +9,6 @@ import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -100,7 +99,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto> {
     public EnumOptions options;
 
     public Builder() {
-      value = Collections.emptyList();
+      value = newMutableList();
     }
 
     public Builder(EnumDescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumOptions.java
@@ -8,7 +8,6 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class EnumOptions extends Message<EnumOptions> {
@@ -59,7 +58,7 @@ public final class EnumOptions extends Message<EnumOptions> {
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = Collections.emptyList();
+      uninterpreted_option = newMutableList();
     }
 
     public Builder(EnumOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/EnumValueOptions.java
@@ -8,7 +8,6 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class EnumValueOptions extends Message<EnumValueOptions> {
@@ -59,7 +58,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions> {
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = Collections.emptyList();
+      uninterpreted_option = newMutableList();
     }
 
     public Builder(EnumValueOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FieldOptions.java
@@ -11,7 +11,6 @@ import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 public final class FieldOptions extends Message<FieldOptions> {
@@ -146,7 +145,7 @@ public final class FieldOptions extends Message<FieldOptions> {
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = Collections.emptyList();
+      uninterpreted_option = newMutableList();
     }
 
     public Builder(FieldOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorProto.java
@@ -9,7 +9,6 @@ import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -174,11 +173,11 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto> {
     public SourceCodeInfo source_code_info;
 
     public Builder() {
-      dependency = Collections.emptyList();
-      message_type = Collections.emptyList();
-      enum_type = Collections.emptyList();
-      service = Collections.emptyList();
-      extension = Collections.emptyList();
+      dependency = newMutableList();
+      message_type = newMutableList();
+      enum_type = newMutableList();
+      service = newMutableList();
+      extension = newMutableList();
     }
 
     public Builder(FileDescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileDescriptorSet.java
@@ -8,7 +8,6 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -60,7 +59,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet> {
     public List<FileDescriptorProto> file;
 
     public Builder() {
-      file = Collections.emptyList();
+      file = newMutableList();
     }
 
     public Builder(FileDescriptorSet message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/FileOptions.java
@@ -11,7 +11,6 @@ import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -232,7 +231,7 @@ public final class FileOptions extends Message<FileOptions> {
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = Collections.emptyList();
+      uninterpreted_option = newMutableList();
     }
 
     public Builder(FileOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MessageOptions.java
@@ -9,7 +9,6 @@ import com.squareup.wire.WireField;
 import java.lang.Boolean;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class MessageOptions extends Message<MessageOptions> {
@@ -111,7 +110,7 @@ public final class MessageOptions extends Message<MessageOptions> {
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = Collections.emptyList();
+      uninterpreted_option = newMutableList();
     }
 
     public Builder(MessageOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/MethodOptions.java
@@ -8,7 +8,6 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class MethodOptions extends Message<MethodOptions> {
@@ -63,7 +62,7 @@ public final class MethodOptions extends Message<MethodOptions> {
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = Collections.emptyList();
+      uninterpreted_option = newMutableList();
     }
 
     public Builder(MethodOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceDescriptorProto.java
@@ -9,7 +9,6 @@ import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -100,7 +99,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     public ServiceOptions options;
 
     public Builder() {
-      method = Collections.emptyList();
+      method = newMutableList();
     }
 
     public Builder(ServiceDescriptorProto message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/ServiceOptions.java
@@ -8,7 +8,6 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class ServiceOptions extends Message<ServiceOptions> {
@@ -63,7 +62,7 @@ public final class ServiceOptions extends Message<ServiceOptions> {
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = Collections.emptyList();
+      uninterpreted_option = newMutableList();
     }
 
     public Builder(ServiceOptions message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/SourceCodeInfo.java
@@ -9,7 +9,6 @@ import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -108,7 +107,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
     public List<Location> location;
 
     public Builder() {
-      location = Collections.emptyList();
+      location = newMutableList();
     }
 
     public Builder(SourceCodeInfo message) {
@@ -263,8 +262,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo> {
       public List<Integer> span;
 
       public Builder() {
-        path = Collections.emptyList();
-        span = Collections.emptyList();
+        path = newMutableList();
+        span = newMutableList();
       }
 
       public Builder(Location message) {

--- a/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/java/com/google/protobuf/UninterpretedOption.java
@@ -12,7 +12,6 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 import okio.ByteString;
 
@@ -151,7 +150,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption> {
     public String aggregate_value;
 
     public Builder() {
-      name = Collections.emptyList();
+      name = newMutableList();
     }
 
     public Builder(UninterpretedOption message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -9,7 +9,6 @@ import com.squareup.wire.WireField;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
@@ -69,8 +68,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked> {
     public List<Integer> pack_int32;
 
     public Builder() {
-      rep_int32 = Collections.emptyList();
-      pack_int32 = Collections.emptyList();
+      rep_int32 = newMutableList();
+      pack_int32 = newMutableList();
     }
 
     public Builder(RepeatedAndPacked message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -15,7 +15,6 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 import okio.ByteString;
 
@@ -1088,37 +1087,37 @@ public final class AllTypes extends Message<AllTypes> {
     public NestedEnum default_nested_enum;
 
     public Builder() {
-      rep_int32 = Collections.emptyList();
-      rep_uint32 = Collections.emptyList();
-      rep_sint32 = Collections.emptyList();
-      rep_fixed32 = Collections.emptyList();
-      rep_sfixed32 = Collections.emptyList();
-      rep_int64 = Collections.emptyList();
-      rep_uint64 = Collections.emptyList();
-      rep_sint64 = Collections.emptyList();
-      rep_fixed64 = Collections.emptyList();
-      rep_sfixed64 = Collections.emptyList();
-      rep_bool = Collections.emptyList();
-      rep_float = Collections.emptyList();
-      rep_double = Collections.emptyList();
-      rep_string = Collections.emptyList();
-      rep_bytes = Collections.emptyList();
-      rep_nested_enum = Collections.emptyList();
-      rep_nested_message = Collections.emptyList();
-      pack_int32 = Collections.emptyList();
-      pack_uint32 = Collections.emptyList();
-      pack_sint32 = Collections.emptyList();
-      pack_fixed32 = Collections.emptyList();
-      pack_sfixed32 = Collections.emptyList();
-      pack_int64 = Collections.emptyList();
-      pack_uint64 = Collections.emptyList();
-      pack_sint64 = Collections.emptyList();
-      pack_fixed64 = Collections.emptyList();
-      pack_sfixed64 = Collections.emptyList();
-      pack_bool = Collections.emptyList();
-      pack_float = Collections.emptyList();
-      pack_double = Collections.emptyList();
-      pack_nested_enum = Collections.emptyList();
+      rep_int32 = newMutableList();
+      rep_uint32 = newMutableList();
+      rep_sint32 = newMutableList();
+      rep_fixed32 = newMutableList();
+      rep_sfixed32 = newMutableList();
+      rep_int64 = newMutableList();
+      rep_uint64 = newMutableList();
+      rep_sint64 = newMutableList();
+      rep_fixed64 = newMutableList();
+      rep_sfixed64 = newMutableList();
+      rep_bool = newMutableList();
+      rep_float = newMutableList();
+      rep_double = newMutableList();
+      rep_string = newMutableList();
+      rep_bytes = newMutableList();
+      rep_nested_enum = newMutableList();
+      rep_nested_message = newMutableList();
+      pack_int32 = newMutableList();
+      pack_uint32 = newMutableList();
+      pack_sint32 = newMutableList();
+      pack_fixed32 = newMutableList();
+      pack_sfixed32 = newMutableList();
+      pack_int64 = newMutableList();
+      pack_uint64 = newMutableList();
+      pack_sint64 = newMutableList();
+      pack_fixed64 = newMutableList();
+      pack_sfixed64 = newMutableList();
+      pack_bool = newMutableList();
+      pack_float = newMutableList();
+      pack_double = newMutableList();
+      pack_nested_enum = newMutableList();
     }
 
     public Builder(AllTypes message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -18,7 +18,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 public final class FooBar extends Message<FooBar> {
@@ -187,8 +186,8 @@ public final class FooBar extends Message<FooBar> {
     public List<FooBar> nested;
 
     public Builder() {
-      fred = Collections.emptyList();
-      nested = Collections.emptyList();
+      fred = newMutableList();
+      nested = newMutableList();
     }
 
     public Builder(FooBar message) {
@@ -357,7 +356,7 @@ public final class FooBar extends Message<FooBar> {
       public List<Integer> serial;
 
       public Builder() {
-        serial = Collections.emptyList();
+        serial = newMutableList();
       }
 
       public Builder(More message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -14,7 +14,6 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 public final class FooBar extends Message<FooBar> {
@@ -137,8 +136,8 @@ public final class FooBar extends Message<FooBar> {
     public List<FooBar> nested;
 
     public Builder() {
-      fred = Collections.emptyList();
-      nested = Collections.emptyList();
+      fred = newMutableList();
+      nested = newMutableList();
     }
 
     public Builder(FooBar message) {
@@ -307,7 +306,7 @@ public final class FooBar extends Message<FooBar> {
       public List<Integer> serial;
 
       public Builder() {
-        serial = Collections.emptyList();
+        serial = newMutableList();
       }
 
       public Builder(More message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/person/Person.java
@@ -11,7 +11,6 @@ import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 public final class Person extends Message<Person> {
@@ -112,7 +111,7 @@ public final class Person extends Message<Person> {
     public List<PhoneNumber> phone;
 
     public Builder() {
-      phone = Collections.emptyList();
+      phone = newMutableList();
     }
 
     public Builder(Person message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -10,7 +10,6 @@ import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 public final class RedactedRepeated extends Message<RedactedRepeated> {
@@ -63,7 +62,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated> {
     public List<String> a;
 
     public Builder() {
-      a = Collections.emptyList();
+      a = newMutableList();
     }
 
     public Builder(RedactedRepeated message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -14,7 +14,6 @@ import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -242,7 +241,7 @@ public final class SimpleMessage extends Message<SimpleMessage> {
     public String o;
 
     public Builder() {
-      repeated_double = Collections.emptyList();
+      repeated_double = newMutableList();
     }
 
     public Builder(SimpleMessage message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Bars.java
@@ -8,7 +8,6 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class Bars extends Message<Bars> {
@@ -56,7 +55,7 @@ public final class Bars extends Message<Bars> {
     public List<Bar> bars;
 
     public Builder() {
-      bars = Collections.emptyList();
+      bars = newMutableList();
     }
 
     public Builder(Bars message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/single_level/Foos.java
@@ -8,7 +8,6 @@ import com.squareup.wire.TagMap;
 import com.squareup.wire.WireField;
 import java.lang.Object;
 import java.lang.Override;
-import java.util.Collections;
 import java.util.List;
 
 public final class Foos extends Message<Foos> {
@@ -56,7 +55,7 @@ public final class Foos extends Message<Foos> {
     public List<Foo> foos;
 
     public Builder() {
-      foos = Collections.emptyList();
+      foos = newMutableList();
     }
 
     public Builder(Foos message) {

--- a/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -11,7 +11,6 @@ import java.lang.Long;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
-import java.util.Collections;
 import java.util.List;
 
 public final class VersionTwo extends Message<VersionTwo> {
@@ -124,7 +123,7 @@ public final class VersionTwo extends Message<VersionTwo> {
     public List<String> v2_rs;
 
     public Builder() {
-      v2_rs = Collections.emptyList();
+      v2_rs = newMutableList();
     }
 
     public Builder(VersionTwo message) {


### PR DESCRIPTION
We incorrectly mixed mutable (copy constructor) and immutable (default constructor) list values when initializing the builder. In the mutable case, we did an entire copy of the immutable list only to make another immutable copy when building. In the immutable case, we allowed it to pass through when building as an optimization. A mutable list is always used in the builder for consistency, but with some special behavior for efficiency:

* When the copy constructor is used, retain the immutable instance inside a mutable container from the original value and re-use it if it goes unchanged when building.
* When the default constructor is used, wrap an emptyList() in a mutable container and use it if no values were added when building.
* If the mutable container is mutated in any way, make a copy of the immutable data and into a proper mutable list and allow mutation.