### PR TITLE
Change options to reference values by member instead of by field.

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnumConstant.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnumConstant.java
@@ -50,7 +50,7 @@ public final class EnumConstant {
     options.link(linker);
   }
 
-  EnumConstant retainAll(MarkSet markSet) {
-    return new EnumConstant(element, options.retainAll(markSet));
+  EnumConstant retainAll(Schema schema, MarkSet markSet) {
+    return new EnumConstant(element, options.retainAll(schema, markSet));
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/MarkSet.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/MarkSet.java
@@ -43,6 +43,10 @@ final class MarkSet {
     return marks.add(type.toString());
   }
 
+  boolean mark(ProtoMember protoMember) {
+    return mark(protoMember.type(), protoMember.member());
+  }
+
   /**
    * Marks a member as transitively reachable by the includes set. Returns true if the mark is new,
    * the member will be retained, and its own dependencies should be traversed.
@@ -83,5 +87,9 @@ final class MarkSet {
     String prefix = typeName + "#";
     String ceiling = marks.ceiling(prefix);
     return ceiling != null && ceiling.startsWith(prefix);
+  }
+
+  public boolean contains(ProtoMember protoMember) {
+    return contains(protoMember.type(), protoMember.member());
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/OneOf.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/OneOf.java
@@ -51,8 +51,8 @@ public final class OneOf {
     }
   }
 
-  OneOf retainAll(MarkSet markSet, ProtoType enclosingType) {
-    ImmutableList<Field> retainedFields = Field.retainAll(markSet, enclosingType, fields);
+  OneOf retainAll(Schema schema, MarkSet markSet, ProtoType enclosingType) {
+    ImmutableList<Field> retainedFields = Field.retainAll(schema, markSet, enclosingType, fields);
     if (retainedFields.isEmpty()) return null;
     return new OneOf(element, retainedFields);
   }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -115,10 +115,10 @@ public final class ProtoFile {
   }
 
   /** Returns a new proto file that omits types and services not in {@code identifiers}. */
-  ProtoFile retainAll(MarkSet markSet) {
+  ProtoFile retainAll(Schema schema, MarkSet markSet) {
     ImmutableList.Builder<Type> retainedTypes = ImmutableList.builder();
     for (Type type : types) {
-      Type retainedType = type.retainAll(markSet);
+      Type retainedType = type.retainAll(schema, markSet);
       if (retainedType != null) {
         retainedTypes.add(retainedType);
       }
@@ -126,14 +126,14 @@ public final class ProtoFile {
 
     ImmutableList.Builder<Service> retainedServices = ImmutableList.builder();
     for (Service service : services) {
-      Service retainedService = service.retainAll(markSet);
+      Service retainedService = service.retainAll(schema, markSet);
       if (retainedService != null) {
         retainedServices.add(retainedService);
       }
     }
 
     return new ProtoFile(element, retainedTypes.build(), retainedServices.build(),
-        extendList, options.retainAll(markSet));
+        extendList, options.retainAll(schema, markSet));
   }
 
   @Override public String toString() {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoMember.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoMember.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2015 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema;
+
+/**
+ * Identifies a field, enum or RPC on a declaring type. Members are encoded as strings containing a
+ * type name, a hash, and a member name, like {@code squareup.dinosaurs.Dinosaur#length_meters}.
+ *
+ * <p>A member's name is typically a simple name like "length_meters" or "packed". If the member
+ * field is an extension to its type, that name is prefixed with its enclosing package. This yields
+ * a member name with two packages, like {@code google.protobuf.FieldOptions#squareup.units.unit}.
+ */
+public final class ProtoMember {
+  private final ProtoType type;
+  private final String member;
+
+  private ProtoMember(ProtoType type, String member) {
+    this.type = type;
+    this.member = member;
+  }
+
+  public static ProtoMember get(String typeAndMember) {
+    int hash = typeAndMember.indexOf('#');
+    if (hash == -1) throw new IllegalArgumentException("expected a '#' in " + typeAndMember);
+    ProtoType type = ProtoType.get(typeAndMember.substring(0, hash));
+    String member = typeAndMember.substring(hash + 1);
+    return new ProtoMember(type, member);
+  }
+
+  public static ProtoMember get(ProtoType type, String member) {
+    return new ProtoMember(type, member);
+  }
+
+  public static ProtoMember get(ProtoType type, Field field) {
+    String member = field.isExtension() ? field.qualifiedName() : field.name();
+    return new ProtoMember(type, member);
+  }
+
+  public ProtoType type() {
+    return type;
+  }
+
+  public String member() {
+    return member;
+  }
+
+  @Override public boolean equals(Object o) {
+    return o instanceof ProtoMember
+        && type.equals(((ProtoMember) o).type)
+        && member.equals(((ProtoMember) o).member);
+  }
+
+  @Override public int hashCode() {
+    return type.hashCode() * 37 + member.hashCode();
+  }
+
+  @Override public String toString() {
+    return type + "#" + member;
+  }
+}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Rpc.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Rpc.java
@@ -69,9 +69,9 @@ public final class Rpc {
     linker.validateImport(location(), responseType);
   }
 
-  Rpc retainAll(MarkSet markSet) {
+  Rpc retainAll(Schema schema, MarkSet markSet) {
     if (!markSet.contains(requestType) || !markSet.contains(responseType)) return null;
-    Rpc result = new Rpc(element, options.retainAll(markSet));
+    Rpc result = new Rpc(element, options.retainAll(schema, markSet));
     result.requestType = requestType;
     result.responseType = responseType;
     return result;

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -89,6 +89,16 @@ public final class Schema {
     return getType(protoType.toString());
   }
 
+  public Field getField(ProtoMember protoMember) {
+    Type type = getType(protoMember.type());
+    if (!(type instanceof MessageType)) return null;
+    Field field = ((MessageType) type).field(protoMember.member());
+    if (field == null) {
+      field = ((MessageType) type).extensionField(protoMember.member());
+    }
+    return field;
+  }
+
   private static ImmutableMap<String, Type> buildTypesIndex(Iterable<ProtoFile> protoFiles) {
     Map<String, Type> result = new LinkedHashMap<>();
     for (ProtoFile protoFile : protoFiles) {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Service.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Service.java
@@ -96,7 +96,7 @@ public final class Service {
     }
   }
 
-  Service retainAll(MarkSet markSet) {
+  Service retainAll(Schema schema, MarkSet markSet) {
     // If this service is not retained, prune it.
     if (!markSet.contains(protoType)) {
       return null;
@@ -104,12 +104,13 @@ public final class Service {
 
     ImmutableList.Builder<Rpc> retainedRpcs = ImmutableList.builder();
     for (Rpc rpc : rpcs) {
-      Rpc retainedRpc = rpc.retainAll(markSet);
+      Rpc retainedRpc = rpc.retainAll(schema, markSet);
       if (retainedRpc != null && markSet.contains(protoType, rpc.name())) {
         retainedRpcs.add(retainedRpc);
       }
     }
 
-    return new Service(protoType, element, retainedRpcs.build(), options.retainAll(markSet));
+    return new Service(protoType, element, retainedRpcs.build(),
+        options.retainAll(schema, markSet));
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
@@ -32,10 +32,10 @@ public abstract class Type {
   public abstract String documentation();
   public abstract Options options();
   public abstract ImmutableList<Type> nestedTypes();
-  abstract void validate(Linker linker);
   abstract void link(Linker linker);
   abstract void linkOptions(Linker linker);
-  abstract Type retainAll(MarkSet markSet);
+  abstract void validate(Linker linker);
+  abstract Type retainAll(Schema schema, MarkSet markSet);
 
   static Type get(String packageName, ProtoType protoType, TypeElement type) {
     if (type instanceof EnumElement) {

--- a/wire-schema/src/test/java/com/squareup/wire/schema/OptionsTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/OptionsTest.java
@@ -45,11 +45,9 @@ public final class OptionsTest {
         .add("google/protobuf/descriptor.proto")
         .build();
 
-    Field fooOptions = extensionField(schema, "foo_options");
-
-    MessageType fooOptionsType = (MessageType) schema.getType("FooOptions");
-    Field opt1 = fooOptionsType.field("opt1");
-    Field opt2 = fooOptionsType.field("opt2");
+    ProtoMember fooOptions = ProtoMember.get(Options.FIELD_OPTIONS, "foo_options");
+    ProtoMember opt1 = ProtoMember.get(ProtoType.get("FooOptions"), "opt1");
+    ProtoMember opt2 = ProtoMember.get(ProtoType.get("FooOptions"), "opt2");
 
     MessageType bar = (MessageType) schema.getType("Bar");
     assertThat(bar.field("a").options().map()).isEqualTo(ImmutableMap.of(
@@ -100,10 +98,11 @@ public final class OptionsTest {
             + "}\n")
         .add("google/protobuf/descriptor.proto")
         .build();
-    Field moreOptions = extensionField(schema, "a.b.more_options");
-    Field evenMoreOptions = extensionField(schema, "a.c.even_more_options");
-    Field stringOption = ((MessageType) schema.getType("a.c.EvenMoreOptions"))
-        .field("string_option");
+    ProtoType moreOptionsType = ProtoType.get("a.b.MoreOptions");
+    ProtoType evenMoreOptionsType = ProtoType.get("a.c.EvenMoreOptions");
+    ProtoMember moreOptions = ProtoMember.get(Options.MESSAGE_OPTIONS, "a.b.more_options");
+    ProtoMember evenMoreOptions = ProtoMember.get(moreOptionsType, "a.c.even_more_options");
+    ProtoMember stringOption = ProtoMember.get(evenMoreOptionsType, "string_option");
     MessageType message = (MessageType) schema.getType("a.d.Message");
     assertThat(message.options().map()).isEqualTo(
         ImmutableMap.of(moreOptions, ImmutableMap.of(
@@ -135,16 +134,5 @@ public final class OptionsTest {
 
   private Set<String> set(String... elements) {
     return new LinkedHashSet<>(asList(elements));
-  }
-
-  private Field extensionField(Schema schema, String qualifiedName) {
-    for (ProtoFile protoFile : schema.protoFiles()) {
-      for (Extend extend : protoFile.extendList()) {
-        for (Field field : extend.fields()) {
-          if (field.qualifiedName().equals(qualifiedName)) return field;
-        }
-      }
-    }
-    return null;
   }
 }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/PrunerTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/PrunerTest.java
@@ -20,6 +20,8 @@ import java.util.Map;
 import org.junit.Test;
 
 import static com.google.common.collect.Iterables.getOnlyElement;
+import static com.squareup.wire.schema.Options.FIELD_OPTIONS;
+import static com.squareup.wire.schema.Options.MESSAGE_OPTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public final class PrunerTest {
@@ -484,8 +486,8 @@ public final class PrunerTest {
         .exclude("google.protobuf.FieldOptions#b")
         .build());
     Field field = ((MessageType) pruned.getType("Message")).field("f");
-    assertThat(field.options().get("a")).isEqualTo("a");
-    assertThat(field.options().get("b")).isNull();
+    assertThat(field.options().get(ProtoMember.get(FIELD_OPTIONS, "a"))).isEqualTo("a");
+    assertThat(field.options().get(ProtoMember.get(FIELD_OPTIONS, "b"))).isNull();
   }
 
   @Test public void excludedTypePrunesTopLevelOption() throws Exception {
@@ -508,9 +510,9 @@ public final class PrunerTest {
         .exclude("SomeFieldOptions")
         .build());
     Field field = ((MessageType) pruned.getType("Message")).field("f");
-    Map<Field, Object> map = field.options().map();
+    Map<ProtoMember, Object> map = field.options().map();
     Map.Entry<?, ?> onlyOption = getOnlyElement(map.entrySet());
-    assertThat(((Field) onlyOption.getKey()).name()).isEqualTo("b");
+    assertThat(((ProtoMember) onlyOption.getKey()).member()).isEqualTo("b");
     assertThat(onlyOption.getValue()).isEqualTo("b");
   }
 
@@ -534,9 +536,10 @@ public final class PrunerTest {
         .exclude("SomeFieldOptions#b")
         .build());
     Field field = ((MessageType) pruned.getType("Message")).field("f");
-    Map<?, ?> map = (Map<?, ?>) field.options().get("some_field_options");
+    Map<?, ?> map = (Map<?, ?>) field.options().get(
+        ProtoMember.get(FIELD_OPTIONS, "some_field_options"));
     Map.Entry<?, ?> onlyOption = getOnlyElement(map.entrySet());
-    assertThat(((Field) onlyOption.getKey()).name()).isEqualTo("a");
+    assertThat(((ProtoMember) onlyOption.getKey()).member()).isEqualTo("a");
     assertThat(onlyOption.getValue()).isEqualTo("a");
   }
 
@@ -569,9 +572,9 @@ public final class PrunerTest {
         .exclude("Dimensions")
         .build());
     Field field = ((MessageType) pruned.getType("Message")).field("f");
-    Map<Field, Object> map = field.options().map();
+    Map<ProtoMember, Object> map = field.options().map();
     Map.Entry<?, ?> onlyOption = getOnlyElement(map.entrySet());
-    assertThat(((Field) onlyOption.getKey()).name()).isEqualTo("b");
+    assertThat(((ProtoMember) onlyOption.getKey()).member()).isEqualTo("b");
     assertThat(onlyOption.getValue()).isEqualTo("b");
   }
 
@@ -616,7 +619,8 @@ public final class PrunerTest {
         .exclude("google.protobuf.MessageOptions#a")
         .build());
     MessageType message = (MessageType) pruned.getType("Message");
-    assertThat(message.options().get("a")).isNull();
-    assertThat(message.options().get("b")).isEqualTo(ImmutableList.of("b1", "b2"));
+    assertThat(message.options().get(ProtoMember.get(MESSAGE_OPTIONS, "a"))).isNull();
+    assertThat(message.options().get(ProtoMember.get(MESSAGE_OPTIONS, "b")))
+        .isEqualTo(ImmutableList.of("b1", "b2"));
   }
 }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
@@ -18,6 +18,7 @@ package com.squareup.wire.schema;
 import com.squareup.wire.schema.internal.Util;
 import org.junit.Test;
 
+import static com.squareup.wire.schema.Options.FIELD_OPTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.fail;
 
@@ -260,14 +261,14 @@ public final class SchemaTest {
     MessageType message = (MessageType) schema.getType("Message");
 
     Options aOptions = message.field("a").options();
-    assertThat(aOptions.get("color")).isNull();
-    assertThat(aOptions.get("deprecated")).isNull();
-    assertThat(aOptions.get("packed")).isNull();
+    assertThat(aOptions.get(ProtoMember.get(FIELD_OPTIONS, "color"))).isNull();
+    assertThat(aOptions.get(ProtoMember.get(FIELD_OPTIONS, "deprecated"))).isNull();
+    assertThat(aOptions.get(ProtoMember.get(FIELD_OPTIONS, "packed"))).isNull();
 
     Options bOptions = message.field("b").options();
-    assertThat(bOptions.get("color")).isEqualTo("red");
-    assertThat(bOptions.get("deprecated")).isEqualTo("true");
-    assertThat(bOptions.get("packed")).isEqualTo("true");
+    assertThat(bOptions.get(ProtoMember.get(FIELD_OPTIONS, "color"))).isEqualTo("red");
+    assertThat(bOptions.get(ProtoMember.get(FIELD_OPTIONS, "deprecated"))).isEqualTo("true");
+    assertThat(bOptions.get(ProtoMember.get(FIELD_OPTIONS, "packed"))).isEqualTo("true");
   }
 
   @Test public void duplicateOption() throws Exception {


### PR DESCRIPTION
The problem with fields is that we replace instances with different
fields when pruning, and that causes options to become stale.