### PR TITLE
Improve performance of TagMap in toString, expose helper API.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/TagMap.java
@@ -227,6 +227,31 @@ public final class TagMap {
     return Arrays.hashCode(array);
   }
 
+  /**
+   * Append comma-prefixed and separated key/value pairs to {@code builder} for the extensions
+   * and unknown fields in this map.
+   */
+  public void appendToString(StringBuilder builder) {
+    for (int i = 0; i < array.length;) {
+      Extension<?, ?> extension = (Extension<?, ?>) array[i];
+      builder.append(", ")
+          .append(extension.isUnknown() ? extension.getTag() : extension.getName())
+          .append("=");
+      int end = runEnd(i);
+      if (end > i + 2) {
+        builder.append('[');
+        for (int start = i; i < end; i += 2) {
+          if (i > start) builder.append(", ");
+          builder.append(array[i + 1]);
+        }
+        builder.append(']');
+      } else {
+        builder.append(array[i + 1]);
+        i += 2;
+      }
+    }
+  }
+
   public static final class Builder {
     static final int INITIAL_CAPACITY = 8;
     static final Object[] EMPTY_ARRAY = new Object[0];

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -16,6 +16,7 @@
 package com.squareup.wire;
 
 import com.squareup.wire.protos.RepeatedAndPacked;
+import com.squareup.wire.protos.edgecases.NoFields;
 import com.squareup.wire.protos.person.Person;
 import com.squareup.wire.protos.person.Person.PhoneNumber;
 import com.squareup.wire.protos.person.Person.PhoneType;
@@ -211,7 +212,7 @@ public class WireTest {
     // Original value shows up as an extension.
     assertThat(msg.toString()).contains("squareup.protos.simple.nested_enum_ext=BAZ");
     // New value is unknown in the tag map.
-    assertThat(newMsg.toString()).contains("ExternalMessage{129=[17]}");
+    assertThat(newMsg.toString()).contains("ExternalMessage{129=17}");
 
     // Serialized outputs are the same.
     byte[] newData = adapter.encode(newMsg);
@@ -380,5 +381,10 @@ public class WireTest {
         .build();
     Person.Builder copyBuilder = new Person.Builder(person);
     copyBuilder.phone.add(phone);
+  }
+
+  @Test public void emptyMessageToString() {
+    NoFields empty = new NoFields();
+    assertThat(empty.toString()).isEqualTo("NoFields{}");
   }
 }


### PR DESCRIPTION
Calling `extensions(true)` and `get(Extension)` are expensive in terms of computation and allocation. This changes the `TagMap` to do an effectively-single-pass traversal of the underlying array appending to an existing `StringBuilder`. This method will also be used by generated code, and the implementation of `toString` in the message adapter has been updated to reflect more closely the behavior of what generated code would look like.

Without a method like this, generating `toString` in code is very verbose.