### PR TITLE
Add a little sugar to get an Adapter from a Message instance

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoAdapter.java
@@ -66,7 +66,12 @@ public abstract class ProtoAdapter<E> {
     return new RuntimeEnumAdapter<>(type);
   }
 
-  /** Returns the default adapter for {@code type}. */
+  /** Returns the adapter for the type of {@code Message}. */
+  public static <M extends Message> ProtoAdapter<M> get(M message) {
+    return (ProtoAdapter<M>) get(message.getClass());
+  }
+
+  /** Returns the adapter for {@code type}. */
   public static <M> ProtoAdapter<M> get(Class<M> type) {
     try {
       return (ProtoAdapter<M>) type.getField("ADAPTER").get(null);

--- a/wire-runtime/src/test/java/com/squareup/wire/ProtoAdapterTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/ProtoAdapterTest.java
@@ -35,6 +35,18 @@ public final class ProtoAdapterTest {
     assertThat(personAdapter.decode(encoded.toByteArray())).isEqualTo(person);
   }
 
+  @Test public void getFromInstanceSameAsFromClass() throws Exception {
+    Person person = new Person.Builder()
+        .id(99)
+        .name("Omar Little")
+        .build();
+
+    ProtoAdapter<Person> instanceAdapter = ProtoAdapter.get(person);
+    ProtoAdapter<Person> classAdapter = ProtoAdapter.get(Person.class);
+
+    assertThat(instanceAdapter).isSameAs(classAdapter);
+  }
+
   @Test public void getFromClassWrongType() throws Exception {
     Message nonGeneratedMessage = new Message(ByteString.EMPTY) {
       @Override public Builder newBuilder() {


### PR DESCRIPTION
Helps avoid messy warning-filled code like this:

```
  public byte[] getBytes(Message message) {
    Class<? extends Message> messageClass = message.getClass();
    // Here we're knowingly dropping type information to make generics
    // workable.
    // ProtoAdapter.get for a message's class will give us that
    // message's adapter.
    ProtoAdapter<Message> protoAdapter = (ProtoAdapter<Message>)
ProtoAdapter.get(messageClass);
    byte[] messageBody = protoAdapter.encode(message);
...
```