### PR TITLE
Allow text format option separator to be omitted when value is a map.

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoParser.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoParser.java
@@ -451,7 +451,10 @@ public final class ProtoParser {
       subName = readName();
       c = readChar();
     }
-    if (c != keyValueSeparator) {
+    if (keyValueSeparator == ':' && c == '{') {
+      // In text format, values which are maps can omit a separator. Backtrack so it can be re-read.
+      pos--;
+    } else if (c != keyValueSeparator) {
       throw unexpected("expected '" + keyValueSeparator + "' in option");
     }
     OptionKindAndValue kindAndValue = readKindAndValue();


### PR DESCRIPTION
This feels dirty. Closes #487.