### PR TITLE
Allow pruning to exclude members.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/CommandLineOptions.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/CommandLineOptions.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire;
 
+import com.squareup.wire.schema.IdentifierSet;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -36,7 +37,7 @@ final class CommandLineOptions {
   final List<String> protoPaths;
   final String javaOut;
   final List<String> sourceFileNames;
-  final List<String> roots;
+  final IdentifierSet identifierSet;
   final boolean emitOptions;
   final boolean quiet;
   final boolean dryRun;
@@ -44,13 +45,13 @@ final class CommandLineOptions {
   final boolean emitCompact;
 
   CommandLineOptions(String protoPath, String javaOut, List<String> sourceFileNames,
-      List<String> roots, boolean emitOptions, boolean quiet, boolean dryRun, boolean emitAndroid,
-      boolean emitCompact) {
+      IdentifierSet identifierSet, boolean emitOptions, boolean quiet, boolean dryRun,
+      boolean emitAndroid, boolean emitCompact) {
     this.emitCompact = emitCompact;
     this.protoPaths = Arrays.asList(protoPath);
     this.javaOut = javaOut;
     this.sourceFileNames = sourceFileNames;
-    this.roots = roots;
+    this.identifierSet = identifierSet;
     this.emitOptions = emitOptions;
     this.quiet = quiet;
     this.dryRun = dryRun;
@@ -106,7 +107,7 @@ final class CommandLineOptions {
    */
   CommandLineOptions(String... args) throws WireException {
     List<String> sourceFileNames = new ArrayList<>();
-    List<String> roots = new ArrayList<>();
+    IdentifierSet.Builder identifierSetBuilder = new IdentifierSet.Builder();
     boolean emitOptions = true;
     List<String> protoPaths = new ArrayList<>();
     String javaOut = null;
@@ -130,7 +131,9 @@ final class CommandLineOptions {
         }
         sourceFileNames.addAll(Arrays.asList(fileNames));
       } else if (arg.startsWith(ROOTS_FLAG)) {
-        roots.addAll(splitArg(arg, ROOTS_FLAG.length()));
+        for (String root : splitArg(arg, ROOTS_FLAG.length())) {
+          identifierSetBuilder.include(root);
+        }
       } else if (arg.equals(NO_OPTIONS_FLAG)) {
         emitOptions = false;
       } else if (arg.equals(QUIET_FLAG)) {
@@ -151,7 +154,7 @@ final class CommandLineOptions {
     this.protoPaths = protoPaths;
     this.javaOut = javaOut;
     this.sourceFileNames = sourceFileNames;
-    this.roots = roots;
+    this.identifierSet = identifierSetBuilder.build();
     this.emitOptions = emitOptions;
     this.quiet = quiet;
     this.dryRun = dryRun;

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.java
@@ -78,9 +78,9 @@ public final class WireCompiler {
     }
     Schema schema = schemaLoader.load();
 
-    if (!options.roots.isEmpty()) {
+    if (!options.identifierSet.includesEverything() || !options.identifierSet.excludesNothing()) {
       log.info("Analyzing dependencies of root types.");
-      schema = schema.retainRoots(options.roots);
+      schema = schema.prune(options.identifierSet);
     }
 
     JavaGenerator javaGenerator = JavaGenerator.get(schema)

--- a/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.java
@@ -85,15 +85,15 @@ public class CommandLineOptionsTest {
 
   @Test public void roots() throws Exception {
     CommandLineOptions options = new CommandLineOptions();
-    assertThat(options.roots).isEmpty();
+    assertThat(options.identifierSet.includesEverything()).isTrue();
+    assertThat(options.identifierSet.excludesNothing()).isTrue();
 
     options = new CommandLineOptions("--roots=com.example.foo");
-    List<String> expected = new ArrayList<>();
-    expected.add("com.example.foo");
-    assertThat(options.roots).isEqualTo(expected);
+    assertThat(options.identifierSet.includes).containsExactly("com.example.foo");
+
     options = new CommandLineOptions("--roots=com.example.foo,com.example.bar");
-    expected.add("com.example.bar");
-    assertThat(options.roots).isEqualTo(expected);
+    assertThat(options.identifierSet.includes)
+        .containsExactly("com.example.foo", "com.example.bar");
   }
 
   @Test public void  emitOptions() throws Exception {

--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.java
@@ -17,12 +17,12 @@ package com.squareup.wire;
 
 import com.google.common.jimfs.Configuration;
 import com.google.common.jimfs.Jimfs;
+import com.squareup.wire.schema.IdentifierSet;
 import com.squareup.wire.schema.SchemaException;
 import java.io.IOException;
 import java.nio.file.FileSystem;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import okio.Okio;
 import okio.Source;
 import org.junit.Test;
@@ -41,7 +41,7 @@ public class WireCompilerErrorTest {
    */
   private void compile(String source) throws Exception {
     CommandLineOptions options = new CommandLineOptions("/source",  "/target",
-        singletonList("test.proto"), new ArrayList<String>(), true,
+        singletonList("test.proto"), new IdentifierSet.Builder().build(), true,
         false, false, false, false);
 
     Path test = fileSystem.getPath("/source/test.proto");

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -6,6 +6,7 @@ import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.wire.java.JavaGenerator;
 import com.squareup.wire.schema.EnumType;
+import com.squareup.wire.schema.IdentifierSet;
 import com.squareup.wire.schema.Location;
 import com.squareup.wire.schema.MessageType;
 import com.squareup.wire.schema.ProtoFile;
@@ -111,7 +112,13 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
     Stopwatch stopwatch = Stopwatch.createStarted();
     int oldSize = countTypes(schema);
 
-    Schema prunedSchema = schema.retainRoots(Arrays.asList(roots));
+    IdentifierSet.Builder identifierSetBuilder = new IdentifierSet.Builder();
+    for (String root : roots) {
+      identifierSetBuilder.include(root);
+    }
+    IdentifierSet identifierSet = identifierSetBuilder.build();
+
+    Schema prunedSchema = schema.prune(identifierSet);
     int newSize = countTypes(prunedSchema);
 
     getLog().info(String.format("Pruned schema from %s types to %s types in %s",

--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.java
@@ -118,21 +118,17 @@ public final class EnumType extends Type {
     }
   }
 
-  @Override Type retainAll(IdentifierSet identifiers) {
+  @Override Type retainAll(MarkSet markSet) {
     // If this type is not retained, prune it.
-    if (!identifiers.contains(protoType)) return null;
+    if (!markSet.contains(protoType)) return null;
 
-    ImmutableList<EnumConstant> retainedConstants = constants;
-    if (!identifiers.containsAllMembers(protoType)) {
-      ImmutableList.Builder<EnumConstant> retainedConstantsBuilder = ImmutableList.builder();
-      for (EnumConstant constant : constants) {
-        if (identifiers.contains(protoType, constant.name())) {
-          retainedConstantsBuilder.add(constant);
-        }
+    ImmutableList.Builder<EnumConstant> retainedConstants = ImmutableList.builder();
+    for (EnumConstant constant : constants) {
+      if (markSet.contains(protoType, constant.name())) {
+        retainedConstants.add(constant);
       }
-      retainedConstants = retainedConstantsBuilder.build();
     }
 
-    return new EnumType(protoType, element, retainedConstants, options);
+    return new EnumType(protoType, element, retainedConstants.build(), options);
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
@@ -132,6 +132,10 @@ public final class Field {
     return extension;
   }
 
+  Field retainAll(MarkSet markSet) {
+    return markSet.contains(type) ? this : null;
+  }
+
   public enum Label {
     OPTIONAL, REQUIRED, REPEATED,
     /** Indicates the field is a member of a {@code oneof} block. */

--- a/wire-schema/src/main/java/com/squareup/wire/schema/MarkSet.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/MarkSet.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema;
+
+import java.util.NavigableSet;
+import java.util.TreeSet;
+
+final class MarkSet {
+  final IdentifierSet identifierSet;
+  final NavigableSet<String> marks;
+
+  public MarkSet(IdentifierSet identifierSet) {
+    this.identifierSet = identifierSet;
+    this.marks = new TreeSet<>();
+
+    for (String include : identifierSet.includes) {
+      marks.add(include);
+      int hash = include.indexOf('#');
+      if (hash != -1) marks.add(include.substring(0, hash));
+    }
+  }
+
+  /**
+   * Marks a type as transitively reachable by the includes set. Returns true if the mark is new,
+   * the type will be retained, and its own dependencies should be traversed.
+   */
+  boolean mark(ProtoType type) {
+    if (type == null) throw new NullPointerException("type == null");
+    if (identifierSet.excludes(type)) return false;
+    return marks.add(type.toString());
+  }
+
+  /**
+   * Marks a member as transitively reachable by the includes set. Returns true if the mark is new,
+   * the member will be retained, and its own dependencies should be traversed.
+   */
+  boolean mark(ProtoType type, String member) {
+    if (identifierSet.excludes(type, member)) return false;
+    if (!contains(type)) throw new IllegalStateException();
+    if (contains(type, member)) return false;
+    return marks.add(type + "#" + member);
+  }
+
+  /** Returns true if {@code member} is marked and should be retained. */
+  boolean contains(ProtoType type, String member) {
+    if (type == null) throw new NullPointerException("type == null");
+    if (member == null) throw new NullPointerException("member == null");
+    if (identifierSet.excludes(type, member)) return false;
+    if (identifierSet.includesEverything()) return true;
+
+    return containsAllMembers(type) || marks.contains(type + "#" + member);
+  }
+
+  /** Returns true if {@code type} is marked and should be retained. */
+  boolean contains(ProtoType type) {
+    if (type == null) throw new NullPointerException("type == null");
+    if (identifierSet.excludes(type)) return false;
+    if (identifierSet.includesEverything()) return true;
+
+    return marks.contains(type.toString());
+  }
+
+  /** Returns true if all members of {@code type} are marked and should be retained. */
+  boolean containsAllMembers(ProtoType type) {
+    return contains(type) && !containsAnyMember(type);
+  }
+
+  private boolean containsAnyMember(ProtoType typeName) {
+    // If there's a member field, it will sort immediately after <Name># in the marks set.
+    String prefix = typeName + "#";
+    String ceiling = marks.ceiling(prefix);
+    return ceiling != null && ceiling.startsWith(prefix);
+  }
+}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -115,10 +115,10 @@ public final class ProtoFile {
   }
 
   /** Returns a new proto file that omits types and services not in {@code identifiers}. */
-  ProtoFile retainAll(IdentifierSet identifiers) {
+  ProtoFile retainAll(MarkSet markSet) {
     ImmutableList.Builder<Type> retainedTypes = ImmutableList.builder();
     for (Type type : types) {
-      Type retainedType = type.retainAll(identifiers);
+      Type retainedType = type.retainAll(markSet);
       if (retainedType != null) {
         retainedTypes.add(retainedType);
       }
@@ -126,7 +126,7 @@ public final class ProtoFile {
 
     ImmutableList.Builder<Service> retainedServices = ImmutableList.builder();
     for (Service service : services) {
-      Service retainedService = service.retainAll(identifiers);
+      Service retainedService = service.retainAll(markSet);
       if (retainedService != null) {
         retainedServices.add(retainedService);
       }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Rpc.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Rpc.java
@@ -68,4 +68,8 @@ public final class Rpc {
     linker.validateImport(location(), requestType);
     linker.validateImport(location(), responseType);
   }
+
+  Rpc retainAll(MarkSet markSet) {
+    return markSet.contains(requestType) && markSet.contains(responseType) ? this : null;
+  }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -19,7 +19,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Ordering;
 import com.squareup.wire.ProtoAdapter;
-import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -51,18 +50,11 @@ public final class Schema {
   }
 
   /**
-   * Returns a copy of this schema that retains only the types and services in {@code roots}, plus
-   * their transitive dependencies. Names in {@code roots} should be of the following forms:
-   *
-   * <ul>
-   *   <li>Fully qualified message names, like {@code squareup.protos.person.Person}.
-   *   <li>Fully qualified service names, like {@code com.squareup.services.ExampleService}.
-   *   <li>Fully qualified service names, followed by a '#', followed by an RPC name, like
-   *       {@code com.squareup.services.ExampleService#SendSomeData}.
-   * </ul>
+   * Returns a copy of this schema that retains only the types and services selected by {@code
+   * identifierSet}, plus their transitive dependencies.
    */
-  public Schema retainRoots(Collection<String> roots) {
-    return new Pruner().retainRoots(this, roots);
+  public Schema prune(IdentifierSet identifierSet) {
+    return new Pruner(this, identifierSet).prune();
   }
 
   /**

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Service.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Service.java
@@ -96,25 +96,20 @@ public final class Service {
     }
   }
 
-  Service retainAll(IdentifierSet identifiers) {
+  Service retainAll(MarkSet markSet) {
     // If this service is not retained, prune it.
-    if (!identifiers.contains(protoType)) {
+    if (!markSet.contains(protoType)) {
       return null;
     }
 
-    ImmutableList<Rpc> retainedRpcs = rpcs;
-
-    // If any of our RPCs are specifically retained, retain only that set.
-    if (!identifiers.containsAllMembers(protoType)) {
-      ImmutableList.Builder<Rpc> retainedRpcsBuilder = ImmutableList.builder();
-      for (Rpc rpc : rpcs) {
-        if (identifiers.contains(protoType, rpc.name())) {
-          retainedRpcsBuilder.add(rpc);
-        }
+    ImmutableList.Builder<Rpc> retainedRpcs = ImmutableList.builder();
+    for (Rpc rpc : rpcs) {
+      Rpc retainedRpc = rpc.retainAll(markSet);
+      if (retainedRpc != null && markSet.contains(protoType, rpc.name())) {
+        retainedRpcs.add(retainedRpc);
       }
-      retainedRpcs = retainedRpcsBuilder.build();
     }
 
-    return new Service(protoType, element, retainedRpcs, options);
+    return new Service(protoType, element, retainedRpcs.build(), options);
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
@@ -35,7 +35,7 @@ public abstract class Type {
   abstract void validate(Linker linker);
   abstract void link(Linker linker);
   abstract void linkOptions(Linker linker);
-  abstract Type retainAll(IdentifierSet identifiers);
+  abstract Type retainAll(MarkSet markSet);
 
   static Type get(String packageName, ProtoType protoType, TypeElement type) {
     if (type instanceof EnumElement) {

--- a/wire-schema/src/test/java/com/squareup/wire/schema/MarkSetTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/MarkSetTest.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class MarkSetTest {
+  @Test public void emptyIncludesContainsEverything() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder().build());
+    assertThat(set.contains(ProtoType.get("a.b.Message"))).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isTrue();
+  }
+
+  @Test public void includeTypesOnly() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .include("a.b.Message")
+        .include("a.b.MessageWithSuffix")
+        .build());
+
+    assertThat(set.contains(ProtoType.get("a.b.Message"))).isTrue();
+    assertThat(set.containsAllMembers(ProtoType.get("a.b.Message"))).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isTrue();
+
+    assertThat(set.contains(ProtoType.get("a.b.Other"))).isFalse();
+    assertThat(set.containsAllMembers(ProtoType.get("a.b.Other"))).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Other"), "member")).isFalse();
+  }
+
+  @Test public void includeMembersOnly() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .include("a.b.Message#member")
+        .build());
+
+    assertThat(set.contains(ProtoType.get("a.b.Message"))).isTrue();
+    assertThat(set.containsAllMembers(ProtoType.get("a.b.Message"))).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "other")).isFalse();
+
+    assertThat(set.contains(ProtoType.get("a.b.Other"))).isFalse();
+    assertThat(set.containsAllMembers(ProtoType.get("a.b.Other"))).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Other"), "member")).isFalse();
+  }
+
+  @Test public void includeTypeAndUnrelatedMember() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .include("a.b.Message")
+        .include("a.b.AnotherMessage#member")
+        .build());
+
+    assertThat(set.contains(ProtoType.get("a.b.Message"))).isTrue();
+    assertThat(set.containsAllMembers(ProtoType.get("a.b.Message"))).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isTrue();
+
+    assertThat(set.contains(ProtoType.get("a.b.AnotherMessage"))).isTrue();
+    assertThat(set.containsAllMembers(ProtoType.get("a.b.AnotherMessage"))).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.AnotherMessage"), "member")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.AnotherMessage"), "other")).isFalse();
+
+    assertThat(set.contains(ProtoType.get("a.b.Other"))).isFalse();
+    assertThat(set.containsAllMembers(ProtoType.get("a.b.Other"))).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Other"), "member")).isFalse();
+  }
+
+  @Test public void markAddsIfAbsent() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .include("a.b.Message#member")
+        .build());
+    assertThat(set.mark(ProtoType.get("a.b.Message"), "another")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "another")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "other")).isFalse(); // Omitted.
+  }
+
+  @Test public void markDoesNotConstrain() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .include("a.b.Message")
+        .build());
+    assertThat(set.mark(ProtoType.get("a.b.Message"), "another")).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "another")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "other")).isTrue(); // Retained!
+  }
+
+  @Test public void markMultipleMembers() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder().build());
+    ProtoType message = ProtoType.get("a.b.Message");
+    assertThat(set.mark(message)).isTrue();
+    assertThat(set.mark(message, "member")).isFalse();
+    assertThat(set.mark(message, "another")).isFalse();
+    assertThat(set.contains(message)).isTrue();
+    assertThat(set.contains(message, "member")).isTrue();
+    assertThat(set.contains(message, "another")).isTrue();
+    assertThat(set.contains(message, "other")).isTrue();
+  }
+
+  @Test public void includeMultipleMembers() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .include("a.b.Message#member")
+        .include("a.b.Message#another")
+        .build());
+    assertThat(set.contains(ProtoType.get("a.b.Message"))).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "another")).isTrue();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "other")).isFalse();
+  }
+
+  @Test public void excludeTypeMarkType() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .exclude("a.b.Message")
+        .build());
+    assertThat(set.mark(ProtoType.get("a.b.Message"))).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Message"))).isFalse();
+  }
+
+  @Test public void excludeTypeMarkMember() throws Exception {
+    MarkSet set = new MarkSet(new IdentifierSet.Builder()
+        .exclude("a.b.Message")
+        .build());
+    assertThat(set.mark(ProtoType.get("a.b.Message"), "member")).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Message"))).isFalse();
+    assertThat(set.contains(ProtoType.get("a.b.Message"), "member")).isFalse();
+  }
+}

--- a/wire-schema/src/test/java/com/squareup/wire/schema/PrunerTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/PrunerTest.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.wire.schema;
 
-import com.google.common.collect.ImmutableList;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -29,7 +28,9 @@ public final class PrunerTest {
             + "message MessageB {\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("MessageA"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("MessageA")
+        .build());
     assertThat(pruned.getType("MessageA")).isNotNull();
     assertThat(pruned.getType("MessageB")).isNull();
   }
@@ -46,7 +47,9 @@ public final class PrunerTest {
             + "  }\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("A.B"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("A.B")
+        .build());
     assertThat(pruned.getType("A")).isNotNull();
     assertThat(pruned.getType("A.B")).isNotNull();
     assertThat(pruned.getType("A.B.C")).isNull();
@@ -67,7 +70,9 @@ public final class PrunerTest {
             + "message MessageD {\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("MessageA"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("MessageA")
+        .build());
     assertThat(pruned.getType("MessageA")).isNotNull();
     assertThat(pruned.getType("MessageB")).isNotNull();
     assertThat(pruned.getType("MessageC")).isNotNull();
@@ -90,7 +95,9 @@ public final class PrunerTest {
             + "  rpc CallB (RequestB) returns (ResponseB);\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Service#CallA"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Service#CallA")
+        .build());
     assertThat(pruned.getService("Service").rpc("CallA")).isNotNull();
     assertThat(pruned.getType("RequestA")).isNotNull();
     assertThat(pruned.getType("ResponseA")).isNotNull();
@@ -109,7 +116,9 @@ public final class PrunerTest {
             + "message MessageB {\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("MessageA#b"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("MessageA#b")
+        .build());
     assertThat(((MessageType) pruned.getType("MessageA")).field("b")).isNotNull();
     assertThat(((MessageType) pruned.getType("MessageA")).field("c")).isNull();
     assertThat(pruned.getType("MessageB")).isNull();
@@ -130,7 +139,9 @@ public final class PrunerTest {
             + "message MessageD {\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("MessageA#b"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("MessageA#b")
+        .build());
     assertThat(pruned.getType("MessageA")).isNotNull();
     assertThat(((MessageType) pruned.getType("MessageA")).field("b")).isNotNull();
     assertThat(((MessageType) pruned.getType("MessageA")).field("d")).isNull();
@@ -154,7 +165,10 @@ public final class PrunerTest {
             + "message MessageD {\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("MessageA#b", "MessageB#c"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("MessageA#b")
+        .include("MessageB#c")
+        .build());
     assertThat(pruned.getType("MessageA")).isNotNull();
     assertThat(((MessageType) pruned.getType("MessageA")).field("b")).isNotNull();
     assertThat(pruned.getType("MessageB")).isNotNull();
@@ -173,7 +187,9 @@ public final class PrunerTest {
             + "  PAPER = 2;\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Roshambo#SCISSORS"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Roshambo#SCISSORS")
+        .build());
     assertThat(((EnumType) pruned.getType("Roshambo")).constant("ROCK")).isNull();
     assertThat(((EnumType) pruned.getType("Roshambo")).constant("SCISSORS")).isNotNull();
     assertThat(((EnumType) pruned.getType("Roshambo")).constant("PAPER")).isNull();
@@ -191,7 +207,10 @@ public final class PrunerTest {
             + "  PAPER = 2;\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Message", "Roshambo#SCISSORS"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Message")
+        .include("Roshambo#SCISSORS")
+        .build());
     assertThat(pruned.getType("Message")).isNotNull();
     assertThat(((MessageType) pruned.getType("Message")).field("roshambo")).isNotNull();
     assertThat(pruned.getType("Roshambo")).isNotNull();
@@ -212,7 +231,9 @@ public final class PrunerTest {
             + "}\n")
         .add("google/protobuf/descriptor.proto")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Message#f"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Message#f")
+        .build());
     assertThat(((MessageType) pruned.getType("Message")).field("f")).isNotNull();
     assertThat(((MessageType) pruned.getType("google.protobuf.FieldOptions"))).isNotNull();
   }
@@ -230,7 +251,9 @@ public final class PrunerTest {
             + "}\n")
         .add("google/protobuf/descriptor.proto")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Message#g"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Message#g")
+        .build());
     assertThat(((MessageType) pruned.getType("google.protobuf.FieldOptions"))).isNull();
   }
 
@@ -251,7 +274,10 @@ public final class PrunerTest {
             + "}\n")
         .add("google/protobuf/descriptor.proto")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Message", "SomeFieldOptions#b"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Message")
+        .include("SomeFieldOptions#b")
+        .build());
     assertThat(((MessageType) pruned.getType("Message")).field("f")).isNotNull();
     assertThat(((MessageType) pruned.getType("SomeFieldOptions")).field("a")).isNotNull();
     assertThat(((MessageType) pruned.getType("SomeFieldOptions")).field("b")).isNotNull();
@@ -275,7 +301,9 @@ public final class PrunerTest {
             + "}\n")
         .add("google/protobuf/descriptor.proto")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Message"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Message")
+        .build());
     assertThat(((MessageType) pruned.getType("Message")).field("f")).isNotNull();
     assertThat(((MessageType) pruned.getType("SomeFieldOptions")).field("a")).isNotNull();
     assertThat(((MessageType) pruned.getType("SomeFieldOptions")).field("b")).isNotNull();
@@ -292,7 +320,9 @@ public final class PrunerTest {
             + "  optional string b = 2;\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Message"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Message")
+        .build());
     assertThat(((MessageType) pruned.getType("Message")).field("a")).isNotNull();
     assertThat(((MessageType) pruned.getType("Message")).extensionField("b")).isNotNull();
   }
@@ -309,10 +339,89 @@ public final class PrunerTest {
             + "  optional string d = 4;\n"
             + "}\n")
         .build();
-    Schema pruned = schema.retainRoots(ImmutableList.of("Message#a", "Message#c"));
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("Message#a")
+        .include("Message#c")
+        .build());
     assertThat(((MessageType) pruned.getType("Message")).field("a")).isNotNull();
     assertThat(((MessageType) pruned.getType("Message")).field("b")).isNull();
     assertThat(((MessageType) pruned.getType("Message")).extensionField("c")).isNotNull();
     assertThat(((MessageType) pruned.getType("Message")).extensionField("d")).isNull();
+  }
+
+  /** When we include excludes only, the mark phase is skipped. */
+  @Test public void excludeWithoutInclude() throws Exception {
+    Schema schema = new SchemaBuilder()
+        .add("service.proto", ""
+            + "message MessageA {\n"
+            + "  optional string b = 1;\n"
+            + "  optional string c = 2;\n"
+            + "}\n")
+        .build();
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .exclude("MessageA#c")
+        .build());
+    assertThat(((MessageType) pruned.getType("MessageA")).field("b")).isNotNull();
+    assertThat(((MessageType) pruned.getType("MessageA")).field("c")).isNull();
+  }
+
+  @Test public void excludeField() throws Exception {
+    Schema schema = new SchemaBuilder()
+        .add("service.proto", ""
+            + "message MessageA {\n"
+            + "  optional string b = 1;\n"
+            + "  optional string c = 2;\n"
+            + "}\n")
+        .build();
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("MessageA")
+        .exclude("MessageA#c")
+        .build());
+    assertThat(((MessageType) pruned.getType("MessageA")).field("b")).isNotNull();
+    assertThat(((MessageType) pruned.getType("MessageA")).field("c")).isNull();
+  }
+
+  @Test public void excludeTypeExcludesField() throws Exception {
+    Schema schema = new SchemaBuilder()
+        .add("service.proto", ""
+            + "message MessageA {\n"
+            + "  optional MessageB b = 1;\n"
+            + "  optional MessageC c = 2;\n"
+            + "}\n"
+            + "message MessageB {\n"
+            + "}\n"
+            + "message MessageC {\n"
+            + "}\n")
+        .build();
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("MessageA")
+        .exclude("MessageC")
+        .build());
+    assertThat(pruned.getType("MessageB")).isNotNull();
+    assertThat(((MessageType) pruned.getType("MessageA")).field("b")).isNotNull();
+    assertThat(pruned.getType("MessageC")).isNull();
+    assertThat(((MessageType) pruned.getType("MessageA")).field("c")).isNull();
+  }
+
+  @Test public void excludeTypeExcludesRpc() throws Exception {
+    Schema schema = new SchemaBuilder()
+        .add("service.proto", ""
+            + "service ServiceA {\n"
+            + "  rpc CallB (MessageB) returns (MessageB);\n"
+            + "  rpc CallC (MessageC) returns (MessageC);\n"
+            + "}\n"
+            + "message MessageB {\n"
+            + "}\n"
+            + "message MessageC {\n"
+            + "}\n")
+        .build();
+    Schema pruned = schema.prune(new IdentifierSet.Builder()
+        .include("ServiceA")
+        .exclude("MessageC")
+        .build());
+    assertThat(pruned.getType("MessageB")).isNotNull();
+    assertThat(pruned.getService("ServiceA").rpc("CallB")).isNotNull();
+    assertThat(pruned.getType("MessageC")).isNull();
+    assertThat(pruned.getService("ServiceA").rpc("CallC")).isNull();
   }
 }


### PR DESCRIPTION
This splits the IdentifierSet class into two:
 - IdentifierSet is the list of includes and excludes. It is immutable.
 - MarkSet keeps track of what has been marked in the marking phase. It
   is a working object that is used once and discarded.

Options are not currently subject to pruning; that needs to come in a follow up.
Also interesting will be excluding by package. Currently only types and members
can be excluded; this is likely insufficient.