### PR TITLE
Load zip files as their own FileSystems.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -71,10 +71,10 @@ public final class WireCompiler {
   public void compile() throws IOException {
     SchemaLoader schemaLoader = new SchemaLoader();
     for (String protoPath : options.protoPaths) {
-      schemaLoader.addDirectory(fs.getPath(protoPath));
+      schemaLoader.addSource(fs.getPath(protoPath));
     }
     for (String sourceFileName : options.sourceFileNames) {
-      schemaLoader.addProto(fs.getPath(sourceFileName));
+      schemaLoader.addProto(sourceFileName);
     }
     Schema schema = schemaLoader.load();
 

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -154,10 +154,10 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
 
     SchemaLoader schemaLoader = new SchemaLoader();
     for (String directory : directories) {
-      schemaLoader.addDirectory(new File(directory));
+      schemaLoader.addSource(new File(directory));
     }
     for (String proto : protos) {
-      schemaLoader.addProto(new File(proto));
+      schemaLoader.addProto(proto);
     }
     Schema schema = schemaLoader.load();
 

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaBuilder.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaBuilder.java
@@ -32,7 +32,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 class SchemaBuilder {
   final FileSystem fs = Jimfs.newFileSystem(Configuration.unix());
   final Path root = fs.getPath("/");
-  final SchemaLoader schemaLoader = new SchemaLoader().addDirectory(root);
+  final SchemaLoader schemaLoader = new SchemaLoader().addSource(root);
 
   public SchemaBuilder add(String name, String protoFile) {
     Path relativePath = fs.getPath(name);
@@ -46,7 +46,7 @@ class SchemaBuilder {
     } catch (IOException e) {
       throw new AssertionError(e);
     }
-    schemaLoader.addProto(relativePath);
+    schemaLoader.addProto(name);
     return this;
   }
 

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaLoaderTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaLoaderTest.java
@@ -20,7 +20,6 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
-import java.nio.file.Paths;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
 import org.junit.Rule;
@@ -39,10 +38,10 @@ public final class SchemaLoaderTest {
     File file2 = tempFolder2.newFile();
 
     new SchemaLoader()
-        .addDirectory(tempFolder1.getRoot())
-        .addDirectory(tempFolder2.getRoot())
-        .addProto(file1)
-        .addProto(file2)
+        .addSource(tempFolder1.getRoot())
+        .addSource(tempFolder2.getRoot())
+        .addProto(file1.getName())
+        .addProto(file2.getName())
         .load();
   }
 
@@ -50,8 +49,8 @@ public final class SchemaLoaderTest {
     File file = tempFolder2.newFile();
 
     SchemaLoader loader = new SchemaLoader()
-        .addDirectory(tempFolder1.getRoot())
-        .addProto(file);
+        .addSource(tempFolder1.getRoot())
+        .addProto(file.getName());
     try {
       loader.load();
       fail();
@@ -67,8 +66,8 @@ public final class SchemaLoaderTest {
     zipOutputStream.close();
 
     Schema schema = new SchemaLoader()
-        .addDirectory(file)
-        .addProto(Paths.get("a", "b", "message.proto"))
+        .addSource(file)
+        .addProto("a/b/message.proto")
         .load();
     assertThat(schema.getType("Message")).isNotNull();
   }
@@ -82,8 +81,8 @@ public final class SchemaLoaderTest {
 
     try {
       new SchemaLoader()
-          .addDirectory(file)
-          .addProto(Paths.get("a", "b", "rabbit_food.proto"))
+          .addSource(file)
+          .addProto("a/b/message.proto")
           .load();
       fail();
     } catch (FileNotFoundException expected) {


### PR DESCRIPTION
Java 7 ships with a built-in FileSystem that can load zip files. Booya!

(Note: #437 is going to kill all the `addProto` stuff which I switched to Strings for use across different FileSystems)