### PR TITLE
Ignore file options when pruning as they go nowhere.

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
@@ -58,11 +58,6 @@ final class Pruner {
     for (ProtoFile protoFile : schema.protoFiles()) {
       markRoots(protoFile);
     }
-
-    // File options are also marked, though not as roots.
-    for (ProtoFile protoFile : schema.protoFiles()) {
-      markOptions(protoFile.options());
-    }
   }
 
   private void markRoots(ProtoFile protoFile) {


### PR DESCRIPTION
File options values have no representation in our generated code and therefore should not cause transitive types to be included.