### PR TITLE
Drop unknown fields when parsing JSON

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
@@ -277,9 +277,10 @@ public class GsonTest {
     String json = gson.toJson(allTypes);
     assertThat(json).isEqualTo("{" + JSON_BASE + JSON_UNKNOWN_FIELDS + "}");
 
+    AllTypes allTypesWithKnownFields = allTypes.withoutUnknownFields();
     AllTypes parsed = gson.fromJson(json, AllTypes.class);
-    assertThat(parsed).isEqualTo(allTypes);
-    assertThat(parsed.toString()).isEqualTo(allTypes.toString());
-    assertThat(gson.toJson(parsed)).isEqualTo(gson.toJson(allTypes));
+    assertThat(parsed).isEqualTo(allTypesWithKnownFields);
+    assertThat(parsed.toString()).isEqualTo(allTypesWithKnownFields.toString());
+    assertThat(gson.toJson(parsed)).isEqualTo(gson.toJson(allTypesWithKnownFields));
   }
 }


### PR DESCRIPTION
Fixes an issue where JSON with unknown fields would result in an exception being thrown due to `MessageTypeAdapter` trying to parse that field as an Integer. Further discussed [here](https://github.com/square/wire/issues/461#issuecomment-158203475).