### PR TITLE
Use the same options mechanism everywhere.

### DIFF
--- a/gen_tests.sh
+++ b/gen_tests.sh
@@ -10,7 +10,6 @@ PROTOS=`find src/test/proto -name '*.proto' | sed 's|^src/test/proto/||'`
 java -jar ../wire-compiler/target/wire-compiler-*-SNAPSHOT-jar-with-dependencies.jar \
   --proto_path=../wire-runtime/src/test/proto \
   --java_out=../wire-runtime/src/test/proto-java \
-  --enum_options=squareup.protos.custom_options.enum_value_option,squareup.protos.custom_options.complex_enum_value_option,squareup.protos.foreign.foreign_enum_value_option \
   ${PROTOS}
 
 # NO OPTIONS
@@ -19,7 +18,6 @@ java -jar ../wire-compiler/target/wire-compiler-*-SNAPSHOT-jar-with-dependencies
   --proto_path=../wire-runtime/src/test/proto \
   --java_out=../wire-runtime/src/test/proto-java.noOptions \
   --no_options \
-  --enum_options=squareup.protos.custom_options.enum_value_option \
   ${PROTOS}
 
 cp src/test/proto-java.noOptions/com/squareup/wire/protos/custom_options/FooBar.java \

--- a/wire-compiler/src/main/java/com/squareup/wire/CommandLineOptions.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/CommandLineOptions.java
@@ -19,10 +19,8 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Scanner;
-import java.util.Set;
 
 final class CommandLineOptions {
   public static final String PROTO_PATH_FLAG = "--proto_path=";
@@ -30,7 +28,6 @@ final class CommandLineOptions {
   public static final String FILES_FLAG = "--files=";
   public static final String ROOTS_FLAG = "--roots=";
   public static final String NO_OPTIONS_FLAG = "--no_options";
-  public static final String ENUM_OPTIONS_FLAG = "--enum_options=";
   public static final String QUIET_FLAG = "--quiet";
   public static final String DRY_RUN_FLAG = "--dry_run";
   public static final String ANDROID = "--android";
@@ -41,22 +38,20 @@ final class CommandLineOptions {
   final List<String> sourceFileNames;
   final List<String> roots;
   final boolean emitOptions;
-  final Set<String> enumOptions;
   final boolean quiet;
   final boolean dryRun;
   final boolean emitAndroid;
   final boolean emitCompact;
 
   CommandLineOptions(String protoPath, String javaOut, List<String> sourceFileNames,
-      List<String> roots, boolean emitOptions, Set<String> enumOptions, boolean quiet,
-      boolean dryRun, boolean emitAndroid, boolean emitCompact) {
+      List<String> roots, boolean emitOptions, boolean quiet, boolean dryRun, boolean emitAndroid,
+      boolean emitCompact) {
     this.emitCompact = emitCompact;
     this.protoPaths = Arrays.asList(protoPath);
     this.javaOut = javaOut;
     this.sourceFileNames = sourceFileNames;
     this.roots = roots;
     this.emitOptions = emitOptions;
-    this.enumOptions = enumOptions;
     this.quiet = quiet;
     this.dryRun = dryRun;
     this.emitAndroid = emitAndroid;
@@ -70,7 +65,6 @@ final class CommandLineOptions {
    *     [--files=&lt;protos.include&gt;]
    *     [--roots=&lt;message_name&gt;[,&lt;message_name&gt;...]]
    *     [--no_options]
-   *     [--enum_options=&lt;option_name&gt;[,&lt;option_name&gt;...]]
    *     [--service_factory=&lt;class_name&gt;]
    *     [--service_factory_opt=&lt;value&gt;]
    *     [--service_factory_opt=&lt;value&gt;]...]
@@ -99,10 +93,6 @@ final class CommandLineOptions {
    * a static member named "FIELD_OPTIONS_&lt;field name&gt;" in the generated code, initialized
    * with the field option values.
    * <p>
-   * Regardless of the value of the {@code --no_options} flag, code will be emitted for all
-   * enum value options listed in the {@code --enum_options} flag. The resulting code will contain
-   * a public static field for each option used within a particular enum type.
-   * <p>
    * If {@code --quiet} is specified, diagnostic messages to stdout are suppressed.
    * <p>
    * The {@code --dry_run} flag causes the compile to just emit the names of the source files that
@@ -120,8 +110,6 @@ final class CommandLineOptions {
     boolean emitOptions = true;
     List<String> protoPaths = new ArrayList<>();
     String javaOut = null;
-    String registryClass = null;
-    List<String> enumOptionsList = new ArrayList<>();
     boolean quiet = false;
     boolean dryRun = false;
     boolean emitAndroid = false;
@@ -145,8 +133,6 @@ final class CommandLineOptions {
         roots.addAll(splitArg(arg, ROOTS_FLAG.length()));
       } else if (arg.equals(NO_OPTIONS_FLAG)) {
         emitOptions = false;
-      } else if (arg.startsWith(ENUM_OPTIONS_FLAG)) {
-        enumOptionsList.addAll(splitArg(arg, ENUM_OPTIONS_FLAG.length()));
       } else if (arg.equals(QUIET_FLAG)) {
         quiet = true;
       } else if (arg.equals(DRY_RUN_FLAG)) {
@@ -167,7 +153,6 @@ final class CommandLineOptions {
     this.sourceFileNames = sourceFileNames;
     this.roots = roots;
     this.emitOptions = emitOptions;
-    this.enumOptions = new LinkedHashSet<>(enumOptionsList);
     this.quiet = quiet;
     this.dryRun = dryRun;
     this.emitAndroid = emitAndroid;

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -84,7 +84,7 @@ public final class WireCompiler {
     }
 
     JavaGenerator javaGenerator = JavaGenerator.get(schema)
-        .withOptions(options.emitOptions, options.enumOptions)
+        .withOptions(options.emitOptions)
         .withAndroid(options.emitAndroid)
         .withCompact(options.emitCompact);
 

--- a/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.java
@@ -6,9 +6,7 @@ import java.io.FileOutputStream;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -104,18 +102,5 @@ public class CommandLineOptionsTest {
 
     options = new CommandLineOptions("--no_options");
     assertThat(options.emitOptions).isFalse();
-  }
-
-  @Test public void enumOptions() throws Exception {
-    CommandLineOptions options = new CommandLineOptions();
-    assertThat(options.enumOptions).isEmpty();
-
-    options = new CommandLineOptions("--enum_options=foo");
-    Set<String> expected = new HashSet<>();
-    expected.add("foo");
-    assertThat(options.enumOptions).isEqualTo(expected);
-    options = new CommandLineOptions("--enum_options=foo,bar");
-    expected.add("bar");
-    assertThat(options.enumOptions).isEqualTo(expected);
   }
 }

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -23,7 +23,6 @@ import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Collections;
 import okio.Okio;
 import okio.Source;
 import org.junit.Test;
@@ -43,7 +42,7 @@ public class WireCompilerErrorTest {
   private void compile(String source) throws Exception {
     CommandLineOptions options = new CommandLineOptions("/source",  "/target",
         singletonList("test.proto"), new ArrayList<String>(), true,
-        Collections.<String>emptySet(), false, false, false, false);
+        false, false, false, false);
 
     Path test = fileSystem.getPath("/source/test.proto");
     Files.createDirectory(fileSystem.getPath("/source"));

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
@@ -63,9 +63,6 @@ public class WireCompilerTest {
     List<String> args = new ArrayList<>();
     args.add("--proto_path=../wire-runtime/src/test/proto");
     args.add("--java_out=" + testDir.getAbsolutePath());
-    args.add("--enum_options=squareup.protos.custom_options.enum_value_option,"
-        + "squareup.protos.custom_options.complex_enum_value_option,"
-        + "squareup.protos.foreign.foreign_enum_value_option");
     args.addAll(Arrays.asList(sources));
     invokeCompiler(args.toArray(new String[args.size()]));
 
@@ -116,13 +113,11 @@ public class WireCompilerTest {
   }
 
   private void testProtoNoOptions(String[] sources, String[] outputs) throws Exception {
-    int numFlags = 4;
+    int numFlags = 3;
     String[] args = new String[numFlags + sources.length];
     args[0] = "--proto_path=../wire-runtime/src/test/proto";
     args[1] = "--no_options";
-    // Emit one of the enum options anyway.
-    args[2] = "--enum_options=squareup.protos.custom_options.enum_value_option";
-    args[3] = "--java_out=" + testDir.getAbsolutePath();
+    args[2] = "--java_out=" + testDir.getAbsolutePath();
     System.arraycopy(sources, 0, args, numFlags, sources.length);
 
     invokeCompiler(args);

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -46,9 +46,6 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
   @Parameter(property = "wire.noOptions")
   private boolean noOptions;
 
-  @Parameter(property = "wire.enumOptions")
-  private String[] enumOptions;
-
   @Parameter(property = "wire.roots")
   private String[] roots;
 
@@ -85,11 +82,8 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
         schema = retainRoots(schema);
       }
 
-      List<String> enumOptionsList = enumOptions != null
-          ? Arrays.asList(enumOptions)
-          : Collections.<String>emptyList();
       JavaGenerator javaGenerator = JavaGenerator.get(schema)
-          .withOptions(!noOptions, enumOptionsList)
+          .withOptions(!noOptions)
           .withAndroid(emitAndroid)
           .withCompact(emitCompact);
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -523,21 +523,18 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
   }
 
   public enum FooBarBazEnum implements WireEnum {
-    FOO(1, 17),
+    FOO(1),
 
-    BAR(2, null),
+    BAR(2),
 
-    BAZ(3, 18);
+    BAZ(3);
 
     public static final ProtoAdapter<FooBarBazEnum> ADAPTER = ProtoAdapter.newEnumAdapter(FooBarBazEnum.class);
 
     private final int value;
 
-    public final Integer enum_value_option;
-
-    FooBarBazEnum(int value, Integer enum_value_option) {
+    FooBarBazEnum(int value) {
       this.value = value;
-      this.enum_value_option = enum_value_option;
     }
 
     /**


### PR DESCRIPTION
If we want to prune enum options, we should use the pruning mechanism.

Closes https://github.com/square/wire/issues/439