### PR TITLE
Message.newBuilder() and withoutUnknownFields().

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -81,7 +81,7 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
   }
 
   @SuppressWarnings("unchecked")
-  private static <M extends Message<M>, B extends Builder<M, B>> Class<B> getBuilderType(
+  static <M extends Message<M>, B extends Builder<M, B>> Class<B> getBuilderType(
       Class<M> messageType) {
     try {
       return (Class<B>) Class.forName(messageType.getName() + "$Builder");
@@ -91,7 +91,7 @@ final class RuntimeMessageAdapter<M extends Message<M>, B extends Builder<M, B>>
     }
   }
 
-  private static <M extends Message<M>, B extends Builder<M, B>> Constructor<B>
+  static <M extends Message<M>, B extends Builder<M, B>> Constructor<B>
   getBuilderCopyConstructor(Class<B> builderType, Class<M> messageType) {
     try {
       return builderType.getConstructor(messageType);


### PR DESCRIPTION
The generics on newBuilder() are brutal, and I'm unhappy with them.