### PR TITLE
Make ProtoAdapter.get() more liberal. Always include @WireField in generated code.

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
+++ b/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire;
 
+import com.google.common.io.Files;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.FileSystem;

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -451,9 +451,7 @@ public final class JavaGenerator {
 
       String fieldName = nameAllocator.get(field);
       FieldSpec.Builder fieldBuilder = FieldSpec.builder(fieldJavaType, fieldName, PUBLIC, FINAL);
-      if (emitCompact) {
-        fieldBuilder.addAnnotation(wireFieldAnnotation(field));
-      }
+      fieldBuilder.addAnnotation(wireFieldAnnotation(field));
       if (!field.documentation().isEmpty()) {
         fieldBuilder.addJavadoc("$L\n", sanitizeJavadoc(field.documentation()));
       }

--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
@@ -67,8 +67,7 @@ public abstract class ProtoAdapter<E> {
   }
 
   /** Returns the default adapter for {@code type}. */
-  public static <M extends Message<M, B>, B extends Builder<M, B>> ProtoAdapter<M> get(
-      Class<M> type) {
+  public static <M> ProtoAdapter<M> get(Class<M> type) {
     try {
       return (ProtoAdapter<M>) type.getField("ADAPTER").get(null);
     } catch (IllegalAccessException | NoSuchFieldException e) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -98,28 +99,76 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
 
   public static final String DEFAULT_NAME = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FieldDescriptorProto> field;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FieldDescriptorProto> extension;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<DescriptorProto> nested_type;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<EnumDescriptorProto> enum_type;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.google.protobuf.DescriptorProto$ExtensionRange#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<ExtensionRange> extension_range;
 
+  @WireField(
+      tag = 8,
+      adapter = "com.google.protobuf.OneofDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<OneofDescriptorProto> oneof_decl;
 
+  @WireField(
+      tag = 7,
+      adapter = "com.google.protobuf.MessageOptions#ADAPTER"
+  )
   public final MessageOptions options;
 
+  @WireField(
+      tag = 9,
+      adapter = "com.google.protobuf.DescriptorProto$ReservedRange#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<ReservedRange> reserved_range;
 
   /**
    * Reserved field names, which may not be used by fields in the same message.
    * A given name may only be reserved once.
    */
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REPEATED
+  )
   public final List<String> reserved_name;
 
   public DescriptorProto(String name, List<FieldDescriptorProto> field, List<FieldDescriptorProto> extension, List<DescriptorProto> nested_type, List<EnumDescriptorProto> enum_type, List<ExtensionRange> extension_range, List<OneofDescriptorProto> oneof_decl, MessageOptions options, List<ReservedRange> reserved_range, List<String> reserved_name) {
@@ -360,8 +409,16 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
 
     public static final Integer DEFAULT_END = 0;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    )
     public final Integer start;
 
+    @WireField(
+        tag = 2,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    )
     public final Integer end;
 
     public ExtensionRange(Integer start, Integer end) {
@@ -495,11 +552,19 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     /**
      * Inclusive.
      */
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    )
     public final Integer start;
 
     /**
      * Exclusive.
      */
+    @WireField(
+        tag = 2,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    )
     public final Integer end;
 
     public ReservedRange(Integer start, Integer end) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -70,10 +71,23 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
 
   public static final String DEFAULT_NAME = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.google.protobuf.EnumValueDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<EnumValueDescriptorProto> value;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.google.protobuf.EnumOptions#ADAPTER"
+  )
   public final EnumOptions options;
 
   public EnumDescriptorProto(String name, List<EnumValueDescriptorProto> value, EnumOptions options) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -78,6 +79,10 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
    * Set this option to true to allow mapping different tag names to the same
    * value.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean allow_alias;
 
   /**
@@ -86,16 +91,29 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
    * for the enum, or it will be completely ignored; in the very least, this
    * is a formalization for deprecating enums.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean deprecated;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
+  @WireField(
+      tag = 999,
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<UninterpretedOption> uninterpreted_option;
 
   /**
    * Extension source: custom_options.proto at 76:3
    */
+  @WireField(
+      tag = 71000,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean enum_option;
 
   public EnumOptions(Boolean allow_alias, Boolean deprecated, List<UninterpretedOption> uninterpreted_option, Boolean enum_option) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -71,10 +72,22 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
 
   public static final Integer DEFAULT_NUMBER = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer number;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.google.protobuf.EnumValueOptions#ADAPTER"
+  )
   public final EnumValueOptions options;
 
   public EnumValueDescriptorProto(String name, Integer number, EnumValueOptions options) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import com.squareup.wire.protos.custom_options.FooBar;
 import java.io.IOException;
 import java.lang.Boolean;
@@ -86,26 +87,47 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
    * for the enum value, or it will be completely ignored; in the very least,
    * this is a formalization for deprecating enum values.
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean deprecated;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
+  @WireField(
+      tag = 999,
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<UninterpretedOption> uninterpreted_option;
 
   /**
    * Extension source: custom_options.proto at 71:3
    */
+  @WireField(
+      tag = 70000,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer enum_value_option;
 
   /**
    * Extension source: custom_options.proto at 72:3
    */
+  @WireField(
+      tag = 70001,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$More#ADAPTER"
+  )
   public final FooBar.More complex_enum_value_option;
 
   /**
    * Extension source: foreign.proto at 39:3
    */
+  @WireField(
+      tag = 70002,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean foreign_enum_value_option;
 
   public EnumValueOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option, Integer enum_value_option, FooBar.More complex_enum_value_option, Boolean foreign_enum_value_option) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -116,16 +117,32 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
 
   public static final Integer DEFAULT_ONEOF_INDEX = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer number;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.google.protobuf.FieldDescriptorProto$Label#ADAPTER"
+  )
   public final Label label;
 
   /**
    * If type_name is set, this need not be set.  If both this and type_name
    * are set, this must be one of TYPE_ENUM, TYPE_MESSAGE or TYPE_GROUP.
    */
+  @WireField(
+      tag = 5,
+      adapter = "com.google.protobuf.FieldDescriptorProto$Type#ADAPTER"
+  )
   public final Type type;
 
   /**
@@ -135,12 +152,20 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
    * message are searched, then within the parent, on up to the root
    * namespace).
    */
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String type_name;
 
   /**
    * For extensions, this is the name of the type being extended.  It is
    * resolved in the same manner as type_name.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String extendee;
 
   /**
@@ -150,14 +175,26 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
    * For bytes, contains the C escaped value.  All bytes >= 128 are escaped.
    * TODO(kenton):  Base-64 encode?
    */
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String default_value;
 
   /**
    * If set, gives the index of a oneof in the containing type's oneof_decl
    * list.  This field is a member of that oneof.
    */
+  @WireField(
+      tag = 9,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer oneof_index;
 
+  @WireField(
+      tag = 8,
+      adapter = "com.google.protobuf.FieldOptions#ADAPTER"
+  )
   public final FieldOptions options;
 
   public FieldDescriptorProto(String name, Integer number, Label label, Type type, String type_name, String extendee, String default_value, Integer oneof_index, FieldOptions options) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import com.squareup.wire.protos.custom_options.FooBar;
 import java.io.IOException;
 import java.lang.Boolean;
@@ -164,6 +165,10 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
    * options below.  This option is not yet implemented in the open source
    * release -- sorry, we'll try to include it in a future version!
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.google.protobuf.FieldOptions$CType#ADAPTER"
+  )
   public final CType ctype;
 
   /**
@@ -173,6 +178,10 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
    * a single length-delimited blob. In proto3, only explicit setting it to
    * false will avoid using packed encoding.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean packed;
 
   /**
@@ -186,6 +195,10 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
    * This option is an enum to permit additional types to be added,
    * e.g. goog.math.Integer.
    */
+  @WireField(
+      tag = 6,
+      adapter = "com.google.protobuf.FieldOptions$JSType#ADAPTER"
+  )
   public final JSType jstype;
 
   /**
@@ -218,6 +231,10 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
    * check its required fields, regardless of whether or not the message has
    * been parsed.
    */
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean lazy;
 
   /**
@@ -226,62 +243,111 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
    * for accessors, or it will be completely ignored; in the very least, this
    * is a formalization for deprecating fields.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean deprecated;
 
   /**
    * For Google-internal migration only. Do not use.
    */
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean weak;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
+  @WireField(
+      tag = 999,
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<UninterpretedOption> uninterpreted_option;
 
   /**
    * Extension source: custom_options.proto at 64:3
    */
+  @WireField(
+      tag = 60001,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer my_field_option_one;
 
   /**
    * Extension source: custom_options.proto at 65:3
    */
+  @WireField(
+      tag = 60002,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+  )
   public final Float my_field_option_two;
 
   /**
    * Extension source: custom_options.proto at 66:3
    */
+  @WireField(
+      tag = 60003,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
+  )
   public final FooBar.FooBarBazEnum my_field_option_three;
 
   /**
    * Extension source: custom_options.proto at 67:3
    */
+  @WireField(
+      tag = 60004,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER"
+  )
   public final FooBar my_field_option_four;
 
   /**
    * Extension source: extension_collision_1.proto at 6:3
    */
+  @WireField(
+      tag = 22101,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String squareup_protos_extension_collision_1_a;
 
   /**
    * Extension source: extension_collision_1.proto at 7:3
    */
+  @WireField(
+      tag = 22102,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String b;
 
   /**
    * Extension source: extension_collision_2.proto at 6:3
    */
+  @WireField(
+      tag = 22103,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String squareup_protos_extension_collision_2_a;
 
   /**
    * Extension source: extension_collision_2.proto at 7:3
    */
+  @WireField(
+      tag = 22104,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String c;
 
   /**
    * Fields marked with redacted are not to be logged, generally for PCI or PII.
    * Extension source: redacted_test.proto at 62:3
    */
+  @WireField(
+      tag = 22200,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean redacted;
 
   public FieldOptions(CType ctype, Boolean packed, JSType jstype, Boolean lazy, Boolean deprecated, Boolean weak, List<UninterpretedOption> uninterpreted_option, Integer my_field_option_one, Float my_field_option_two, FooBar.FooBarBazEnum my_field_option_three, FooBar my_field_option_four, String squareup_protos_extension_collision_1_a, String b, String squareup_protos_extension_collision_2_a, String c, Boolean redacted) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -109,40 +110,87 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
   /**
    * file name, relative to root of source tree
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
   /**
    * e.g. "foo", "foo.bar", etc.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String package_;
 
   /**
    * Names of files imported by this file.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REPEATED
+  )
   public final List<String> dependency;
 
   /**
    * Indexes of the public imported files in the dependency list above.
    */
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> public_dependency;
 
   /**
    * Indexes of the weak imported files in the dependency list.
    * For Google-internal migration only. Do not use.
    */
+  @WireField(
+      tag = 11,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> weak_dependency;
 
   /**
    * All top-level definitions in this file.
    */
+  @WireField(
+      tag = 4,
+      adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<DescriptorProto> message_type;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<EnumDescriptorProto> enum_type;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.google.protobuf.ServiceDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<ServiceDescriptorProto> service;
 
+  @WireField(
+      tag = 7,
+      adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FieldDescriptorProto> extension;
 
+  @WireField(
+      tag = 8,
+      adapter = "com.google.protobuf.FileOptions#ADAPTER"
+  )
   public final FileOptions options;
 
   /**
@@ -151,12 +199,20 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
    * functionality of the descriptors -- the information is needed only by
    * development tools.
    */
+  @WireField(
+      tag = 9,
+      adapter = "com.google.protobuf.SourceCodeInfo#ADAPTER"
+  )
   public final SourceCodeInfo source_code_info;
 
   /**
    * The syntax of the proto file.
    * The supported values are "proto2" and "proto3".
    */
+  @WireField(
+      tag = 12,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String syntax;
 
   public FileDescriptorProto(String name, String package_, List<String> dependency, List<Integer> public_dependency, List<Integer> weak_dependency, List<DescriptorProto> message_type, List<EnumDescriptorProto> enum_type, List<ServiceDescriptorProto> service, List<FieldDescriptorProto> extension, FileOptions options, SourceCodeInfo source_code_info, String syntax) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -62,6 +63,11 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.google.protobuf.FileDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FileDescriptorProto> file;
 
   public FileDescriptorSet(List<FileDescriptorProto> file) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -175,6 +176,10 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    * inappropriate because proto packages do not normally start with backwards
    * domain names.
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String java_package;
 
   /**
@@ -184,6 +189,10 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    * a .proto always translates to a single class, but you may want to
    * explicitly choose the class name).
    */
+  @WireField(
+      tag = 8,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String java_outer_classname;
 
   /**
@@ -194,6 +203,10 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    * generated to contain the file's getDescriptor() method as well as any
    * top-level extensions defined in the file.
    */
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean java_multiple_files;
 
   /**
@@ -208,6 +221,10 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    * than object identity. (Implementations should not assume that hashcodes
    * will be consistent across runtimes or versions of the protocol compiler.)
    */
+  @WireField(
+      tag = 20,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean java_generate_equals_and_hash;
 
   /**
@@ -218,8 +235,16 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    * However, an extension field still accepts non-UTF-8 byte sequences.
    * This option has no effect on when used with the lite runtime.
    */
+  @WireField(
+      tag = 27,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean java_string_check_utf8;
 
+  @WireField(
+      tag = 9,
+      adapter = "com.google.protobuf.FileOptions$OptimizeMode#ADAPTER"
+  )
   public final OptimizeMode optimize_for;
 
   /**
@@ -229,6 +254,10 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    *   - Otherwise, the package statement in the .proto file, if present.
    *   - Otherwise, the basename of the .proto file, without extension.
    */
+  @WireField(
+      tag = 11,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String go_package;
 
   /**
@@ -243,10 +272,22 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    * these default to false.  Old code which depends on generic services should
    * explicitly set them to true.
    */
+  @WireField(
+      tag = 16,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean cc_generic_services;
 
+  @WireField(
+      tag = 17,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean java_generic_services;
 
+  @WireField(
+      tag = 18,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean py_generic_services;
 
   /**
@@ -255,28 +296,49 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
    * for everything in the file, or it will be completely ignored; in the very
    * least, this is a formalization for deprecating files.
    */
+  @WireField(
+      tag = 23,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean deprecated;
 
   /**
    * Enables the use of arenas for the proto messages in this file. This applies
    * only to generated classes for C++.
    */
+  @WireField(
+      tag = 31,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean cc_enable_arenas;
 
   /**
    * Sets the objective c class prefix which is prepended to all objective c
    * generated classes from this .proto. There is no default.
    */
+  @WireField(
+      tag = 36,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String objc_class_prefix;
 
   /**
    * Namespace for generated classes; defaults to the package.
    */
+  @WireField(
+      tag = 37,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String csharp_namespace;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
+  @WireField(
+      tag = 999,
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<UninterpretedOption> uninterpreted_option;
 
   public FileOptions(String java_package, String java_outer_classname, Boolean java_multiple_files, Boolean java_generate_equals_and_hash, Boolean java_string_check_utf8, OptimizeMode optimize_for, String go_package, Boolean cc_generic_services, Boolean java_generic_services, Boolean py_generic_services, Boolean deprecated, Boolean cc_enable_arenas, String objc_class_prefix, String csharp_namespace, List<UninterpretedOption> uninterpreted_option) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import com.squareup.wire.protos.custom_options.FooBar;
 import com.squareup.wire.protos.foreign.ForeignMessage;
 import java.io.IOException;
@@ -139,6 +140,10 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
    * Because this is an option, the above two restrictions are not enforced by
    * the protocol compiler.
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean message_set_wire_format;
 
   /**
@@ -146,6 +151,10 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
    * conflict with a field of the same name.  This is meant to make migration
    * from proto1 easier; new code should avoid fields named "descriptor".
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean no_standard_descriptor_accessor;
 
   /**
@@ -154,6 +163,10 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
    * for the message, or it will be completely ignored; in the very least,
    * this is a formalization for deprecating messages.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean deprecated;
 
   /**
@@ -179,46 +192,83 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
    * instead. The option should only be implicitly set by the proto compiler
    * parser.
    */
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean map_entry;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
+  @WireField(
+      tag = 999,
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<UninterpretedOption> uninterpreted_option;
 
   /**
    * Extension source: custom_options.proto at 55:3
    */
+  @WireField(
+      tag = 50001,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER"
+  )
   public final FooBar my_message_option_one;
 
   /**
    * Extension source: custom_options.proto at 56:3
    */
+  @WireField(
+      tag = 50002,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+  )
   public final Float my_message_option_two;
 
   /**
    * Extension source: custom_options.proto at 57:3
    */
+  @WireField(
+      tag = 50003,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER"
+  )
   public final FooBar my_message_option_three;
 
   /**
    * Extension source: custom_options.proto at 58:3
    */
+  @WireField(
+      tag = 50004,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
+  )
   public final FooBar.FooBarBazEnum my_message_option_four;
 
   /**
    * Extension source: custom_options.proto at 59:3
    */
+  @WireField(
+      tag = 50005,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER"
+  )
   public final FooBar my_message_option_five;
 
   /**
    * Extension source: custom_options.proto at 60:3
    */
+  @WireField(
+      tag = 50006,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER"
+  )
   public final FooBar my_message_option_six;
 
   /**
    * Extension source: foreign.proto at 35:3
    */
+  @WireField(
+      tag = 50007,
+      adapter = "com.squareup.wire.protos.foreign.ForeignMessage#ADAPTER"
+  )
   public final ForeignMessage foreign_message_option;
 
   public MessageOptions(Boolean message_set_wire_format, Boolean no_standard_descriptor_accessor, Boolean deprecated, Boolean map_entry, List<UninterpretedOption> uninterpreted_option, FooBar my_message_option_one, Float my_message_option_two, FooBar my_message_option_three, FooBar.FooBarBazEnum my_message_option_four, FooBar my_message_option_five, FooBar my_message_option_six, ForeignMessage foreign_message_option) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -86,26 +87,50 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto, 
 
   public static final Boolean DEFAULT_SERVER_STREAMING = false;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
   /**
    * Input and output type names.  These are resolved in the same way as
    * FieldDescriptorProto.type_name, but must refer to a message type.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String input_type;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String output_type;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.google.protobuf.MethodOptions#ADAPTER"
+  )
   public final MethodOptions options;
 
   /**
    * Identifies if client streams multiple client messages
    */
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean client_streaming;
 
   /**
    * Identifies if server streams multiple server messages
    */
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean server_streaming;
 
   public MethodDescriptorProto(String name, String input_type, String output_type, MethodOptions options, Boolean client_streaming, Boolean server_streaming) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -74,11 +75,20 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
    * for the method, or it will be completely ignored; in the very least,
    * this is a formalization for deprecating methods.
    */
+  @WireField(
+      tag = 33,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean deprecated;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
+  @WireField(
+      tag = 999,
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<UninterpretedOption> uninterpreted_option;
 
   public MethodOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -61,6 +62,10 @@ public final class OneofDescriptorProto extends Message<OneofDescriptorProto, On
 
   public static final String DEFAULT_NAME = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
   public OneofDescriptorProto(String name) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -70,10 +71,23 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
 
   public static final String DEFAULT_NAME = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String name;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.google.protobuf.MethodDescriptorProto#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<MethodDescriptorProto> method;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.google.protobuf.ServiceOptions#ADAPTER"
+  )
   public final ServiceOptions options;
 
   public ServiceDescriptorProto(String name, List<MethodDescriptorProto> method, ServiceOptions options) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -74,11 +75,20 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
    * for the service, or it will be completely ignored; in the very least,
    * this is a formalization for deprecating services.
    */
+  @WireField(
+      tag = 33,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean deprecated;
 
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
+  @WireField(
+      tag = 999,
+      adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<UninterpretedOption> uninterpreted_option;
 
   public ServiceOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -110,6 +111,11 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
    *   ignore those that it doesn't understand, as more types of locations could
    *   be recorded in the future.
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.google.protobuf.SourceCodeInfo$Location#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<Location> location;
 
   public SourceCodeInfo(List<Location> location) {
@@ -303,6 +309,11 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
      * this path refers to the whole field declaration (from the beginning
      * of the label to the terminating semicolon).
      */
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
+        label = WireField.Label.PACKED
+    )
     public final List<Integer> path;
 
     /**
@@ -312,6 +323,11 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
      * and column numbers are zero-based -- typically you will want to add
      * 1 to each before displaying to a user.
      */
+    @WireField(
+        tag = 2,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
+        label = WireField.Label.PACKED
+    )
     public final List<Integer> span;
 
     /**
@@ -363,10 +379,23 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
      *
      *   // ignored detached comments.
      */
+    @WireField(
+        tag = 3,
+        adapter = "com.squareup.wire.ProtoAdapter#STRING"
+    )
     public final String leading_comments;
 
+    @WireField(
+        tag = 4,
+        adapter = "com.squareup.wire.ProtoAdapter#STRING"
+    )
     public final String trailing_comments;
 
+    @WireField(
+        tag = 6,
+        adapter = "com.squareup.wire.ProtoAdapter#STRING",
+        label = WireField.Label.REPEATED
+    )
     public final List<String> leading_detached_comments;
 
     public Location(List<Integer> path, List<Integer> span, String leading_comments, String trailing_comments, List<String> leading_detached_comments) {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -99,22 +100,51 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
 
   public static final String DEFAULT_AGGREGATE_VALUE = "";
 
+  @WireField(
+      tag = 2,
+      adapter = "com.google.protobuf.UninterpretedOption$NamePart#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<NamePart> name;
 
   /**
    * The value of the uninterpreted option, in whatever type the tokenizer
    * identified it as during parsing. Exactly one of these should be set.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String identifier_value;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+  )
   public final Long positive_int_value;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+  )
   public final Long negative_int_value;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+  )
   public final Double double_value;
 
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString string_value;
 
+  @WireField(
+      tag = 8,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String aggregate_value;
 
   public UninterpretedOption(List<NamePart> name, String identifier_value, Long positive_int_value, Long negative_int_value, Double double_value, ByteString string_value, String aggregate_value) {
@@ -312,8 +342,18 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
 
     public static final Boolean DEFAULT_IS_EXTENSION = false;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#STRING",
+        label = WireField.Label.REQUIRED
+    )
     public final String name_part;
 
+    @WireField(
+        tag = 2,
+        adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+        label = WireField.Label.REQUIRED
+    )
     public final Boolean is_extension;
 
     public NamePart(String name_part, Boolean is_extension) {

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -218,6 +219,10 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
       public static final String DEFAULT_BOO = "";
 
+      @WireField(
+          tag = 1,
+          adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      )
       public final String boo;
 
       public Moo(String boo) {

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -8,6 +8,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.differentpackage.protos.bar.Bar$Baz$Moo#ADAPTER"
+  )
   public final Bar.Baz.Moo moo;
 
   public Foo(Bar.Baz.Moo moo) {

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -218,6 +219,10 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
       public static final String DEFAULT_BOO = "";
 
+      @WireField(
+          tag = 1,
+          adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      )
       public final String boo;
 
       public Moo(String boo) {

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
@@ -8,6 +8,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.foobar.protos.bar.Bar$Baz$Moo#ADAPTER"
+  )
   public final Bar.Baz.Moo moo;
 
   public Foo(Bar.Baz.Moo moo) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString data;
 
   public HeresAllTheDataRequest(ByteString data) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString data;
 
   public HeresAllTheDataResponse(ByteString data) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequ
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString data;
 
   public LetsDataRequest(ByteString data) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class LetsDataResponse extends Message<LetsDataResponse, LetsDataRe
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString data;
 
   public LetsDataResponse(ByteString data) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class SendDataRequest extends Message<SendDataRequest, SendDataRequ
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString data;
 
   public SendDataRequest(ByteString data) {

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class SendDataResponse extends Message<SendDataResponse, SendDataRe
 
   public static final ByteString DEFAULT_DATA = ByteString.EMPTY;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString data;
 
   public SendDataResponse(ByteString data) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.io.IOException;
 import java.lang.Object;
@@ -66,6 +67,10 @@ public final class ChildPackage extends Message<ChildPackage, ChildPackage.Build
 
   public static final ForeignEnum DEFAULT_INNER_FOREIGN_ENUM = ForeignEnum.BAV;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.foreign.ForeignEnum#ADAPTER"
+  )
   public final ForeignEnum inner_foreign_enum;
 
   public ChildPackage(ForeignEnum inner_foreign_enum) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -61,8 +62,18 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 201,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> rep_int32;
 
+  @WireField(
+      tag = 301,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> pack_int32;
 
   public RepeatedAndPacked(List<Integer> rep_int32, List<Integer> pack_int32) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -637,406 +638,1001 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final NestedEnum DEFAULT_EXT_OPT_NESTED_ENUM = NestedEnum.A;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer opt_int32;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+  )
   public final Integer opt_uint32;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+  )
   public final Integer opt_sint32;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+  )
   public final Integer opt_fixed32;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+  )
   public final Integer opt_sfixed32;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+  )
   public final Long opt_int64;
 
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+  )
   public final Long opt_uint64;
 
+  @WireField(
+      tag = 8,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+  )
   public final Long opt_sint64;
 
+  @WireField(
+      tag = 9,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+  )
   public final Long opt_fixed64;
 
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+  )
   public final Long opt_sfixed64;
 
+  @WireField(
+      tag = 11,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean opt_bool;
 
+  @WireField(
+      tag = 12,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+  )
   public final Float opt_float;
 
+  @WireField(
+      tag = 13,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+  )
   public final Double opt_double;
 
+  @WireField(
+      tag = 14,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String opt_string;
 
+  @WireField(
+      tag = 15,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString opt_bytes;
 
+  @WireField(
+      tag = 16,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER"
+  )
   public final NestedEnum opt_nested_enum;
 
+  @WireField(
+      tag = 17,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER"
+  )
   public final NestedMessage opt_nested_message;
 
+  @WireField(
+      tag = 101,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer req_int32;
 
+  @WireField(
+      tag = 102,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer req_uint32;
 
+  @WireField(
+      tag = 103,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer req_sint32;
 
+  @WireField(
+      tag = 104,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer req_fixed32;
 
+  @WireField(
+      tag = 105,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer req_sfixed32;
 
+  @WireField(
+      tag = 106,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      label = WireField.Label.REQUIRED
+  )
   public final Long req_int64;
 
+  @WireField(
+      tag = 107,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      label = WireField.Label.REQUIRED
+  )
   public final Long req_uint64;
 
+  @WireField(
+      tag = 108,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      label = WireField.Label.REQUIRED
+  )
   public final Long req_sint64;
 
+  @WireField(
+      tag = 109,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      label = WireField.Label.REQUIRED
+  )
   public final Long req_fixed64;
 
+  @WireField(
+      tag = 110,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      label = WireField.Label.REQUIRED
+  )
   public final Long req_sfixed64;
 
+  @WireField(
+      tag = 111,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      label = WireField.Label.REQUIRED
+  )
   public final Boolean req_bool;
 
+  @WireField(
+      tag = 112,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      label = WireField.Label.REQUIRED
+  )
   public final Float req_float;
 
+  @WireField(
+      tag = 113,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      label = WireField.Label.REQUIRED
+  )
   public final Double req_double;
 
+  @WireField(
+      tag = 114,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED
+  )
   public final String req_string;
 
+  @WireField(
+      tag = 115,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      label = WireField.Label.REQUIRED
+  )
   public final ByteString req_bytes;
 
+  @WireField(
+      tag = 116,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
+      label = WireField.Label.REQUIRED
+  )
   public final NestedEnum req_nested_enum;
 
+  @WireField(
+      tag = 117,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER",
+      label = WireField.Label.REQUIRED
+  )
   public final NestedMessage req_nested_message;
 
+  @WireField(
+      tag = 201,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> rep_int32;
 
+  @WireField(
+      tag = 202,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> rep_uint32;
 
+  @WireField(
+      tag = 203,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> rep_sint32;
 
+  @WireField(
+      tag = 204,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> rep_fixed32;
 
+  @WireField(
+      tag = 205,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> rep_sfixed32;
 
+  @WireField(
+      tag = 206,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> rep_int64;
 
+  @WireField(
+      tag = 207,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> rep_uint64;
 
+  @WireField(
+      tag = 208,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> rep_sint64;
 
+  @WireField(
+      tag = 209,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> rep_fixed64;
 
+  @WireField(
+      tag = 210,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> rep_sfixed64;
 
+  @WireField(
+      tag = 211,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      label = WireField.Label.REPEATED
+  )
   public final List<Boolean> rep_bool;
 
+  @WireField(
+      tag = 212,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      label = WireField.Label.REPEATED
+  )
   public final List<Float> rep_float;
 
+  @WireField(
+      tag = 213,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      label = WireField.Label.REPEATED
+  )
   public final List<Double> rep_double;
 
+  @WireField(
+      tag = 214,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REPEATED
+  )
   public final List<String> rep_string;
 
+  @WireField(
+      tag = 215,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      label = WireField.Label.REPEATED
+  )
   public final List<ByteString> rep_bytes;
 
+  @WireField(
+      tag = 216,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<NestedEnum> rep_nested_enum;
 
+  @WireField(
+      tag = 217,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<NestedMessage> rep_nested_message;
 
+  @WireField(
+      tag = 301,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> pack_int32;
 
+  @WireField(
+      tag = 302,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> pack_uint32;
 
+  @WireField(
+      tag = 303,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> pack_sint32;
 
+  @WireField(
+      tag = 304,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> pack_fixed32;
 
+  @WireField(
+      tag = 305,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> pack_sfixed32;
 
+  @WireField(
+      tag = 306,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> pack_int64;
 
+  @WireField(
+      tag = 307,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> pack_uint64;
 
+  @WireField(
+      tag = 308,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> pack_sint64;
 
+  @WireField(
+      tag = 309,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> pack_fixed64;
 
+  @WireField(
+      tag = 310,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> pack_sfixed64;
 
+  @WireField(
+      tag = 311,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      label = WireField.Label.PACKED
+  )
   public final List<Boolean> pack_bool;
 
+  @WireField(
+      tag = 312,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      label = WireField.Label.PACKED
+  )
   public final List<Float> pack_float;
 
+  @WireField(
+      tag = 313,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      label = WireField.Label.PACKED
+  )
   public final List<Double> pack_double;
 
+  @WireField(
+      tag = 316,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
+      label = WireField.Label.PACKED
+  )
   public final List<NestedEnum> pack_nested_enum;
 
+  @WireField(
+      tag = 401,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer default_int32;
 
+  @WireField(
+      tag = 402,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+  )
   public final Integer default_uint32;
 
+  @WireField(
+      tag = 403,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+  )
   public final Integer default_sint32;
 
+  @WireField(
+      tag = 404,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+  )
   public final Integer default_fixed32;
 
+  @WireField(
+      tag = 405,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+  )
   public final Integer default_sfixed32;
 
+  @WireField(
+      tag = 406,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+  )
   public final Long default_int64;
 
+  @WireField(
+      tag = 407,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+  )
   public final Long default_uint64;
 
+  @WireField(
+      tag = 408,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+  )
   public final Long default_sint64;
 
+  @WireField(
+      tag = 409,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+  )
   public final Long default_fixed64;
 
+  @WireField(
+      tag = 410,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+  )
   public final Long default_sfixed64;
 
+  @WireField(
+      tag = 411,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean default_bool;
 
+  @WireField(
+      tag = 412,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+  )
   public final Float default_float;
 
+  @WireField(
+      tag = 413,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+  )
   public final Double default_double;
 
+  @WireField(
+      tag = 414,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String default_string;
 
+  @WireField(
+      tag = 415,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString default_bytes;
 
+  @WireField(
+      tag = 416,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER"
+  )
   public final NestedEnum default_nested_enum;
 
   /**
    * Extension source: all_types.proto at 123:3
    */
+  @WireField(
+      tag = 1001,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer ext_opt_int32;
 
   /**
    * Extension source: all_types.proto at 124:3
    */
+  @WireField(
+      tag = 1002,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+  )
   public final Integer ext_opt_uint32;
 
   /**
    * Extension source: all_types.proto at 125:3
    */
+  @WireField(
+      tag = 1003,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+  )
   public final Integer ext_opt_sint32;
 
   /**
    * Extension source: all_types.proto at 126:3
    */
+  @WireField(
+      tag = 1004,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+  )
   public final Integer ext_opt_fixed32;
 
   /**
    * Extension source: all_types.proto at 127:3
    */
+  @WireField(
+      tag = 1005,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+  )
   public final Integer ext_opt_sfixed32;
 
   /**
    * Extension source: all_types.proto at 128:3
    */
+  @WireField(
+      tag = 1006,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+  )
   public final Long ext_opt_int64;
 
   /**
    * Extension source: all_types.proto at 129:3
    */
+  @WireField(
+      tag = 1007,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+  )
   public final Long ext_opt_uint64;
 
   /**
    * Extension source: all_types.proto at 130:3
    */
+  @WireField(
+      tag = 1008,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+  )
   public final Long ext_opt_sint64;
 
   /**
    * Extension source: all_types.proto at 131:3
    */
+  @WireField(
+      tag = 1009,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+  )
   public final Long ext_opt_fixed64;
 
   /**
    * Extension source: all_types.proto at 132:3
    */
+  @WireField(
+      tag = 1010,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+  )
   public final Long ext_opt_sfixed64;
 
   /**
    * Extension source: all_types.proto at 133:3
    */
+  @WireField(
+      tag = 1011,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
   public final Boolean ext_opt_bool;
 
   /**
    * Extension source: all_types.proto at 134:3
    */
+  @WireField(
+      tag = 1012,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+  )
   public final Float ext_opt_float;
 
   /**
    * Extension source: all_types.proto at 135:3
    */
+  @WireField(
+      tag = 1013,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+  )
   public final Double ext_opt_double;
 
   /**
    * Extension source: all_types.proto at 136:3
    */
+  @WireField(
+      tag = 1014,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String ext_opt_string;
 
   /**
    * Extension source: all_types.proto at 137:3
    */
+  @WireField(
+      tag = 1015,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString ext_opt_bytes;
 
   /**
    * Extension source: all_types.proto at 138:3
    */
+  @WireField(
+      tag = 1016,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER"
+  )
   public final NestedEnum ext_opt_nested_enum;
 
   /**
    * Extension source: all_types.proto at 139:3
    */
+  @WireField(
+      tag = 1017,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER"
+  )
   public final NestedMessage ext_opt_nested_message;
 
   /**
    * Extension source: all_types.proto at 141:3
    */
+  @WireField(
+      tag = 1101,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> ext_rep_int32;
 
   /**
    * Extension source: all_types.proto at 142:3
    */
+  @WireField(
+      tag = 1102,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> ext_rep_uint32;
 
   /**
    * Extension source: all_types.proto at 143:3
    */
+  @WireField(
+      tag = 1103,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> ext_rep_sint32;
 
   /**
    * Extension source: all_types.proto at 144:3
    */
+  @WireField(
+      tag = 1104,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> ext_rep_fixed32;
 
   /**
    * Extension source: all_types.proto at 145:3
    */
+  @WireField(
+      tag = 1105,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> ext_rep_sfixed32;
 
   /**
    * Extension source: all_types.proto at 146:3
    */
+  @WireField(
+      tag = 1106,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> ext_rep_int64;
 
   /**
    * Extension source: all_types.proto at 147:3
    */
+  @WireField(
+      tag = 1107,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> ext_rep_uint64;
 
   /**
    * Extension source: all_types.proto at 148:3
    */
+  @WireField(
+      tag = 1108,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> ext_rep_sint64;
 
   /**
    * Extension source: all_types.proto at 149:3
    */
+  @WireField(
+      tag = 1109,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> ext_rep_fixed64;
 
   /**
    * Extension source: all_types.proto at 150:3
    */
+  @WireField(
+      tag = 1110,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      label = WireField.Label.REPEATED
+  )
   public final List<Long> ext_rep_sfixed64;
 
   /**
    * Extension source: all_types.proto at 151:3
    */
+  @WireField(
+      tag = 1111,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      label = WireField.Label.REPEATED
+  )
   public final List<Boolean> ext_rep_bool;
 
   /**
    * Extension source: all_types.proto at 152:3
    */
+  @WireField(
+      tag = 1112,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      label = WireField.Label.REPEATED
+  )
   public final List<Float> ext_rep_float;
 
   /**
    * Extension source: all_types.proto at 153:3
    */
+  @WireField(
+      tag = 1113,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      label = WireField.Label.REPEATED
+  )
   public final List<Double> ext_rep_double;
 
   /**
    * Extension source: all_types.proto at 154:3
    */
+  @WireField(
+      tag = 1114,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REPEATED
+  )
   public final List<String> ext_rep_string;
 
   /**
    * Extension source: all_types.proto at 155:3
    */
+  @WireField(
+      tag = 1115,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      label = WireField.Label.REPEATED
+  )
   public final List<ByteString> ext_rep_bytes;
 
   /**
    * Extension source: all_types.proto at 156:3
    */
+  @WireField(
+      tag = 1116,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<NestedEnum> ext_rep_nested_enum;
 
   /**
    * Extension source: all_types.proto at 157:3
    */
+  @WireField(
+      tag = 1117,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedMessage#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<NestedMessage> ext_rep_nested_message;
 
   /**
    * Extension source: all_types.proto at 159:3
    */
+  @WireField(
+      tag = 1201,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> ext_pack_int32;
 
   /**
    * Extension source: all_types.proto at 160:3
    */
+  @WireField(
+      tag = 1202,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> ext_pack_uint32;
 
   /**
    * Extension source: all_types.proto at 161:3
    */
+  @WireField(
+      tag = 1203,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> ext_pack_sint32;
 
   /**
    * Extension source: all_types.proto at 162:3
    */
+  @WireField(
+      tag = 1204,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> ext_pack_fixed32;
 
   /**
    * Extension source: all_types.proto at 163:3
    */
+  @WireField(
+      tag = 1205,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      label = WireField.Label.PACKED
+  )
   public final List<Integer> ext_pack_sfixed32;
 
   /**
    * Extension source: all_types.proto at 164:3
    */
+  @WireField(
+      tag = 1206,
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> ext_pack_int64;
 
   /**
    * Extension source: all_types.proto at 165:3
    */
+  @WireField(
+      tag = 1207,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> ext_pack_uint64;
 
   /**
    * Extension source: all_types.proto at 166:3
    */
+  @WireField(
+      tag = 1208,
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> ext_pack_sint64;
 
   /**
    * Extension source: all_types.proto at 167:3
    */
+  @WireField(
+      tag = 1209,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> ext_pack_fixed64;
 
   /**
    * Extension source: all_types.proto at 168:3
    */
+  @WireField(
+      tag = 1210,
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      label = WireField.Label.PACKED
+  )
   public final List<Long> ext_pack_sfixed64;
 
   /**
    * Extension source: all_types.proto at 169:3
    */
+  @WireField(
+      tag = 1211,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      label = WireField.Label.PACKED
+  )
   public final List<Boolean> ext_pack_bool;
 
   /**
    * Extension source: all_types.proto at 170:3
    */
+  @WireField(
+      tag = 1212,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      label = WireField.Label.PACKED
+  )
   public final List<Float> ext_pack_float;
 
   /**
    * Extension source: all_types.proto at 171:3
    */
+  @WireField(
+      tag = 1213,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      label = WireField.Label.PACKED
+  )
   public final List<Double> ext_pack_double;
 
   /**
    * Extension source: all_types.proto at 172:3
    */
+  @WireField(
+      tag = 1216,
+      adapter = "com.squareup.wire.protos.alltypes.AllTypes$NestedEnum#ADAPTER",
+      label = WireField.Label.PACKED
+  )
   public final List<NestedEnum> ext_pack_nested_enum;
 
   public AllTypes(Integer opt_int32, Integer opt_uint32, Integer opt_sint32, Integer opt_fixed32, Integer opt_sfixed32, Long opt_int64, Long opt_uint64, Long opt_sint64, Long opt_fixed64, Long opt_sfixed64, Boolean opt_bool, Float opt_float, Double opt_double, String opt_string, ByteString opt_bytes, NestedEnum opt_nested_enum, NestedMessage opt_nested_message, Integer req_int32, Integer req_uint32, Integer req_sint32, Integer req_fixed32, Integer req_sfixed32, Long req_int64, Long req_uint64, Long req_sint64, Long req_fixed64, Long req_sfixed64, Boolean req_bool, Float req_float, Double req_double, String req_string, ByteString req_bytes, NestedEnum req_nested_enum, NestedMessage req_nested_message, List<Integer> rep_int32, List<Integer> rep_uint32, List<Integer> rep_sint32, List<Integer> rep_fixed32, List<Integer> rep_sfixed32, List<Long> rep_int64, List<Long> rep_uint64, List<Long> rep_sint64, List<Long> rep_fixed64, List<Long> rep_sfixed64, List<Boolean> rep_bool, List<Float> rep_float, List<Double> rep_double, List<String> rep_string, List<ByteString> rep_bytes, List<NestedEnum> rep_nested_enum, List<NestedMessage> rep_nested_message, List<Integer> pack_int32, List<Integer> pack_uint32, List<Integer> pack_sint32, List<Integer> pack_fixed32, List<Integer> pack_sfixed32, List<Long> pack_int64, List<Long> pack_uint64, List<Long> pack_sint64, List<Long> pack_fixed64, List<Long> pack_sfixed64, List<Boolean> pack_bool, List<Float> pack_float, List<Double> pack_double, List<NestedEnum> pack_nested_enum, Integer default_int32, Integer default_uint32, Integer default_sint32, Integer default_fixed32, Integer default_sfixed32, Long default_int64, Long default_uint64, Long default_sint64, Long default_fixed64, Long default_sfixed64, Boolean default_bool, Float default_float, Double default_double, String default_string, ByteString default_bytes, NestedEnum default_nested_enum, Integer ext_opt_int32, Integer ext_opt_uint32, Integer ext_opt_sint32, Integer ext_opt_fixed32, Integer ext_opt_sfixed32, Long ext_opt_int64, Long ext_opt_uint64, Long ext_opt_sint64, Long ext_opt_fixed64, Long ext_opt_sfixed64, Boolean ext_opt_bool, Float ext_opt_float, Double ext_opt_double, String ext_opt_string, ByteString ext_opt_bytes, NestedEnum ext_opt_nested_enum, NestedMessage ext_opt_nested_message, List<Integer> ext_rep_int32, List<Integer> ext_rep_uint32, List<Integer> ext_rep_sint32, List<Integer> ext_rep_fixed32, List<Integer> ext_rep_sfixed32, List<Long> ext_rep_int64, List<Long> ext_rep_uint64, List<Long> ext_rep_sint64, List<Long> ext_rep_fixed64, List<Long> ext_rep_sfixed64, List<Boolean> ext_rep_bool, List<Float> ext_rep_float, List<Double> ext_rep_double, List<String> ext_rep_string, List<ByteString> ext_rep_bytes, List<NestedEnum> ext_rep_nested_enum, List<NestedMessage> ext_rep_nested_message, List<Integer> ext_pack_int32, List<Integer> ext_pack_uint32, List<Integer> ext_pack_sint32, List<Integer> ext_pack_fixed32, List<Integer> ext_pack_sfixed32, List<Long> ext_pack_int64, List<Long> ext_pack_uint64, List<Long> ext_pack_sint64, List<Long> ext_pack_fixed64, List<Long> ext_pack_sfixed64, List<Boolean> ext_pack_bool, List<Float> ext_pack_float, List<Double> ext_pack_double, List<NestedEnum> ext_pack_nested_enum) {
@@ -2866,6 +3462,10 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
     public static final Integer DEFAULT_A = 0;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    )
     public final Integer a;
 
     public NestedMessage(Integer a) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -162,28 +163,67 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
   public static final FooBarBazEnum DEFAULT_EXT = FooBarBazEnum.FOO;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer foo;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String bar;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$Nested#ADAPTER"
+  )
   public final Nested baz;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+  )
   public final Long qux;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      label = WireField.Label.REPEATED
+  )
   public final List<Float> fred;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+  )
   public final Double daisy;
 
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FooBar> nested;
 
   /**
    * Extension source: custom_options.proto at 80:3
    */
+  @WireField(
+      tag = 101,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
+  )
   public final FooBarBazEnum ext;
 
   /**
    * Extension source: custom_options.proto at 81:3
    */
+  @WireField(
+      tag = 102,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FooBarBazEnum> rep;
 
   public FooBar(Integer foo, String bar, Nested baz, Long qux, List<Float> fred, Double daisy, List<FooBar> nested, FooBarBazEnum ext, List<FooBarBazEnum> rep) {
@@ -400,6 +440,10 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     public static final FooBarBazEnum DEFAULT_VALUE = FooBarBazEnum.FOO;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
+    )
     public final FooBarBazEnum value;
 
     public Nested(FooBarBazEnum value) {
@@ -506,6 +550,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     private static final long serialVersionUID = 0L;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
+        label = WireField.Label.REPEATED
+    )
     public final List<Integer> serial;
 
     public More(List<Integer> serial) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Double;
 import java.lang.Float;
@@ -112,28 +113,67 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
   public static final FooBarBazEnum DEFAULT_EXT = FooBarBazEnum.FOO;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer foo;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String bar;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$Nested#ADAPTER"
+  )
   public final Nested baz;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+  )
   public final Long qux;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      label = WireField.Label.REPEATED
+  )
   public final List<Float> fred;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+  )
   public final Double daisy;
 
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FooBar> nested;
 
   /**
    * Extension source: custom_options.proto at 80:3
    */
+  @WireField(
+      tag = 101,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
+  )
   public final FooBarBazEnum ext;
 
   /**
    * Extension source: custom_options.proto at 81:3
    */
+  @WireField(
+      tag = 102,
+      adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<FooBarBazEnum> rep;
 
   public FooBar(Integer foo, String bar, Nested baz, Long qux, List<Float> fred, Double daisy, List<FooBar> nested, FooBarBazEnum ext, List<FooBarBazEnum> rep) {
@@ -350,6 +390,10 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     public static final FooBarBazEnum DEFAULT_VALUE = FooBarBazEnum.FOO;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.protos.custom_options.FooBar$FooBarBazEnum#ADAPTER"
+    )
     public final FooBarBazEnum value;
 
     public Nested(FooBarBazEnum value) {
@@ -456,6 +500,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     private static final long serialVersionUID = 0L;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32",
+        label = WireField.Label.REPEATED
+    )
     public final List<Integer> serial;
 
     public More(List<Integer> serial) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class OneBytesField extends Message<OneBytesField, OneBytesField.Bu
 
   public static final ByteString DEFAULT_OPT_BYTES = ByteString.EMPTY;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+  )
   public final ByteString opt_bytes;
 
   public OneBytesField(ByteString opt_bytes) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class OneField extends Message<OneField, OneField.Builder> {
 
   public static final Integer DEFAULT_OPT_INT32 = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer opt_int32;
 
   public OneField(Integer opt_int32) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -63,8 +64,16 @@ public final class Recursive extends Message<Recursive, Recursive.Builder> {
 
   public static final Integer DEFAULT_VALUE = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer value;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.edgecases.Recursive#ADAPTER"
+  )
   public final Recursive recursive;
 
   public Recursive(Integer value, Recursive recursive) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -64,11 +65,19 @@ public final class ForeignMessage extends Message<ForeignMessage, ForeignMessage
 
   public static final Integer DEFAULT_J = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
   /**
    * Extension source: simple_message.proto at 79:3
    */
+  @WireField(
+      tag = 100,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer j;
 
   public ForeignMessage(Integer i, Integer j) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
@@ -6,6 +6,7 @@ import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -102,24 +103,64 @@ public final class Message extends com.squareup.wire.Message<Message, Message.Bu
 
   public static final String DEFAULT_MESSAGE = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String unknownFields;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String other;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String o;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String result;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String hashCode;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String serialVersionUID_;
 
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String ADAPTER_;
 
+  @WireField(
+      tag = 8,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String MESSAGE_OPTIONS_;
 
+  @WireField(
+      tag = 9,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String this_;
 
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String message;
 
   public Message(String unknownFields, String other, String o, String result, String hashCode, String serialVersionUID_, String ADAPTER_, String MESSAGE_OPTIONS_, String this_, String message) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,10 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   public static final String DEFAULT_BAR = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String bar;
 
   public Foo(String bar) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -62,11 +63,19 @@ public final class OneExtension extends Message<OneExtension, OneExtension.Build
 
   public static final String DEFAULT_ID = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String id;
 
   /**
    * Extension source: one_extension.proto at 31:3
    */
+  @WireField(
+      tag = 1000,
+      adapter = "com.squareup.wire.protos.one_extension.Foo#ADAPTER"
+  )
   public final Foo foo;
 
   public OneExtension(String id, Foo foo) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -72,16 +73,28 @@ public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Build
   /**
    * What foo.
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer foo;
 
   /**
    * Such bar.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String bar;
 
   /**
    * Nice baz.
    */
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String baz;
 
   public OneOfMessage(Integer foo, String bar, String baz) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -78,21 +79,40 @@ public final class Person extends Message<Person, Person.Builder> {
   /**
    * The customer's full name.
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED
+  )
   public final String name;
 
   /**
    * The customer's ID number.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer id;
 
   /**
    * Email address for the customer.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String email;
 
   /**
    * A list of the customer's phone numbers.
    */
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<PhoneNumber> phone;
 
   public Person(String name, Integer id, String email, List<PhoneNumber> phone) {
@@ -306,11 +326,20 @@ public final class Person extends Message<Person, Person.Builder> {
     /**
      * The customer's phone number.
      */
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#STRING",
+        label = WireField.Label.REQUIRED
+    )
     public final String number;
 
     /**
      * The type of phone stored here.
      */
+    @WireField(
+        tag = 2,
+        adapter = "com.squareup.wire.protos.person.Person$PhoneType#ADAPTER"
+    )
     public final PhoneType type;
 
     public PhoneNumber(String number, PhoneType type) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -97,21 +98,40 @@ public final class Person extends Message<Person, Person.Builder> implements Par
   /**
    * The customer's full name.
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED
+  )
   public final String name;
 
   /**
    * The customer's ID number.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer id;
 
   /**
    * Email address for the customer.
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String email;
 
   /**
    * A list of the customer's phone numbers.
    */
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<PhoneNumber> phone;
 
   public Person(String name, Integer id, String email, List<PhoneNumber> phone) {
@@ -351,11 +371,20 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     /**
      * The customer's phone number.
      */
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#STRING",
+        label = WireField.Label.REQUIRED
+    )
     public final String number;
 
     /**
      * The type of phone stored here.
      */
+    @WireField(
+        tag = 2,
+        adapter = "com.squareup.wire.protos.person.Person$PhoneType#ADAPTER"
+    )
     public final PhoneType type;
 
     public PhoneNumber(String number, PhoneType type) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -63,8 +64,16 @@ public final class NotRedacted extends Message<NotRedacted, NotRedacted.Builder>
 
   public static final String DEFAULT_B = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String a;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String b;
 
   public NotRedacted(String a, String b) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
@@ -8,6 +8,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -82,15 +83,32 @@ public final class Redacted extends Message<Redacted, Redacted.Builder> {
 
   public static final String DEFAULT_C = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      redacted = true
+  )
   public final String a;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String b;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String c;
 
   /**
    * Extension source: redacted_test.proto at 71:3
    */
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.protos.redacted.RedactedExtension#ADAPTER"
+  )
   public final RedactedExtension extension;
 
   public Redacted(String a, String b, String c, RedactedExtension extension) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -66,10 +67,22 @@ public final class RedactedChild extends Message<RedactedChild, RedactedChild.Bu
 
   public static final String DEFAULT_A = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String a;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.redacted.Redacted#ADAPTER"
+  )
   public final Redacted b;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.protos.redacted.NotRedacted#ADAPTER"
+  )
   public final NotRedacted c;
 
   public RedactedChild(String a, Redacted b, NotRedacted c) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -57,6 +58,10 @@ public final class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.redacted.RedactedCycleB#ADAPTER"
+  )
   public final RedactedCycleB b;
 
   public RedactedCycleA(RedactedCycleB b) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -57,6 +58,10 @@ public final class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.redacted.RedactedCycleA#ADAPTER"
+  )
   public final RedactedCycleA a;
 
   public RedactedCycleB(RedactedCycleA a) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -8,6 +8,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -69,8 +70,17 @@ public final class RedactedExtension extends Message<RedactedExtension, Redacted
 
   public static final String DEFAULT_E = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      redacted = true
+  )
   public final String d;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String e;
 
   public RedactedExtension(String d, String e) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -8,6 +8,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -68,11 +69,22 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
       .redacted(true)
       .build();
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REPEATED,
+      redacted = true
+  )
   public final List<String> a;
 
   /**
    * Values in the repeated type need redacting.
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.redacted.Redacted#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<Redacted> b;
 
   public RedactedRepeated(List<String> a, List<Redacted> b) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -8,6 +8,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -62,6 +63,12 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
 
   public static final String DEFAULT_A = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED,
+      redacted = true
+  )
   public final String a;
 
   public RedactedRequired(String a) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -76,8 +77,16 @@ public final class A extends Message<A, A.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.roots.B#ADAPTER"
+  )
   public final B c;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.roots.D#ADAPTER"
+  )
   public final D d;
 
   public A(B c, D d) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -72,6 +73,10 @@ public final class A extends Message<A, A.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.roots.D#ADAPTER"
+  )
   public final D d;
 
   public A(D d) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -57,6 +58,11 @@ public final class B extends Message<B, B.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.roots.C#ADAPTER",
+      label = WireField.Label.REQUIRED
+  )
   public final C c;
 
   public B(C c) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class C extends Message<C, C.Builder> {
 
   public static final Integer DEFAULT_I = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
   public C(Integer i) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class D extends Message<D, D.Builder> {
 
   public static final Integer DEFAULT_I = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
   public D(Integer i) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class D extends Message<D, D.Builder> {
 
   public static final Integer DEFAULT_I = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
   public D(Integer i) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -70,8 +71,16 @@ public final class E extends Message<E, E.Builder> {
 
   public static final G DEFAULT_G = G.FOO;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.roots.E$F#ADAPTER"
+  )
   public final F f;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.roots.G#ADAPTER"
+  )
   public final G g;
 
   public E(F f, G g) {
@@ -191,6 +200,10 @@ public final class E extends Message<E, E.Builder> {
 
     public static final Integer DEFAULT_I = 0;
 
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    )
     public final Integer i;
 
     public F(Integer i) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -57,6 +58,10 @@ public final class H extends Message<H, H.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.roots.E$F#ADAPTER"
+  )
   public final E.F ef;
 
   public H(E.F ef) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -63,11 +64,19 @@ public final class I extends Message<I, I.Builder> {
 
   public static final Integer DEFAULT_I = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
   /**
    * Extension source: roots.proto at 84:3
    */
+  @WireField(
+      tag = 1000,
+      adapter = "com.squareup.wire.protos.roots.J#ADAPTER"
+  )
   public final J j;
 
   public I(Integer i, J j) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -57,6 +58,10 @@ public final class J extends Message<J, J.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.roots.K#ADAPTER"
+  )
   public final K k;
 
   public J(K k) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class K extends Message<K, K.Builder> {
 
   public static final Integer DEFAULT_I = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
   public K(Integer i) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Float;
 import java.lang.Integer;
@@ -90,31 +91,56 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
 
   public static final SimpleMessage.NestedEnum DEFAULT_NESTED_ENUM_EXT = SimpleMessage.NestedEnum.FOO;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+  )
   public final Float f;
 
   /**
    * Extension source: simple_message.proto at 71:3
    */
+  @WireField(
+      tag = 125,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REPEATED
+  )
   public final List<Integer> fooext;
 
   /**
    * Extension source: simple_message.proto at 72:3
    */
+  @WireField(
+      tag = 126,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer barext;
 
   /**
    * Extension source: simple_message.proto at 73:3
    */
+  @WireField(
+      tag = 127,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer bazext;
 
   /**
    * Extension source: simple_message.proto at 74:3
    */
+  @WireField(
+      tag = 128,
+      adapter = "com.squareup.wire.protos.simple.SimpleMessage$NestedMessage#ADAPTER"
+  )
   public final SimpleMessage.NestedMessage nested_message_ext;
 
   /**
    * Extension source: simple_message.proto at 75:3
    */
+  @WireField(
+      tag = 129,
+      adapter = "com.squareup.wire.protos.simple.SimpleMessage$NestedEnum#ADAPTER"
+  )
   public final SimpleMessage.NestedEnum nested_enum_ext;
 
   public ExternalMessage(Float f, List<Integer> fooext, Integer barext, Integer bazext, SimpleMessage.NestedMessage nested_message_ext, SimpleMessage.NestedEnum nested_enum_ext) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
+import com.squareup.wire.WireField;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.io.IOException;
 import java.lang.Boolean;
@@ -144,60 +145,110 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
   /**
    * An optional int32
    */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer optional_int32;
 
   /**
    * An optional NestedMessage, deprecated
    */
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.simple.SimpleMessage$NestedMessage#ADAPTER"
+  )
   @Deprecated
   public final NestedMessage optional_nested_msg;
 
   /**
    * An optional ExternalMessage
    */
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.protos.simple.ExternalMessage#ADAPTER"
+  )
   public final ExternalMessage optional_external_msg;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.protos.simple.SimpleMessage$NestedEnum#ADAPTER"
+  )
   public final NestedEnum default_nested_enum;
 
   /**
    * A required int32
    */
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.REQUIRED
+  )
   public final Integer required_int32;
 
   /**
    * A repeated double, deprecated
    */
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      label = WireField.Label.REPEATED
+  )
   @Deprecated
   public final List<Double> repeated_double;
 
   /**
    * enum from another package with an explicit default
    */
+  @WireField(
+      tag = 7,
+      adapter = "com.squareup.wire.protos.foreign.ForeignEnum#ADAPTER"
+  )
   public final ForeignEnum default_foreign_enum;
 
   /**
    * enum from another package without an explicit default
    */
+  @WireField(
+      tag = 8,
+      adapter = "com.squareup.wire.protos.foreign.ForeignEnum#ADAPTER"
+  )
   public final ForeignEnum no_default_foreign_enum;
 
   /**
    * field with the same name as a Java keyword
    */
+  @WireField(
+      tag = 9,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String package_;
 
   /**
    * field with the name "result"
    */
+  @WireField(
+      tag = 10,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String result;
 
   /**
    * field with the name "other"
    */
+  @WireField(
+      tag = 11,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String other;
 
   /**
    * field with the name "o"
    */
+  @WireField(
+      tag = 12,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String o;
 
   public SimpleMessage(Integer optional_int32, NestedMessage optional_nested_msg, ExternalMessage optional_external_msg, NestedEnum default_nested_enum, Integer required_int32, List<Double> repeated_double, ForeignEnum default_foreign_enum, ForeignEnum no_default_foreign_enum, String package_, String result, String other, String o) {
@@ -480,6 +531,10 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     /**
      * An optional int32
      */
+    @WireField(
+        tag = 1,
+        adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    )
     public final Integer bb;
 
     public NestedMessage(Integer bb) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   public static final Integer DEFAULT_BAZ = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer baz;
 
   public Bar(Integer baz) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,11 @@ public final class Bars extends Message<Bars, Bars.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.single_level.Bar#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<Bar> bars;
 
   public Bars(List<Bar> bars) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   public static final Integer DEFAULT_BAR = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer bar;
 
   public Foo(Integer bar) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,6 +59,11 @@ public final class Foos extends Message<Foos, Foos.Builder> {
 
   private static final long serialVersionUID = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.protos.single_level.Foo#ADAPTER",
+      label = WireField.Label.REPEATED
+  )
   public final List<Foo> foos;
 
   public Foos(List<Foo> foos) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,6 +60,10 @@ public final class VersionOne extends Message<VersionOne, VersionOne.Builder> {
 
   public static final Integer DEFAULT_I = 0;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
   public VersionOne(Integer i) {

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -7,6 +7,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Long;
@@ -84,16 +85,41 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
 
   public static final Long DEFAULT_V2_F64 = 0L;
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer i;
 
+  @WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
   public final Integer v2_i;
 
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String v2_s;
 
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+  )
   public final Integer v2_f32;
 
+  @WireField(
+      tag = 5,
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+  )
   public final Long v2_f64;
 
+  @WireField(
+      tag = 6,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REPEATED
+  )
   public final List<String> v2_rs;
 
   public VersionTwo(Integer i, Integer v2_i, String v2_s, Integer v2_f32, Long v2_f64, List<String> v2_rs) {

--- a/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
@@ -8,6 +8,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
+import com.squareup.wire.WireField;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -66,6 +67,10 @@ public final class CollisionSubject extends Message<CollisionSubject, CollisionS
 
   public static final String DEFAULT_F = "";
 
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
   public final String f;
 
   public CollisionSubject(String f) {


### PR DESCRIPTION
1. "Be liberal in what you accept and conservative in what you return." Changed ProtoAdapter.get() to be more accepting. This code is typically called in reflective situations where you don't know the types until run time. With the old design, one would basically have to resort to raw types to get things to compile.

2. Always include @WireField in generated code. This way, the Gson adapter will work with non-compact generated code.