### PR TITLE
Promote some utility methods to public to avoid synthetic accessors.

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -1188,37 +1189,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.req_bytes = req_bytes;
     this.req_nested_enum = req_nested_enum;
     this.req_nested_message = req_nested_message;
-    this.rep_int32 = immutableCopyOf("rep_int32", rep_int32);
-    this.rep_uint32 = immutableCopyOf("rep_uint32", rep_uint32);
-    this.rep_sint32 = immutableCopyOf("rep_sint32", rep_sint32);
-    this.rep_fixed32 = immutableCopyOf("rep_fixed32", rep_fixed32);
-    this.rep_sfixed32 = immutableCopyOf("rep_sfixed32", rep_sfixed32);
-    this.rep_int64 = immutableCopyOf("rep_int64", rep_int64);
-    this.rep_uint64 = immutableCopyOf("rep_uint64", rep_uint64);
-    this.rep_sint64 = immutableCopyOf("rep_sint64", rep_sint64);
-    this.rep_fixed64 = immutableCopyOf("rep_fixed64", rep_fixed64);
-    this.rep_sfixed64 = immutableCopyOf("rep_sfixed64", rep_sfixed64);
-    this.rep_bool = immutableCopyOf("rep_bool", rep_bool);
-    this.rep_float = immutableCopyOf("rep_float", rep_float);
-    this.rep_double = immutableCopyOf("rep_double", rep_double);
-    this.rep_string = immutableCopyOf("rep_string", rep_string);
-    this.rep_bytes = immutableCopyOf("rep_bytes", rep_bytes);
-    this.rep_nested_enum = immutableCopyOf("rep_nested_enum", rep_nested_enum);
-    this.rep_nested_message = immutableCopyOf("rep_nested_message", rep_nested_message);
-    this.pack_int32 = immutableCopyOf("pack_int32", pack_int32);
-    this.pack_uint32 = immutableCopyOf("pack_uint32", pack_uint32);
-    this.pack_sint32 = immutableCopyOf("pack_sint32", pack_sint32);
-    this.pack_fixed32 = immutableCopyOf("pack_fixed32", pack_fixed32);
-    this.pack_sfixed32 = immutableCopyOf("pack_sfixed32", pack_sfixed32);
-    this.pack_int64 = immutableCopyOf("pack_int64", pack_int64);
-    this.pack_uint64 = immutableCopyOf("pack_uint64", pack_uint64);
-    this.pack_sint64 = immutableCopyOf("pack_sint64", pack_sint64);
-    this.pack_fixed64 = immutableCopyOf("pack_fixed64", pack_fixed64);
-    this.pack_sfixed64 = immutableCopyOf("pack_sfixed64", pack_sfixed64);
-    this.pack_bool = immutableCopyOf("pack_bool", pack_bool);
-    this.pack_float = immutableCopyOf("pack_float", pack_float);
-    this.pack_double = immutableCopyOf("pack_double", pack_double);
-    this.pack_nested_enum = immutableCopyOf("pack_nested_enum", pack_nested_enum);
+    this.rep_int32 = WireInternal.immutableCopyOf("rep_int32", rep_int32);
+    this.rep_uint32 = WireInternal.immutableCopyOf("rep_uint32", rep_uint32);
+    this.rep_sint32 = WireInternal.immutableCopyOf("rep_sint32", rep_sint32);
+    this.rep_fixed32 = WireInternal.immutableCopyOf("rep_fixed32", rep_fixed32);
+    this.rep_sfixed32 = WireInternal.immutableCopyOf("rep_sfixed32", rep_sfixed32);
+    this.rep_int64 = WireInternal.immutableCopyOf("rep_int64", rep_int64);
+    this.rep_uint64 = WireInternal.immutableCopyOf("rep_uint64", rep_uint64);
+    this.rep_sint64 = WireInternal.immutableCopyOf("rep_sint64", rep_sint64);
+    this.rep_fixed64 = WireInternal.immutableCopyOf("rep_fixed64", rep_fixed64);
+    this.rep_sfixed64 = WireInternal.immutableCopyOf("rep_sfixed64", rep_sfixed64);
+    this.rep_bool = WireInternal.immutableCopyOf("rep_bool", rep_bool);
+    this.rep_float = WireInternal.immutableCopyOf("rep_float", rep_float);
+    this.rep_double = WireInternal.immutableCopyOf("rep_double", rep_double);
+    this.rep_string = WireInternal.immutableCopyOf("rep_string", rep_string);
+    this.rep_bytes = WireInternal.immutableCopyOf("rep_bytes", rep_bytes);
+    this.rep_nested_enum = WireInternal.immutableCopyOf("rep_nested_enum", rep_nested_enum);
+    this.rep_nested_message = WireInternal.immutableCopyOf("rep_nested_message", rep_nested_message);
+    this.pack_int32 = WireInternal.immutableCopyOf("pack_int32", pack_int32);
+    this.pack_uint32 = WireInternal.immutableCopyOf("pack_uint32", pack_uint32);
+    this.pack_sint32 = WireInternal.immutableCopyOf("pack_sint32", pack_sint32);
+    this.pack_fixed32 = WireInternal.immutableCopyOf("pack_fixed32", pack_fixed32);
+    this.pack_sfixed32 = WireInternal.immutableCopyOf("pack_sfixed32", pack_sfixed32);
+    this.pack_int64 = WireInternal.immutableCopyOf("pack_int64", pack_int64);
+    this.pack_uint64 = WireInternal.immutableCopyOf("pack_uint64", pack_uint64);
+    this.pack_sint64 = WireInternal.immutableCopyOf("pack_sint64", pack_sint64);
+    this.pack_fixed64 = WireInternal.immutableCopyOf("pack_fixed64", pack_fixed64);
+    this.pack_sfixed64 = WireInternal.immutableCopyOf("pack_sfixed64", pack_sfixed64);
+    this.pack_bool = WireInternal.immutableCopyOf("pack_bool", pack_bool);
+    this.pack_float = WireInternal.immutableCopyOf("pack_float", pack_float);
+    this.pack_double = WireInternal.immutableCopyOf("pack_double", pack_double);
+    this.pack_nested_enum = WireInternal.immutableCopyOf("pack_nested_enum", pack_nested_enum);
     this.default_int32 = default_int32;
     this.default_uint32 = default_uint32;
     this.default_sint32 = default_sint32;
@@ -1252,37 +1253,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.ext_opt_bytes = ext_opt_bytes;
     this.ext_opt_nested_enum = ext_opt_nested_enum;
     this.ext_opt_nested_message = ext_opt_nested_message;
-    this.ext_rep_int32 = immutableCopyOf("ext_rep_int32", ext_rep_int32);
-    this.ext_rep_uint32 = immutableCopyOf("ext_rep_uint32", ext_rep_uint32);
-    this.ext_rep_sint32 = immutableCopyOf("ext_rep_sint32", ext_rep_sint32);
-    this.ext_rep_fixed32 = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32);
-    this.ext_rep_sfixed32 = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32);
-    this.ext_rep_int64 = immutableCopyOf("ext_rep_int64", ext_rep_int64);
-    this.ext_rep_uint64 = immutableCopyOf("ext_rep_uint64", ext_rep_uint64);
-    this.ext_rep_sint64 = immutableCopyOf("ext_rep_sint64", ext_rep_sint64);
-    this.ext_rep_fixed64 = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64);
-    this.ext_rep_sfixed64 = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64);
-    this.ext_rep_bool = immutableCopyOf("ext_rep_bool", ext_rep_bool);
-    this.ext_rep_float = immutableCopyOf("ext_rep_float", ext_rep_float);
-    this.ext_rep_double = immutableCopyOf("ext_rep_double", ext_rep_double);
-    this.ext_rep_string = immutableCopyOf("ext_rep_string", ext_rep_string);
-    this.ext_rep_bytes = immutableCopyOf("ext_rep_bytes", ext_rep_bytes);
-    this.ext_rep_nested_enum = immutableCopyOf("ext_rep_nested_enum", ext_rep_nested_enum);
-    this.ext_rep_nested_message = immutableCopyOf("ext_rep_nested_message", ext_rep_nested_message);
-    this.ext_pack_int32 = immutableCopyOf("ext_pack_int32", ext_pack_int32);
-    this.ext_pack_uint32 = immutableCopyOf("ext_pack_uint32", ext_pack_uint32);
-    this.ext_pack_sint32 = immutableCopyOf("ext_pack_sint32", ext_pack_sint32);
-    this.ext_pack_fixed32 = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32);
-    this.ext_pack_sfixed32 = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32);
-    this.ext_pack_int64 = immutableCopyOf("ext_pack_int64", ext_pack_int64);
-    this.ext_pack_uint64 = immutableCopyOf("ext_pack_uint64", ext_pack_uint64);
-    this.ext_pack_sint64 = immutableCopyOf("ext_pack_sint64", ext_pack_sint64);
-    this.ext_pack_fixed64 = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64);
-    this.ext_pack_sfixed64 = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64);
-    this.ext_pack_bool = immutableCopyOf("ext_pack_bool", ext_pack_bool);
-    this.ext_pack_float = immutableCopyOf("ext_pack_float", ext_pack_float);
-    this.ext_pack_double = immutableCopyOf("ext_pack_double", ext_pack_double);
-    this.ext_pack_nested_enum = immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
+    this.ext_rep_int32 = WireInternal.immutableCopyOf("ext_rep_int32", ext_rep_int32);
+    this.ext_rep_uint32 = WireInternal.immutableCopyOf("ext_rep_uint32", ext_rep_uint32);
+    this.ext_rep_sint32 = WireInternal.immutableCopyOf("ext_rep_sint32", ext_rep_sint32);
+    this.ext_rep_fixed32 = WireInternal.immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32);
+    this.ext_rep_sfixed32 = WireInternal.immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32);
+    this.ext_rep_int64 = WireInternal.immutableCopyOf("ext_rep_int64", ext_rep_int64);
+    this.ext_rep_uint64 = WireInternal.immutableCopyOf("ext_rep_uint64", ext_rep_uint64);
+    this.ext_rep_sint64 = WireInternal.immutableCopyOf("ext_rep_sint64", ext_rep_sint64);
+    this.ext_rep_fixed64 = WireInternal.immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64);
+    this.ext_rep_sfixed64 = WireInternal.immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64);
+    this.ext_rep_bool = WireInternal.immutableCopyOf("ext_rep_bool", ext_rep_bool);
+    this.ext_rep_float = WireInternal.immutableCopyOf("ext_rep_float", ext_rep_float);
+    this.ext_rep_double = WireInternal.immutableCopyOf("ext_rep_double", ext_rep_double);
+    this.ext_rep_string = WireInternal.immutableCopyOf("ext_rep_string", ext_rep_string);
+    this.ext_rep_bytes = WireInternal.immutableCopyOf("ext_rep_bytes", ext_rep_bytes);
+    this.ext_rep_nested_enum = WireInternal.immutableCopyOf("ext_rep_nested_enum", ext_rep_nested_enum);
+    this.ext_rep_nested_message = WireInternal.immutableCopyOf("ext_rep_nested_message", ext_rep_nested_message);
+    this.ext_pack_int32 = WireInternal.immutableCopyOf("ext_pack_int32", ext_pack_int32);
+    this.ext_pack_uint32 = WireInternal.immutableCopyOf("ext_pack_uint32", ext_pack_uint32);
+    this.ext_pack_sint32 = WireInternal.immutableCopyOf("ext_pack_sint32", ext_pack_sint32);
+    this.ext_pack_fixed32 = WireInternal.immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32);
+    this.ext_pack_sfixed32 = WireInternal.immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32);
+    this.ext_pack_int64 = WireInternal.immutableCopyOf("ext_pack_int64", ext_pack_int64);
+    this.ext_pack_uint64 = WireInternal.immutableCopyOf("ext_pack_uint64", ext_pack_uint64);
+    this.ext_pack_sint64 = WireInternal.immutableCopyOf("ext_pack_sint64", ext_pack_sint64);
+    this.ext_pack_fixed64 = WireInternal.immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64);
+    this.ext_pack_sfixed64 = WireInternal.immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64);
+    this.ext_pack_bool = WireInternal.immutableCopyOf("ext_pack_bool", ext_pack_bool);
+    this.ext_pack_float = WireInternal.immutableCopyOf("ext_pack_float", ext_pack_float);
+    this.ext_pack_double = WireInternal.immutableCopyOf("ext_pack_double", ext_pack_double);
+    this.ext_pack_nested_enum = WireInternal.immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
   }
 
   @Override
@@ -1322,37 +1323,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     builder.req_bytes = req_bytes;
     builder.req_nested_enum = req_nested_enum;
     builder.req_nested_message = req_nested_message;
-    builder.rep_int32 = copyOf("rep_int32", rep_int32);
-    builder.rep_uint32 = copyOf("rep_uint32", rep_uint32);
-    builder.rep_sint32 = copyOf("rep_sint32", rep_sint32);
-    builder.rep_fixed32 = copyOf("rep_fixed32", rep_fixed32);
-    builder.rep_sfixed32 = copyOf("rep_sfixed32", rep_sfixed32);
-    builder.rep_int64 = copyOf("rep_int64", rep_int64);
-    builder.rep_uint64 = copyOf("rep_uint64", rep_uint64);
-    builder.rep_sint64 = copyOf("rep_sint64", rep_sint64);
-    builder.rep_fixed64 = copyOf("rep_fixed64", rep_fixed64);
-    builder.rep_sfixed64 = copyOf("rep_sfixed64", rep_sfixed64);
-    builder.rep_bool = copyOf("rep_bool", rep_bool);
-    builder.rep_float = copyOf("rep_float", rep_float);
-    builder.rep_double = copyOf("rep_double", rep_double);
-    builder.rep_string = copyOf("rep_string", rep_string);
-    builder.rep_bytes = copyOf("rep_bytes", rep_bytes);
-    builder.rep_nested_enum = copyOf("rep_nested_enum", rep_nested_enum);
-    builder.rep_nested_message = copyOf("rep_nested_message", rep_nested_message);
-    builder.pack_int32 = copyOf("pack_int32", pack_int32);
-    builder.pack_uint32 = copyOf("pack_uint32", pack_uint32);
-    builder.pack_sint32 = copyOf("pack_sint32", pack_sint32);
-    builder.pack_fixed32 = copyOf("pack_fixed32", pack_fixed32);
-    builder.pack_sfixed32 = copyOf("pack_sfixed32", pack_sfixed32);
-    builder.pack_int64 = copyOf("pack_int64", pack_int64);
-    builder.pack_uint64 = copyOf("pack_uint64", pack_uint64);
-    builder.pack_sint64 = copyOf("pack_sint64", pack_sint64);
-    builder.pack_fixed64 = copyOf("pack_fixed64", pack_fixed64);
-    builder.pack_sfixed64 = copyOf("pack_sfixed64", pack_sfixed64);
-    builder.pack_bool = copyOf("pack_bool", pack_bool);
-    builder.pack_float = copyOf("pack_float", pack_float);
-    builder.pack_double = copyOf("pack_double", pack_double);
-    builder.pack_nested_enum = copyOf("pack_nested_enum", pack_nested_enum);
+    builder.rep_int32 = WireInternal.copyOf("rep_int32", rep_int32);
+    builder.rep_uint32 = WireInternal.copyOf("rep_uint32", rep_uint32);
+    builder.rep_sint32 = WireInternal.copyOf("rep_sint32", rep_sint32);
+    builder.rep_fixed32 = WireInternal.copyOf("rep_fixed32", rep_fixed32);
+    builder.rep_sfixed32 = WireInternal.copyOf("rep_sfixed32", rep_sfixed32);
+    builder.rep_int64 = WireInternal.copyOf("rep_int64", rep_int64);
+    builder.rep_uint64 = WireInternal.copyOf("rep_uint64", rep_uint64);
+    builder.rep_sint64 = WireInternal.copyOf("rep_sint64", rep_sint64);
+    builder.rep_fixed64 = WireInternal.copyOf("rep_fixed64", rep_fixed64);
+    builder.rep_sfixed64 = WireInternal.copyOf("rep_sfixed64", rep_sfixed64);
+    builder.rep_bool = WireInternal.copyOf("rep_bool", rep_bool);
+    builder.rep_float = WireInternal.copyOf("rep_float", rep_float);
+    builder.rep_double = WireInternal.copyOf("rep_double", rep_double);
+    builder.rep_string = WireInternal.copyOf("rep_string", rep_string);
+    builder.rep_bytes = WireInternal.copyOf("rep_bytes", rep_bytes);
+    builder.rep_nested_enum = WireInternal.copyOf("rep_nested_enum", rep_nested_enum);
+    builder.rep_nested_message = WireInternal.copyOf("rep_nested_message", rep_nested_message);
+    builder.pack_int32 = WireInternal.copyOf("pack_int32", pack_int32);
+    builder.pack_uint32 = WireInternal.copyOf("pack_uint32", pack_uint32);
+    builder.pack_sint32 = WireInternal.copyOf("pack_sint32", pack_sint32);
+    builder.pack_fixed32 = WireInternal.copyOf("pack_fixed32", pack_fixed32);
+    builder.pack_sfixed32 = WireInternal.copyOf("pack_sfixed32", pack_sfixed32);
+    builder.pack_int64 = WireInternal.copyOf("pack_int64", pack_int64);
+    builder.pack_uint64 = WireInternal.copyOf("pack_uint64", pack_uint64);
+    builder.pack_sint64 = WireInternal.copyOf("pack_sint64", pack_sint64);
+    builder.pack_fixed64 = WireInternal.copyOf("pack_fixed64", pack_fixed64);
+    builder.pack_sfixed64 = WireInternal.copyOf("pack_sfixed64", pack_sfixed64);
+    builder.pack_bool = WireInternal.copyOf("pack_bool", pack_bool);
+    builder.pack_float = WireInternal.copyOf("pack_float", pack_float);
+    builder.pack_double = WireInternal.copyOf("pack_double", pack_double);
+    builder.pack_nested_enum = WireInternal.copyOf("pack_nested_enum", pack_nested_enum);
     builder.default_int32 = default_int32;
     builder.default_uint32 = default_uint32;
     builder.default_sint32 = default_sint32;
@@ -1386,37 +1387,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     builder.ext_opt_bytes = ext_opt_bytes;
     builder.ext_opt_nested_enum = ext_opt_nested_enum;
     builder.ext_opt_nested_message = ext_opt_nested_message;
-    builder.ext_rep_int32 = copyOf("ext_rep_int32", ext_rep_int32);
-    builder.ext_rep_uint32 = copyOf("ext_rep_uint32", ext_rep_uint32);
-    builder.ext_rep_sint32 = copyOf("ext_rep_sint32", ext_rep_sint32);
-    builder.ext_rep_fixed32 = copyOf("ext_rep_fixed32", ext_rep_fixed32);
-    builder.ext_rep_sfixed32 = copyOf("ext_rep_sfixed32", ext_rep_sfixed32);
-    builder.ext_rep_int64 = copyOf("ext_rep_int64", ext_rep_int64);
-    builder.ext_rep_uint64 = copyOf("ext_rep_uint64", ext_rep_uint64);
-    builder.ext_rep_sint64 = copyOf("ext_rep_sint64", ext_rep_sint64);
-    builder.ext_rep_fixed64 = copyOf("ext_rep_fixed64", ext_rep_fixed64);
-    builder.ext_rep_sfixed64 = copyOf("ext_rep_sfixed64", ext_rep_sfixed64);
-    builder.ext_rep_bool = copyOf("ext_rep_bool", ext_rep_bool);
-    builder.ext_rep_float = copyOf("ext_rep_float", ext_rep_float);
-    builder.ext_rep_double = copyOf("ext_rep_double", ext_rep_double);
-    builder.ext_rep_string = copyOf("ext_rep_string", ext_rep_string);
-    builder.ext_rep_bytes = copyOf("ext_rep_bytes", ext_rep_bytes);
-    builder.ext_rep_nested_enum = copyOf("ext_rep_nested_enum", ext_rep_nested_enum);
-    builder.ext_rep_nested_message = copyOf("ext_rep_nested_message", ext_rep_nested_message);
-    builder.ext_pack_int32 = copyOf("ext_pack_int32", ext_pack_int32);
-    builder.ext_pack_uint32 = copyOf("ext_pack_uint32", ext_pack_uint32);
-    builder.ext_pack_sint32 = copyOf("ext_pack_sint32", ext_pack_sint32);
-    builder.ext_pack_fixed32 = copyOf("ext_pack_fixed32", ext_pack_fixed32);
-    builder.ext_pack_sfixed32 = copyOf("ext_pack_sfixed32", ext_pack_sfixed32);
-    builder.ext_pack_int64 = copyOf("ext_pack_int64", ext_pack_int64);
-    builder.ext_pack_uint64 = copyOf("ext_pack_uint64", ext_pack_uint64);
-    builder.ext_pack_sint64 = copyOf("ext_pack_sint64", ext_pack_sint64);
-    builder.ext_pack_fixed64 = copyOf("ext_pack_fixed64", ext_pack_fixed64);
-    builder.ext_pack_sfixed64 = copyOf("ext_pack_sfixed64", ext_pack_sfixed64);
-    builder.ext_pack_bool = copyOf("ext_pack_bool", ext_pack_bool);
-    builder.ext_pack_float = copyOf("ext_pack_float", ext_pack_float);
-    builder.ext_pack_double = copyOf("ext_pack_double", ext_pack_double);
-    builder.ext_pack_nested_enum = copyOf("ext_pack_nested_enum", ext_pack_nested_enum);
+    builder.ext_rep_int32 = WireInternal.copyOf("ext_rep_int32", ext_rep_int32);
+    builder.ext_rep_uint32 = WireInternal.copyOf("ext_rep_uint32", ext_rep_uint32);
+    builder.ext_rep_sint32 = WireInternal.copyOf("ext_rep_sint32", ext_rep_sint32);
+    builder.ext_rep_fixed32 = WireInternal.copyOf("ext_rep_fixed32", ext_rep_fixed32);
+    builder.ext_rep_sfixed32 = WireInternal.copyOf("ext_rep_sfixed32", ext_rep_sfixed32);
+    builder.ext_rep_int64 = WireInternal.copyOf("ext_rep_int64", ext_rep_int64);
+    builder.ext_rep_uint64 = WireInternal.copyOf("ext_rep_uint64", ext_rep_uint64);
+    builder.ext_rep_sint64 = WireInternal.copyOf("ext_rep_sint64", ext_rep_sint64);
+    builder.ext_rep_fixed64 = WireInternal.copyOf("ext_rep_fixed64", ext_rep_fixed64);
+    builder.ext_rep_sfixed64 = WireInternal.copyOf("ext_rep_sfixed64", ext_rep_sfixed64);
+    builder.ext_rep_bool = WireInternal.copyOf("ext_rep_bool", ext_rep_bool);
+    builder.ext_rep_float = WireInternal.copyOf("ext_rep_float", ext_rep_float);
+    builder.ext_rep_double = WireInternal.copyOf("ext_rep_double", ext_rep_double);
+    builder.ext_rep_string = WireInternal.copyOf("ext_rep_string", ext_rep_string);
+    builder.ext_rep_bytes = WireInternal.copyOf("ext_rep_bytes", ext_rep_bytes);
+    builder.ext_rep_nested_enum = WireInternal.copyOf("ext_rep_nested_enum", ext_rep_nested_enum);
+    builder.ext_rep_nested_message = WireInternal.copyOf("ext_rep_nested_message", ext_rep_nested_message);
+    builder.ext_pack_int32 = WireInternal.copyOf("ext_pack_int32", ext_pack_int32);
+    builder.ext_pack_uint32 = WireInternal.copyOf("ext_pack_uint32", ext_pack_uint32);
+    builder.ext_pack_sint32 = WireInternal.copyOf("ext_pack_sint32", ext_pack_sint32);
+    builder.ext_pack_fixed32 = WireInternal.copyOf("ext_pack_fixed32", ext_pack_fixed32);
+    builder.ext_pack_sfixed32 = WireInternal.copyOf("ext_pack_sfixed32", ext_pack_sfixed32);
+    builder.ext_pack_int64 = WireInternal.copyOf("ext_pack_int64", ext_pack_int64);
+    builder.ext_pack_uint64 = WireInternal.copyOf("ext_pack_uint64", ext_pack_uint64);
+    builder.ext_pack_sint64 = WireInternal.copyOf("ext_pack_sint64", ext_pack_sint64);
+    builder.ext_pack_fixed64 = WireInternal.copyOf("ext_pack_fixed64", ext_pack_fixed64);
+    builder.ext_pack_sfixed64 = WireInternal.copyOf("ext_pack_sfixed64", ext_pack_sfixed64);
+    builder.ext_pack_bool = WireInternal.copyOf("ext_pack_bool", ext_pack_bool);
+    builder.ext_pack_float = WireInternal.copyOf("ext_pack_float", ext_pack_float);
+    builder.ext_pack_double = WireInternal.copyOf("ext_pack_double", ext_pack_double);
+    builder.ext_pack_nested_enum = WireInternal.copyOf("ext_pack_nested_enum", ext_pack_nested_enum);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -1426,136 +1427,136 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(opt_int32, o.opt_int32)
-        && equals(opt_uint32, o.opt_uint32)
-        && equals(opt_sint32, o.opt_sint32)
-        && equals(opt_fixed32, o.opt_fixed32)
-        && equals(opt_sfixed32, o.opt_sfixed32)
-        && equals(opt_int64, o.opt_int64)
-        && equals(opt_uint64, o.opt_uint64)
-        && equals(opt_sint64, o.opt_sint64)
-        && equals(opt_fixed64, o.opt_fixed64)
-        && equals(opt_sfixed64, o.opt_sfixed64)
-        && equals(opt_bool, o.opt_bool)
-        && equals(opt_float, o.opt_float)
-        && equals(opt_double, o.opt_double)
-        && equals(opt_string, o.opt_string)
-        && equals(opt_bytes, o.opt_bytes)
-        && equals(opt_nested_enum, o.opt_nested_enum)
-        && equals(opt_nested_message, o.opt_nested_message)
-        && equals(req_int32, o.req_int32)
-        && equals(req_uint32, o.req_uint32)
-        && equals(req_sint32, o.req_sint32)
-        && equals(req_fixed32, o.req_fixed32)
-        && equals(req_sfixed32, o.req_sfixed32)
-        && equals(req_int64, o.req_int64)
-        && equals(req_uint64, o.req_uint64)
-        && equals(req_sint64, o.req_sint64)
-        && equals(req_fixed64, o.req_fixed64)
-        && equals(req_sfixed64, o.req_sfixed64)
-        && equals(req_bool, o.req_bool)
-        && equals(req_float, o.req_float)
-        && equals(req_double, o.req_double)
-        && equals(req_string, o.req_string)
-        && equals(req_bytes, o.req_bytes)
-        && equals(req_nested_enum, o.req_nested_enum)
-        && equals(req_nested_message, o.req_nested_message)
-        && equals(rep_int32, o.rep_int32)
-        && equals(rep_uint32, o.rep_uint32)
-        && equals(rep_sint32, o.rep_sint32)
-        && equals(rep_fixed32, o.rep_fixed32)
-        && equals(rep_sfixed32, o.rep_sfixed32)
-        && equals(rep_int64, o.rep_int64)
-        && equals(rep_uint64, o.rep_uint64)
-        && equals(rep_sint64, o.rep_sint64)
-        && equals(rep_fixed64, o.rep_fixed64)
-        && equals(rep_sfixed64, o.rep_sfixed64)
-        && equals(rep_bool, o.rep_bool)
-        && equals(rep_float, o.rep_float)
-        && equals(rep_double, o.rep_double)
-        && equals(rep_string, o.rep_string)
-        && equals(rep_bytes, o.rep_bytes)
-        && equals(rep_nested_enum, o.rep_nested_enum)
-        && equals(rep_nested_message, o.rep_nested_message)
-        && equals(pack_int32, o.pack_int32)
-        && equals(pack_uint32, o.pack_uint32)
-        && equals(pack_sint32, o.pack_sint32)
-        && equals(pack_fixed32, o.pack_fixed32)
-        && equals(pack_sfixed32, o.pack_sfixed32)
-        && equals(pack_int64, o.pack_int64)
-        && equals(pack_uint64, o.pack_uint64)
-        && equals(pack_sint64, o.pack_sint64)
-        && equals(pack_fixed64, o.pack_fixed64)
-        && equals(pack_sfixed64, o.pack_sfixed64)
-        && equals(pack_bool, o.pack_bool)
-        && equals(pack_float, o.pack_float)
-        && equals(pack_double, o.pack_double)
-        && equals(pack_nested_enum, o.pack_nested_enum)
-        && equals(default_int32, o.default_int32)
-        && equals(default_uint32, o.default_uint32)
-        && equals(default_sint32, o.default_sint32)
-        && equals(default_fixed32, o.default_fixed32)
-        && equals(default_sfixed32, o.default_sfixed32)
-        && equals(default_int64, o.default_int64)
-        && equals(default_uint64, o.default_uint64)
-        && equals(default_sint64, o.default_sint64)
-        && equals(default_fixed64, o.default_fixed64)
-        && equals(default_sfixed64, o.default_sfixed64)
-        && equals(default_bool, o.default_bool)
-        && equals(default_float, o.default_float)
-        && equals(default_double, o.default_double)
-        && equals(default_string, o.default_string)
-        && equals(default_bytes, o.default_bytes)
-        && equals(default_nested_enum, o.default_nested_enum)
-        && equals(ext_opt_int32, o.ext_opt_int32)
-        && equals(ext_opt_uint32, o.ext_opt_uint32)
-        && equals(ext_opt_sint32, o.ext_opt_sint32)
-        && equals(ext_opt_fixed32, o.ext_opt_fixed32)
-        && equals(ext_opt_sfixed32, o.ext_opt_sfixed32)
-        && equals(ext_opt_int64, o.ext_opt_int64)
-        && equals(ext_opt_uint64, o.ext_opt_uint64)
-        && equals(ext_opt_sint64, o.ext_opt_sint64)
-        && equals(ext_opt_fixed64, o.ext_opt_fixed64)
-        && equals(ext_opt_sfixed64, o.ext_opt_sfixed64)
-        && equals(ext_opt_bool, o.ext_opt_bool)
-        && equals(ext_opt_float, o.ext_opt_float)
-        && equals(ext_opt_double, o.ext_opt_double)
-        && equals(ext_opt_string, o.ext_opt_string)
-        && equals(ext_opt_bytes, o.ext_opt_bytes)
-        && equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
-        && equals(ext_opt_nested_message, o.ext_opt_nested_message)
-        && equals(ext_rep_int32, o.ext_rep_int32)
-        && equals(ext_rep_uint32, o.ext_rep_uint32)
-        && equals(ext_rep_sint32, o.ext_rep_sint32)
-        && equals(ext_rep_fixed32, o.ext_rep_fixed32)
-        && equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
-        && equals(ext_rep_int64, o.ext_rep_int64)
-        && equals(ext_rep_uint64, o.ext_rep_uint64)
-        && equals(ext_rep_sint64, o.ext_rep_sint64)
-        && equals(ext_rep_fixed64, o.ext_rep_fixed64)
-        && equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
-        && equals(ext_rep_bool, o.ext_rep_bool)
-        && equals(ext_rep_float, o.ext_rep_float)
-        && equals(ext_rep_double, o.ext_rep_double)
-        && equals(ext_rep_string, o.ext_rep_string)
-        && equals(ext_rep_bytes, o.ext_rep_bytes)
-        && equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
-        && equals(ext_rep_nested_message, o.ext_rep_nested_message)
-        && equals(ext_pack_int32, o.ext_pack_int32)
-        && equals(ext_pack_uint32, o.ext_pack_uint32)
-        && equals(ext_pack_sint32, o.ext_pack_sint32)
-        && equals(ext_pack_fixed32, o.ext_pack_fixed32)
-        && equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
-        && equals(ext_pack_int64, o.ext_pack_int64)
-        && equals(ext_pack_uint64, o.ext_pack_uint64)
-        && equals(ext_pack_sint64, o.ext_pack_sint64)
-        && equals(ext_pack_fixed64, o.ext_pack_fixed64)
-        && equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
-        && equals(ext_pack_bool, o.ext_pack_bool)
-        && equals(ext_pack_float, o.ext_pack_float)
-        && equals(ext_pack_double, o.ext_pack_double)
-        && equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(opt_int32, o.opt_int32)
+        && WireInternal.equals(opt_uint32, o.opt_uint32)
+        && WireInternal.equals(opt_sint32, o.opt_sint32)
+        && WireInternal.equals(opt_fixed32, o.opt_fixed32)
+        && WireInternal.equals(opt_sfixed32, o.opt_sfixed32)
+        && WireInternal.equals(opt_int64, o.opt_int64)
+        && WireInternal.equals(opt_uint64, o.opt_uint64)
+        && WireInternal.equals(opt_sint64, o.opt_sint64)
+        && WireInternal.equals(opt_fixed64, o.opt_fixed64)
+        && WireInternal.equals(opt_sfixed64, o.opt_sfixed64)
+        && WireInternal.equals(opt_bool, o.opt_bool)
+        && WireInternal.equals(opt_float, o.opt_float)
+        && WireInternal.equals(opt_double, o.opt_double)
+        && WireInternal.equals(opt_string, o.opt_string)
+        && WireInternal.equals(opt_bytes, o.opt_bytes)
+        && WireInternal.equals(opt_nested_enum, o.opt_nested_enum)
+        && WireInternal.equals(opt_nested_message, o.opt_nested_message)
+        && WireInternal.equals(req_int32, o.req_int32)
+        && WireInternal.equals(req_uint32, o.req_uint32)
+        && WireInternal.equals(req_sint32, o.req_sint32)
+        && WireInternal.equals(req_fixed32, o.req_fixed32)
+        && WireInternal.equals(req_sfixed32, o.req_sfixed32)
+        && WireInternal.equals(req_int64, o.req_int64)
+        && WireInternal.equals(req_uint64, o.req_uint64)
+        && WireInternal.equals(req_sint64, o.req_sint64)
+        && WireInternal.equals(req_fixed64, o.req_fixed64)
+        && WireInternal.equals(req_sfixed64, o.req_sfixed64)
+        && WireInternal.equals(req_bool, o.req_bool)
+        && WireInternal.equals(req_float, o.req_float)
+        && WireInternal.equals(req_double, o.req_double)
+        && WireInternal.equals(req_string, o.req_string)
+        && WireInternal.equals(req_bytes, o.req_bytes)
+        && WireInternal.equals(req_nested_enum, o.req_nested_enum)
+        && WireInternal.equals(req_nested_message, o.req_nested_message)
+        && WireInternal.equals(rep_int32, o.rep_int32)
+        && WireInternal.equals(rep_uint32, o.rep_uint32)
+        && WireInternal.equals(rep_sint32, o.rep_sint32)
+        && WireInternal.equals(rep_fixed32, o.rep_fixed32)
+        && WireInternal.equals(rep_sfixed32, o.rep_sfixed32)
+        && WireInternal.equals(rep_int64, o.rep_int64)
+        && WireInternal.equals(rep_uint64, o.rep_uint64)
+        && WireInternal.equals(rep_sint64, o.rep_sint64)
+        && WireInternal.equals(rep_fixed64, o.rep_fixed64)
+        && WireInternal.equals(rep_sfixed64, o.rep_sfixed64)
+        && WireInternal.equals(rep_bool, o.rep_bool)
+        && WireInternal.equals(rep_float, o.rep_float)
+        && WireInternal.equals(rep_double, o.rep_double)
+        && WireInternal.equals(rep_string, o.rep_string)
+        && WireInternal.equals(rep_bytes, o.rep_bytes)
+        && WireInternal.equals(rep_nested_enum, o.rep_nested_enum)
+        && WireInternal.equals(rep_nested_message, o.rep_nested_message)
+        && WireInternal.equals(pack_int32, o.pack_int32)
+        && WireInternal.equals(pack_uint32, o.pack_uint32)
+        && WireInternal.equals(pack_sint32, o.pack_sint32)
+        && WireInternal.equals(pack_fixed32, o.pack_fixed32)
+        && WireInternal.equals(pack_sfixed32, o.pack_sfixed32)
+        && WireInternal.equals(pack_int64, o.pack_int64)
+        && WireInternal.equals(pack_uint64, o.pack_uint64)
+        && WireInternal.equals(pack_sint64, o.pack_sint64)
+        && WireInternal.equals(pack_fixed64, o.pack_fixed64)
+        && WireInternal.equals(pack_sfixed64, o.pack_sfixed64)
+        && WireInternal.equals(pack_bool, o.pack_bool)
+        && WireInternal.equals(pack_float, o.pack_float)
+        && WireInternal.equals(pack_double, o.pack_double)
+        && WireInternal.equals(pack_nested_enum, o.pack_nested_enum)
+        && WireInternal.equals(default_int32, o.default_int32)
+        && WireInternal.equals(default_uint32, o.default_uint32)
+        && WireInternal.equals(default_sint32, o.default_sint32)
+        && WireInternal.equals(default_fixed32, o.default_fixed32)
+        && WireInternal.equals(default_sfixed32, o.default_sfixed32)
+        && WireInternal.equals(default_int64, o.default_int64)
+        && WireInternal.equals(default_uint64, o.default_uint64)
+        && WireInternal.equals(default_sint64, o.default_sint64)
+        && WireInternal.equals(default_fixed64, o.default_fixed64)
+        && WireInternal.equals(default_sfixed64, o.default_sfixed64)
+        && WireInternal.equals(default_bool, o.default_bool)
+        && WireInternal.equals(default_float, o.default_float)
+        && WireInternal.equals(default_double, o.default_double)
+        && WireInternal.equals(default_string, o.default_string)
+        && WireInternal.equals(default_bytes, o.default_bytes)
+        && WireInternal.equals(default_nested_enum, o.default_nested_enum)
+        && WireInternal.equals(ext_opt_int32, o.ext_opt_int32)
+        && WireInternal.equals(ext_opt_uint32, o.ext_opt_uint32)
+        && WireInternal.equals(ext_opt_sint32, o.ext_opt_sint32)
+        && WireInternal.equals(ext_opt_fixed32, o.ext_opt_fixed32)
+        && WireInternal.equals(ext_opt_sfixed32, o.ext_opt_sfixed32)
+        && WireInternal.equals(ext_opt_int64, o.ext_opt_int64)
+        && WireInternal.equals(ext_opt_uint64, o.ext_opt_uint64)
+        && WireInternal.equals(ext_opt_sint64, o.ext_opt_sint64)
+        && WireInternal.equals(ext_opt_fixed64, o.ext_opt_fixed64)
+        && WireInternal.equals(ext_opt_sfixed64, o.ext_opt_sfixed64)
+        && WireInternal.equals(ext_opt_bool, o.ext_opt_bool)
+        && WireInternal.equals(ext_opt_float, o.ext_opt_float)
+        && WireInternal.equals(ext_opt_double, o.ext_opt_double)
+        && WireInternal.equals(ext_opt_string, o.ext_opt_string)
+        && WireInternal.equals(ext_opt_bytes, o.ext_opt_bytes)
+        && WireInternal.equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
+        && WireInternal.equals(ext_opt_nested_message, o.ext_opt_nested_message)
+        && WireInternal.equals(ext_rep_int32, o.ext_rep_int32)
+        && WireInternal.equals(ext_rep_uint32, o.ext_rep_uint32)
+        && WireInternal.equals(ext_rep_sint32, o.ext_rep_sint32)
+        && WireInternal.equals(ext_rep_fixed32, o.ext_rep_fixed32)
+        && WireInternal.equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
+        && WireInternal.equals(ext_rep_int64, o.ext_rep_int64)
+        && WireInternal.equals(ext_rep_uint64, o.ext_rep_uint64)
+        && WireInternal.equals(ext_rep_sint64, o.ext_rep_sint64)
+        && WireInternal.equals(ext_rep_fixed64, o.ext_rep_fixed64)
+        && WireInternal.equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
+        && WireInternal.equals(ext_rep_bool, o.ext_rep_bool)
+        && WireInternal.equals(ext_rep_float, o.ext_rep_float)
+        && WireInternal.equals(ext_rep_double, o.ext_rep_double)
+        && WireInternal.equals(ext_rep_string, o.ext_rep_string)
+        && WireInternal.equals(ext_rep_bytes, o.ext_rep_bytes)
+        && WireInternal.equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
+        && WireInternal.equals(ext_rep_nested_message, o.ext_rep_nested_message)
+        && WireInternal.equals(ext_pack_int32, o.ext_pack_int32)
+        && WireInternal.equals(ext_pack_uint32, o.ext_pack_uint32)
+        && WireInternal.equals(ext_pack_sint32, o.ext_pack_sint32)
+        && WireInternal.equals(ext_pack_fixed32, o.ext_pack_fixed32)
+        && WireInternal.equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
+        && WireInternal.equals(ext_pack_int64, o.ext_pack_int64)
+        && WireInternal.equals(ext_pack_uint64, o.ext_pack_uint64)
+        && WireInternal.equals(ext_pack_sint64, o.ext_pack_sint64)
+        && WireInternal.equals(ext_pack_fixed64, o.ext_pack_fixed64)
+        && WireInternal.equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
+        && WireInternal.equals(ext_pack_bool, o.ext_pack_bool)
+        && WireInternal.equals(ext_pack_float, o.ext_pack_float)
+        && WireInternal.equals(ext_pack_double, o.ext_pack_double)
+        && WireInternal.equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
   }
 
   @Override
@@ -1957,68 +1958,68 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     public List<NestedEnum> ext_pack_nested_enum;
 
     public Builder() {
-      rep_int32 = newMutableList();
-      rep_uint32 = newMutableList();
-      rep_sint32 = newMutableList();
-      rep_fixed32 = newMutableList();
-      rep_sfixed32 = newMutableList();
-      rep_int64 = newMutableList();
-      rep_uint64 = newMutableList();
-      rep_sint64 = newMutableList();
-      rep_fixed64 = newMutableList();
-      rep_sfixed64 = newMutableList();
-      rep_bool = newMutableList();
-      rep_float = newMutableList();
-      rep_double = newMutableList();
-      rep_string = newMutableList();
-      rep_bytes = newMutableList();
-      rep_nested_enum = newMutableList();
-      rep_nested_message = newMutableList();
-      pack_int32 = newMutableList();
-      pack_uint32 = newMutableList();
-      pack_sint32 = newMutableList();
-      pack_fixed32 = newMutableList();
-      pack_sfixed32 = newMutableList();
-      pack_int64 = newMutableList();
-      pack_uint64 = newMutableList();
-      pack_sint64 = newMutableList();
-      pack_fixed64 = newMutableList();
-      pack_sfixed64 = newMutableList();
-      pack_bool = newMutableList();
-      pack_float = newMutableList();
-      pack_double = newMutableList();
-      pack_nested_enum = newMutableList();
-      ext_rep_int32 = newMutableList();
-      ext_rep_uint32 = newMutableList();
-      ext_rep_sint32 = newMutableList();
-      ext_rep_fixed32 = newMutableList();
-      ext_rep_sfixed32 = newMutableList();
-      ext_rep_int64 = newMutableList();
-      ext_rep_uint64 = newMutableList();
-      ext_rep_sint64 = newMutableList();
-      ext_rep_fixed64 = newMutableList();
-      ext_rep_sfixed64 = newMutableList();
-      ext_rep_bool = newMutableList();
-      ext_rep_float = newMutableList();
-      ext_rep_double = newMutableList();
-      ext_rep_string = newMutableList();
-      ext_rep_bytes = newMutableList();
-      ext_rep_nested_enum = newMutableList();
-      ext_rep_nested_message = newMutableList();
-      ext_pack_int32 = newMutableList();
-      ext_pack_uint32 = newMutableList();
-      ext_pack_sint32 = newMutableList();
-      ext_pack_fixed32 = newMutableList();
-      ext_pack_sfixed32 = newMutableList();
-      ext_pack_int64 = newMutableList();
-      ext_pack_uint64 = newMutableList();
-      ext_pack_sint64 = newMutableList();
-      ext_pack_fixed64 = newMutableList();
-      ext_pack_sfixed64 = newMutableList();
-      ext_pack_bool = newMutableList();
-      ext_pack_float = newMutableList();
-      ext_pack_double = newMutableList();
-      ext_pack_nested_enum = newMutableList();
+      rep_int32 = WireInternal.newMutableList();
+      rep_uint32 = WireInternal.newMutableList();
+      rep_sint32 = WireInternal.newMutableList();
+      rep_fixed32 = WireInternal.newMutableList();
+      rep_sfixed32 = WireInternal.newMutableList();
+      rep_int64 = WireInternal.newMutableList();
+      rep_uint64 = WireInternal.newMutableList();
+      rep_sint64 = WireInternal.newMutableList();
+      rep_fixed64 = WireInternal.newMutableList();
+      rep_sfixed64 = WireInternal.newMutableList();
+      rep_bool = WireInternal.newMutableList();
+      rep_float = WireInternal.newMutableList();
+      rep_double = WireInternal.newMutableList();
+      rep_string = WireInternal.newMutableList();
+      rep_bytes = WireInternal.newMutableList();
+      rep_nested_enum = WireInternal.newMutableList();
+      rep_nested_message = WireInternal.newMutableList();
+      pack_int32 = WireInternal.newMutableList();
+      pack_uint32 = WireInternal.newMutableList();
+      pack_sint32 = WireInternal.newMutableList();
+      pack_fixed32 = WireInternal.newMutableList();
+      pack_sfixed32 = WireInternal.newMutableList();
+      pack_int64 = WireInternal.newMutableList();
+      pack_uint64 = WireInternal.newMutableList();
+      pack_sint64 = WireInternal.newMutableList();
+      pack_fixed64 = WireInternal.newMutableList();
+      pack_sfixed64 = WireInternal.newMutableList();
+      pack_bool = WireInternal.newMutableList();
+      pack_float = WireInternal.newMutableList();
+      pack_double = WireInternal.newMutableList();
+      pack_nested_enum = WireInternal.newMutableList();
+      ext_rep_int32 = WireInternal.newMutableList();
+      ext_rep_uint32 = WireInternal.newMutableList();
+      ext_rep_sint32 = WireInternal.newMutableList();
+      ext_rep_fixed32 = WireInternal.newMutableList();
+      ext_rep_sfixed32 = WireInternal.newMutableList();
+      ext_rep_int64 = WireInternal.newMutableList();
+      ext_rep_uint64 = WireInternal.newMutableList();
+      ext_rep_sint64 = WireInternal.newMutableList();
+      ext_rep_fixed64 = WireInternal.newMutableList();
+      ext_rep_sfixed64 = WireInternal.newMutableList();
+      ext_rep_bool = WireInternal.newMutableList();
+      ext_rep_float = WireInternal.newMutableList();
+      ext_rep_double = WireInternal.newMutableList();
+      ext_rep_string = WireInternal.newMutableList();
+      ext_rep_bytes = WireInternal.newMutableList();
+      ext_rep_nested_enum = WireInternal.newMutableList();
+      ext_rep_nested_message = WireInternal.newMutableList();
+      ext_pack_int32 = WireInternal.newMutableList();
+      ext_pack_uint32 = WireInternal.newMutableList();
+      ext_pack_sint32 = WireInternal.newMutableList();
+      ext_pack_fixed32 = WireInternal.newMutableList();
+      ext_pack_sfixed32 = WireInternal.newMutableList();
+      ext_pack_int64 = WireInternal.newMutableList();
+      ext_pack_uint64 = WireInternal.newMutableList();
+      ext_pack_sint64 = WireInternal.newMutableList();
+      ext_pack_fixed64 = WireInternal.newMutableList();
+      ext_pack_sfixed64 = WireInternal.newMutableList();
+      ext_pack_bool = WireInternal.newMutableList();
+      ext_pack_float = WireInternal.newMutableList();
+      ext_pack_double = WireInternal.newMutableList();
+      ext_pack_nested_enum = WireInternal.newMutableList();
     }
 
     public Builder opt_int32(Integer opt_int32) {
@@ -2192,187 +2193,187 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
 
     public Builder rep_int32(List<Integer> rep_int32) {
-      checkElementsNotNull(rep_int32);
+      WireInternal.checkElementsNotNull(rep_int32);
       this.rep_int32 = rep_int32;
       return this;
     }
 
     public Builder rep_uint32(List<Integer> rep_uint32) {
-      checkElementsNotNull(rep_uint32);
+      WireInternal.checkElementsNotNull(rep_uint32);
       this.rep_uint32 = rep_uint32;
       return this;
     }
 
     public Builder rep_sint32(List<Integer> rep_sint32) {
-      checkElementsNotNull(rep_sint32);
+      WireInternal.checkElementsNotNull(rep_sint32);
       this.rep_sint32 = rep_sint32;
       return this;
     }
 
     public Builder rep_fixed32(List<Integer> rep_fixed32) {
-      checkElementsNotNull(rep_fixed32);
+      WireInternal.checkElementsNotNull(rep_fixed32);
       this.rep_fixed32 = rep_fixed32;
       return this;
     }
 
     public Builder rep_sfixed32(List<Integer> rep_sfixed32) {
-      checkElementsNotNull(rep_sfixed32);
+      WireInternal.checkElementsNotNull(rep_sfixed32);
       this.rep_sfixed32 = rep_sfixed32;
       return this;
     }
 
     public Builder rep_int64(List<Long> rep_int64) {
-      checkElementsNotNull(rep_int64);
+      WireInternal.checkElementsNotNull(rep_int64);
       this.rep_int64 = rep_int64;
       return this;
     }
 
     public Builder rep_uint64(List<Long> rep_uint64) {
-      checkElementsNotNull(rep_uint64);
+      WireInternal.checkElementsNotNull(rep_uint64);
       this.rep_uint64 = rep_uint64;
       return this;
     }
 
     public Builder rep_sint64(List<Long> rep_sint64) {
-      checkElementsNotNull(rep_sint64);
+      WireInternal.checkElementsNotNull(rep_sint64);
       this.rep_sint64 = rep_sint64;
       return this;
     }
 
     public Builder rep_fixed64(List<Long> rep_fixed64) {
-      checkElementsNotNull(rep_fixed64);
+      WireInternal.checkElementsNotNull(rep_fixed64);
       this.rep_fixed64 = rep_fixed64;
       return this;
     }
 
     public Builder rep_sfixed64(List<Long> rep_sfixed64) {
-      checkElementsNotNull(rep_sfixed64);
+      WireInternal.checkElementsNotNull(rep_sfixed64);
       this.rep_sfixed64 = rep_sfixed64;
       return this;
     }
 
     public Builder rep_bool(List<Boolean> rep_bool) {
-      checkElementsNotNull(rep_bool);
+      WireInternal.checkElementsNotNull(rep_bool);
       this.rep_bool = rep_bool;
       return this;
     }
 
     public Builder rep_float(List<Float> rep_float) {
-      checkElementsNotNull(rep_float);
+      WireInternal.checkElementsNotNull(rep_float);
       this.rep_float = rep_float;
       return this;
     }
 
     public Builder rep_double(List<Double> rep_double) {
-      checkElementsNotNull(rep_double);
+      WireInternal.checkElementsNotNull(rep_double);
       this.rep_double = rep_double;
       return this;
     }
 
     public Builder rep_string(List<String> rep_string) {
-      checkElementsNotNull(rep_string);
+      WireInternal.checkElementsNotNull(rep_string);
       this.rep_string = rep_string;
       return this;
     }
 
     public Builder rep_bytes(List<ByteString> rep_bytes) {
-      checkElementsNotNull(rep_bytes);
+      WireInternal.checkElementsNotNull(rep_bytes);
       this.rep_bytes = rep_bytes;
       return this;
     }
 
     public Builder rep_nested_enum(List<NestedEnum> rep_nested_enum) {
-      checkElementsNotNull(rep_nested_enum);
+      WireInternal.checkElementsNotNull(rep_nested_enum);
       this.rep_nested_enum = rep_nested_enum;
       return this;
     }
 
     public Builder rep_nested_message(List<NestedMessage> rep_nested_message) {
-      checkElementsNotNull(rep_nested_message);
+      WireInternal.checkElementsNotNull(rep_nested_message);
       this.rep_nested_message = rep_nested_message;
       return this;
     }
 
     public Builder pack_int32(List<Integer> pack_int32) {
-      checkElementsNotNull(pack_int32);
+      WireInternal.checkElementsNotNull(pack_int32);
       this.pack_int32 = pack_int32;
       return this;
     }
 
     public Builder pack_uint32(List<Integer> pack_uint32) {
-      checkElementsNotNull(pack_uint32);
+      WireInternal.checkElementsNotNull(pack_uint32);
       this.pack_uint32 = pack_uint32;
       return this;
     }
 
     public Builder pack_sint32(List<Integer> pack_sint32) {
-      checkElementsNotNull(pack_sint32);
+      WireInternal.checkElementsNotNull(pack_sint32);
       this.pack_sint32 = pack_sint32;
       return this;
     }
 
     public Builder pack_fixed32(List<Integer> pack_fixed32) {
-      checkElementsNotNull(pack_fixed32);
+      WireInternal.checkElementsNotNull(pack_fixed32);
       this.pack_fixed32 = pack_fixed32;
       return this;
     }
 
     public Builder pack_sfixed32(List<Integer> pack_sfixed32) {
-      checkElementsNotNull(pack_sfixed32);
+      WireInternal.checkElementsNotNull(pack_sfixed32);
       this.pack_sfixed32 = pack_sfixed32;
       return this;
     }
 
     public Builder pack_int64(List<Long> pack_int64) {
-      checkElementsNotNull(pack_int64);
+      WireInternal.checkElementsNotNull(pack_int64);
       this.pack_int64 = pack_int64;
       return this;
     }
 
     public Builder pack_uint64(List<Long> pack_uint64) {
-      checkElementsNotNull(pack_uint64);
+      WireInternal.checkElementsNotNull(pack_uint64);
       this.pack_uint64 = pack_uint64;
       return this;
     }
 
     public Builder pack_sint64(List<Long> pack_sint64) {
-      checkElementsNotNull(pack_sint64);
+      WireInternal.checkElementsNotNull(pack_sint64);
       this.pack_sint64 = pack_sint64;
       return this;
     }
 
     public Builder pack_fixed64(List<Long> pack_fixed64) {
-      checkElementsNotNull(pack_fixed64);
+      WireInternal.checkElementsNotNull(pack_fixed64);
       this.pack_fixed64 = pack_fixed64;
       return this;
     }
 
     public Builder pack_sfixed64(List<Long> pack_sfixed64) {
-      checkElementsNotNull(pack_sfixed64);
+      WireInternal.checkElementsNotNull(pack_sfixed64);
       this.pack_sfixed64 = pack_sfixed64;
       return this;
     }
 
     public Builder pack_bool(List<Boolean> pack_bool) {
-      checkElementsNotNull(pack_bool);
+      WireInternal.checkElementsNotNull(pack_bool);
       this.pack_bool = pack_bool;
       return this;
     }
 
     public Builder pack_float(List<Float> pack_float) {
-      checkElementsNotNull(pack_float);
+      WireInternal.checkElementsNotNull(pack_float);
       this.pack_float = pack_float;
       return this;
     }
 
     public Builder pack_double(List<Double> pack_double) {
-      checkElementsNotNull(pack_double);
+      WireInternal.checkElementsNotNull(pack_double);
       this.pack_double = pack_double;
       return this;
     }
 
     public Builder pack_nested_enum(List<NestedEnum> pack_nested_enum) {
-      checkElementsNotNull(pack_nested_enum);
+      WireInternal.checkElementsNotNull(pack_nested_enum);
       this.pack_nested_enum = pack_nested_enum;
       return this;
     }
@@ -2543,187 +2544,187 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
 
     public Builder ext_rep_int32(List<Integer> ext_rep_int32) {
-      checkElementsNotNull(ext_rep_int32);
+      WireInternal.checkElementsNotNull(ext_rep_int32);
       this.ext_rep_int32 = ext_rep_int32;
       return this;
     }
 
     public Builder ext_rep_uint32(List<Integer> ext_rep_uint32) {
-      checkElementsNotNull(ext_rep_uint32);
+      WireInternal.checkElementsNotNull(ext_rep_uint32);
       this.ext_rep_uint32 = ext_rep_uint32;
       return this;
     }
 
     public Builder ext_rep_sint32(List<Integer> ext_rep_sint32) {
-      checkElementsNotNull(ext_rep_sint32);
+      WireInternal.checkElementsNotNull(ext_rep_sint32);
       this.ext_rep_sint32 = ext_rep_sint32;
       return this;
     }
 
     public Builder ext_rep_fixed32(List<Integer> ext_rep_fixed32) {
-      checkElementsNotNull(ext_rep_fixed32);
+      WireInternal.checkElementsNotNull(ext_rep_fixed32);
       this.ext_rep_fixed32 = ext_rep_fixed32;
       return this;
     }
 
     public Builder ext_rep_sfixed32(List<Integer> ext_rep_sfixed32) {
-      checkElementsNotNull(ext_rep_sfixed32);
+      WireInternal.checkElementsNotNull(ext_rep_sfixed32);
       this.ext_rep_sfixed32 = ext_rep_sfixed32;
       return this;
     }
 
     public Builder ext_rep_int64(List<Long> ext_rep_int64) {
-      checkElementsNotNull(ext_rep_int64);
+      WireInternal.checkElementsNotNull(ext_rep_int64);
       this.ext_rep_int64 = ext_rep_int64;
       return this;
     }
 
     public Builder ext_rep_uint64(List<Long> ext_rep_uint64) {
-      checkElementsNotNull(ext_rep_uint64);
+      WireInternal.checkElementsNotNull(ext_rep_uint64);
       this.ext_rep_uint64 = ext_rep_uint64;
       return this;
     }
 
     public Builder ext_rep_sint64(List<Long> ext_rep_sint64) {
-      checkElementsNotNull(ext_rep_sint64);
+      WireInternal.checkElementsNotNull(ext_rep_sint64);
       this.ext_rep_sint64 = ext_rep_sint64;
       return this;
     }
 
     public Builder ext_rep_fixed64(List<Long> ext_rep_fixed64) {
-      checkElementsNotNull(ext_rep_fixed64);
+      WireInternal.checkElementsNotNull(ext_rep_fixed64);
       this.ext_rep_fixed64 = ext_rep_fixed64;
       return this;
     }
 
     public Builder ext_rep_sfixed64(List<Long> ext_rep_sfixed64) {
-      checkElementsNotNull(ext_rep_sfixed64);
+      WireInternal.checkElementsNotNull(ext_rep_sfixed64);
       this.ext_rep_sfixed64 = ext_rep_sfixed64;
       return this;
     }
 
     public Builder ext_rep_bool(List<Boolean> ext_rep_bool) {
-      checkElementsNotNull(ext_rep_bool);
+      WireInternal.checkElementsNotNull(ext_rep_bool);
       this.ext_rep_bool = ext_rep_bool;
       return this;
     }
 
     public Builder ext_rep_float(List<Float> ext_rep_float) {
-      checkElementsNotNull(ext_rep_float);
+      WireInternal.checkElementsNotNull(ext_rep_float);
       this.ext_rep_float = ext_rep_float;
       return this;
     }
 
     public Builder ext_rep_double(List<Double> ext_rep_double) {
-      checkElementsNotNull(ext_rep_double);
+      WireInternal.checkElementsNotNull(ext_rep_double);
       this.ext_rep_double = ext_rep_double;
       return this;
     }
 
     public Builder ext_rep_string(List<String> ext_rep_string) {
-      checkElementsNotNull(ext_rep_string);
+      WireInternal.checkElementsNotNull(ext_rep_string);
       this.ext_rep_string = ext_rep_string;
       return this;
     }
 
     public Builder ext_rep_bytes(List<ByteString> ext_rep_bytes) {
-      checkElementsNotNull(ext_rep_bytes);
+      WireInternal.checkElementsNotNull(ext_rep_bytes);
       this.ext_rep_bytes = ext_rep_bytes;
       return this;
     }
 
     public Builder ext_rep_nested_enum(List<NestedEnum> ext_rep_nested_enum) {
-      checkElementsNotNull(ext_rep_nested_enum);
+      WireInternal.checkElementsNotNull(ext_rep_nested_enum);
       this.ext_rep_nested_enum = ext_rep_nested_enum;
       return this;
     }
 
     public Builder ext_rep_nested_message(List<NestedMessage> ext_rep_nested_message) {
-      checkElementsNotNull(ext_rep_nested_message);
+      WireInternal.checkElementsNotNull(ext_rep_nested_message);
       this.ext_rep_nested_message = ext_rep_nested_message;
       return this;
     }
 
     public Builder ext_pack_int32(List<Integer> ext_pack_int32) {
-      checkElementsNotNull(ext_pack_int32);
+      WireInternal.checkElementsNotNull(ext_pack_int32);
       this.ext_pack_int32 = ext_pack_int32;
       return this;
     }
 
     public Builder ext_pack_uint32(List<Integer> ext_pack_uint32) {
-      checkElementsNotNull(ext_pack_uint32);
+      WireInternal.checkElementsNotNull(ext_pack_uint32);
       this.ext_pack_uint32 = ext_pack_uint32;
       return this;
     }
 
     public Builder ext_pack_sint32(List<Integer> ext_pack_sint32) {
-      checkElementsNotNull(ext_pack_sint32);
+      WireInternal.checkElementsNotNull(ext_pack_sint32);
       this.ext_pack_sint32 = ext_pack_sint32;
       return this;
     }
 
     public Builder ext_pack_fixed32(List<Integer> ext_pack_fixed32) {
-      checkElementsNotNull(ext_pack_fixed32);
+      WireInternal.checkElementsNotNull(ext_pack_fixed32);
       this.ext_pack_fixed32 = ext_pack_fixed32;
       return this;
     }
 
     public Builder ext_pack_sfixed32(List<Integer> ext_pack_sfixed32) {
-      checkElementsNotNull(ext_pack_sfixed32);
+      WireInternal.checkElementsNotNull(ext_pack_sfixed32);
       this.ext_pack_sfixed32 = ext_pack_sfixed32;
       return this;
     }
 
     public Builder ext_pack_int64(List<Long> ext_pack_int64) {
-      checkElementsNotNull(ext_pack_int64);
+      WireInternal.checkElementsNotNull(ext_pack_int64);
       this.ext_pack_int64 = ext_pack_int64;
       return this;
     }
 
     public Builder ext_pack_uint64(List<Long> ext_pack_uint64) {
-      checkElementsNotNull(ext_pack_uint64);
+      WireInternal.checkElementsNotNull(ext_pack_uint64);
       this.ext_pack_uint64 = ext_pack_uint64;
       return this;
     }
 
     public Builder ext_pack_sint64(List<Long> ext_pack_sint64) {
-      checkElementsNotNull(ext_pack_sint64);
+      WireInternal.checkElementsNotNull(ext_pack_sint64);
       this.ext_pack_sint64 = ext_pack_sint64;
       return this;
     }
 
     public Builder ext_pack_fixed64(List<Long> ext_pack_fixed64) {
-      checkElementsNotNull(ext_pack_fixed64);
+      WireInternal.checkElementsNotNull(ext_pack_fixed64);
       this.ext_pack_fixed64 = ext_pack_fixed64;
       return this;
     }
 
     public Builder ext_pack_sfixed64(List<Long> ext_pack_sfixed64) {
-      checkElementsNotNull(ext_pack_sfixed64);
+      WireInternal.checkElementsNotNull(ext_pack_sfixed64);
       this.ext_pack_sfixed64 = ext_pack_sfixed64;
       return this;
     }
 
     public Builder ext_pack_bool(List<Boolean> ext_pack_bool) {
-      checkElementsNotNull(ext_pack_bool);
+      WireInternal.checkElementsNotNull(ext_pack_bool);
       this.ext_pack_bool = ext_pack_bool;
       return this;
     }
 
     public Builder ext_pack_float(List<Float> ext_pack_float) {
-      checkElementsNotNull(ext_pack_float);
+      WireInternal.checkElementsNotNull(ext_pack_float);
       this.ext_pack_float = ext_pack_float;
       return this;
     }
 
     public Builder ext_pack_double(List<Double> ext_pack_double) {
-      checkElementsNotNull(ext_pack_double);
+      WireInternal.checkElementsNotNull(ext_pack_double);
       this.ext_pack_double = ext_pack_double;
       return this;
     }
 
     public Builder ext_pack_nested_enum(List<NestedEnum> ext_pack_nested_enum) {
-      checkElementsNotNull(ext_pack_nested_enum);
+      WireInternal.checkElementsNotNull(ext_pack_nested_enum);
       this.ext_pack_nested_enum = ext_pack_nested_enum;
       return this;
     }
@@ -2747,7 +2748,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
           || req_bytes == null
           || req_nested_enum == null
           || req_nested_message == null) {
-        throw missingRequiredFields(req_int32, "req_int32",
+        throw WireInternal.missingRequiredFields(req_int32, "req_int32",
             req_uint32, "req_uint32",
             req_sint32, "req_sint32",
             req_fixed32, "req_fixed32",
@@ -2831,8 +2832,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(a, o.a);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(a, o.a);
     }
 
     @Override

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -42,6 +42,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import com.squareup.wire.schema.EnumConstant;
 import com.squareup.wire.schema.EnumType;
 import com.squareup.wire.schema.Field;
@@ -735,7 +736,8 @@ public final class JavaGenerator {
       } else if (!field.type().isScalar() && !isEnum(field.type())) {
         if (field.isRepeated()) {
           CodeBlock adapter = singleAdapterFor(field);
-          result.addStatement("redactElements(builder.$N, $L)", fieldName, adapter);
+          result.addStatement("$T.redactElements(builder.$N, $L)", WireInternal.class, fieldName,
+              adapter);
         } else {
           CodeBlock adapter = adapterFor(field);
           result.addStatement("if (builder.$1N != null) builder.$1N = $2L.redact(builder.$1N)",
@@ -893,7 +895,7 @@ public final class JavaGenerator {
         first = false;
       }
       CodeBlock fieldNames = fieldNamesBuilder.build();
-      result.beginControlFlow("if (countNonNull($L) > 1)", fieldNames);
+      result.beginControlFlow("if ($T.countNonNull($L) > 1)", WireInternal.class, fieldNames);
       result.addStatement("throw new IllegalArgumentException($S)",
           "at most one of " + fieldNames + " may be non-null");
       result.endControlFlow();
@@ -907,7 +909,8 @@ public final class JavaGenerator {
       }
       result.addParameter(param.build());
       if (field.isRepeated()) {
-        result.addStatement("this.$1L = immutableCopyOf($1S, $1L)", fieldName);
+        result.addStatement("this.$1L = $2T.immutableCopyOf($1S, $1L)", fieldName,
+            WireInternal.class);
       } else {
         result.addStatement("this.$1L = $1L", fieldName);
       }
@@ -949,10 +952,11 @@ public final class JavaGenerator {
     result.addStatement("if (!($N instanceof $T)) return false", otherName, javaType);
 
     result.addStatement("$T $N = ($T) $N", javaType, oName, javaType, otherName);
-    result.addCode("$[return equals(unknownFields(), $N.unknownFields())", oName);
+    result.addCode("$[return $T.equals(unknownFields(), $N.unknownFields())", WireInternal.class,
+        oName);
     for (Field field : fields) {
       String fieldName = nameAllocator.get(field);
-      result.addCode("\n&& equals($L, $N.$L)", fieldName, oName, fieldName);
+      result.addCode("\n&& $T.equals($L, $N.$L)", WireInternal.class, fieldName, oName, fieldName);
     }
     result.addCode(";\n$]");
 
@@ -1067,7 +1071,7 @@ public final class JavaGenerator {
     for (Field field : type.fieldsAndOneOfFields()) {
       if (field.isPacked() || field.isRepeated()) {
         String fieldName = nameAllocator.get(field);
-        result.addStatement("$L = newMutableList()", fieldName);
+        result.addStatement("$L = $T.newMutableList()", fieldName, WireInternal.class);
       }
     }
     return result.build();
@@ -1098,7 +1102,8 @@ public final class JavaGenerator {
     for (Field field : fields) {
       String fieldName = nameAllocator.get(field);
       if (field.isRepeated()) {
-        result.addStatement("$1L.$2L = copyOf($2S, $2L)", builderName, fieldName);
+        result.addStatement("$1L.$2L = $3T.copyOf($2S, $2L)", builderName, fieldName,
+            WireInternal.class);
       } else {
         result.addStatement("$1L.$2L = $2L", builderName, fieldName);
       }
@@ -1128,7 +1133,7 @@ public final class JavaGenerator {
     }
 
     if (field.isRepeated()) {
-      result.addStatement("checkElementsNotNull($L)", fieldName);
+      result.addStatement("$T.checkElementsNotNull($L)", WireInternal.class, fieldName);
     }
     result.addStatement("this.$L = $L", fieldName, fieldName);
 
@@ -1177,7 +1182,8 @@ public final class JavaGenerator {
       }
 
       result.beginControlFlow("if ($L)", conditionals.add("$]").build())
-          .addStatement("throw missingRequiredFields($L)", missingArgs.build())
+          .addStatement("throw $T.missingRequiredFields($L)", WireInternal.class,
+              missingArgs.build())
           .endControlFlow();
     }
 

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -18,9 +18,6 @@ package com.squareup.wire;
 import java.io.IOException;
 import java.io.ObjectStreamException;
 import java.io.Serializable;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
 import okio.Buffer;
 import okio.ByteString;
 
@@ -66,7 +63,7 @@ public abstract class Message<M extends Message<M, B>, B extends Message.Builder
 
   @SuppressWarnings("unchecked")
   @Override public String toString() {
-    return ProtoAdapter.get((Class<Message>) getClass()).toString(this);
+    return ProtoAdapter.get(this).toString(this);
   }
 
   protected final Object writeReplace() throws ObjectStreamException {
@@ -136,106 +133,4 @@ public abstract class Message<M extends Message<M, B>, B extends Message.Builder
     public abstract T build();
   }
 
-  /** <b>For generated code only.</b> */
-  protected static <T> List<T> newMutableList() {
-    return new MutableOnWriteList<>(Collections.<T>emptyList());
-  }
-
-  /** <b>For generated code only.</b> Utility method to return a mutable copy of {@code list}. */
-  protected static <T> List<T> copyOf(String name, List<T> list) {
-    if (list == null) throw new NullPointerException(name + " == null");
-    if (list == Collections.emptyList() || list instanceof ImmutableList) {
-      return new MutableOnWriteList<>(list);
-    }
-    return new ArrayList<>(list);
-  }
-
-  /** <b>For generated code only.</b> Utility method to return an immutable copy of {@code list}. */
-  protected static <T> List<T> immutableCopyOf(String name, List<T> list) {
-    if (list == null) throw new NullPointerException(name + " == null");
-    if (list instanceof MutableOnWriteList) {
-      list = ((MutableOnWriteList<T>) list).mutableList;
-    }
-    if (list == Collections.emptyList() || list instanceof ImmutableList) {
-      return list;
-    }
-    ImmutableList<T> result = new ImmutableList<>(list);
-    // Check after the list has been copied to defend against races.
-    if (result.contains(null)) {
-      throw new IllegalArgumentException(name + ".contains(null)");
-    }
-    return result;
-  }
-
-  /** <b>For generated code only.</b> */
-  protected static <T> void redactElements(List<T> list, ProtoAdapter<T> adapter) {
-    for (int i = 0, count = list.size(); i < count; i++) {
-      list.set(i, adapter.redact(list.get(i)));
-    }
-  }
-
-  /** <b>For generated code only.</b> */
-  protected static boolean equals(Object a, Object b) {
-    return a == b || (a != null && a.equals(b));
-  }
-
-  /**
-   * <b>For generated code only.</b> Create an exception for missing required fields.
-   *
-   * @param args Alternating field value and field name pairs.
-   */
-  protected static IllegalStateException missingRequiredFields(Object... args) {
-    StringBuilder sb = new StringBuilder();
-    String plural = "";
-    for (int i = 0, size = args.length; i < size; i += 2) {
-      if (args[i] == null) {
-        if (sb.length() > 0) {
-          plural = "s"; // Found more than one missing field
-        }
-        sb.append("\n  ");
-        sb.append(args[i + 1]);
-      }
-    }
-    throw new IllegalStateException("Required field" + plural + " not set:" + sb);
-  }
-
-  /**
-   * <b>For generated code only.</b> Throw {@link NullPointerException} if {@code list} or one of
-   * its items are null.
-   */
-  protected static void checkElementsNotNull(List<?> list) {
-    if (list == null) throw new NullPointerException("list == null");
-    for (int i = 0, size = list.size(); i < size; i++) {
-      Object element = list.get(i);
-      if (element == null) {
-        throw new NullPointerException("Element at index " + i + " is null");
-      }
-    }
-  }
-
-  /** Returns the number of non-null values in {@code a, b}. */
-  protected static int countNonNull(Object a, Object b) {
-    return (a != null ? 1 : 0)
-        + (b != null ? 1 : 0);
-  }
-
-  /** Returns the number of non-null values in {@code a, b, c}. */
-  protected static int countNonNull(Object a, Object b, Object c) {
-    return (a != null ? 1 : 0)
-        + (b != null ? 1 : 0)
-        + (c != null ? 1 : 0);
-  }
-
-  /** Returns the number of non-null values in {@code a, b, c, d, rest}. */
-  protected static int countNonNull(Object a, Object b, Object c, Object d, Object... rest) {
-    int result = 0;
-    if (a != null) result++;
-    if (b != null) result++;
-    if (c != null) result++;
-    if (d != null) result++;
-    for (Object o : rest) {
-      if (o != null) result++;
-    }
-    return result;
-  }
 }

--- a/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/RuntimeMessageAdapter.java
@@ -126,7 +126,7 @@ final class RuntimeMessageAdapter<M extends Message<M, B>, B extends Builder<M, 
         List<Object> values = (List<Object>) fieldBinding.getFromBuilder(builder);
         //noinspection unchecked
         ProtoAdapter<Object> adapter = (ProtoAdapter<Object>) fieldBinding.singleAdapter();
-        Message.redactElements(values, adapter);
+        WireInternal.redactElements(values, adapter);
       }
     }
     builder.clearUnknownFields();

--- a/wire-runtime/src/main/java/com/squareup/wire/WireInternal.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/WireInternal.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2013 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/** Methods for generated code only. Not subject to public API rules. */
+public final class WireInternal {
+  private WireInternal() {
+  }
+
+  public static <T> List<T> newMutableList() {
+    return new MutableOnWriteList<>(Collections.<T>emptyList());
+  }
+
+  public static <T> List<T> copyOf(String name, List<T> list) {
+    if (list == null) throw new NullPointerException(name + " == null");
+    if (list == Collections.emptyList() || list instanceof ImmutableList) {
+      return new MutableOnWriteList<>(list);
+    }
+    return new ArrayList<>(list);
+  }
+
+  public static <T> List<T> immutableCopyOf(String name, List<T> list) {
+    if (list == null) throw new NullPointerException(name + " == null");
+    if (list instanceof MutableOnWriteList) {
+      list = ((MutableOnWriteList<T>) list).mutableList;
+    }
+    if (list == Collections.emptyList() || list instanceof ImmutableList) {
+      return list;
+    }
+    ImmutableList<T> result = new ImmutableList<>(list);
+    // Check after the list has been copied to defend against races.
+    if (result.contains(null)) {
+      throw new IllegalArgumentException(name + ".contains(null)");
+    }
+    return result;
+  }
+
+  public static <T> void redactElements(List<T> list, ProtoAdapter<T> adapter) {
+    for (int i = 0, count = list.size(); i < count; i++) {
+      list.set(i, adapter.redact(list.get(i)));
+    }
+  }
+
+  public static boolean equals(Object a, Object b) {
+    return a == b || (a != null && a.equals(b));
+  }
+
+  /**
+   * Create an exception for missing required fields.
+   *
+   * @param args Alternating field value and field name pairs.
+   */
+  public static IllegalStateException missingRequiredFields(Object... args) {
+    StringBuilder sb = new StringBuilder();
+    String plural = "";
+    for (int i = 0, size = args.length; i < size; i += 2) {
+      if (args[i] == null) {
+        if (sb.length() > 0) {
+          plural = "s"; // Found more than one missing field
+        }
+        sb.append("\n  ");
+        sb.append(args[i + 1]);
+      }
+    }
+    throw new IllegalStateException("Required field" + plural + " not set:" + sb);
+  }
+
+  /** Throw {@link NullPointerException} if {@code list} or one of its items are null. */
+  public static void checkElementsNotNull(List<?> list) {
+    if (list == null) throw new NullPointerException("list == null");
+    for (int i = 0, size = list.size(); i < size; i++) {
+      Object element = list.get(i);
+      if (element == null) {
+        throw new NullPointerException("Element at index " + i + " is null");
+      }
+    }
+  }
+
+  /** Returns the number of non-null values in {@code a, b}. */
+  public static int countNonNull(Object a, Object b) {
+    return (a != null ? 1 : 0)
+        + (b != null ? 1 : 0);
+  }
+
+  /** Returns the number of non-null values in {@code a, b, c}. */
+  public static int countNonNull(Object a, Object b, Object c) {
+    return (a != null ? 1 : 0)
+        + (b != null ? 1 : 0)
+        + (c != null ? 1 : 0);
+  }
+
+  /** Returns the number of non-null values in {@code a, b, c, d, rest}. */
+  public static int countNonNull(Object a, Object b, Object c, Object d, Object... rest) {
+    int result = 0;
+    if (a != null) result++;
+    if (b != null) result++;
+    if (c != null) result++;
+    if (d != null) result++;
+    for (Object o : rest) {
+      if (o != null) result++;
+    }
+    return result;
+  }
+}

--- a/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/OneOfTest.java
@@ -76,18 +76,6 @@ public class OneOfTest {
     }
   }
 
-  @Test public void countNonNull() throws Exception {
-    assertThat(Message.countNonNull(null, null)).isEqualTo(0);
-    assertThat(Message.countNonNull("xx", null)).isEqualTo(1);
-    assertThat(Message.countNonNull("xx", "xx")).isEqualTo(2);
-    assertThat(Message.countNonNull("xx", "xx", null)).isEqualTo(2);
-    assertThat(Message.countNonNull("xx", "xx", "xx")).isEqualTo(3);
-    assertThat(Message.countNonNull("xx", "xx", "xx", null)).isEqualTo(3);
-    assertThat(Message.countNonNull("xx", "xx", "xx", "xx")).isEqualTo(4);
-    assertThat(Message.countNonNull("xx", "xx", "xx", "xx", (Object) null)).isEqualTo(4);
-    assertThat(Message.countNonNull("xx", "xx", "xx", "xx", "xx")).isEqualTo(5);
-  }
-
   private void validate(OneOfMessage.Builder builder, Integer expectedFoo, String expectedBar,
       byte[] expectedBytes) throws IOException {
     // Check builder fields

--- a/wire-runtime/src/test/java/com/squareup/wire/WireInternalTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireInternalTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public final class WireInternalTest {
+  @Test public void countNonNull() throws Exception {
+    assertThat(WireInternal.countNonNull(null, null)).isEqualTo(0);
+    assertThat(WireInternal.countNonNull("xx", null)).isEqualTo(1);
+    assertThat(WireInternal.countNonNull("xx", "xx")).isEqualTo(2);
+    assertThat(WireInternal.countNonNull("xx", "xx", null)).isEqualTo(2);
+    assertThat(WireInternal.countNonNull("xx", "xx", "xx")).isEqualTo(3);
+    assertThat(WireInternal.countNonNull("xx", "xx", "xx", null)).isEqualTo(3);
+    assertThat(WireInternal.countNonNull("xx", "xx", "xx", "xx")).isEqualTo(4);
+    assertThat(WireInternal.countNonNull("xx", "xx", "xx", "xx", (Object) null)).isEqualTo(4);
+    assertThat(WireInternal.countNonNull("xx", "xx", "xx", "xx", "xx")).isEqualTo(5);
+  }
+}

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -106,30 +107,30 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
   public DescriptorProto(String name, List<FieldDescriptorProto> field, List<FieldDescriptorProto> extension, List<DescriptorProto> nested_type, List<EnumDescriptorProto> enum_type, List<ExtensionRange> extension_range, List<OneofDescriptorProto> oneof_decl, MessageOptions options, List<ReservedRange> reserved_range, List<String> reserved_name, ByteString unknownFields) {
     super(unknownFields);
     this.name = name;
-    this.field = immutableCopyOf("field", field);
-    this.extension = immutableCopyOf("extension", extension);
-    this.nested_type = immutableCopyOf("nested_type", nested_type);
-    this.enum_type = immutableCopyOf("enum_type", enum_type);
-    this.extension_range = immutableCopyOf("extension_range", extension_range);
-    this.oneof_decl = immutableCopyOf("oneof_decl", oneof_decl);
+    this.field = WireInternal.immutableCopyOf("field", field);
+    this.extension = WireInternal.immutableCopyOf("extension", extension);
+    this.nested_type = WireInternal.immutableCopyOf("nested_type", nested_type);
+    this.enum_type = WireInternal.immutableCopyOf("enum_type", enum_type);
+    this.extension_range = WireInternal.immutableCopyOf("extension_range", extension_range);
+    this.oneof_decl = WireInternal.immutableCopyOf("oneof_decl", oneof_decl);
     this.options = options;
-    this.reserved_range = immutableCopyOf("reserved_range", reserved_range);
-    this.reserved_name = immutableCopyOf("reserved_name", reserved_name);
+    this.reserved_range = WireInternal.immutableCopyOf("reserved_range", reserved_range);
+    this.reserved_name = WireInternal.immutableCopyOf("reserved_name", reserved_name);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
     builder.name = name;
-    builder.field = copyOf("field", field);
-    builder.extension = copyOf("extension", extension);
-    builder.nested_type = copyOf("nested_type", nested_type);
-    builder.enum_type = copyOf("enum_type", enum_type);
-    builder.extension_range = copyOf("extension_range", extension_range);
-    builder.oneof_decl = copyOf("oneof_decl", oneof_decl);
+    builder.field = WireInternal.copyOf("field", field);
+    builder.extension = WireInternal.copyOf("extension", extension);
+    builder.nested_type = WireInternal.copyOf("nested_type", nested_type);
+    builder.enum_type = WireInternal.copyOf("enum_type", enum_type);
+    builder.extension_range = WireInternal.copyOf("extension_range", extension_range);
+    builder.oneof_decl = WireInternal.copyOf("oneof_decl", oneof_decl);
     builder.options = options;
-    builder.reserved_range = copyOf("reserved_range", reserved_range);
-    builder.reserved_name = copyOf("reserved_name", reserved_name);
+    builder.reserved_range = WireInternal.copyOf("reserved_range", reserved_range);
+    builder.reserved_name = WireInternal.copyOf("reserved_name", reserved_name);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -139,17 +140,17 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     if (other == this) return true;
     if (!(other instanceof DescriptorProto)) return false;
     DescriptorProto o = (DescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(field, o.field)
-        && equals(extension, o.extension)
-        && equals(nested_type, o.nested_type)
-        && equals(enum_type, o.enum_type)
-        && equals(extension_range, o.extension_range)
-        && equals(oneof_decl, o.oneof_decl)
-        && equals(options, o.options)
-        && equals(reserved_range, o.reserved_range)
-        && equals(reserved_name, o.reserved_name);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(field, o.field)
+        && WireInternal.equals(extension, o.extension)
+        && WireInternal.equals(nested_type, o.nested_type)
+        && WireInternal.equals(enum_type, o.enum_type)
+        && WireInternal.equals(extension_range, o.extension_range)
+        && WireInternal.equals(oneof_decl, o.oneof_decl)
+        && WireInternal.equals(options, o.options)
+        && WireInternal.equals(reserved_range, o.reserved_range)
+        && WireInternal.equals(reserved_name, o.reserved_name);
   }
 
   @Override
@@ -210,14 +211,14 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     public List<String> reserved_name;
 
     public Builder() {
-      field = newMutableList();
-      extension = newMutableList();
-      nested_type = newMutableList();
-      enum_type = newMutableList();
-      extension_range = newMutableList();
-      oneof_decl = newMutableList();
-      reserved_range = newMutableList();
-      reserved_name = newMutableList();
+      field = WireInternal.newMutableList();
+      extension = WireInternal.newMutableList();
+      nested_type = WireInternal.newMutableList();
+      enum_type = WireInternal.newMutableList();
+      extension_range = WireInternal.newMutableList();
+      oneof_decl = WireInternal.newMutableList();
+      reserved_range = WireInternal.newMutableList();
+      reserved_name = WireInternal.newMutableList();
     }
 
     public Builder name(String name) {
@@ -226,37 +227,37 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     }
 
     public Builder field(List<FieldDescriptorProto> field) {
-      checkElementsNotNull(field);
+      WireInternal.checkElementsNotNull(field);
       this.field = field;
       return this;
     }
 
     public Builder extension(List<FieldDescriptorProto> extension) {
-      checkElementsNotNull(extension);
+      WireInternal.checkElementsNotNull(extension);
       this.extension = extension;
       return this;
     }
 
     public Builder nested_type(List<DescriptorProto> nested_type) {
-      checkElementsNotNull(nested_type);
+      WireInternal.checkElementsNotNull(nested_type);
       this.nested_type = nested_type;
       return this;
     }
 
     public Builder enum_type(List<EnumDescriptorProto> enum_type) {
-      checkElementsNotNull(enum_type);
+      WireInternal.checkElementsNotNull(enum_type);
       this.enum_type = enum_type;
       return this;
     }
 
     public Builder extension_range(List<ExtensionRange> extension_range) {
-      checkElementsNotNull(extension_range);
+      WireInternal.checkElementsNotNull(extension_range);
       this.extension_range = extension_range;
       return this;
     }
 
     public Builder oneof_decl(List<OneofDescriptorProto> oneof_decl) {
-      checkElementsNotNull(oneof_decl);
+      WireInternal.checkElementsNotNull(oneof_decl);
       this.oneof_decl = oneof_decl;
       return this;
     }
@@ -267,7 +268,7 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     }
 
     public Builder reserved_range(List<ReservedRange> reserved_range) {
-      checkElementsNotNull(reserved_range);
+      WireInternal.checkElementsNotNull(reserved_range);
       this.reserved_range = reserved_range;
       return this;
     }
@@ -277,7 +278,7 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
      * A given name may only be reserved once.
      */
     public Builder reserved_name(List<String> reserved_name) {
-      checkElementsNotNull(reserved_name);
+      WireInternal.checkElementsNotNull(reserved_name);
       this.reserved_name = reserved_name;
       return this;
     }
@@ -333,9 +334,9 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
       if (other == this) return true;
       if (!(other instanceof ExtensionRange)) return false;
       ExtensionRange o = (ExtensionRange) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(start, o.start)
-          && equals(end, o.end);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(start, o.start)
+          && WireInternal.equals(end, o.end);
     }
 
     @Override
@@ -485,9 +486,9 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
       if (other == this) return true;
       if (!(other instanceof ReservedRange)) return false;
       ReservedRange o = (ReservedRange) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(start, o.start)
-          && equals(end, o.end);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(start, o.start)
+          && WireInternal.equals(end, o.end);
     }
 
     @Override
@@ -652,14 +653,14 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     @Override
     public DescriptorProto redact(DescriptorProto value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.field, FieldDescriptorProto.ADAPTER);
-      redactElements(builder.extension, FieldDescriptorProto.ADAPTER);
-      redactElements(builder.nested_type, DescriptorProto.ADAPTER);
-      redactElements(builder.enum_type, EnumDescriptorProto.ADAPTER);
-      redactElements(builder.extension_range, ExtensionRange.ADAPTER);
-      redactElements(builder.oneof_decl, OneofDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.field, FieldDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.extension, FieldDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.nested_type, DescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.enum_type, EnumDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.extension_range, ExtensionRange.ADAPTER);
+      WireInternal.redactElements(builder.oneof_decl, OneofDescriptorProto.ADAPTER);
       if (builder.options != null) builder.options = MessageOptions.ADAPTER.redact(builder.options);
-      redactElements(builder.reserved_range, ReservedRange.ADAPTER);
+      WireInternal.redactElements(builder.reserved_range, ReservedRange.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -52,7 +53,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
   public EnumDescriptorProto(String name, List<EnumValueDescriptorProto> value, EnumOptions options, ByteString unknownFields) {
     super(unknownFields);
     this.name = name;
-    this.value = immutableCopyOf("value", value);
+    this.value = WireInternal.immutableCopyOf("value", value);
     this.options = options;
   }
 
@@ -60,7 +61,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
   public Builder newBuilder() {
     Builder builder = new Builder();
     builder.name = name;
-    builder.value = copyOf("value", value);
+    builder.value = WireInternal.copyOf("value", value);
     builder.options = options;
     builder.addUnknownFields(unknownFields());
     return builder;
@@ -71,10 +72,10 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     if (other == this) return true;
     if (!(other instanceof EnumDescriptorProto)) return false;
     EnumDescriptorProto o = (EnumDescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(value, o.value)
-        && equals(options, o.options);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(value, o.value)
+        && WireInternal.equals(options, o.options);
   }
 
   @Override
@@ -107,7 +108,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     public EnumOptions options;
 
     public Builder() {
-      value = newMutableList();
+      value = WireInternal.newMutableList();
     }
 
     public Builder name(String name) {
@@ -116,7 +117,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     }
 
     public Builder value(List<EnumValueDescriptorProto> value) {
-      checkElementsNotNull(value);
+      WireInternal.checkElementsNotNull(value);
       this.value = value;
       return this;
     }
@@ -176,7 +177,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     @Override
     public EnumDescriptorProto redact(EnumDescriptorProto value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.value, EnumValueDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.value, EnumValueDescriptorProto.ADAPTER);
       if (builder.options != null) builder.options = EnumOptions.ADAPTER.redact(builder.options);
       builder.clearUnknownFields();
       return builder.build();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -77,7 +78,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     super(unknownFields);
     this.allow_alias = allow_alias;
     this.deprecated = deprecated;
-    this.uninterpreted_option = immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.uninterpreted_option = WireInternal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
     this.enum_option = enum_option;
   }
 
@@ -86,7 +87,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     Builder builder = new Builder();
     builder.allow_alias = allow_alias;
     builder.deprecated = deprecated;
-    builder.uninterpreted_option = copyOf("uninterpreted_option", uninterpreted_option);
+    builder.uninterpreted_option = WireInternal.copyOf("uninterpreted_option", uninterpreted_option);
     builder.enum_option = enum_option;
     builder.addUnknownFields(unknownFields());
     return builder;
@@ -97,11 +98,11 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     if (other == this) return true;
     if (!(other instanceof EnumOptions)) return false;
     EnumOptions o = (EnumOptions) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(allow_alias, o.allow_alias)
-        && equals(deprecated, o.deprecated)
-        && equals(uninterpreted_option, o.uninterpreted_option)
-        && equals(enum_option, o.enum_option);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(allow_alias, o.allow_alias)
+        && WireInternal.equals(deprecated, o.deprecated)
+        && WireInternal.equals(uninterpreted_option, o.uninterpreted_option)
+        && WireInternal.equals(enum_option, o.enum_option);
   }
 
   @Override
@@ -138,7 +139,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     public Boolean enum_option;
 
     public Builder() {
-      uninterpreted_option = newMutableList();
+      uninterpreted_option = WireInternal.newMutableList();
     }
 
     /**
@@ -165,7 +166,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      checkElementsNotNull(uninterpreted_option);
+      WireInternal.checkElementsNotNull(uninterpreted_option);
       this.uninterpreted_option = uninterpreted_option;
       return this;
     }
@@ -228,7 +229,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     @Override
     public EnumOptions redact(EnumOptions value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
+      WireInternal.redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -72,10 +73,10 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
     if (other == this) return true;
     if (!(other instanceof EnumValueDescriptorProto)) return false;
     EnumValueDescriptorProto o = (EnumValueDescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(number, o.number)
-        && equals(options, o.options);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(number, o.number)
+        && WireInternal.equals(options, o.options);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import com.squareup.wire.protos.custom_options.FooBar;
 import java.io.IOException;
 import java.lang.Boolean;
@@ -86,7 +87,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
   public EnumValueOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option, Integer enum_value_option, FooBar.More complex_enum_value_option, Boolean foreign_enum_value_option, ByteString unknownFields) {
     super(unknownFields);
     this.deprecated = deprecated;
-    this.uninterpreted_option = immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.uninterpreted_option = WireInternal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
     this.enum_value_option = enum_value_option;
     this.complex_enum_value_option = complex_enum_value_option;
     this.foreign_enum_value_option = foreign_enum_value_option;
@@ -96,7 +97,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
   public Builder newBuilder() {
     Builder builder = new Builder();
     builder.deprecated = deprecated;
-    builder.uninterpreted_option = copyOf("uninterpreted_option", uninterpreted_option);
+    builder.uninterpreted_option = WireInternal.copyOf("uninterpreted_option", uninterpreted_option);
     builder.enum_value_option = enum_value_option;
     builder.complex_enum_value_option = complex_enum_value_option;
     builder.foreign_enum_value_option = foreign_enum_value_option;
@@ -109,12 +110,12 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
     if (other == this) return true;
     if (!(other instanceof EnumValueOptions)) return false;
     EnumValueOptions o = (EnumValueOptions) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(deprecated, o.deprecated)
-        && equals(uninterpreted_option, o.uninterpreted_option)
-        && equals(enum_value_option, o.enum_value_option)
-        && equals(complex_enum_value_option, o.complex_enum_value_option)
-        && equals(foreign_enum_value_option, o.foreign_enum_value_option);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(deprecated, o.deprecated)
+        && WireInternal.equals(uninterpreted_option, o.uninterpreted_option)
+        && WireInternal.equals(enum_value_option, o.enum_value_option)
+        && WireInternal.equals(complex_enum_value_option, o.complex_enum_value_option)
+        && WireInternal.equals(foreign_enum_value_option, o.foreign_enum_value_option);
   }
 
   @Override
@@ -155,7 +156,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
     public Boolean foreign_enum_value_option;
 
     public Builder() {
-      uninterpreted_option = newMutableList();
+      uninterpreted_option = WireInternal.newMutableList();
     }
 
     /**
@@ -173,7 +174,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      checkElementsNotNull(uninterpreted_option);
+      WireInternal.checkElementsNotNull(uninterpreted_option);
       this.uninterpreted_option = uninterpreted_option;
       return this;
     }
@@ -249,7 +250,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
     @Override
     public EnumValueOptions redact(EnumValueOptions value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
+      WireInternal.redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
       if (builder.complex_enum_value_option != null) builder.complex_enum_value_option = FooBar.More.ADAPTER.redact(builder.complex_enum_value_option);
       builder.clearUnknownFields();
       return builder.build();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -159,16 +160,16 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
     if (other == this) return true;
     if (!(other instanceof FieldDescriptorProto)) return false;
     FieldDescriptorProto o = (FieldDescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(number, o.number)
-        && equals(label, o.label)
-        && equals(type, o.type)
-        && equals(type_name, o.type_name)
-        && equals(extendee, o.extendee)
-        && equals(default_value, o.default_value)
-        && equals(oneof_index, o.oneof_index)
-        && equals(options, o.options);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(number, o.number)
+        && WireInternal.equals(label, o.label)
+        && WireInternal.equals(type, o.type)
+        && WireInternal.equals(type_name, o.type_name)
+        && WireInternal.equals(extendee, o.extendee)
+        && WireInternal.equals(default_value, o.default_value)
+        && WireInternal.equals(oneof_index, o.oneof_index)
+        && WireInternal.equals(options, o.options);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import com.squareup.wire.protos.custom_options.FooBar;
 import java.io.IOException;
 import java.lang.Boolean;
@@ -257,7 +258,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     this.lazy = lazy;
     this.deprecated = deprecated;
     this.weak = weak;
-    this.uninterpreted_option = immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.uninterpreted_option = WireInternal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
     this.my_field_option_one = my_field_option_one;
     this.my_field_option_two = my_field_option_two;
     this.my_field_option_three = my_field_option_three;
@@ -278,7 +279,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     builder.lazy = lazy;
     builder.deprecated = deprecated;
     builder.weak = weak;
-    builder.uninterpreted_option = copyOf("uninterpreted_option", uninterpreted_option);
+    builder.uninterpreted_option = WireInternal.copyOf("uninterpreted_option", uninterpreted_option);
     builder.my_field_option_one = my_field_option_one;
     builder.my_field_option_two = my_field_option_two;
     builder.my_field_option_three = my_field_option_three;
@@ -297,23 +298,23 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     if (other == this) return true;
     if (!(other instanceof FieldOptions)) return false;
     FieldOptions o = (FieldOptions) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(ctype, o.ctype)
-        && equals(packed, o.packed)
-        && equals(jstype, o.jstype)
-        && equals(lazy, o.lazy)
-        && equals(deprecated, o.deprecated)
-        && equals(weak, o.weak)
-        && equals(uninterpreted_option, o.uninterpreted_option)
-        && equals(my_field_option_one, o.my_field_option_one)
-        && equals(my_field_option_two, o.my_field_option_two)
-        && equals(my_field_option_three, o.my_field_option_three)
-        && equals(my_field_option_four, o.my_field_option_four)
-        && equals(squareup_protos_extension_collision_1_a, o.squareup_protos_extension_collision_1_a)
-        && equals(b, o.b)
-        && equals(squareup_protos_extension_collision_2_a, o.squareup_protos_extension_collision_2_a)
-        && equals(c, o.c)
-        && equals(redacted, o.redacted);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(ctype, o.ctype)
+        && WireInternal.equals(packed, o.packed)
+        && WireInternal.equals(jstype, o.jstype)
+        && WireInternal.equals(lazy, o.lazy)
+        && WireInternal.equals(deprecated, o.deprecated)
+        && WireInternal.equals(weak, o.weak)
+        && WireInternal.equals(uninterpreted_option, o.uninterpreted_option)
+        && WireInternal.equals(my_field_option_one, o.my_field_option_one)
+        && WireInternal.equals(my_field_option_two, o.my_field_option_two)
+        && WireInternal.equals(my_field_option_three, o.my_field_option_three)
+        && WireInternal.equals(my_field_option_four, o.my_field_option_four)
+        && WireInternal.equals(squareup_protos_extension_collision_1_a, o.squareup_protos_extension_collision_1_a)
+        && WireInternal.equals(b, o.b)
+        && WireInternal.equals(squareup_protos_extension_collision_2_a, o.squareup_protos_extension_collision_2_a)
+        && WireInternal.equals(c, o.c)
+        && WireInternal.equals(redacted, o.redacted);
   }
 
   @Override
@@ -398,7 +399,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     public Boolean redacted;
 
     public Builder() {
-      uninterpreted_option = newMutableList();
+      uninterpreted_option = WireInternal.newMutableList();
     }
 
     /**
@@ -498,7 +499,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      checkElementsNotNull(uninterpreted_option);
+      WireInternal.checkElementsNotNull(uninterpreted_option);
       this.uninterpreted_option = uninterpreted_option;
       return this;
     }
@@ -739,7 +740,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     @Override
     public FieldOptions redact(FieldOptions value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
+      WireInternal.redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
       if (builder.my_field_option_four != null) builder.my_field_option_four = FooBar.ADAPTER.redact(builder.my_field_option_four);
       builder.clearUnknownFields();
       return builder.build();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -147,13 +148,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     super(unknownFields);
     this.name = name;
     this.package_ = package_;
-    this.dependency = immutableCopyOf("dependency", dependency);
-    this.public_dependency = immutableCopyOf("public_dependency", public_dependency);
-    this.weak_dependency = immutableCopyOf("weak_dependency", weak_dependency);
-    this.message_type = immutableCopyOf("message_type", message_type);
-    this.enum_type = immutableCopyOf("enum_type", enum_type);
-    this.service = immutableCopyOf("service", service);
-    this.extension = immutableCopyOf("extension", extension);
+    this.dependency = WireInternal.immutableCopyOf("dependency", dependency);
+    this.public_dependency = WireInternal.immutableCopyOf("public_dependency", public_dependency);
+    this.weak_dependency = WireInternal.immutableCopyOf("weak_dependency", weak_dependency);
+    this.message_type = WireInternal.immutableCopyOf("message_type", message_type);
+    this.enum_type = WireInternal.immutableCopyOf("enum_type", enum_type);
+    this.service = WireInternal.immutableCopyOf("service", service);
+    this.extension = WireInternal.immutableCopyOf("extension", extension);
     this.options = options;
     this.source_code_info = source_code_info;
     this.syntax = syntax;
@@ -164,13 +165,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     Builder builder = new Builder();
     builder.name = name;
     builder.package_ = package_;
-    builder.dependency = copyOf("dependency", dependency);
-    builder.public_dependency = copyOf("public_dependency", public_dependency);
-    builder.weak_dependency = copyOf("weak_dependency", weak_dependency);
-    builder.message_type = copyOf("message_type", message_type);
-    builder.enum_type = copyOf("enum_type", enum_type);
-    builder.service = copyOf("service", service);
-    builder.extension = copyOf("extension", extension);
+    builder.dependency = WireInternal.copyOf("dependency", dependency);
+    builder.public_dependency = WireInternal.copyOf("public_dependency", public_dependency);
+    builder.weak_dependency = WireInternal.copyOf("weak_dependency", weak_dependency);
+    builder.message_type = WireInternal.copyOf("message_type", message_type);
+    builder.enum_type = WireInternal.copyOf("enum_type", enum_type);
+    builder.service = WireInternal.copyOf("service", service);
+    builder.extension = WireInternal.copyOf("extension", extension);
     builder.options = options;
     builder.source_code_info = source_code_info;
     builder.syntax = syntax;
@@ -183,19 +184,19 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     if (other == this) return true;
     if (!(other instanceof FileDescriptorProto)) return false;
     FileDescriptorProto o = (FileDescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(package_, o.package_)
-        && equals(dependency, o.dependency)
-        && equals(public_dependency, o.public_dependency)
-        && equals(weak_dependency, o.weak_dependency)
-        && equals(message_type, o.message_type)
-        && equals(enum_type, o.enum_type)
-        && equals(service, o.service)
-        && equals(extension, o.extension)
-        && equals(options, o.options)
-        && equals(source_code_info, o.source_code_info)
-        && equals(syntax, o.syntax);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(package_, o.package_)
+        && WireInternal.equals(dependency, o.dependency)
+        && WireInternal.equals(public_dependency, o.public_dependency)
+        && WireInternal.equals(weak_dependency, o.weak_dependency)
+        && WireInternal.equals(message_type, o.message_type)
+        && WireInternal.equals(enum_type, o.enum_type)
+        && WireInternal.equals(service, o.service)
+        && WireInternal.equals(extension, o.extension)
+        && WireInternal.equals(options, o.options)
+        && WireInternal.equals(source_code_info, o.source_code_info)
+        && WireInternal.equals(syntax, o.syntax);
   }
 
   @Override
@@ -264,13 +265,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     public String syntax;
 
     public Builder() {
-      dependency = newMutableList();
-      public_dependency = newMutableList();
-      weak_dependency = newMutableList();
-      message_type = newMutableList();
-      enum_type = newMutableList();
-      service = newMutableList();
-      extension = newMutableList();
+      dependency = WireInternal.newMutableList();
+      public_dependency = WireInternal.newMutableList();
+      weak_dependency = WireInternal.newMutableList();
+      message_type = WireInternal.newMutableList();
+      enum_type = WireInternal.newMutableList();
+      service = WireInternal.newMutableList();
+      extension = WireInternal.newMutableList();
     }
 
     /**
@@ -293,7 +294,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
      * Names of files imported by this file.
      */
     public Builder dependency(List<String> dependency) {
-      checkElementsNotNull(dependency);
+      WireInternal.checkElementsNotNull(dependency);
       this.dependency = dependency;
       return this;
     }
@@ -302,7 +303,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
      * Indexes of the public imported files in the dependency list above.
      */
     public Builder public_dependency(List<Integer> public_dependency) {
-      checkElementsNotNull(public_dependency);
+      WireInternal.checkElementsNotNull(public_dependency);
       this.public_dependency = public_dependency;
       return this;
     }
@@ -312,7 +313,7 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
      * For Google-internal migration only. Do not use.
      */
     public Builder weak_dependency(List<Integer> weak_dependency) {
-      checkElementsNotNull(weak_dependency);
+      WireInternal.checkElementsNotNull(weak_dependency);
       this.weak_dependency = weak_dependency;
       return this;
     }
@@ -321,25 +322,25 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
      * All top-level definitions in this file.
      */
     public Builder message_type(List<DescriptorProto> message_type) {
-      checkElementsNotNull(message_type);
+      WireInternal.checkElementsNotNull(message_type);
       this.message_type = message_type;
       return this;
     }
 
     public Builder enum_type(List<EnumDescriptorProto> enum_type) {
-      checkElementsNotNull(enum_type);
+      WireInternal.checkElementsNotNull(enum_type);
       this.enum_type = enum_type;
       return this;
     }
 
     public Builder service(List<ServiceDescriptorProto> service) {
-      checkElementsNotNull(service);
+      WireInternal.checkElementsNotNull(service);
       this.service = service;
       return this;
     }
 
     public Builder extension(List<FieldDescriptorProto> extension) {
-      checkElementsNotNull(extension);
+      WireInternal.checkElementsNotNull(extension);
       this.extension = extension;
       return this;
     }
@@ -446,10 +447,10 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     @Override
     public FileDescriptorProto redact(FileDescriptorProto value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.message_type, DescriptorProto.ADAPTER);
-      redactElements(builder.enum_type, EnumDescriptorProto.ADAPTER);
-      redactElements(builder.service, ServiceDescriptorProto.ADAPTER);
-      redactElements(builder.extension, FieldDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.message_type, DescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.enum_type, EnumDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.service, ServiceDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.extension, FieldDescriptorProto.ADAPTER);
       if (builder.options != null) builder.options = FileOptions.ADAPTER.redact(builder.options);
       if (builder.source_code_info != null) builder.source_code_info = SourceCodeInfo.ADAPTER.redact(builder.source_code_info);
       builder.clearUnknownFields();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -38,13 +39,13 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
 
   public FileDescriptorSet(List<FileDescriptorProto> file, ByteString unknownFields) {
     super(unknownFields);
-    this.file = immutableCopyOf("file", file);
+    this.file = WireInternal.immutableCopyOf("file", file);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.file = copyOf("file", file);
+    builder.file = WireInternal.copyOf("file", file);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -54,8 +55,8 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
     if (other == this) return true;
     if (!(other instanceof FileDescriptorSet)) return false;
     FileDescriptorSet o = (FileDescriptorSet) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(file, o.file);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(file, o.file);
   }
 
   @Override
@@ -80,11 +81,11 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
     public List<FileDescriptorProto> file;
 
     public Builder() {
-      file = newMutableList();
+      file = WireInternal.newMutableList();
     }
 
     public Builder file(List<FileDescriptorProto> file) {
-      checkElementsNotNull(file);
+      WireInternal.checkElementsNotNull(file);
       this.file = file;
       return this;
     }
@@ -133,7 +134,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
     @Override
     public FileDescriptorSet redact(FileDescriptorSet value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.file, FileDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.file, FileDescriptorProto.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -274,7 +275,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     this.cc_enable_arenas = cc_enable_arenas;
     this.objc_class_prefix = objc_class_prefix;
     this.csharp_namespace = csharp_namespace;
-    this.uninterpreted_option = immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.uninterpreted_option = WireInternal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
   }
 
   @Override
@@ -294,7 +295,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     builder.cc_enable_arenas = cc_enable_arenas;
     builder.objc_class_prefix = objc_class_prefix;
     builder.csharp_namespace = csharp_namespace;
-    builder.uninterpreted_option = copyOf("uninterpreted_option", uninterpreted_option);
+    builder.uninterpreted_option = WireInternal.copyOf("uninterpreted_option", uninterpreted_option);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -304,22 +305,22 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     if (other == this) return true;
     if (!(other instanceof FileOptions)) return false;
     FileOptions o = (FileOptions) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(java_package, o.java_package)
-        && equals(java_outer_classname, o.java_outer_classname)
-        && equals(java_multiple_files, o.java_multiple_files)
-        && equals(java_generate_equals_and_hash, o.java_generate_equals_and_hash)
-        && equals(java_string_check_utf8, o.java_string_check_utf8)
-        && equals(optimize_for, o.optimize_for)
-        && equals(go_package, o.go_package)
-        && equals(cc_generic_services, o.cc_generic_services)
-        && equals(java_generic_services, o.java_generic_services)
-        && equals(py_generic_services, o.py_generic_services)
-        && equals(deprecated, o.deprecated)
-        && equals(cc_enable_arenas, o.cc_enable_arenas)
-        && equals(objc_class_prefix, o.objc_class_prefix)
-        && equals(csharp_namespace, o.csharp_namespace)
-        && equals(uninterpreted_option, o.uninterpreted_option);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(java_package, o.java_package)
+        && WireInternal.equals(java_outer_classname, o.java_outer_classname)
+        && WireInternal.equals(java_multiple_files, o.java_multiple_files)
+        && WireInternal.equals(java_generate_equals_and_hash, o.java_generate_equals_and_hash)
+        && WireInternal.equals(java_string_check_utf8, o.java_string_check_utf8)
+        && WireInternal.equals(optimize_for, o.optimize_for)
+        && WireInternal.equals(go_package, o.go_package)
+        && WireInternal.equals(cc_generic_services, o.cc_generic_services)
+        && WireInternal.equals(java_generic_services, o.java_generic_services)
+        && WireInternal.equals(py_generic_services, o.py_generic_services)
+        && WireInternal.equals(deprecated, o.deprecated)
+        && WireInternal.equals(cc_enable_arenas, o.cc_enable_arenas)
+        && WireInternal.equals(objc_class_prefix, o.objc_class_prefix)
+        && WireInternal.equals(csharp_namespace, o.csharp_namespace)
+        && WireInternal.equals(uninterpreted_option, o.uninterpreted_option);
   }
 
   @Override
@@ -400,7 +401,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = newMutableList();
+      uninterpreted_option = WireInternal.newMutableList();
     }
 
     /**
@@ -554,7 +555,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      checkElementsNotNull(uninterpreted_option);
+      WireInternal.checkElementsNotNull(uninterpreted_option);
       this.uninterpreted_option = uninterpreted_option;
       return this;
     }
@@ -698,7 +699,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     @Override
     public FileOptions redact(FileOptions value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
+      WireInternal.redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import com.squareup.wire.protos.custom_options.FooBar;
 import com.squareup.wire.protos.foreign.ForeignMessage;
 import java.io.IOException;
@@ -198,7 +199,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     this.no_standard_descriptor_accessor = no_standard_descriptor_accessor;
     this.deprecated = deprecated;
     this.map_entry = map_entry;
-    this.uninterpreted_option = immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.uninterpreted_option = WireInternal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
     this.my_message_option_one = my_message_option_one;
     this.my_message_option_two = my_message_option_two;
     this.my_message_option_three = my_message_option_three;
@@ -215,7 +216,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     builder.no_standard_descriptor_accessor = no_standard_descriptor_accessor;
     builder.deprecated = deprecated;
     builder.map_entry = map_entry;
-    builder.uninterpreted_option = copyOf("uninterpreted_option", uninterpreted_option);
+    builder.uninterpreted_option = WireInternal.copyOf("uninterpreted_option", uninterpreted_option);
     builder.my_message_option_one = my_message_option_one;
     builder.my_message_option_two = my_message_option_two;
     builder.my_message_option_three = my_message_option_three;
@@ -232,19 +233,19 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     if (other == this) return true;
     if (!(other instanceof MessageOptions)) return false;
     MessageOptions o = (MessageOptions) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(message_set_wire_format, o.message_set_wire_format)
-        && equals(no_standard_descriptor_accessor, o.no_standard_descriptor_accessor)
-        && equals(deprecated, o.deprecated)
-        && equals(map_entry, o.map_entry)
-        && equals(uninterpreted_option, o.uninterpreted_option)
-        && equals(my_message_option_one, o.my_message_option_one)
-        && equals(my_message_option_two, o.my_message_option_two)
-        && equals(my_message_option_three, o.my_message_option_three)
-        && equals(my_message_option_four, o.my_message_option_four)
-        && equals(my_message_option_five, o.my_message_option_five)
-        && equals(my_message_option_six, o.my_message_option_six)
-        && equals(foreign_message_option, o.foreign_message_option);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(message_set_wire_format, o.message_set_wire_format)
+        && WireInternal.equals(no_standard_descriptor_accessor, o.no_standard_descriptor_accessor)
+        && WireInternal.equals(deprecated, o.deprecated)
+        && WireInternal.equals(map_entry, o.map_entry)
+        && WireInternal.equals(uninterpreted_option, o.uninterpreted_option)
+        && WireInternal.equals(my_message_option_one, o.my_message_option_one)
+        && WireInternal.equals(my_message_option_two, o.my_message_option_two)
+        && WireInternal.equals(my_message_option_three, o.my_message_option_three)
+        && WireInternal.equals(my_message_option_four, o.my_message_option_four)
+        && WireInternal.equals(my_message_option_five, o.my_message_option_five)
+        && WireInternal.equals(my_message_option_six, o.my_message_option_six)
+        && WireInternal.equals(foreign_message_option, o.foreign_message_option);
   }
 
   @Override
@@ -313,7 +314,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     public ForeignMessage foreign_message_option;
 
     public Builder() {
-      uninterpreted_option = newMutableList();
+      uninterpreted_option = WireInternal.newMutableList();
     }
 
     /**
@@ -394,7 +395,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      checkElementsNotNull(uninterpreted_option);
+      WireInternal.checkElementsNotNull(uninterpreted_option);
       this.uninterpreted_option = uninterpreted_option;
       return this;
     }
@@ -518,7 +519,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     @Override
     public MessageOptions redact(MessageOptions value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
+      WireInternal.redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
       if (builder.my_message_option_one != null) builder.my_message_option_one = FooBar.ADAPTER.redact(builder.my_message_option_one);
       if (builder.my_message_option_three != null) builder.my_message_option_three = FooBar.ADAPTER.redact(builder.my_message_option_three);
       if (builder.my_message_option_five != null) builder.my_message_option_five = FooBar.ADAPTER.redact(builder.my_message_option_five);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -112,13 +113,13 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto, 
     if (other == this) return true;
     if (!(other instanceof MethodDescriptorProto)) return false;
     MethodDescriptorProto o = (MethodDescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(input_type, o.input_type)
-        && equals(output_type, o.output_type)
-        && equals(options, o.options)
-        && equals(client_streaming, o.client_streaming)
-        && equals(server_streaming, o.server_streaming);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(input_type, o.input_type)
+        && WireInternal.equals(output_type, o.output_type)
+        && WireInternal.equals(options, o.options)
+        && WireInternal.equals(client_streaming, o.client_streaming)
+        && WireInternal.equals(server_streaming, o.server_streaming);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -57,14 +58,14 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
   public MethodOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option, ByteString unknownFields) {
     super(unknownFields);
     this.deprecated = deprecated;
-    this.uninterpreted_option = immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.uninterpreted_option = WireInternal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
     builder.deprecated = deprecated;
-    builder.uninterpreted_option = copyOf("uninterpreted_option", uninterpreted_option);
+    builder.uninterpreted_option = WireInternal.copyOf("uninterpreted_option", uninterpreted_option);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -74,9 +75,9 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     if (other == this) return true;
     if (!(other instanceof MethodOptions)) return false;
     MethodOptions o = (MethodOptions) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(deprecated, o.deprecated)
-        && equals(uninterpreted_option, o.uninterpreted_option);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(deprecated, o.deprecated)
+        && WireInternal.equals(uninterpreted_option, o.uninterpreted_option);
   }
 
   @Override
@@ -105,7 +106,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = newMutableList();
+      uninterpreted_option = WireInternal.newMutableList();
     }
 
     /**
@@ -127,7 +128,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      checkElementsNotNull(uninterpreted_option);
+      WireInternal.checkElementsNotNull(uninterpreted_option);
       this.uninterpreted_option = uninterpreted_option;
       return this;
     }
@@ -179,7 +180,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     @Override
     public MethodOptions redact(MethodOptions value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
+      WireInternal.redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -53,8 +54,8 @@ public final class OneofDescriptorProto extends Message<OneofDescriptorProto, On
     if (other == this) return true;
     if (!(other instanceof OneofDescriptorProto)) return false;
     OneofDescriptorProto o = (OneofDescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -52,7 +53,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
   public ServiceDescriptorProto(String name, List<MethodDescriptorProto> method, ServiceOptions options, ByteString unknownFields) {
     super(unknownFields);
     this.name = name;
-    this.method = immutableCopyOf("method", method);
+    this.method = WireInternal.immutableCopyOf("method", method);
     this.options = options;
   }
 
@@ -60,7 +61,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
   public Builder newBuilder() {
     Builder builder = new Builder();
     builder.name = name;
-    builder.method = copyOf("method", method);
+    builder.method = WireInternal.copyOf("method", method);
     builder.options = options;
     builder.addUnknownFields(unknownFields());
     return builder;
@@ -71,10 +72,10 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     if (other == this) return true;
     if (!(other instanceof ServiceDescriptorProto)) return false;
     ServiceDescriptorProto o = (ServiceDescriptorProto) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(method, o.method)
-        && equals(options, o.options);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(method, o.method)
+        && WireInternal.equals(options, o.options);
   }
 
   @Override
@@ -107,7 +108,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     public ServiceOptions options;
 
     public Builder() {
-      method = newMutableList();
+      method = WireInternal.newMutableList();
     }
 
     public Builder name(String name) {
@@ -116,7 +117,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     }
 
     public Builder method(List<MethodDescriptorProto> method) {
-      checkElementsNotNull(method);
+      WireInternal.checkElementsNotNull(method);
       this.method = method;
       return this;
     }
@@ -176,7 +177,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     @Override
     public ServiceDescriptorProto redact(ServiceDescriptorProto value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.method, MethodDescriptorProto.ADAPTER);
+      WireInternal.redactElements(builder.method, MethodDescriptorProto.ADAPTER);
       if (builder.options != null) builder.options = ServiceOptions.ADAPTER.redact(builder.options);
       builder.clearUnknownFields();
       return builder.build();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Object;
@@ -57,14 +58,14 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
   public ServiceOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option, ByteString unknownFields) {
     super(unknownFields);
     this.deprecated = deprecated;
-    this.uninterpreted_option = immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.uninterpreted_option = WireInternal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
     builder.deprecated = deprecated;
-    builder.uninterpreted_option = copyOf("uninterpreted_option", uninterpreted_option);
+    builder.uninterpreted_option = WireInternal.copyOf("uninterpreted_option", uninterpreted_option);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -74,9 +75,9 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     if (other == this) return true;
     if (!(other instanceof ServiceOptions)) return false;
     ServiceOptions o = (ServiceOptions) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(deprecated, o.deprecated)
-        && equals(uninterpreted_option, o.uninterpreted_option);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(deprecated, o.deprecated)
+        && WireInternal.equals(uninterpreted_option, o.uninterpreted_option);
   }
 
   @Override
@@ -105,7 +106,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     public List<UninterpretedOption> uninterpreted_option;
 
     public Builder() {
-      uninterpreted_option = newMutableList();
+      uninterpreted_option = WireInternal.newMutableList();
     }
 
     /**
@@ -127,7 +128,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
      * The parser stores options it doesn't recognize here. See above.
      */
     public Builder uninterpreted_option(List<UninterpretedOption> uninterpreted_option) {
-      checkElementsNotNull(uninterpreted_option);
+      WireInternal.checkElementsNotNull(uninterpreted_option);
       this.uninterpreted_option = uninterpreted_option;
       return this;
     }
@@ -179,7 +180,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     @Override
     public ServiceOptions redact(ServiceOptions value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
+      WireInternal.redactElements(builder.uninterpreted_option, UninterpretedOption.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -86,13 +87,13 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
 
   public SourceCodeInfo(List<Location> location, ByteString unknownFields) {
     super(unknownFields);
-    this.location = immutableCopyOf("location", location);
+    this.location = WireInternal.immutableCopyOf("location", location);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.location = copyOf("location", location);
+    builder.location = WireInternal.copyOf("location", location);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -102,8 +103,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     if (other == this) return true;
     if (!(other instanceof SourceCodeInfo)) return false;
     SourceCodeInfo o = (SourceCodeInfo) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(location, o.location);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(location, o.location);
   }
 
   @Override
@@ -128,7 +129,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     public List<Location> location;
 
     public Builder() {
-      location = newMutableList();
+      location = WireInternal.newMutableList();
     }
 
     /**
@@ -177,7 +178,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
      *   be recorded in the future.
      */
     public Builder location(List<Location> location) {
-      checkElementsNotNull(location);
+      WireInternal.checkElementsNotNull(location);
       this.location = location;
       return this;
     }
@@ -317,21 +318,21 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
 
     public Location(List<Integer> path, List<Integer> span, String leading_comments, String trailing_comments, List<String> leading_detached_comments, ByteString unknownFields) {
       super(unknownFields);
-      this.path = immutableCopyOf("path", path);
-      this.span = immutableCopyOf("span", span);
+      this.path = WireInternal.immutableCopyOf("path", path);
+      this.span = WireInternal.immutableCopyOf("span", span);
       this.leading_comments = leading_comments;
       this.trailing_comments = trailing_comments;
-      this.leading_detached_comments = immutableCopyOf("leading_detached_comments", leading_detached_comments);
+      this.leading_detached_comments = WireInternal.immutableCopyOf("leading_detached_comments", leading_detached_comments);
     }
 
     @Override
     public Builder newBuilder() {
       Builder builder = new Builder();
-      builder.path = copyOf("path", path);
-      builder.span = copyOf("span", span);
+      builder.path = WireInternal.copyOf("path", path);
+      builder.span = WireInternal.copyOf("span", span);
       builder.leading_comments = leading_comments;
       builder.trailing_comments = trailing_comments;
-      builder.leading_detached_comments = copyOf("leading_detached_comments", leading_detached_comments);
+      builder.leading_detached_comments = WireInternal.copyOf("leading_detached_comments", leading_detached_comments);
       builder.addUnknownFields(unknownFields());
       return builder;
     }
@@ -341,12 +342,12 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
       if (other == this) return true;
       if (!(other instanceof Location)) return false;
       Location o = (Location) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(path, o.path)
-          && equals(span, o.span)
-          && equals(leading_comments, o.leading_comments)
-          && equals(trailing_comments, o.trailing_comments)
-          && equals(leading_detached_comments, o.leading_detached_comments);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(path, o.path)
+          && WireInternal.equals(span, o.span)
+          && WireInternal.equals(leading_comments, o.leading_comments)
+          && WireInternal.equals(trailing_comments, o.trailing_comments)
+          && WireInternal.equals(leading_detached_comments, o.leading_detached_comments);
     }
 
     @Override
@@ -387,9 +388,9 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
       public List<String> leading_detached_comments;
 
       public Builder() {
-        path = newMutableList();
-        span = newMutableList();
-        leading_detached_comments = newMutableList();
+        path = WireInternal.newMutableList();
+        span = WireInternal.newMutableList();
+        leading_detached_comments = WireInternal.newMutableList();
       }
 
       /**
@@ -418,7 +419,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
        * of the label to the terminating semicolon).
        */
       public Builder path(List<Integer> path) {
-        checkElementsNotNull(path);
+        WireInternal.checkElementsNotNull(path);
         this.path = path;
         return this;
       }
@@ -431,7 +432,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
        * 1 to each before displaying to a user.
        */
       public Builder span(List<Integer> span) {
-        checkElementsNotNull(span);
+        WireInternal.checkElementsNotNull(span);
         this.span = span;
         return this;
       }
@@ -496,7 +497,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
       }
 
       public Builder leading_detached_comments(List<String> leading_detached_comments) {
-        checkElementsNotNull(leading_detached_comments);
+        WireInternal.checkElementsNotNull(leading_detached_comments);
         this.leading_detached_comments = leading_detached_comments;
         return this;
       }
@@ -601,7 +602,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     @Override
     public SourceCodeInfo redact(SourceCodeInfo value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.location, Location.ADAPTER);
+      WireInternal.redactElements(builder.location, Location.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -97,7 +98,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
 
   public UninterpretedOption(List<NamePart> name, String identifier_value, Long positive_int_value, Long negative_int_value, Double double_value, ByteString string_value, String aggregate_value, ByteString unknownFields) {
     super(unknownFields);
-    this.name = immutableCopyOf("name", name);
+    this.name = WireInternal.immutableCopyOf("name", name);
     this.identifier_value = identifier_value;
     this.positive_int_value = positive_int_value;
     this.negative_int_value = negative_int_value;
@@ -109,7 +110,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.name = copyOf("name", name);
+    builder.name = WireInternal.copyOf("name", name);
     builder.identifier_value = identifier_value;
     builder.positive_int_value = positive_int_value;
     builder.negative_int_value = negative_int_value;
@@ -125,14 +126,14 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
     if (other == this) return true;
     if (!(other instanceof UninterpretedOption)) return false;
     UninterpretedOption o = (UninterpretedOption) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(identifier_value, o.identifier_value)
-        && equals(positive_int_value, o.positive_int_value)
-        && equals(negative_int_value, o.negative_int_value)
-        && equals(double_value, o.double_value)
-        && equals(string_value, o.string_value)
-        && equals(aggregate_value, o.aggregate_value);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(identifier_value, o.identifier_value)
+        && WireInternal.equals(positive_int_value, o.positive_int_value)
+        && WireInternal.equals(negative_int_value, o.negative_int_value)
+        && WireInternal.equals(double_value, o.double_value)
+        && WireInternal.equals(string_value, o.string_value)
+        && WireInternal.equals(aggregate_value, o.aggregate_value);
   }
 
   @Override
@@ -181,11 +182,11 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
     public String aggregate_value;
 
     public Builder() {
-      name = newMutableList();
+      name = WireInternal.newMutableList();
     }
 
     public Builder name(List<NamePart> name) {
-      checkElementsNotNull(name);
+      WireInternal.checkElementsNotNull(name);
       this.name = name;
       return this;
     }
@@ -284,9 +285,9 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
       if (other == this) return true;
       if (!(other instanceof NamePart)) return false;
       NamePart o = (NamePart) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(name_part, o.name_part)
-          && equals(is_extension, o.is_extension);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(name_part, o.name_part)
+          && WireInternal.equals(is_extension, o.is_extension);
     }
 
     @Override
@@ -331,7 +332,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
       public NamePart build() {
         if (name_part == null
             || is_extension == null) {
-          throw missingRequiredFields(name_part, "name_part",
+          throw WireInternal.missingRequiredFields(name_part, "name_part",
               is_extension, "is_extension");
         }
         return new NamePart(name_part, is_extension, buildUnknownFields());
@@ -441,7 +442,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
     @Override
     public UninterpretedOption redact(UninterpretedOption value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.name, NamePart.ADAPTER);
+      WireInternal.redactElements(builder.name, NamePart.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -142,8 +143,8 @@ public final class Bar extends Message<Bar, Bar.Builder> {
         if (other == this) return true;
         if (!(other instanceof Moo)) return false;
         Moo o = (Moo) other;
-        return equals(unknownFields(), o.unknownFields())
-            && equals(boo, o.boo);
+        return WireInternal.equals(unknownFields(), o.unknownFields())
+            && WireInternal.equals(boo, o.boo);
       }
 
       @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -49,8 +50,8 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(moo, o.moo);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(moo, o.moo);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -142,8 +143,8 @@ public final class Bar extends Message<Bar, Bar.Builder> {
         if (other == this) return true;
         if (!(other instanceof Moo)) return false;
         Moo o = (Moo) other;
-        return equals(unknownFields(), o.unknownFields())
-            && equals(boo, o.boo);
+        return WireInternal.equals(unknownFields(), o.unknownFields())
+            && WireInternal.equals(boo, o.boo);
       }
 
       @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -49,8 +50,8 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(moo, o.moo);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(moo, o.moo);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
     if (other == this) return true;
     if (!(other instanceof HeresAllTheDataRequest)) return false;
     HeresAllTheDataRequest o = (HeresAllTheDataRequest) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(data, o.data);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(data, o.data);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
     if (other == this) return true;
     if (!(other instanceof HeresAllTheDataResponse)) return false;
     HeresAllTheDataResponse o = (HeresAllTheDataResponse) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(data, o.data);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(data, o.data);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequ
     if (other == this) return true;
     if (!(other instanceof LetsDataRequest)) return false;
     LetsDataRequest o = (LetsDataRequest) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(data, o.data);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(data, o.data);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class LetsDataResponse extends Message<LetsDataResponse, LetsDataRe
     if (other == this) return true;
     if (!(other instanceof LetsDataResponse)) return false;
     LetsDataResponse o = (LetsDataResponse) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(data, o.data);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(data, o.data);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class SendDataRequest extends Message<SendDataRequest, SendDataRequ
     if (other == this) return true;
     if (!(other instanceof SendDataRequest)) return false;
     SendDataRequest o = (SendDataRequest) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(data, o.data);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(data, o.data);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class SendDataResponse extends Message<SendDataResponse, SendDataRe
     if (other == this) return true;
     if (!(other instanceof SendDataResponse)) return false;
     SendDataResponse o = (SendDataResponse) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(data, o.data);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(data, o.data);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.io.IOException;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class ChildPackage extends Message<ChildPackage, ChildPackage.Build
     if (other == this) return true;
     if (!(other instanceof ChildPackage)) return false;
     ChildPackage o = (ChildPackage) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(inner_foreign_enum, o.inner_foreign_enum);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(inner_foreign_enum, o.inner_foreign_enum);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -42,15 +43,15 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
 
   public RepeatedAndPacked(List<Integer> rep_int32, List<Integer> pack_int32, ByteString unknownFields) {
     super(unknownFields);
-    this.rep_int32 = immutableCopyOf("rep_int32", rep_int32);
-    this.pack_int32 = immutableCopyOf("pack_int32", pack_int32);
+    this.rep_int32 = WireInternal.immutableCopyOf("rep_int32", rep_int32);
+    this.pack_int32 = WireInternal.immutableCopyOf("pack_int32", pack_int32);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.rep_int32 = copyOf("rep_int32", rep_int32);
-    builder.pack_int32 = copyOf("pack_int32", pack_int32);
+    builder.rep_int32 = WireInternal.copyOf("rep_int32", rep_int32);
+    builder.pack_int32 = WireInternal.copyOf("pack_int32", pack_int32);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -60,9 +61,9 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
     if (other == this) return true;
     if (!(other instanceof RepeatedAndPacked)) return false;
     RepeatedAndPacked o = (RepeatedAndPacked) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(rep_int32, o.rep_int32)
-        && equals(pack_int32, o.pack_int32);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(rep_int32, o.rep_int32)
+        && WireInternal.equals(pack_int32, o.pack_int32);
   }
 
   @Override
@@ -91,18 +92,18 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
     public List<Integer> pack_int32;
 
     public Builder() {
-      rep_int32 = newMutableList();
-      pack_int32 = newMutableList();
+      rep_int32 = WireInternal.newMutableList();
+      pack_int32 = WireInternal.newMutableList();
     }
 
     public Builder rep_int32(List<Integer> rep_int32) {
-      checkElementsNotNull(rep_int32);
+      WireInternal.checkElementsNotNull(rep_int32);
       this.rep_int32 = rep_int32;
       return this;
     }
 
     public Builder pack_int32(List<Integer> pack_int32) {
-      checkElementsNotNull(pack_int32);
+      WireInternal.checkElementsNotNull(pack_int32);
       this.pack_int32 = pack_int32;
       return this;
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -1193,37 +1194,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.req_bytes = req_bytes;
     this.req_nested_enum = req_nested_enum;
     this.req_nested_message = req_nested_message;
-    this.rep_int32 = immutableCopyOf("rep_int32", rep_int32);
-    this.rep_uint32 = immutableCopyOf("rep_uint32", rep_uint32);
-    this.rep_sint32 = immutableCopyOf("rep_sint32", rep_sint32);
-    this.rep_fixed32 = immutableCopyOf("rep_fixed32", rep_fixed32);
-    this.rep_sfixed32 = immutableCopyOf("rep_sfixed32", rep_sfixed32);
-    this.rep_int64 = immutableCopyOf("rep_int64", rep_int64);
-    this.rep_uint64 = immutableCopyOf("rep_uint64", rep_uint64);
-    this.rep_sint64 = immutableCopyOf("rep_sint64", rep_sint64);
-    this.rep_fixed64 = immutableCopyOf("rep_fixed64", rep_fixed64);
-    this.rep_sfixed64 = immutableCopyOf("rep_sfixed64", rep_sfixed64);
-    this.rep_bool = immutableCopyOf("rep_bool", rep_bool);
-    this.rep_float = immutableCopyOf("rep_float", rep_float);
-    this.rep_double = immutableCopyOf("rep_double", rep_double);
-    this.rep_string = immutableCopyOf("rep_string", rep_string);
-    this.rep_bytes = immutableCopyOf("rep_bytes", rep_bytes);
-    this.rep_nested_enum = immutableCopyOf("rep_nested_enum", rep_nested_enum);
-    this.rep_nested_message = immutableCopyOf("rep_nested_message", rep_nested_message);
-    this.pack_int32 = immutableCopyOf("pack_int32", pack_int32);
-    this.pack_uint32 = immutableCopyOf("pack_uint32", pack_uint32);
-    this.pack_sint32 = immutableCopyOf("pack_sint32", pack_sint32);
-    this.pack_fixed32 = immutableCopyOf("pack_fixed32", pack_fixed32);
-    this.pack_sfixed32 = immutableCopyOf("pack_sfixed32", pack_sfixed32);
-    this.pack_int64 = immutableCopyOf("pack_int64", pack_int64);
-    this.pack_uint64 = immutableCopyOf("pack_uint64", pack_uint64);
-    this.pack_sint64 = immutableCopyOf("pack_sint64", pack_sint64);
-    this.pack_fixed64 = immutableCopyOf("pack_fixed64", pack_fixed64);
-    this.pack_sfixed64 = immutableCopyOf("pack_sfixed64", pack_sfixed64);
-    this.pack_bool = immutableCopyOf("pack_bool", pack_bool);
-    this.pack_float = immutableCopyOf("pack_float", pack_float);
-    this.pack_double = immutableCopyOf("pack_double", pack_double);
-    this.pack_nested_enum = immutableCopyOf("pack_nested_enum", pack_nested_enum);
+    this.rep_int32 = WireInternal.immutableCopyOf("rep_int32", rep_int32);
+    this.rep_uint32 = WireInternal.immutableCopyOf("rep_uint32", rep_uint32);
+    this.rep_sint32 = WireInternal.immutableCopyOf("rep_sint32", rep_sint32);
+    this.rep_fixed32 = WireInternal.immutableCopyOf("rep_fixed32", rep_fixed32);
+    this.rep_sfixed32 = WireInternal.immutableCopyOf("rep_sfixed32", rep_sfixed32);
+    this.rep_int64 = WireInternal.immutableCopyOf("rep_int64", rep_int64);
+    this.rep_uint64 = WireInternal.immutableCopyOf("rep_uint64", rep_uint64);
+    this.rep_sint64 = WireInternal.immutableCopyOf("rep_sint64", rep_sint64);
+    this.rep_fixed64 = WireInternal.immutableCopyOf("rep_fixed64", rep_fixed64);
+    this.rep_sfixed64 = WireInternal.immutableCopyOf("rep_sfixed64", rep_sfixed64);
+    this.rep_bool = WireInternal.immutableCopyOf("rep_bool", rep_bool);
+    this.rep_float = WireInternal.immutableCopyOf("rep_float", rep_float);
+    this.rep_double = WireInternal.immutableCopyOf("rep_double", rep_double);
+    this.rep_string = WireInternal.immutableCopyOf("rep_string", rep_string);
+    this.rep_bytes = WireInternal.immutableCopyOf("rep_bytes", rep_bytes);
+    this.rep_nested_enum = WireInternal.immutableCopyOf("rep_nested_enum", rep_nested_enum);
+    this.rep_nested_message = WireInternal.immutableCopyOf("rep_nested_message", rep_nested_message);
+    this.pack_int32 = WireInternal.immutableCopyOf("pack_int32", pack_int32);
+    this.pack_uint32 = WireInternal.immutableCopyOf("pack_uint32", pack_uint32);
+    this.pack_sint32 = WireInternal.immutableCopyOf("pack_sint32", pack_sint32);
+    this.pack_fixed32 = WireInternal.immutableCopyOf("pack_fixed32", pack_fixed32);
+    this.pack_sfixed32 = WireInternal.immutableCopyOf("pack_sfixed32", pack_sfixed32);
+    this.pack_int64 = WireInternal.immutableCopyOf("pack_int64", pack_int64);
+    this.pack_uint64 = WireInternal.immutableCopyOf("pack_uint64", pack_uint64);
+    this.pack_sint64 = WireInternal.immutableCopyOf("pack_sint64", pack_sint64);
+    this.pack_fixed64 = WireInternal.immutableCopyOf("pack_fixed64", pack_fixed64);
+    this.pack_sfixed64 = WireInternal.immutableCopyOf("pack_sfixed64", pack_sfixed64);
+    this.pack_bool = WireInternal.immutableCopyOf("pack_bool", pack_bool);
+    this.pack_float = WireInternal.immutableCopyOf("pack_float", pack_float);
+    this.pack_double = WireInternal.immutableCopyOf("pack_double", pack_double);
+    this.pack_nested_enum = WireInternal.immutableCopyOf("pack_nested_enum", pack_nested_enum);
     this.default_int32 = default_int32;
     this.default_uint32 = default_uint32;
     this.default_sint32 = default_sint32;
@@ -1257,37 +1258,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.ext_opt_bytes = ext_opt_bytes;
     this.ext_opt_nested_enum = ext_opt_nested_enum;
     this.ext_opt_nested_message = ext_opt_nested_message;
-    this.ext_rep_int32 = immutableCopyOf("ext_rep_int32", ext_rep_int32);
-    this.ext_rep_uint32 = immutableCopyOf("ext_rep_uint32", ext_rep_uint32);
-    this.ext_rep_sint32 = immutableCopyOf("ext_rep_sint32", ext_rep_sint32);
-    this.ext_rep_fixed32 = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32);
-    this.ext_rep_sfixed32 = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32);
-    this.ext_rep_int64 = immutableCopyOf("ext_rep_int64", ext_rep_int64);
-    this.ext_rep_uint64 = immutableCopyOf("ext_rep_uint64", ext_rep_uint64);
-    this.ext_rep_sint64 = immutableCopyOf("ext_rep_sint64", ext_rep_sint64);
-    this.ext_rep_fixed64 = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64);
-    this.ext_rep_sfixed64 = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64);
-    this.ext_rep_bool = immutableCopyOf("ext_rep_bool", ext_rep_bool);
-    this.ext_rep_float = immutableCopyOf("ext_rep_float", ext_rep_float);
-    this.ext_rep_double = immutableCopyOf("ext_rep_double", ext_rep_double);
-    this.ext_rep_string = immutableCopyOf("ext_rep_string", ext_rep_string);
-    this.ext_rep_bytes = immutableCopyOf("ext_rep_bytes", ext_rep_bytes);
-    this.ext_rep_nested_enum = immutableCopyOf("ext_rep_nested_enum", ext_rep_nested_enum);
-    this.ext_rep_nested_message = immutableCopyOf("ext_rep_nested_message", ext_rep_nested_message);
-    this.ext_pack_int32 = immutableCopyOf("ext_pack_int32", ext_pack_int32);
-    this.ext_pack_uint32 = immutableCopyOf("ext_pack_uint32", ext_pack_uint32);
-    this.ext_pack_sint32 = immutableCopyOf("ext_pack_sint32", ext_pack_sint32);
-    this.ext_pack_fixed32 = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32);
-    this.ext_pack_sfixed32 = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32);
-    this.ext_pack_int64 = immutableCopyOf("ext_pack_int64", ext_pack_int64);
-    this.ext_pack_uint64 = immutableCopyOf("ext_pack_uint64", ext_pack_uint64);
-    this.ext_pack_sint64 = immutableCopyOf("ext_pack_sint64", ext_pack_sint64);
-    this.ext_pack_fixed64 = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64);
-    this.ext_pack_sfixed64 = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64);
-    this.ext_pack_bool = immutableCopyOf("ext_pack_bool", ext_pack_bool);
-    this.ext_pack_float = immutableCopyOf("ext_pack_float", ext_pack_float);
-    this.ext_pack_double = immutableCopyOf("ext_pack_double", ext_pack_double);
-    this.ext_pack_nested_enum = immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
+    this.ext_rep_int32 = WireInternal.immutableCopyOf("ext_rep_int32", ext_rep_int32);
+    this.ext_rep_uint32 = WireInternal.immutableCopyOf("ext_rep_uint32", ext_rep_uint32);
+    this.ext_rep_sint32 = WireInternal.immutableCopyOf("ext_rep_sint32", ext_rep_sint32);
+    this.ext_rep_fixed32 = WireInternal.immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32);
+    this.ext_rep_sfixed32 = WireInternal.immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32);
+    this.ext_rep_int64 = WireInternal.immutableCopyOf("ext_rep_int64", ext_rep_int64);
+    this.ext_rep_uint64 = WireInternal.immutableCopyOf("ext_rep_uint64", ext_rep_uint64);
+    this.ext_rep_sint64 = WireInternal.immutableCopyOf("ext_rep_sint64", ext_rep_sint64);
+    this.ext_rep_fixed64 = WireInternal.immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64);
+    this.ext_rep_sfixed64 = WireInternal.immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64);
+    this.ext_rep_bool = WireInternal.immutableCopyOf("ext_rep_bool", ext_rep_bool);
+    this.ext_rep_float = WireInternal.immutableCopyOf("ext_rep_float", ext_rep_float);
+    this.ext_rep_double = WireInternal.immutableCopyOf("ext_rep_double", ext_rep_double);
+    this.ext_rep_string = WireInternal.immutableCopyOf("ext_rep_string", ext_rep_string);
+    this.ext_rep_bytes = WireInternal.immutableCopyOf("ext_rep_bytes", ext_rep_bytes);
+    this.ext_rep_nested_enum = WireInternal.immutableCopyOf("ext_rep_nested_enum", ext_rep_nested_enum);
+    this.ext_rep_nested_message = WireInternal.immutableCopyOf("ext_rep_nested_message", ext_rep_nested_message);
+    this.ext_pack_int32 = WireInternal.immutableCopyOf("ext_pack_int32", ext_pack_int32);
+    this.ext_pack_uint32 = WireInternal.immutableCopyOf("ext_pack_uint32", ext_pack_uint32);
+    this.ext_pack_sint32 = WireInternal.immutableCopyOf("ext_pack_sint32", ext_pack_sint32);
+    this.ext_pack_fixed32 = WireInternal.immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32);
+    this.ext_pack_sfixed32 = WireInternal.immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32);
+    this.ext_pack_int64 = WireInternal.immutableCopyOf("ext_pack_int64", ext_pack_int64);
+    this.ext_pack_uint64 = WireInternal.immutableCopyOf("ext_pack_uint64", ext_pack_uint64);
+    this.ext_pack_sint64 = WireInternal.immutableCopyOf("ext_pack_sint64", ext_pack_sint64);
+    this.ext_pack_fixed64 = WireInternal.immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64);
+    this.ext_pack_sfixed64 = WireInternal.immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64);
+    this.ext_pack_bool = WireInternal.immutableCopyOf("ext_pack_bool", ext_pack_bool);
+    this.ext_pack_float = WireInternal.immutableCopyOf("ext_pack_float", ext_pack_float);
+    this.ext_pack_double = WireInternal.immutableCopyOf("ext_pack_double", ext_pack_double);
+    this.ext_pack_nested_enum = WireInternal.immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
   }
 
   @Override
@@ -1327,37 +1328,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     builder.req_bytes = req_bytes;
     builder.req_nested_enum = req_nested_enum;
     builder.req_nested_message = req_nested_message;
-    builder.rep_int32 = copyOf("rep_int32", rep_int32);
-    builder.rep_uint32 = copyOf("rep_uint32", rep_uint32);
-    builder.rep_sint32 = copyOf("rep_sint32", rep_sint32);
-    builder.rep_fixed32 = copyOf("rep_fixed32", rep_fixed32);
-    builder.rep_sfixed32 = copyOf("rep_sfixed32", rep_sfixed32);
-    builder.rep_int64 = copyOf("rep_int64", rep_int64);
-    builder.rep_uint64 = copyOf("rep_uint64", rep_uint64);
-    builder.rep_sint64 = copyOf("rep_sint64", rep_sint64);
-    builder.rep_fixed64 = copyOf("rep_fixed64", rep_fixed64);
-    builder.rep_sfixed64 = copyOf("rep_sfixed64", rep_sfixed64);
-    builder.rep_bool = copyOf("rep_bool", rep_bool);
-    builder.rep_float = copyOf("rep_float", rep_float);
-    builder.rep_double = copyOf("rep_double", rep_double);
-    builder.rep_string = copyOf("rep_string", rep_string);
-    builder.rep_bytes = copyOf("rep_bytes", rep_bytes);
-    builder.rep_nested_enum = copyOf("rep_nested_enum", rep_nested_enum);
-    builder.rep_nested_message = copyOf("rep_nested_message", rep_nested_message);
-    builder.pack_int32 = copyOf("pack_int32", pack_int32);
-    builder.pack_uint32 = copyOf("pack_uint32", pack_uint32);
-    builder.pack_sint32 = copyOf("pack_sint32", pack_sint32);
-    builder.pack_fixed32 = copyOf("pack_fixed32", pack_fixed32);
-    builder.pack_sfixed32 = copyOf("pack_sfixed32", pack_sfixed32);
-    builder.pack_int64 = copyOf("pack_int64", pack_int64);
-    builder.pack_uint64 = copyOf("pack_uint64", pack_uint64);
-    builder.pack_sint64 = copyOf("pack_sint64", pack_sint64);
-    builder.pack_fixed64 = copyOf("pack_fixed64", pack_fixed64);
-    builder.pack_sfixed64 = copyOf("pack_sfixed64", pack_sfixed64);
-    builder.pack_bool = copyOf("pack_bool", pack_bool);
-    builder.pack_float = copyOf("pack_float", pack_float);
-    builder.pack_double = copyOf("pack_double", pack_double);
-    builder.pack_nested_enum = copyOf("pack_nested_enum", pack_nested_enum);
+    builder.rep_int32 = WireInternal.copyOf("rep_int32", rep_int32);
+    builder.rep_uint32 = WireInternal.copyOf("rep_uint32", rep_uint32);
+    builder.rep_sint32 = WireInternal.copyOf("rep_sint32", rep_sint32);
+    builder.rep_fixed32 = WireInternal.copyOf("rep_fixed32", rep_fixed32);
+    builder.rep_sfixed32 = WireInternal.copyOf("rep_sfixed32", rep_sfixed32);
+    builder.rep_int64 = WireInternal.copyOf("rep_int64", rep_int64);
+    builder.rep_uint64 = WireInternal.copyOf("rep_uint64", rep_uint64);
+    builder.rep_sint64 = WireInternal.copyOf("rep_sint64", rep_sint64);
+    builder.rep_fixed64 = WireInternal.copyOf("rep_fixed64", rep_fixed64);
+    builder.rep_sfixed64 = WireInternal.copyOf("rep_sfixed64", rep_sfixed64);
+    builder.rep_bool = WireInternal.copyOf("rep_bool", rep_bool);
+    builder.rep_float = WireInternal.copyOf("rep_float", rep_float);
+    builder.rep_double = WireInternal.copyOf("rep_double", rep_double);
+    builder.rep_string = WireInternal.copyOf("rep_string", rep_string);
+    builder.rep_bytes = WireInternal.copyOf("rep_bytes", rep_bytes);
+    builder.rep_nested_enum = WireInternal.copyOf("rep_nested_enum", rep_nested_enum);
+    builder.rep_nested_message = WireInternal.copyOf("rep_nested_message", rep_nested_message);
+    builder.pack_int32 = WireInternal.copyOf("pack_int32", pack_int32);
+    builder.pack_uint32 = WireInternal.copyOf("pack_uint32", pack_uint32);
+    builder.pack_sint32 = WireInternal.copyOf("pack_sint32", pack_sint32);
+    builder.pack_fixed32 = WireInternal.copyOf("pack_fixed32", pack_fixed32);
+    builder.pack_sfixed32 = WireInternal.copyOf("pack_sfixed32", pack_sfixed32);
+    builder.pack_int64 = WireInternal.copyOf("pack_int64", pack_int64);
+    builder.pack_uint64 = WireInternal.copyOf("pack_uint64", pack_uint64);
+    builder.pack_sint64 = WireInternal.copyOf("pack_sint64", pack_sint64);
+    builder.pack_fixed64 = WireInternal.copyOf("pack_fixed64", pack_fixed64);
+    builder.pack_sfixed64 = WireInternal.copyOf("pack_sfixed64", pack_sfixed64);
+    builder.pack_bool = WireInternal.copyOf("pack_bool", pack_bool);
+    builder.pack_float = WireInternal.copyOf("pack_float", pack_float);
+    builder.pack_double = WireInternal.copyOf("pack_double", pack_double);
+    builder.pack_nested_enum = WireInternal.copyOf("pack_nested_enum", pack_nested_enum);
     builder.default_int32 = default_int32;
     builder.default_uint32 = default_uint32;
     builder.default_sint32 = default_sint32;
@@ -1391,37 +1392,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     builder.ext_opt_bytes = ext_opt_bytes;
     builder.ext_opt_nested_enum = ext_opt_nested_enum;
     builder.ext_opt_nested_message = ext_opt_nested_message;
-    builder.ext_rep_int32 = copyOf("ext_rep_int32", ext_rep_int32);
-    builder.ext_rep_uint32 = copyOf("ext_rep_uint32", ext_rep_uint32);
-    builder.ext_rep_sint32 = copyOf("ext_rep_sint32", ext_rep_sint32);
-    builder.ext_rep_fixed32 = copyOf("ext_rep_fixed32", ext_rep_fixed32);
-    builder.ext_rep_sfixed32 = copyOf("ext_rep_sfixed32", ext_rep_sfixed32);
-    builder.ext_rep_int64 = copyOf("ext_rep_int64", ext_rep_int64);
-    builder.ext_rep_uint64 = copyOf("ext_rep_uint64", ext_rep_uint64);
-    builder.ext_rep_sint64 = copyOf("ext_rep_sint64", ext_rep_sint64);
-    builder.ext_rep_fixed64 = copyOf("ext_rep_fixed64", ext_rep_fixed64);
-    builder.ext_rep_sfixed64 = copyOf("ext_rep_sfixed64", ext_rep_sfixed64);
-    builder.ext_rep_bool = copyOf("ext_rep_bool", ext_rep_bool);
-    builder.ext_rep_float = copyOf("ext_rep_float", ext_rep_float);
-    builder.ext_rep_double = copyOf("ext_rep_double", ext_rep_double);
-    builder.ext_rep_string = copyOf("ext_rep_string", ext_rep_string);
-    builder.ext_rep_bytes = copyOf("ext_rep_bytes", ext_rep_bytes);
-    builder.ext_rep_nested_enum = copyOf("ext_rep_nested_enum", ext_rep_nested_enum);
-    builder.ext_rep_nested_message = copyOf("ext_rep_nested_message", ext_rep_nested_message);
-    builder.ext_pack_int32 = copyOf("ext_pack_int32", ext_pack_int32);
-    builder.ext_pack_uint32 = copyOf("ext_pack_uint32", ext_pack_uint32);
-    builder.ext_pack_sint32 = copyOf("ext_pack_sint32", ext_pack_sint32);
-    builder.ext_pack_fixed32 = copyOf("ext_pack_fixed32", ext_pack_fixed32);
-    builder.ext_pack_sfixed32 = copyOf("ext_pack_sfixed32", ext_pack_sfixed32);
-    builder.ext_pack_int64 = copyOf("ext_pack_int64", ext_pack_int64);
-    builder.ext_pack_uint64 = copyOf("ext_pack_uint64", ext_pack_uint64);
-    builder.ext_pack_sint64 = copyOf("ext_pack_sint64", ext_pack_sint64);
-    builder.ext_pack_fixed64 = copyOf("ext_pack_fixed64", ext_pack_fixed64);
-    builder.ext_pack_sfixed64 = copyOf("ext_pack_sfixed64", ext_pack_sfixed64);
-    builder.ext_pack_bool = copyOf("ext_pack_bool", ext_pack_bool);
-    builder.ext_pack_float = copyOf("ext_pack_float", ext_pack_float);
-    builder.ext_pack_double = copyOf("ext_pack_double", ext_pack_double);
-    builder.ext_pack_nested_enum = copyOf("ext_pack_nested_enum", ext_pack_nested_enum);
+    builder.ext_rep_int32 = WireInternal.copyOf("ext_rep_int32", ext_rep_int32);
+    builder.ext_rep_uint32 = WireInternal.copyOf("ext_rep_uint32", ext_rep_uint32);
+    builder.ext_rep_sint32 = WireInternal.copyOf("ext_rep_sint32", ext_rep_sint32);
+    builder.ext_rep_fixed32 = WireInternal.copyOf("ext_rep_fixed32", ext_rep_fixed32);
+    builder.ext_rep_sfixed32 = WireInternal.copyOf("ext_rep_sfixed32", ext_rep_sfixed32);
+    builder.ext_rep_int64 = WireInternal.copyOf("ext_rep_int64", ext_rep_int64);
+    builder.ext_rep_uint64 = WireInternal.copyOf("ext_rep_uint64", ext_rep_uint64);
+    builder.ext_rep_sint64 = WireInternal.copyOf("ext_rep_sint64", ext_rep_sint64);
+    builder.ext_rep_fixed64 = WireInternal.copyOf("ext_rep_fixed64", ext_rep_fixed64);
+    builder.ext_rep_sfixed64 = WireInternal.copyOf("ext_rep_sfixed64", ext_rep_sfixed64);
+    builder.ext_rep_bool = WireInternal.copyOf("ext_rep_bool", ext_rep_bool);
+    builder.ext_rep_float = WireInternal.copyOf("ext_rep_float", ext_rep_float);
+    builder.ext_rep_double = WireInternal.copyOf("ext_rep_double", ext_rep_double);
+    builder.ext_rep_string = WireInternal.copyOf("ext_rep_string", ext_rep_string);
+    builder.ext_rep_bytes = WireInternal.copyOf("ext_rep_bytes", ext_rep_bytes);
+    builder.ext_rep_nested_enum = WireInternal.copyOf("ext_rep_nested_enum", ext_rep_nested_enum);
+    builder.ext_rep_nested_message = WireInternal.copyOf("ext_rep_nested_message", ext_rep_nested_message);
+    builder.ext_pack_int32 = WireInternal.copyOf("ext_pack_int32", ext_pack_int32);
+    builder.ext_pack_uint32 = WireInternal.copyOf("ext_pack_uint32", ext_pack_uint32);
+    builder.ext_pack_sint32 = WireInternal.copyOf("ext_pack_sint32", ext_pack_sint32);
+    builder.ext_pack_fixed32 = WireInternal.copyOf("ext_pack_fixed32", ext_pack_fixed32);
+    builder.ext_pack_sfixed32 = WireInternal.copyOf("ext_pack_sfixed32", ext_pack_sfixed32);
+    builder.ext_pack_int64 = WireInternal.copyOf("ext_pack_int64", ext_pack_int64);
+    builder.ext_pack_uint64 = WireInternal.copyOf("ext_pack_uint64", ext_pack_uint64);
+    builder.ext_pack_sint64 = WireInternal.copyOf("ext_pack_sint64", ext_pack_sint64);
+    builder.ext_pack_fixed64 = WireInternal.copyOf("ext_pack_fixed64", ext_pack_fixed64);
+    builder.ext_pack_sfixed64 = WireInternal.copyOf("ext_pack_sfixed64", ext_pack_sfixed64);
+    builder.ext_pack_bool = WireInternal.copyOf("ext_pack_bool", ext_pack_bool);
+    builder.ext_pack_float = WireInternal.copyOf("ext_pack_float", ext_pack_float);
+    builder.ext_pack_double = WireInternal.copyOf("ext_pack_double", ext_pack_double);
+    builder.ext_pack_nested_enum = WireInternal.copyOf("ext_pack_nested_enum", ext_pack_nested_enum);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -1431,136 +1432,136 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(opt_int32, o.opt_int32)
-        && equals(opt_uint32, o.opt_uint32)
-        && equals(opt_sint32, o.opt_sint32)
-        && equals(opt_fixed32, o.opt_fixed32)
-        && equals(opt_sfixed32, o.opt_sfixed32)
-        && equals(opt_int64, o.opt_int64)
-        && equals(opt_uint64, o.opt_uint64)
-        && equals(opt_sint64, o.opt_sint64)
-        && equals(opt_fixed64, o.opt_fixed64)
-        && equals(opt_sfixed64, o.opt_sfixed64)
-        && equals(opt_bool, o.opt_bool)
-        && equals(opt_float, o.opt_float)
-        && equals(opt_double, o.opt_double)
-        && equals(opt_string, o.opt_string)
-        && equals(opt_bytes, o.opt_bytes)
-        && equals(opt_nested_enum, o.opt_nested_enum)
-        && equals(opt_nested_message, o.opt_nested_message)
-        && equals(req_int32, o.req_int32)
-        && equals(req_uint32, o.req_uint32)
-        && equals(req_sint32, o.req_sint32)
-        && equals(req_fixed32, o.req_fixed32)
-        && equals(req_sfixed32, o.req_sfixed32)
-        && equals(req_int64, o.req_int64)
-        && equals(req_uint64, o.req_uint64)
-        && equals(req_sint64, o.req_sint64)
-        && equals(req_fixed64, o.req_fixed64)
-        && equals(req_sfixed64, o.req_sfixed64)
-        && equals(req_bool, o.req_bool)
-        && equals(req_float, o.req_float)
-        && equals(req_double, o.req_double)
-        && equals(req_string, o.req_string)
-        && equals(req_bytes, o.req_bytes)
-        && equals(req_nested_enum, o.req_nested_enum)
-        && equals(req_nested_message, o.req_nested_message)
-        && equals(rep_int32, o.rep_int32)
-        && equals(rep_uint32, o.rep_uint32)
-        && equals(rep_sint32, o.rep_sint32)
-        && equals(rep_fixed32, o.rep_fixed32)
-        && equals(rep_sfixed32, o.rep_sfixed32)
-        && equals(rep_int64, o.rep_int64)
-        && equals(rep_uint64, o.rep_uint64)
-        && equals(rep_sint64, o.rep_sint64)
-        && equals(rep_fixed64, o.rep_fixed64)
-        && equals(rep_sfixed64, o.rep_sfixed64)
-        && equals(rep_bool, o.rep_bool)
-        && equals(rep_float, o.rep_float)
-        && equals(rep_double, o.rep_double)
-        && equals(rep_string, o.rep_string)
-        && equals(rep_bytes, o.rep_bytes)
-        && equals(rep_nested_enum, o.rep_nested_enum)
-        && equals(rep_nested_message, o.rep_nested_message)
-        && equals(pack_int32, o.pack_int32)
-        && equals(pack_uint32, o.pack_uint32)
-        && equals(pack_sint32, o.pack_sint32)
-        && equals(pack_fixed32, o.pack_fixed32)
-        && equals(pack_sfixed32, o.pack_sfixed32)
-        && equals(pack_int64, o.pack_int64)
-        && equals(pack_uint64, o.pack_uint64)
-        && equals(pack_sint64, o.pack_sint64)
-        && equals(pack_fixed64, o.pack_fixed64)
-        && equals(pack_sfixed64, o.pack_sfixed64)
-        && equals(pack_bool, o.pack_bool)
-        && equals(pack_float, o.pack_float)
-        && equals(pack_double, o.pack_double)
-        && equals(pack_nested_enum, o.pack_nested_enum)
-        && equals(default_int32, o.default_int32)
-        && equals(default_uint32, o.default_uint32)
-        && equals(default_sint32, o.default_sint32)
-        && equals(default_fixed32, o.default_fixed32)
-        && equals(default_sfixed32, o.default_sfixed32)
-        && equals(default_int64, o.default_int64)
-        && equals(default_uint64, o.default_uint64)
-        && equals(default_sint64, o.default_sint64)
-        && equals(default_fixed64, o.default_fixed64)
-        && equals(default_sfixed64, o.default_sfixed64)
-        && equals(default_bool, o.default_bool)
-        && equals(default_float, o.default_float)
-        && equals(default_double, o.default_double)
-        && equals(default_string, o.default_string)
-        && equals(default_bytes, o.default_bytes)
-        && equals(default_nested_enum, o.default_nested_enum)
-        && equals(ext_opt_int32, o.ext_opt_int32)
-        && equals(ext_opt_uint32, o.ext_opt_uint32)
-        && equals(ext_opt_sint32, o.ext_opt_sint32)
-        && equals(ext_opt_fixed32, o.ext_opt_fixed32)
-        && equals(ext_opt_sfixed32, o.ext_opt_sfixed32)
-        && equals(ext_opt_int64, o.ext_opt_int64)
-        && equals(ext_opt_uint64, o.ext_opt_uint64)
-        && equals(ext_opt_sint64, o.ext_opt_sint64)
-        && equals(ext_opt_fixed64, o.ext_opt_fixed64)
-        && equals(ext_opt_sfixed64, o.ext_opt_sfixed64)
-        && equals(ext_opt_bool, o.ext_opt_bool)
-        && equals(ext_opt_float, o.ext_opt_float)
-        && equals(ext_opt_double, o.ext_opt_double)
-        && equals(ext_opt_string, o.ext_opt_string)
-        && equals(ext_opt_bytes, o.ext_opt_bytes)
-        && equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
-        && equals(ext_opt_nested_message, o.ext_opt_nested_message)
-        && equals(ext_rep_int32, o.ext_rep_int32)
-        && equals(ext_rep_uint32, o.ext_rep_uint32)
-        && equals(ext_rep_sint32, o.ext_rep_sint32)
-        && equals(ext_rep_fixed32, o.ext_rep_fixed32)
-        && equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
-        && equals(ext_rep_int64, o.ext_rep_int64)
-        && equals(ext_rep_uint64, o.ext_rep_uint64)
-        && equals(ext_rep_sint64, o.ext_rep_sint64)
-        && equals(ext_rep_fixed64, o.ext_rep_fixed64)
-        && equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
-        && equals(ext_rep_bool, o.ext_rep_bool)
-        && equals(ext_rep_float, o.ext_rep_float)
-        && equals(ext_rep_double, o.ext_rep_double)
-        && equals(ext_rep_string, o.ext_rep_string)
-        && equals(ext_rep_bytes, o.ext_rep_bytes)
-        && equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
-        && equals(ext_rep_nested_message, o.ext_rep_nested_message)
-        && equals(ext_pack_int32, o.ext_pack_int32)
-        && equals(ext_pack_uint32, o.ext_pack_uint32)
-        && equals(ext_pack_sint32, o.ext_pack_sint32)
-        && equals(ext_pack_fixed32, o.ext_pack_fixed32)
-        && equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
-        && equals(ext_pack_int64, o.ext_pack_int64)
-        && equals(ext_pack_uint64, o.ext_pack_uint64)
-        && equals(ext_pack_sint64, o.ext_pack_sint64)
-        && equals(ext_pack_fixed64, o.ext_pack_fixed64)
-        && equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
-        && equals(ext_pack_bool, o.ext_pack_bool)
-        && equals(ext_pack_float, o.ext_pack_float)
-        && equals(ext_pack_double, o.ext_pack_double)
-        && equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(opt_int32, o.opt_int32)
+        && WireInternal.equals(opt_uint32, o.opt_uint32)
+        && WireInternal.equals(opt_sint32, o.opt_sint32)
+        && WireInternal.equals(opt_fixed32, o.opt_fixed32)
+        && WireInternal.equals(opt_sfixed32, o.opt_sfixed32)
+        && WireInternal.equals(opt_int64, o.opt_int64)
+        && WireInternal.equals(opt_uint64, o.opt_uint64)
+        && WireInternal.equals(opt_sint64, o.opt_sint64)
+        && WireInternal.equals(opt_fixed64, o.opt_fixed64)
+        && WireInternal.equals(opt_sfixed64, o.opt_sfixed64)
+        && WireInternal.equals(opt_bool, o.opt_bool)
+        && WireInternal.equals(opt_float, o.opt_float)
+        && WireInternal.equals(opt_double, o.opt_double)
+        && WireInternal.equals(opt_string, o.opt_string)
+        && WireInternal.equals(opt_bytes, o.opt_bytes)
+        && WireInternal.equals(opt_nested_enum, o.opt_nested_enum)
+        && WireInternal.equals(opt_nested_message, o.opt_nested_message)
+        && WireInternal.equals(req_int32, o.req_int32)
+        && WireInternal.equals(req_uint32, o.req_uint32)
+        && WireInternal.equals(req_sint32, o.req_sint32)
+        && WireInternal.equals(req_fixed32, o.req_fixed32)
+        && WireInternal.equals(req_sfixed32, o.req_sfixed32)
+        && WireInternal.equals(req_int64, o.req_int64)
+        && WireInternal.equals(req_uint64, o.req_uint64)
+        && WireInternal.equals(req_sint64, o.req_sint64)
+        && WireInternal.equals(req_fixed64, o.req_fixed64)
+        && WireInternal.equals(req_sfixed64, o.req_sfixed64)
+        && WireInternal.equals(req_bool, o.req_bool)
+        && WireInternal.equals(req_float, o.req_float)
+        && WireInternal.equals(req_double, o.req_double)
+        && WireInternal.equals(req_string, o.req_string)
+        && WireInternal.equals(req_bytes, o.req_bytes)
+        && WireInternal.equals(req_nested_enum, o.req_nested_enum)
+        && WireInternal.equals(req_nested_message, o.req_nested_message)
+        && WireInternal.equals(rep_int32, o.rep_int32)
+        && WireInternal.equals(rep_uint32, o.rep_uint32)
+        && WireInternal.equals(rep_sint32, o.rep_sint32)
+        && WireInternal.equals(rep_fixed32, o.rep_fixed32)
+        && WireInternal.equals(rep_sfixed32, o.rep_sfixed32)
+        && WireInternal.equals(rep_int64, o.rep_int64)
+        && WireInternal.equals(rep_uint64, o.rep_uint64)
+        && WireInternal.equals(rep_sint64, o.rep_sint64)
+        && WireInternal.equals(rep_fixed64, o.rep_fixed64)
+        && WireInternal.equals(rep_sfixed64, o.rep_sfixed64)
+        && WireInternal.equals(rep_bool, o.rep_bool)
+        && WireInternal.equals(rep_float, o.rep_float)
+        && WireInternal.equals(rep_double, o.rep_double)
+        && WireInternal.equals(rep_string, o.rep_string)
+        && WireInternal.equals(rep_bytes, o.rep_bytes)
+        && WireInternal.equals(rep_nested_enum, o.rep_nested_enum)
+        && WireInternal.equals(rep_nested_message, o.rep_nested_message)
+        && WireInternal.equals(pack_int32, o.pack_int32)
+        && WireInternal.equals(pack_uint32, o.pack_uint32)
+        && WireInternal.equals(pack_sint32, o.pack_sint32)
+        && WireInternal.equals(pack_fixed32, o.pack_fixed32)
+        && WireInternal.equals(pack_sfixed32, o.pack_sfixed32)
+        && WireInternal.equals(pack_int64, o.pack_int64)
+        && WireInternal.equals(pack_uint64, o.pack_uint64)
+        && WireInternal.equals(pack_sint64, o.pack_sint64)
+        && WireInternal.equals(pack_fixed64, o.pack_fixed64)
+        && WireInternal.equals(pack_sfixed64, o.pack_sfixed64)
+        && WireInternal.equals(pack_bool, o.pack_bool)
+        && WireInternal.equals(pack_float, o.pack_float)
+        && WireInternal.equals(pack_double, o.pack_double)
+        && WireInternal.equals(pack_nested_enum, o.pack_nested_enum)
+        && WireInternal.equals(default_int32, o.default_int32)
+        && WireInternal.equals(default_uint32, o.default_uint32)
+        && WireInternal.equals(default_sint32, o.default_sint32)
+        && WireInternal.equals(default_fixed32, o.default_fixed32)
+        && WireInternal.equals(default_sfixed32, o.default_sfixed32)
+        && WireInternal.equals(default_int64, o.default_int64)
+        && WireInternal.equals(default_uint64, o.default_uint64)
+        && WireInternal.equals(default_sint64, o.default_sint64)
+        && WireInternal.equals(default_fixed64, o.default_fixed64)
+        && WireInternal.equals(default_sfixed64, o.default_sfixed64)
+        && WireInternal.equals(default_bool, o.default_bool)
+        && WireInternal.equals(default_float, o.default_float)
+        && WireInternal.equals(default_double, o.default_double)
+        && WireInternal.equals(default_string, o.default_string)
+        && WireInternal.equals(default_bytes, o.default_bytes)
+        && WireInternal.equals(default_nested_enum, o.default_nested_enum)
+        && WireInternal.equals(ext_opt_int32, o.ext_opt_int32)
+        && WireInternal.equals(ext_opt_uint32, o.ext_opt_uint32)
+        && WireInternal.equals(ext_opt_sint32, o.ext_opt_sint32)
+        && WireInternal.equals(ext_opt_fixed32, o.ext_opt_fixed32)
+        && WireInternal.equals(ext_opt_sfixed32, o.ext_opt_sfixed32)
+        && WireInternal.equals(ext_opt_int64, o.ext_opt_int64)
+        && WireInternal.equals(ext_opt_uint64, o.ext_opt_uint64)
+        && WireInternal.equals(ext_opt_sint64, o.ext_opt_sint64)
+        && WireInternal.equals(ext_opt_fixed64, o.ext_opt_fixed64)
+        && WireInternal.equals(ext_opt_sfixed64, o.ext_opt_sfixed64)
+        && WireInternal.equals(ext_opt_bool, o.ext_opt_bool)
+        && WireInternal.equals(ext_opt_float, o.ext_opt_float)
+        && WireInternal.equals(ext_opt_double, o.ext_opt_double)
+        && WireInternal.equals(ext_opt_string, o.ext_opt_string)
+        && WireInternal.equals(ext_opt_bytes, o.ext_opt_bytes)
+        && WireInternal.equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
+        && WireInternal.equals(ext_opt_nested_message, o.ext_opt_nested_message)
+        && WireInternal.equals(ext_rep_int32, o.ext_rep_int32)
+        && WireInternal.equals(ext_rep_uint32, o.ext_rep_uint32)
+        && WireInternal.equals(ext_rep_sint32, o.ext_rep_sint32)
+        && WireInternal.equals(ext_rep_fixed32, o.ext_rep_fixed32)
+        && WireInternal.equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
+        && WireInternal.equals(ext_rep_int64, o.ext_rep_int64)
+        && WireInternal.equals(ext_rep_uint64, o.ext_rep_uint64)
+        && WireInternal.equals(ext_rep_sint64, o.ext_rep_sint64)
+        && WireInternal.equals(ext_rep_fixed64, o.ext_rep_fixed64)
+        && WireInternal.equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
+        && WireInternal.equals(ext_rep_bool, o.ext_rep_bool)
+        && WireInternal.equals(ext_rep_float, o.ext_rep_float)
+        && WireInternal.equals(ext_rep_double, o.ext_rep_double)
+        && WireInternal.equals(ext_rep_string, o.ext_rep_string)
+        && WireInternal.equals(ext_rep_bytes, o.ext_rep_bytes)
+        && WireInternal.equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
+        && WireInternal.equals(ext_rep_nested_message, o.ext_rep_nested_message)
+        && WireInternal.equals(ext_pack_int32, o.ext_pack_int32)
+        && WireInternal.equals(ext_pack_uint32, o.ext_pack_uint32)
+        && WireInternal.equals(ext_pack_sint32, o.ext_pack_sint32)
+        && WireInternal.equals(ext_pack_fixed32, o.ext_pack_fixed32)
+        && WireInternal.equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
+        && WireInternal.equals(ext_pack_int64, o.ext_pack_int64)
+        && WireInternal.equals(ext_pack_uint64, o.ext_pack_uint64)
+        && WireInternal.equals(ext_pack_sint64, o.ext_pack_sint64)
+        && WireInternal.equals(ext_pack_fixed64, o.ext_pack_fixed64)
+        && WireInternal.equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
+        && WireInternal.equals(ext_pack_bool, o.ext_pack_bool)
+        && WireInternal.equals(ext_pack_float, o.ext_pack_float)
+        && WireInternal.equals(ext_pack_double, o.ext_pack_double)
+        && WireInternal.equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
   }
 
   @Override
@@ -2097,68 +2098,68 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     public List<NestedEnum> ext_pack_nested_enum;
 
     public Builder() {
-      rep_int32 = newMutableList();
-      rep_uint32 = newMutableList();
-      rep_sint32 = newMutableList();
-      rep_fixed32 = newMutableList();
-      rep_sfixed32 = newMutableList();
-      rep_int64 = newMutableList();
-      rep_uint64 = newMutableList();
-      rep_sint64 = newMutableList();
-      rep_fixed64 = newMutableList();
-      rep_sfixed64 = newMutableList();
-      rep_bool = newMutableList();
-      rep_float = newMutableList();
-      rep_double = newMutableList();
-      rep_string = newMutableList();
-      rep_bytes = newMutableList();
-      rep_nested_enum = newMutableList();
-      rep_nested_message = newMutableList();
-      pack_int32 = newMutableList();
-      pack_uint32 = newMutableList();
-      pack_sint32 = newMutableList();
-      pack_fixed32 = newMutableList();
-      pack_sfixed32 = newMutableList();
-      pack_int64 = newMutableList();
-      pack_uint64 = newMutableList();
-      pack_sint64 = newMutableList();
-      pack_fixed64 = newMutableList();
-      pack_sfixed64 = newMutableList();
-      pack_bool = newMutableList();
-      pack_float = newMutableList();
-      pack_double = newMutableList();
-      pack_nested_enum = newMutableList();
-      ext_rep_int32 = newMutableList();
-      ext_rep_uint32 = newMutableList();
-      ext_rep_sint32 = newMutableList();
-      ext_rep_fixed32 = newMutableList();
-      ext_rep_sfixed32 = newMutableList();
-      ext_rep_int64 = newMutableList();
-      ext_rep_uint64 = newMutableList();
-      ext_rep_sint64 = newMutableList();
-      ext_rep_fixed64 = newMutableList();
-      ext_rep_sfixed64 = newMutableList();
-      ext_rep_bool = newMutableList();
-      ext_rep_float = newMutableList();
-      ext_rep_double = newMutableList();
-      ext_rep_string = newMutableList();
-      ext_rep_bytes = newMutableList();
-      ext_rep_nested_enum = newMutableList();
-      ext_rep_nested_message = newMutableList();
-      ext_pack_int32 = newMutableList();
-      ext_pack_uint32 = newMutableList();
-      ext_pack_sint32 = newMutableList();
-      ext_pack_fixed32 = newMutableList();
-      ext_pack_sfixed32 = newMutableList();
-      ext_pack_int64 = newMutableList();
-      ext_pack_uint64 = newMutableList();
-      ext_pack_sint64 = newMutableList();
-      ext_pack_fixed64 = newMutableList();
-      ext_pack_sfixed64 = newMutableList();
-      ext_pack_bool = newMutableList();
-      ext_pack_float = newMutableList();
-      ext_pack_double = newMutableList();
-      ext_pack_nested_enum = newMutableList();
+      rep_int32 = WireInternal.newMutableList();
+      rep_uint32 = WireInternal.newMutableList();
+      rep_sint32 = WireInternal.newMutableList();
+      rep_fixed32 = WireInternal.newMutableList();
+      rep_sfixed32 = WireInternal.newMutableList();
+      rep_int64 = WireInternal.newMutableList();
+      rep_uint64 = WireInternal.newMutableList();
+      rep_sint64 = WireInternal.newMutableList();
+      rep_fixed64 = WireInternal.newMutableList();
+      rep_sfixed64 = WireInternal.newMutableList();
+      rep_bool = WireInternal.newMutableList();
+      rep_float = WireInternal.newMutableList();
+      rep_double = WireInternal.newMutableList();
+      rep_string = WireInternal.newMutableList();
+      rep_bytes = WireInternal.newMutableList();
+      rep_nested_enum = WireInternal.newMutableList();
+      rep_nested_message = WireInternal.newMutableList();
+      pack_int32 = WireInternal.newMutableList();
+      pack_uint32 = WireInternal.newMutableList();
+      pack_sint32 = WireInternal.newMutableList();
+      pack_fixed32 = WireInternal.newMutableList();
+      pack_sfixed32 = WireInternal.newMutableList();
+      pack_int64 = WireInternal.newMutableList();
+      pack_uint64 = WireInternal.newMutableList();
+      pack_sint64 = WireInternal.newMutableList();
+      pack_fixed64 = WireInternal.newMutableList();
+      pack_sfixed64 = WireInternal.newMutableList();
+      pack_bool = WireInternal.newMutableList();
+      pack_float = WireInternal.newMutableList();
+      pack_double = WireInternal.newMutableList();
+      pack_nested_enum = WireInternal.newMutableList();
+      ext_rep_int32 = WireInternal.newMutableList();
+      ext_rep_uint32 = WireInternal.newMutableList();
+      ext_rep_sint32 = WireInternal.newMutableList();
+      ext_rep_fixed32 = WireInternal.newMutableList();
+      ext_rep_sfixed32 = WireInternal.newMutableList();
+      ext_rep_int64 = WireInternal.newMutableList();
+      ext_rep_uint64 = WireInternal.newMutableList();
+      ext_rep_sint64 = WireInternal.newMutableList();
+      ext_rep_fixed64 = WireInternal.newMutableList();
+      ext_rep_sfixed64 = WireInternal.newMutableList();
+      ext_rep_bool = WireInternal.newMutableList();
+      ext_rep_float = WireInternal.newMutableList();
+      ext_rep_double = WireInternal.newMutableList();
+      ext_rep_string = WireInternal.newMutableList();
+      ext_rep_bytes = WireInternal.newMutableList();
+      ext_rep_nested_enum = WireInternal.newMutableList();
+      ext_rep_nested_message = WireInternal.newMutableList();
+      ext_pack_int32 = WireInternal.newMutableList();
+      ext_pack_uint32 = WireInternal.newMutableList();
+      ext_pack_sint32 = WireInternal.newMutableList();
+      ext_pack_fixed32 = WireInternal.newMutableList();
+      ext_pack_sfixed32 = WireInternal.newMutableList();
+      ext_pack_int64 = WireInternal.newMutableList();
+      ext_pack_uint64 = WireInternal.newMutableList();
+      ext_pack_sint64 = WireInternal.newMutableList();
+      ext_pack_fixed64 = WireInternal.newMutableList();
+      ext_pack_sfixed64 = WireInternal.newMutableList();
+      ext_pack_bool = WireInternal.newMutableList();
+      ext_pack_float = WireInternal.newMutableList();
+      ext_pack_double = WireInternal.newMutableList();
+      ext_pack_nested_enum = WireInternal.newMutableList();
     }
 
     public Builder opt_int32(Integer opt_int32) {
@@ -2332,187 +2333,187 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
 
     public Builder rep_int32(List<Integer> rep_int32) {
-      checkElementsNotNull(rep_int32);
+      WireInternal.checkElementsNotNull(rep_int32);
       this.rep_int32 = rep_int32;
       return this;
     }
 
     public Builder rep_uint32(List<Integer> rep_uint32) {
-      checkElementsNotNull(rep_uint32);
+      WireInternal.checkElementsNotNull(rep_uint32);
       this.rep_uint32 = rep_uint32;
       return this;
     }
 
     public Builder rep_sint32(List<Integer> rep_sint32) {
-      checkElementsNotNull(rep_sint32);
+      WireInternal.checkElementsNotNull(rep_sint32);
       this.rep_sint32 = rep_sint32;
       return this;
     }
 
     public Builder rep_fixed32(List<Integer> rep_fixed32) {
-      checkElementsNotNull(rep_fixed32);
+      WireInternal.checkElementsNotNull(rep_fixed32);
       this.rep_fixed32 = rep_fixed32;
       return this;
     }
 
     public Builder rep_sfixed32(List<Integer> rep_sfixed32) {
-      checkElementsNotNull(rep_sfixed32);
+      WireInternal.checkElementsNotNull(rep_sfixed32);
       this.rep_sfixed32 = rep_sfixed32;
       return this;
     }
 
     public Builder rep_int64(List<Long> rep_int64) {
-      checkElementsNotNull(rep_int64);
+      WireInternal.checkElementsNotNull(rep_int64);
       this.rep_int64 = rep_int64;
       return this;
     }
 
     public Builder rep_uint64(List<Long> rep_uint64) {
-      checkElementsNotNull(rep_uint64);
+      WireInternal.checkElementsNotNull(rep_uint64);
       this.rep_uint64 = rep_uint64;
       return this;
     }
 
     public Builder rep_sint64(List<Long> rep_sint64) {
-      checkElementsNotNull(rep_sint64);
+      WireInternal.checkElementsNotNull(rep_sint64);
       this.rep_sint64 = rep_sint64;
       return this;
     }
 
     public Builder rep_fixed64(List<Long> rep_fixed64) {
-      checkElementsNotNull(rep_fixed64);
+      WireInternal.checkElementsNotNull(rep_fixed64);
       this.rep_fixed64 = rep_fixed64;
       return this;
     }
 
     public Builder rep_sfixed64(List<Long> rep_sfixed64) {
-      checkElementsNotNull(rep_sfixed64);
+      WireInternal.checkElementsNotNull(rep_sfixed64);
       this.rep_sfixed64 = rep_sfixed64;
       return this;
     }
 
     public Builder rep_bool(List<Boolean> rep_bool) {
-      checkElementsNotNull(rep_bool);
+      WireInternal.checkElementsNotNull(rep_bool);
       this.rep_bool = rep_bool;
       return this;
     }
 
     public Builder rep_float(List<Float> rep_float) {
-      checkElementsNotNull(rep_float);
+      WireInternal.checkElementsNotNull(rep_float);
       this.rep_float = rep_float;
       return this;
     }
 
     public Builder rep_double(List<Double> rep_double) {
-      checkElementsNotNull(rep_double);
+      WireInternal.checkElementsNotNull(rep_double);
       this.rep_double = rep_double;
       return this;
     }
 
     public Builder rep_string(List<String> rep_string) {
-      checkElementsNotNull(rep_string);
+      WireInternal.checkElementsNotNull(rep_string);
       this.rep_string = rep_string;
       return this;
     }
 
     public Builder rep_bytes(List<ByteString> rep_bytes) {
-      checkElementsNotNull(rep_bytes);
+      WireInternal.checkElementsNotNull(rep_bytes);
       this.rep_bytes = rep_bytes;
       return this;
     }
 
     public Builder rep_nested_enum(List<NestedEnum> rep_nested_enum) {
-      checkElementsNotNull(rep_nested_enum);
+      WireInternal.checkElementsNotNull(rep_nested_enum);
       this.rep_nested_enum = rep_nested_enum;
       return this;
     }
 
     public Builder rep_nested_message(List<NestedMessage> rep_nested_message) {
-      checkElementsNotNull(rep_nested_message);
+      WireInternal.checkElementsNotNull(rep_nested_message);
       this.rep_nested_message = rep_nested_message;
       return this;
     }
 
     public Builder pack_int32(List<Integer> pack_int32) {
-      checkElementsNotNull(pack_int32);
+      WireInternal.checkElementsNotNull(pack_int32);
       this.pack_int32 = pack_int32;
       return this;
     }
 
     public Builder pack_uint32(List<Integer> pack_uint32) {
-      checkElementsNotNull(pack_uint32);
+      WireInternal.checkElementsNotNull(pack_uint32);
       this.pack_uint32 = pack_uint32;
       return this;
     }
 
     public Builder pack_sint32(List<Integer> pack_sint32) {
-      checkElementsNotNull(pack_sint32);
+      WireInternal.checkElementsNotNull(pack_sint32);
       this.pack_sint32 = pack_sint32;
       return this;
     }
 
     public Builder pack_fixed32(List<Integer> pack_fixed32) {
-      checkElementsNotNull(pack_fixed32);
+      WireInternal.checkElementsNotNull(pack_fixed32);
       this.pack_fixed32 = pack_fixed32;
       return this;
     }
 
     public Builder pack_sfixed32(List<Integer> pack_sfixed32) {
-      checkElementsNotNull(pack_sfixed32);
+      WireInternal.checkElementsNotNull(pack_sfixed32);
       this.pack_sfixed32 = pack_sfixed32;
       return this;
     }
 
     public Builder pack_int64(List<Long> pack_int64) {
-      checkElementsNotNull(pack_int64);
+      WireInternal.checkElementsNotNull(pack_int64);
       this.pack_int64 = pack_int64;
       return this;
     }
 
     public Builder pack_uint64(List<Long> pack_uint64) {
-      checkElementsNotNull(pack_uint64);
+      WireInternal.checkElementsNotNull(pack_uint64);
       this.pack_uint64 = pack_uint64;
       return this;
     }
 
     public Builder pack_sint64(List<Long> pack_sint64) {
-      checkElementsNotNull(pack_sint64);
+      WireInternal.checkElementsNotNull(pack_sint64);
       this.pack_sint64 = pack_sint64;
       return this;
     }
 
     public Builder pack_fixed64(List<Long> pack_fixed64) {
-      checkElementsNotNull(pack_fixed64);
+      WireInternal.checkElementsNotNull(pack_fixed64);
       this.pack_fixed64 = pack_fixed64;
       return this;
     }
 
     public Builder pack_sfixed64(List<Long> pack_sfixed64) {
-      checkElementsNotNull(pack_sfixed64);
+      WireInternal.checkElementsNotNull(pack_sfixed64);
       this.pack_sfixed64 = pack_sfixed64;
       return this;
     }
 
     public Builder pack_bool(List<Boolean> pack_bool) {
-      checkElementsNotNull(pack_bool);
+      WireInternal.checkElementsNotNull(pack_bool);
       this.pack_bool = pack_bool;
       return this;
     }
 
     public Builder pack_float(List<Float> pack_float) {
-      checkElementsNotNull(pack_float);
+      WireInternal.checkElementsNotNull(pack_float);
       this.pack_float = pack_float;
       return this;
     }
 
     public Builder pack_double(List<Double> pack_double) {
-      checkElementsNotNull(pack_double);
+      WireInternal.checkElementsNotNull(pack_double);
       this.pack_double = pack_double;
       return this;
     }
 
     public Builder pack_nested_enum(List<NestedEnum> pack_nested_enum) {
-      checkElementsNotNull(pack_nested_enum);
+      WireInternal.checkElementsNotNull(pack_nested_enum);
       this.pack_nested_enum = pack_nested_enum;
       return this;
     }
@@ -2683,187 +2684,187 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
 
     public Builder ext_rep_int32(List<Integer> ext_rep_int32) {
-      checkElementsNotNull(ext_rep_int32);
+      WireInternal.checkElementsNotNull(ext_rep_int32);
       this.ext_rep_int32 = ext_rep_int32;
       return this;
     }
 
     public Builder ext_rep_uint32(List<Integer> ext_rep_uint32) {
-      checkElementsNotNull(ext_rep_uint32);
+      WireInternal.checkElementsNotNull(ext_rep_uint32);
       this.ext_rep_uint32 = ext_rep_uint32;
       return this;
     }
 
     public Builder ext_rep_sint32(List<Integer> ext_rep_sint32) {
-      checkElementsNotNull(ext_rep_sint32);
+      WireInternal.checkElementsNotNull(ext_rep_sint32);
       this.ext_rep_sint32 = ext_rep_sint32;
       return this;
     }
 
     public Builder ext_rep_fixed32(List<Integer> ext_rep_fixed32) {
-      checkElementsNotNull(ext_rep_fixed32);
+      WireInternal.checkElementsNotNull(ext_rep_fixed32);
       this.ext_rep_fixed32 = ext_rep_fixed32;
       return this;
     }
 
     public Builder ext_rep_sfixed32(List<Integer> ext_rep_sfixed32) {
-      checkElementsNotNull(ext_rep_sfixed32);
+      WireInternal.checkElementsNotNull(ext_rep_sfixed32);
       this.ext_rep_sfixed32 = ext_rep_sfixed32;
       return this;
     }
 
     public Builder ext_rep_int64(List<Long> ext_rep_int64) {
-      checkElementsNotNull(ext_rep_int64);
+      WireInternal.checkElementsNotNull(ext_rep_int64);
       this.ext_rep_int64 = ext_rep_int64;
       return this;
     }
 
     public Builder ext_rep_uint64(List<Long> ext_rep_uint64) {
-      checkElementsNotNull(ext_rep_uint64);
+      WireInternal.checkElementsNotNull(ext_rep_uint64);
       this.ext_rep_uint64 = ext_rep_uint64;
       return this;
     }
 
     public Builder ext_rep_sint64(List<Long> ext_rep_sint64) {
-      checkElementsNotNull(ext_rep_sint64);
+      WireInternal.checkElementsNotNull(ext_rep_sint64);
       this.ext_rep_sint64 = ext_rep_sint64;
       return this;
     }
 
     public Builder ext_rep_fixed64(List<Long> ext_rep_fixed64) {
-      checkElementsNotNull(ext_rep_fixed64);
+      WireInternal.checkElementsNotNull(ext_rep_fixed64);
       this.ext_rep_fixed64 = ext_rep_fixed64;
       return this;
     }
 
     public Builder ext_rep_sfixed64(List<Long> ext_rep_sfixed64) {
-      checkElementsNotNull(ext_rep_sfixed64);
+      WireInternal.checkElementsNotNull(ext_rep_sfixed64);
       this.ext_rep_sfixed64 = ext_rep_sfixed64;
       return this;
     }
 
     public Builder ext_rep_bool(List<Boolean> ext_rep_bool) {
-      checkElementsNotNull(ext_rep_bool);
+      WireInternal.checkElementsNotNull(ext_rep_bool);
       this.ext_rep_bool = ext_rep_bool;
       return this;
     }
 
     public Builder ext_rep_float(List<Float> ext_rep_float) {
-      checkElementsNotNull(ext_rep_float);
+      WireInternal.checkElementsNotNull(ext_rep_float);
       this.ext_rep_float = ext_rep_float;
       return this;
     }
 
     public Builder ext_rep_double(List<Double> ext_rep_double) {
-      checkElementsNotNull(ext_rep_double);
+      WireInternal.checkElementsNotNull(ext_rep_double);
       this.ext_rep_double = ext_rep_double;
       return this;
     }
 
     public Builder ext_rep_string(List<String> ext_rep_string) {
-      checkElementsNotNull(ext_rep_string);
+      WireInternal.checkElementsNotNull(ext_rep_string);
       this.ext_rep_string = ext_rep_string;
       return this;
     }
 
     public Builder ext_rep_bytes(List<ByteString> ext_rep_bytes) {
-      checkElementsNotNull(ext_rep_bytes);
+      WireInternal.checkElementsNotNull(ext_rep_bytes);
       this.ext_rep_bytes = ext_rep_bytes;
       return this;
     }
 
     public Builder ext_rep_nested_enum(List<NestedEnum> ext_rep_nested_enum) {
-      checkElementsNotNull(ext_rep_nested_enum);
+      WireInternal.checkElementsNotNull(ext_rep_nested_enum);
       this.ext_rep_nested_enum = ext_rep_nested_enum;
       return this;
     }
 
     public Builder ext_rep_nested_message(List<NestedMessage> ext_rep_nested_message) {
-      checkElementsNotNull(ext_rep_nested_message);
+      WireInternal.checkElementsNotNull(ext_rep_nested_message);
       this.ext_rep_nested_message = ext_rep_nested_message;
       return this;
     }
 
     public Builder ext_pack_int32(List<Integer> ext_pack_int32) {
-      checkElementsNotNull(ext_pack_int32);
+      WireInternal.checkElementsNotNull(ext_pack_int32);
       this.ext_pack_int32 = ext_pack_int32;
       return this;
     }
 
     public Builder ext_pack_uint32(List<Integer> ext_pack_uint32) {
-      checkElementsNotNull(ext_pack_uint32);
+      WireInternal.checkElementsNotNull(ext_pack_uint32);
       this.ext_pack_uint32 = ext_pack_uint32;
       return this;
     }
 
     public Builder ext_pack_sint32(List<Integer> ext_pack_sint32) {
-      checkElementsNotNull(ext_pack_sint32);
+      WireInternal.checkElementsNotNull(ext_pack_sint32);
       this.ext_pack_sint32 = ext_pack_sint32;
       return this;
     }
 
     public Builder ext_pack_fixed32(List<Integer> ext_pack_fixed32) {
-      checkElementsNotNull(ext_pack_fixed32);
+      WireInternal.checkElementsNotNull(ext_pack_fixed32);
       this.ext_pack_fixed32 = ext_pack_fixed32;
       return this;
     }
 
     public Builder ext_pack_sfixed32(List<Integer> ext_pack_sfixed32) {
-      checkElementsNotNull(ext_pack_sfixed32);
+      WireInternal.checkElementsNotNull(ext_pack_sfixed32);
       this.ext_pack_sfixed32 = ext_pack_sfixed32;
       return this;
     }
 
     public Builder ext_pack_int64(List<Long> ext_pack_int64) {
-      checkElementsNotNull(ext_pack_int64);
+      WireInternal.checkElementsNotNull(ext_pack_int64);
       this.ext_pack_int64 = ext_pack_int64;
       return this;
     }
 
     public Builder ext_pack_uint64(List<Long> ext_pack_uint64) {
-      checkElementsNotNull(ext_pack_uint64);
+      WireInternal.checkElementsNotNull(ext_pack_uint64);
       this.ext_pack_uint64 = ext_pack_uint64;
       return this;
     }
 
     public Builder ext_pack_sint64(List<Long> ext_pack_sint64) {
-      checkElementsNotNull(ext_pack_sint64);
+      WireInternal.checkElementsNotNull(ext_pack_sint64);
       this.ext_pack_sint64 = ext_pack_sint64;
       return this;
     }
 
     public Builder ext_pack_fixed64(List<Long> ext_pack_fixed64) {
-      checkElementsNotNull(ext_pack_fixed64);
+      WireInternal.checkElementsNotNull(ext_pack_fixed64);
       this.ext_pack_fixed64 = ext_pack_fixed64;
       return this;
     }
 
     public Builder ext_pack_sfixed64(List<Long> ext_pack_sfixed64) {
-      checkElementsNotNull(ext_pack_sfixed64);
+      WireInternal.checkElementsNotNull(ext_pack_sfixed64);
       this.ext_pack_sfixed64 = ext_pack_sfixed64;
       return this;
     }
 
     public Builder ext_pack_bool(List<Boolean> ext_pack_bool) {
-      checkElementsNotNull(ext_pack_bool);
+      WireInternal.checkElementsNotNull(ext_pack_bool);
       this.ext_pack_bool = ext_pack_bool;
       return this;
     }
 
     public Builder ext_pack_float(List<Float> ext_pack_float) {
-      checkElementsNotNull(ext_pack_float);
+      WireInternal.checkElementsNotNull(ext_pack_float);
       this.ext_pack_float = ext_pack_float;
       return this;
     }
 
     public Builder ext_pack_double(List<Double> ext_pack_double) {
-      checkElementsNotNull(ext_pack_double);
+      WireInternal.checkElementsNotNull(ext_pack_double);
       this.ext_pack_double = ext_pack_double;
       return this;
     }
 
     public Builder ext_pack_nested_enum(List<NestedEnum> ext_pack_nested_enum) {
-      checkElementsNotNull(ext_pack_nested_enum);
+      WireInternal.checkElementsNotNull(ext_pack_nested_enum);
       this.ext_pack_nested_enum = ext_pack_nested_enum;
       return this;
     }
@@ -2887,7 +2888,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
           || req_bytes == null
           || req_nested_enum == null
           || req_nested_message == null) {
-        throw missingRequiredFields(req_int32, "req_int32",
+        throw WireInternal.missingRequiredFields(req_int32, "req_int32",
             req_uint32, "req_uint32",
             req_sint32, "req_sint32",
             req_fixed32, "req_fixed32",
@@ -2971,8 +2972,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(a, o.a);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(a, o.a);
     }
 
     @Override
@@ -3534,9 +3535,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       Builder builder = value.newBuilder();
       if (builder.opt_nested_message != null) builder.opt_nested_message = NestedMessage.ADAPTER.redact(builder.opt_nested_message);
       if (builder.req_nested_message != null) builder.req_nested_message = NestedMessage.ADAPTER.redact(builder.req_nested_message);
-      redactElements(builder.rep_nested_message, NestedMessage.ADAPTER);
+      WireInternal.redactElements(builder.rep_nested_message, NestedMessage.ADAPTER);
       if (builder.ext_opt_nested_message != null) builder.ext_opt_nested_message = NestedMessage.ADAPTER.redact(builder.ext_opt_nested_message);
-      redactElements(builder.ext_rep_nested_message, NestedMessage.ADAPTER);
+      WireInternal.redactElements(builder.ext_rep_nested_message, NestedMessage.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
@@ -6,6 +6,7 @@ import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
@@ -1188,37 +1189,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.req_bytes = req_bytes;
     this.req_nested_enum = req_nested_enum;
     this.req_nested_message = req_nested_message;
-    this.rep_int32 = immutableCopyOf("rep_int32", rep_int32);
-    this.rep_uint32 = immutableCopyOf("rep_uint32", rep_uint32);
-    this.rep_sint32 = immutableCopyOf("rep_sint32", rep_sint32);
-    this.rep_fixed32 = immutableCopyOf("rep_fixed32", rep_fixed32);
-    this.rep_sfixed32 = immutableCopyOf("rep_sfixed32", rep_sfixed32);
-    this.rep_int64 = immutableCopyOf("rep_int64", rep_int64);
-    this.rep_uint64 = immutableCopyOf("rep_uint64", rep_uint64);
-    this.rep_sint64 = immutableCopyOf("rep_sint64", rep_sint64);
-    this.rep_fixed64 = immutableCopyOf("rep_fixed64", rep_fixed64);
-    this.rep_sfixed64 = immutableCopyOf("rep_sfixed64", rep_sfixed64);
-    this.rep_bool = immutableCopyOf("rep_bool", rep_bool);
-    this.rep_float = immutableCopyOf("rep_float", rep_float);
-    this.rep_double = immutableCopyOf("rep_double", rep_double);
-    this.rep_string = immutableCopyOf("rep_string", rep_string);
-    this.rep_bytes = immutableCopyOf("rep_bytes", rep_bytes);
-    this.rep_nested_enum = immutableCopyOf("rep_nested_enum", rep_nested_enum);
-    this.rep_nested_message = immutableCopyOf("rep_nested_message", rep_nested_message);
-    this.pack_int32 = immutableCopyOf("pack_int32", pack_int32);
-    this.pack_uint32 = immutableCopyOf("pack_uint32", pack_uint32);
-    this.pack_sint32 = immutableCopyOf("pack_sint32", pack_sint32);
-    this.pack_fixed32 = immutableCopyOf("pack_fixed32", pack_fixed32);
-    this.pack_sfixed32 = immutableCopyOf("pack_sfixed32", pack_sfixed32);
-    this.pack_int64 = immutableCopyOf("pack_int64", pack_int64);
-    this.pack_uint64 = immutableCopyOf("pack_uint64", pack_uint64);
-    this.pack_sint64 = immutableCopyOf("pack_sint64", pack_sint64);
-    this.pack_fixed64 = immutableCopyOf("pack_fixed64", pack_fixed64);
-    this.pack_sfixed64 = immutableCopyOf("pack_sfixed64", pack_sfixed64);
-    this.pack_bool = immutableCopyOf("pack_bool", pack_bool);
-    this.pack_float = immutableCopyOf("pack_float", pack_float);
-    this.pack_double = immutableCopyOf("pack_double", pack_double);
-    this.pack_nested_enum = immutableCopyOf("pack_nested_enum", pack_nested_enum);
+    this.rep_int32 = WireInternal.immutableCopyOf("rep_int32", rep_int32);
+    this.rep_uint32 = WireInternal.immutableCopyOf("rep_uint32", rep_uint32);
+    this.rep_sint32 = WireInternal.immutableCopyOf("rep_sint32", rep_sint32);
+    this.rep_fixed32 = WireInternal.immutableCopyOf("rep_fixed32", rep_fixed32);
+    this.rep_sfixed32 = WireInternal.immutableCopyOf("rep_sfixed32", rep_sfixed32);
+    this.rep_int64 = WireInternal.immutableCopyOf("rep_int64", rep_int64);
+    this.rep_uint64 = WireInternal.immutableCopyOf("rep_uint64", rep_uint64);
+    this.rep_sint64 = WireInternal.immutableCopyOf("rep_sint64", rep_sint64);
+    this.rep_fixed64 = WireInternal.immutableCopyOf("rep_fixed64", rep_fixed64);
+    this.rep_sfixed64 = WireInternal.immutableCopyOf("rep_sfixed64", rep_sfixed64);
+    this.rep_bool = WireInternal.immutableCopyOf("rep_bool", rep_bool);
+    this.rep_float = WireInternal.immutableCopyOf("rep_float", rep_float);
+    this.rep_double = WireInternal.immutableCopyOf("rep_double", rep_double);
+    this.rep_string = WireInternal.immutableCopyOf("rep_string", rep_string);
+    this.rep_bytes = WireInternal.immutableCopyOf("rep_bytes", rep_bytes);
+    this.rep_nested_enum = WireInternal.immutableCopyOf("rep_nested_enum", rep_nested_enum);
+    this.rep_nested_message = WireInternal.immutableCopyOf("rep_nested_message", rep_nested_message);
+    this.pack_int32 = WireInternal.immutableCopyOf("pack_int32", pack_int32);
+    this.pack_uint32 = WireInternal.immutableCopyOf("pack_uint32", pack_uint32);
+    this.pack_sint32 = WireInternal.immutableCopyOf("pack_sint32", pack_sint32);
+    this.pack_fixed32 = WireInternal.immutableCopyOf("pack_fixed32", pack_fixed32);
+    this.pack_sfixed32 = WireInternal.immutableCopyOf("pack_sfixed32", pack_sfixed32);
+    this.pack_int64 = WireInternal.immutableCopyOf("pack_int64", pack_int64);
+    this.pack_uint64 = WireInternal.immutableCopyOf("pack_uint64", pack_uint64);
+    this.pack_sint64 = WireInternal.immutableCopyOf("pack_sint64", pack_sint64);
+    this.pack_fixed64 = WireInternal.immutableCopyOf("pack_fixed64", pack_fixed64);
+    this.pack_sfixed64 = WireInternal.immutableCopyOf("pack_sfixed64", pack_sfixed64);
+    this.pack_bool = WireInternal.immutableCopyOf("pack_bool", pack_bool);
+    this.pack_float = WireInternal.immutableCopyOf("pack_float", pack_float);
+    this.pack_double = WireInternal.immutableCopyOf("pack_double", pack_double);
+    this.pack_nested_enum = WireInternal.immutableCopyOf("pack_nested_enum", pack_nested_enum);
     this.default_int32 = default_int32;
     this.default_uint32 = default_uint32;
     this.default_sint32 = default_sint32;
@@ -1252,37 +1253,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.ext_opt_bytes = ext_opt_bytes;
     this.ext_opt_nested_enum = ext_opt_nested_enum;
     this.ext_opt_nested_message = ext_opt_nested_message;
-    this.ext_rep_int32 = immutableCopyOf("ext_rep_int32", ext_rep_int32);
-    this.ext_rep_uint32 = immutableCopyOf("ext_rep_uint32", ext_rep_uint32);
-    this.ext_rep_sint32 = immutableCopyOf("ext_rep_sint32", ext_rep_sint32);
-    this.ext_rep_fixed32 = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32);
-    this.ext_rep_sfixed32 = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32);
-    this.ext_rep_int64 = immutableCopyOf("ext_rep_int64", ext_rep_int64);
-    this.ext_rep_uint64 = immutableCopyOf("ext_rep_uint64", ext_rep_uint64);
-    this.ext_rep_sint64 = immutableCopyOf("ext_rep_sint64", ext_rep_sint64);
-    this.ext_rep_fixed64 = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64);
-    this.ext_rep_sfixed64 = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64);
-    this.ext_rep_bool = immutableCopyOf("ext_rep_bool", ext_rep_bool);
-    this.ext_rep_float = immutableCopyOf("ext_rep_float", ext_rep_float);
-    this.ext_rep_double = immutableCopyOf("ext_rep_double", ext_rep_double);
-    this.ext_rep_string = immutableCopyOf("ext_rep_string", ext_rep_string);
-    this.ext_rep_bytes = immutableCopyOf("ext_rep_bytes", ext_rep_bytes);
-    this.ext_rep_nested_enum = immutableCopyOf("ext_rep_nested_enum", ext_rep_nested_enum);
-    this.ext_rep_nested_message = immutableCopyOf("ext_rep_nested_message", ext_rep_nested_message);
-    this.ext_pack_int32 = immutableCopyOf("ext_pack_int32", ext_pack_int32);
-    this.ext_pack_uint32 = immutableCopyOf("ext_pack_uint32", ext_pack_uint32);
-    this.ext_pack_sint32 = immutableCopyOf("ext_pack_sint32", ext_pack_sint32);
-    this.ext_pack_fixed32 = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32);
-    this.ext_pack_sfixed32 = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32);
-    this.ext_pack_int64 = immutableCopyOf("ext_pack_int64", ext_pack_int64);
-    this.ext_pack_uint64 = immutableCopyOf("ext_pack_uint64", ext_pack_uint64);
-    this.ext_pack_sint64 = immutableCopyOf("ext_pack_sint64", ext_pack_sint64);
-    this.ext_pack_fixed64 = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64);
-    this.ext_pack_sfixed64 = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64);
-    this.ext_pack_bool = immutableCopyOf("ext_pack_bool", ext_pack_bool);
-    this.ext_pack_float = immutableCopyOf("ext_pack_float", ext_pack_float);
-    this.ext_pack_double = immutableCopyOf("ext_pack_double", ext_pack_double);
-    this.ext_pack_nested_enum = immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
+    this.ext_rep_int32 = WireInternal.immutableCopyOf("ext_rep_int32", ext_rep_int32);
+    this.ext_rep_uint32 = WireInternal.immutableCopyOf("ext_rep_uint32", ext_rep_uint32);
+    this.ext_rep_sint32 = WireInternal.immutableCopyOf("ext_rep_sint32", ext_rep_sint32);
+    this.ext_rep_fixed32 = WireInternal.immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32);
+    this.ext_rep_sfixed32 = WireInternal.immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32);
+    this.ext_rep_int64 = WireInternal.immutableCopyOf("ext_rep_int64", ext_rep_int64);
+    this.ext_rep_uint64 = WireInternal.immutableCopyOf("ext_rep_uint64", ext_rep_uint64);
+    this.ext_rep_sint64 = WireInternal.immutableCopyOf("ext_rep_sint64", ext_rep_sint64);
+    this.ext_rep_fixed64 = WireInternal.immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64);
+    this.ext_rep_sfixed64 = WireInternal.immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64);
+    this.ext_rep_bool = WireInternal.immutableCopyOf("ext_rep_bool", ext_rep_bool);
+    this.ext_rep_float = WireInternal.immutableCopyOf("ext_rep_float", ext_rep_float);
+    this.ext_rep_double = WireInternal.immutableCopyOf("ext_rep_double", ext_rep_double);
+    this.ext_rep_string = WireInternal.immutableCopyOf("ext_rep_string", ext_rep_string);
+    this.ext_rep_bytes = WireInternal.immutableCopyOf("ext_rep_bytes", ext_rep_bytes);
+    this.ext_rep_nested_enum = WireInternal.immutableCopyOf("ext_rep_nested_enum", ext_rep_nested_enum);
+    this.ext_rep_nested_message = WireInternal.immutableCopyOf("ext_rep_nested_message", ext_rep_nested_message);
+    this.ext_pack_int32 = WireInternal.immutableCopyOf("ext_pack_int32", ext_pack_int32);
+    this.ext_pack_uint32 = WireInternal.immutableCopyOf("ext_pack_uint32", ext_pack_uint32);
+    this.ext_pack_sint32 = WireInternal.immutableCopyOf("ext_pack_sint32", ext_pack_sint32);
+    this.ext_pack_fixed32 = WireInternal.immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32);
+    this.ext_pack_sfixed32 = WireInternal.immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32);
+    this.ext_pack_int64 = WireInternal.immutableCopyOf("ext_pack_int64", ext_pack_int64);
+    this.ext_pack_uint64 = WireInternal.immutableCopyOf("ext_pack_uint64", ext_pack_uint64);
+    this.ext_pack_sint64 = WireInternal.immutableCopyOf("ext_pack_sint64", ext_pack_sint64);
+    this.ext_pack_fixed64 = WireInternal.immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64);
+    this.ext_pack_sfixed64 = WireInternal.immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64);
+    this.ext_pack_bool = WireInternal.immutableCopyOf("ext_pack_bool", ext_pack_bool);
+    this.ext_pack_float = WireInternal.immutableCopyOf("ext_pack_float", ext_pack_float);
+    this.ext_pack_double = WireInternal.immutableCopyOf("ext_pack_double", ext_pack_double);
+    this.ext_pack_nested_enum = WireInternal.immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
   }
 
   @Override
@@ -1322,37 +1323,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     builder.req_bytes = req_bytes;
     builder.req_nested_enum = req_nested_enum;
     builder.req_nested_message = req_nested_message;
-    builder.rep_int32 = copyOf("rep_int32", rep_int32);
-    builder.rep_uint32 = copyOf("rep_uint32", rep_uint32);
-    builder.rep_sint32 = copyOf("rep_sint32", rep_sint32);
-    builder.rep_fixed32 = copyOf("rep_fixed32", rep_fixed32);
-    builder.rep_sfixed32 = copyOf("rep_sfixed32", rep_sfixed32);
-    builder.rep_int64 = copyOf("rep_int64", rep_int64);
-    builder.rep_uint64 = copyOf("rep_uint64", rep_uint64);
-    builder.rep_sint64 = copyOf("rep_sint64", rep_sint64);
-    builder.rep_fixed64 = copyOf("rep_fixed64", rep_fixed64);
-    builder.rep_sfixed64 = copyOf("rep_sfixed64", rep_sfixed64);
-    builder.rep_bool = copyOf("rep_bool", rep_bool);
-    builder.rep_float = copyOf("rep_float", rep_float);
-    builder.rep_double = copyOf("rep_double", rep_double);
-    builder.rep_string = copyOf("rep_string", rep_string);
-    builder.rep_bytes = copyOf("rep_bytes", rep_bytes);
-    builder.rep_nested_enum = copyOf("rep_nested_enum", rep_nested_enum);
-    builder.rep_nested_message = copyOf("rep_nested_message", rep_nested_message);
-    builder.pack_int32 = copyOf("pack_int32", pack_int32);
-    builder.pack_uint32 = copyOf("pack_uint32", pack_uint32);
-    builder.pack_sint32 = copyOf("pack_sint32", pack_sint32);
-    builder.pack_fixed32 = copyOf("pack_fixed32", pack_fixed32);
-    builder.pack_sfixed32 = copyOf("pack_sfixed32", pack_sfixed32);
-    builder.pack_int64 = copyOf("pack_int64", pack_int64);
-    builder.pack_uint64 = copyOf("pack_uint64", pack_uint64);
-    builder.pack_sint64 = copyOf("pack_sint64", pack_sint64);
-    builder.pack_fixed64 = copyOf("pack_fixed64", pack_fixed64);
-    builder.pack_sfixed64 = copyOf("pack_sfixed64", pack_sfixed64);
-    builder.pack_bool = copyOf("pack_bool", pack_bool);
-    builder.pack_float = copyOf("pack_float", pack_float);
-    builder.pack_double = copyOf("pack_double", pack_double);
-    builder.pack_nested_enum = copyOf("pack_nested_enum", pack_nested_enum);
+    builder.rep_int32 = WireInternal.copyOf("rep_int32", rep_int32);
+    builder.rep_uint32 = WireInternal.copyOf("rep_uint32", rep_uint32);
+    builder.rep_sint32 = WireInternal.copyOf("rep_sint32", rep_sint32);
+    builder.rep_fixed32 = WireInternal.copyOf("rep_fixed32", rep_fixed32);
+    builder.rep_sfixed32 = WireInternal.copyOf("rep_sfixed32", rep_sfixed32);
+    builder.rep_int64 = WireInternal.copyOf("rep_int64", rep_int64);
+    builder.rep_uint64 = WireInternal.copyOf("rep_uint64", rep_uint64);
+    builder.rep_sint64 = WireInternal.copyOf("rep_sint64", rep_sint64);
+    builder.rep_fixed64 = WireInternal.copyOf("rep_fixed64", rep_fixed64);
+    builder.rep_sfixed64 = WireInternal.copyOf("rep_sfixed64", rep_sfixed64);
+    builder.rep_bool = WireInternal.copyOf("rep_bool", rep_bool);
+    builder.rep_float = WireInternal.copyOf("rep_float", rep_float);
+    builder.rep_double = WireInternal.copyOf("rep_double", rep_double);
+    builder.rep_string = WireInternal.copyOf("rep_string", rep_string);
+    builder.rep_bytes = WireInternal.copyOf("rep_bytes", rep_bytes);
+    builder.rep_nested_enum = WireInternal.copyOf("rep_nested_enum", rep_nested_enum);
+    builder.rep_nested_message = WireInternal.copyOf("rep_nested_message", rep_nested_message);
+    builder.pack_int32 = WireInternal.copyOf("pack_int32", pack_int32);
+    builder.pack_uint32 = WireInternal.copyOf("pack_uint32", pack_uint32);
+    builder.pack_sint32 = WireInternal.copyOf("pack_sint32", pack_sint32);
+    builder.pack_fixed32 = WireInternal.copyOf("pack_fixed32", pack_fixed32);
+    builder.pack_sfixed32 = WireInternal.copyOf("pack_sfixed32", pack_sfixed32);
+    builder.pack_int64 = WireInternal.copyOf("pack_int64", pack_int64);
+    builder.pack_uint64 = WireInternal.copyOf("pack_uint64", pack_uint64);
+    builder.pack_sint64 = WireInternal.copyOf("pack_sint64", pack_sint64);
+    builder.pack_fixed64 = WireInternal.copyOf("pack_fixed64", pack_fixed64);
+    builder.pack_sfixed64 = WireInternal.copyOf("pack_sfixed64", pack_sfixed64);
+    builder.pack_bool = WireInternal.copyOf("pack_bool", pack_bool);
+    builder.pack_float = WireInternal.copyOf("pack_float", pack_float);
+    builder.pack_double = WireInternal.copyOf("pack_double", pack_double);
+    builder.pack_nested_enum = WireInternal.copyOf("pack_nested_enum", pack_nested_enum);
     builder.default_int32 = default_int32;
     builder.default_uint32 = default_uint32;
     builder.default_sint32 = default_sint32;
@@ -1386,37 +1387,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     builder.ext_opt_bytes = ext_opt_bytes;
     builder.ext_opt_nested_enum = ext_opt_nested_enum;
     builder.ext_opt_nested_message = ext_opt_nested_message;
-    builder.ext_rep_int32 = copyOf("ext_rep_int32", ext_rep_int32);
-    builder.ext_rep_uint32 = copyOf("ext_rep_uint32", ext_rep_uint32);
-    builder.ext_rep_sint32 = copyOf("ext_rep_sint32", ext_rep_sint32);
-    builder.ext_rep_fixed32 = copyOf("ext_rep_fixed32", ext_rep_fixed32);
-    builder.ext_rep_sfixed32 = copyOf("ext_rep_sfixed32", ext_rep_sfixed32);
-    builder.ext_rep_int64 = copyOf("ext_rep_int64", ext_rep_int64);
-    builder.ext_rep_uint64 = copyOf("ext_rep_uint64", ext_rep_uint64);
-    builder.ext_rep_sint64 = copyOf("ext_rep_sint64", ext_rep_sint64);
-    builder.ext_rep_fixed64 = copyOf("ext_rep_fixed64", ext_rep_fixed64);
-    builder.ext_rep_sfixed64 = copyOf("ext_rep_sfixed64", ext_rep_sfixed64);
-    builder.ext_rep_bool = copyOf("ext_rep_bool", ext_rep_bool);
-    builder.ext_rep_float = copyOf("ext_rep_float", ext_rep_float);
-    builder.ext_rep_double = copyOf("ext_rep_double", ext_rep_double);
-    builder.ext_rep_string = copyOf("ext_rep_string", ext_rep_string);
-    builder.ext_rep_bytes = copyOf("ext_rep_bytes", ext_rep_bytes);
-    builder.ext_rep_nested_enum = copyOf("ext_rep_nested_enum", ext_rep_nested_enum);
-    builder.ext_rep_nested_message = copyOf("ext_rep_nested_message", ext_rep_nested_message);
-    builder.ext_pack_int32 = copyOf("ext_pack_int32", ext_pack_int32);
-    builder.ext_pack_uint32 = copyOf("ext_pack_uint32", ext_pack_uint32);
-    builder.ext_pack_sint32 = copyOf("ext_pack_sint32", ext_pack_sint32);
-    builder.ext_pack_fixed32 = copyOf("ext_pack_fixed32", ext_pack_fixed32);
-    builder.ext_pack_sfixed32 = copyOf("ext_pack_sfixed32", ext_pack_sfixed32);
-    builder.ext_pack_int64 = copyOf("ext_pack_int64", ext_pack_int64);
-    builder.ext_pack_uint64 = copyOf("ext_pack_uint64", ext_pack_uint64);
-    builder.ext_pack_sint64 = copyOf("ext_pack_sint64", ext_pack_sint64);
-    builder.ext_pack_fixed64 = copyOf("ext_pack_fixed64", ext_pack_fixed64);
-    builder.ext_pack_sfixed64 = copyOf("ext_pack_sfixed64", ext_pack_sfixed64);
-    builder.ext_pack_bool = copyOf("ext_pack_bool", ext_pack_bool);
-    builder.ext_pack_float = copyOf("ext_pack_float", ext_pack_float);
-    builder.ext_pack_double = copyOf("ext_pack_double", ext_pack_double);
-    builder.ext_pack_nested_enum = copyOf("ext_pack_nested_enum", ext_pack_nested_enum);
+    builder.ext_rep_int32 = WireInternal.copyOf("ext_rep_int32", ext_rep_int32);
+    builder.ext_rep_uint32 = WireInternal.copyOf("ext_rep_uint32", ext_rep_uint32);
+    builder.ext_rep_sint32 = WireInternal.copyOf("ext_rep_sint32", ext_rep_sint32);
+    builder.ext_rep_fixed32 = WireInternal.copyOf("ext_rep_fixed32", ext_rep_fixed32);
+    builder.ext_rep_sfixed32 = WireInternal.copyOf("ext_rep_sfixed32", ext_rep_sfixed32);
+    builder.ext_rep_int64 = WireInternal.copyOf("ext_rep_int64", ext_rep_int64);
+    builder.ext_rep_uint64 = WireInternal.copyOf("ext_rep_uint64", ext_rep_uint64);
+    builder.ext_rep_sint64 = WireInternal.copyOf("ext_rep_sint64", ext_rep_sint64);
+    builder.ext_rep_fixed64 = WireInternal.copyOf("ext_rep_fixed64", ext_rep_fixed64);
+    builder.ext_rep_sfixed64 = WireInternal.copyOf("ext_rep_sfixed64", ext_rep_sfixed64);
+    builder.ext_rep_bool = WireInternal.copyOf("ext_rep_bool", ext_rep_bool);
+    builder.ext_rep_float = WireInternal.copyOf("ext_rep_float", ext_rep_float);
+    builder.ext_rep_double = WireInternal.copyOf("ext_rep_double", ext_rep_double);
+    builder.ext_rep_string = WireInternal.copyOf("ext_rep_string", ext_rep_string);
+    builder.ext_rep_bytes = WireInternal.copyOf("ext_rep_bytes", ext_rep_bytes);
+    builder.ext_rep_nested_enum = WireInternal.copyOf("ext_rep_nested_enum", ext_rep_nested_enum);
+    builder.ext_rep_nested_message = WireInternal.copyOf("ext_rep_nested_message", ext_rep_nested_message);
+    builder.ext_pack_int32 = WireInternal.copyOf("ext_pack_int32", ext_pack_int32);
+    builder.ext_pack_uint32 = WireInternal.copyOf("ext_pack_uint32", ext_pack_uint32);
+    builder.ext_pack_sint32 = WireInternal.copyOf("ext_pack_sint32", ext_pack_sint32);
+    builder.ext_pack_fixed32 = WireInternal.copyOf("ext_pack_fixed32", ext_pack_fixed32);
+    builder.ext_pack_sfixed32 = WireInternal.copyOf("ext_pack_sfixed32", ext_pack_sfixed32);
+    builder.ext_pack_int64 = WireInternal.copyOf("ext_pack_int64", ext_pack_int64);
+    builder.ext_pack_uint64 = WireInternal.copyOf("ext_pack_uint64", ext_pack_uint64);
+    builder.ext_pack_sint64 = WireInternal.copyOf("ext_pack_sint64", ext_pack_sint64);
+    builder.ext_pack_fixed64 = WireInternal.copyOf("ext_pack_fixed64", ext_pack_fixed64);
+    builder.ext_pack_sfixed64 = WireInternal.copyOf("ext_pack_sfixed64", ext_pack_sfixed64);
+    builder.ext_pack_bool = WireInternal.copyOf("ext_pack_bool", ext_pack_bool);
+    builder.ext_pack_float = WireInternal.copyOf("ext_pack_float", ext_pack_float);
+    builder.ext_pack_double = WireInternal.copyOf("ext_pack_double", ext_pack_double);
+    builder.ext_pack_nested_enum = WireInternal.copyOf("ext_pack_nested_enum", ext_pack_nested_enum);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -1426,136 +1427,136 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(opt_int32, o.opt_int32)
-        && equals(opt_uint32, o.opt_uint32)
-        && equals(opt_sint32, o.opt_sint32)
-        && equals(opt_fixed32, o.opt_fixed32)
-        && equals(opt_sfixed32, o.opt_sfixed32)
-        && equals(opt_int64, o.opt_int64)
-        && equals(opt_uint64, o.opt_uint64)
-        && equals(opt_sint64, o.opt_sint64)
-        && equals(opt_fixed64, o.opt_fixed64)
-        && equals(opt_sfixed64, o.opt_sfixed64)
-        && equals(opt_bool, o.opt_bool)
-        && equals(opt_float, o.opt_float)
-        && equals(opt_double, o.opt_double)
-        && equals(opt_string, o.opt_string)
-        && equals(opt_bytes, o.opt_bytes)
-        && equals(opt_nested_enum, o.opt_nested_enum)
-        && equals(opt_nested_message, o.opt_nested_message)
-        && equals(req_int32, o.req_int32)
-        && equals(req_uint32, o.req_uint32)
-        && equals(req_sint32, o.req_sint32)
-        && equals(req_fixed32, o.req_fixed32)
-        && equals(req_sfixed32, o.req_sfixed32)
-        && equals(req_int64, o.req_int64)
-        && equals(req_uint64, o.req_uint64)
-        && equals(req_sint64, o.req_sint64)
-        && equals(req_fixed64, o.req_fixed64)
-        && equals(req_sfixed64, o.req_sfixed64)
-        && equals(req_bool, o.req_bool)
-        && equals(req_float, o.req_float)
-        && equals(req_double, o.req_double)
-        && equals(req_string, o.req_string)
-        && equals(req_bytes, o.req_bytes)
-        && equals(req_nested_enum, o.req_nested_enum)
-        && equals(req_nested_message, o.req_nested_message)
-        && equals(rep_int32, o.rep_int32)
-        && equals(rep_uint32, o.rep_uint32)
-        && equals(rep_sint32, o.rep_sint32)
-        && equals(rep_fixed32, o.rep_fixed32)
-        && equals(rep_sfixed32, o.rep_sfixed32)
-        && equals(rep_int64, o.rep_int64)
-        && equals(rep_uint64, o.rep_uint64)
-        && equals(rep_sint64, o.rep_sint64)
-        && equals(rep_fixed64, o.rep_fixed64)
-        && equals(rep_sfixed64, o.rep_sfixed64)
-        && equals(rep_bool, o.rep_bool)
-        && equals(rep_float, o.rep_float)
-        && equals(rep_double, o.rep_double)
-        && equals(rep_string, o.rep_string)
-        && equals(rep_bytes, o.rep_bytes)
-        && equals(rep_nested_enum, o.rep_nested_enum)
-        && equals(rep_nested_message, o.rep_nested_message)
-        && equals(pack_int32, o.pack_int32)
-        && equals(pack_uint32, o.pack_uint32)
-        && equals(pack_sint32, o.pack_sint32)
-        && equals(pack_fixed32, o.pack_fixed32)
-        && equals(pack_sfixed32, o.pack_sfixed32)
-        && equals(pack_int64, o.pack_int64)
-        && equals(pack_uint64, o.pack_uint64)
-        && equals(pack_sint64, o.pack_sint64)
-        && equals(pack_fixed64, o.pack_fixed64)
-        && equals(pack_sfixed64, o.pack_sfixed64)
-        && equals(pack_bool, o.pack_bool)
-        && equals(pack_float, o.pack_float)
-        && equals(pack_double, o.pack_double)
-        && equals(pack_nested_enum, o.pack_nested_enum)
-        && equals(default_int32, o.default_int32)
-        && equals(default_uint32, o.default_uint32)
-        && equals(default_sint32, o.default_sint32)
-        && equals(default_fixed32, o.default_fixed32)
-        && equals(default_sfixed32, o.default_sfixed32)
-        && equals(default_int64, o.default_int64)
-        && equals(default_uint64, o.default_uint64)
-        && equals(default_sint64, o.default_sint64)
-        && equals(default_fixed64, o.default_fixed64)
-        && equals(default_sfixed64, o.default_sfixed64)
-        && equals(default_bool, o.default_bool)
-        && equals(default_float, o.default_float)
-        && equals(default_double, o.default_double)
-        && equals(default_string, o.default_string)
-        && equals(default_bytes, o.default_bytes)
-        && equals(default_nested_enum, o.default_nested_enum)
-        && equals(ext_opt_int32, o.ext_opt_int32)
-        && equals(ext_opt_uint32, o.ext_opt_uint32)
-        && equals(ext_opt_sint32, o.ext_opt_sint32)
-        && equals(ext_opt_fixed32, o.ext_opt_fixed32)
-        && equals(ext_opt_sfixed32, o.ext_opt_sfixed32)
-        && equals(ext_opt_int64, o.ext_opt_int64)
-        && equals(ext_opt_uint64, o.ext_opt_uint64)
-        && equals(ext_opt_sint64, o.ext_opt_sint64)
-        && equals(ext_opt_fixed64, o.ext_opt_fixed64)
-        && equals(ext_opt_sfixed64, o.ext_opt_sfixed64)
-        && equals(ext_opt_bool, o.ext_opt_bool)
-        && equals(ext_opt_float, o.ext_opt_float)
-        && equals(ext_opt_double, o.ext_opt_double)
-        && equals(ext_opt_string, o.ext_opt_string)
-        && equals(ext_opt_bytes, o.ext_opt_bytes)
-        && equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
-        && equals(ext_opt_nested_message, o.ext_opt_nested_message)
-        && equals(ext_rep_int32, o.ext_rep_int32)
-        && equals(ext_rep_uint32, o.ext_rep_uint32)
-        && equals(ext_rep_sint32, o.ext_rep_sint32)
-        && equals(ext_rep_fixed32, o.ext_rep_fixed32)
-        && equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
-        && equals(ext_rep_int64, o.ext_rep_int64)
-        && equals(ext_rep_uint64, o.ext_rep_uint64)
-        && equals(ext_rep_sint64, o.ext_rep_sint64)
-        && equals(ext_rep_fixed64, o.ext_rep_fixed64)
-        && equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
-        && equals(ext_rep_bool, o.ext_rep_bool)
-        && equals(ext_rep_float, o.ext_rep_float)
-        && equals(ext_rep_double, o.ext_rep_double)
-        && equals(ext_rep_string, o.ext_rep_string)
-        && equals(ext_rep_bytes, o.ext_rep_bytes)
-        && equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
-        && equals(ext_rep_nested_message, o.ext_rep_nested_message)
-        && equals(ext_pack_int32, o.ext_pack_int32)
-        && equals(ext_pack_uint32, o.ext_pack_uint32)
-        && equals(ext_pack_sint32, o.ext_pack_sint32)
-        && equals(ext_pack_fixed32, o.ext_pack_fixed32)
-        && equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
-        && equals(ext_pack_int64, o.ext_pack_int64)
-        && equals(ext_pack_uint64, o.ext_pack_uint64)
-        && equals(ext_pack_sint64, o.ext_pack_sint64)
-        && equals(ext_pack_fixed64, o.ext_pack_fixed64)
-        && equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
-        && equals(ext_pack_bool, o.ext_pack_bool)
-        && equals(ext_pack_float, o.ext_pack_float)
-        && equals(ext_pack_double, o.ext_pack_double)
-        && equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(opt_int32, o.opt_int32)
+        && WireInternal.equals(opt_uint32, o.opt_uint32)
+        && WireInternal.equals(opt_sint32, o.opt_sint32)
+        && WireInternal.equals(opt_fixed32, o.opt_fixed32)
+        && WireInternal.equals(opt_sfixed32, o.opt_sfixed32)
+        && WireInternal.equals(opt_int64, o.opt_int64)
+        && WireInternal.equals(opt_uint64, o.opt_uint64)
+        && WireInternal.equals(opt_sint64, o.opt_sint64)
+        && WireInternal.equals(opt_fixed64, o.opt_fixed64)
+        && WireInternal.equals(opt_sfixed64, o.opt_sfixed64)
+        && WireInternal.equals(opt_bool, o.opt_bool)
+        && WireInternal.equals(opt_float, o.opt_float)
+        && WireInternal.equals(opt_double, o.opt_double)
+        && WireInternal.equals(opt_string, o.opt_string)
+        && WireInternal.equals(opt_bytes, o.opt_bytes)
+        && WireInternal.equals(opt_nested_enum, o.opt_nested_enum)
+        && WireInternal.equals(opt_nested_message, o.opt_nested_message)
+        && WireInternal.equals(req_int32, o.req_int32)
+        && WireInternal.equals(req_uint32, o.req_uint32)
+        && WireInternal.equals(req_sint32, o.req_sint32)
+        && WireInternal.equals(req_fixed32, o.req_fixed32)
+        && WireInternal.equals(req_sfixed32, o.req_sfixed32)
+        && WireInternal.equals(req_int64, o.req_int64)
+        && WireInternal.equals(req_uint64, o.req_uint64)
+        && WireInternal.equals(req_sint64, o.req_sint64)
+        && WireInternal.equals(req_fixed64, o.req_fixed64)
+        && WireInternal.equals(req_sfixed64, o.req_sfixed64)
+        && WireInternal.equals(req_bool, o.req_bool)
+        && WireInternal.equals(req_float, o.req_float)
+        && WireInternal.equals(req_double, o.req_double)
+        && WireInternal.equals(req_string, o.req_string)
+        && WireInternal.equals(req_bytes, o.req_bytes)
+        && WireInternal.equals(req_nested_enum, o.req_nested_enum)
+        && WireInternal.equals(req_nested_message, o.req_nested_message)
+        && WireInternal.equals(rep_int32, o.rep_int32)
+        && WireInternal.equals(rep_uint32, o.rep_uint32)
+        && WireInternal.equals(rep_sint32, o.rep_sint32)
+        && WireInternal.equals(rep_fixed32, o.rep_fixed32)
+        && WireInternal.equals(rep_sfixed32, o.rep_sfixed32)
+        && WireInternal.equals(rep_int64, o.rep_int64)
+        && WireInternal.equals(rep_uint64, o.rep_uint64)
+        && WireInternal.equals(rep_sint64, o.rep_sint64)
+        && WireInternal.equals(rep_fixed64, o.rep_fixed64)
+        && WireInternal.equals(rep_sfixed64, o.rep_sfixed64)
+        && WireInternal.equals(rep_bool, o.rep_bool)
+        && WireInternal.equals(rep_float, o.rep_float)
+        && WireInternal.equals(rep_double, o.rep_double)
+        && WireInternal.equals(rep_string, o.rep_string)
+        && WireInternal.equals(rep_bytes, o.rep_bytes)
+        && WireInternal.equals(rep_nested_enum, o.rep_nested_enum)
+        && WireInternal.equals(rep_nested_message, o.rep_nested_message)
+        && WireInternal.equals(pack_int32, o.pack_int32)
+        && WireInternal.equals(pack_uint32, o.pack_uint32)
+        && WireInternal.equals(pack_sint32, o.pack_sint32)
+        && WireInternal.equals(pack_fixed32, o.pack_fixed32)
+        && WireInternal.equals(pack_sfixed32, o.pack_sfixed32)
+        && WireInternal.equals(pack_int64, o.pack_int64)
+        && WireInternal.equals(pack_uint64, o.pack_uint64)
+        && WireInternal.equals(pack_sint64, o.pack_sint64)
+        && WireInternal.equals(pack_fixed64, o.pack_fixed64)
+        && WireInternal.equals(pack_sfixed64, o.pack_sfixed64)
+        && WireInternal.equals(pack_bool, o.pack_bool)
+        && WireInternal.equals(pack_float, o.pack_float)
+        && WireInternal.equals(pack_double, o.pack_double)
+        && WireInternal.equals(pack_nested_enum, o.pack_nested_enum)
+        && WireInternal.equals(default_int32, o.default_int32)
+        && WireInternal.equals(default_uint32, o.default_uint32)
+        && WireInternal.equals(default_sint32, o.default_sint32)
+        && WireInternal.equals(default_fixed32, o.default_fixed32)
+        && WireInternal.equals(default_sfixed32, o.default_sfixed32)
+        && WireInternal.equals(default_int64, o.default_int64)
+        && WireInternal.equals(default_uint64, o.default_uint64)
+        && WireInternal.equals(default_sint64, o.default_sint64)
+        && WireInternal.equals(default_fixed64, o.default_fixed64)
+        && WireInternal.equals(default_sfixed64, o.default_sfixed64)
+        && WireInternal.equals(default_bool, o.default_bool)
+        && WireInternal.equals(default_float, o.default_float)
+        && WireInternal.equals(default_double, o.default_double)
+        && WireInternal.equals(default_string, o.default_string)
+        && WireInternal.equals(default_bytes, o.default_bytes)
+        && WireInternal.equals(default_nested_enum, o.default_nested_enum)
+        && WireInternal.equals(ext_opt_int32, o.ext_opt_int32)
+        && WireInternal.equals(ext_opt_uint32, o.ext_opt_uint32)
+        && WireInternal.equals(ext_opt_sint32, o.ext_opt_sint32)
+        && WireInternal.equals(ext_opt_fixed32, o.ext_opt_fixed32)
+        && WireInternal.equals(ext_opt_sfixed32, o.ext_opt_sfixed32)
+        && WireInternal.equals(ext_opt_int64, o.ext_opt_int64)
+        && WireInternal.equals(ext_opt_uint64, o.ext_opt_uint64)
+        && WireInternal.equals(ext_opt_sint64, o.ext_opt_sint64)
+        && WireInternal.equals(ext_opt_fixed64, o.ext_opt_fixed64)
+        && WireInternal.equals(ext_opt_sfixed64, o.ext_opt_sfixed64)
+        && WireInternal.equals(ext_opt_bool, o.ext_opt_bool)
+        && WireInternal.equals(ext_opt_float, o.ext_opt_float)
+        && WireInternal.equals(ext_opt_double, o.ext_opt_double)
+        && WireInternal.equals(ext_opt_string, o.ext_opt_string)
+        && WireInternal.equals(ext_opt_bytes, o.ext_opt_bytes)
+        && WireInternal.equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
+        && WireInternal.equals(ext_opt_nested_message, o.ext_opt_nested_message)
+        && WireInternal.equals(ext_rep_int32, o.ext_rep_int32)
+        && WireInternal.equals(ext_rep_uint32, o.ext_rep_uint32)
+        && WireInternal.equals(ext_rep_sint32, o.ext_rep_sint32)
+        && WireInternal.equals(ext_rep_fixed32, o.ext_rep_fixed32)
+        && WireInternal.equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
+        && WireInternal.equals(ext_rep_int64, o.ext_rep_int64)
+        && WireInternal.equals(ext_rep_uint64, o.ext_rep_uint64)
+        && WireInternal.equals(ext_rep_sint64, o.ext_rep_sint64)
+        && WireInternal.equals(ext_rep_fixed64, o.ext_rep_fixed64)
+        && WireInternal.equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
+        && WireInternal.equals(ext_rep_bool, o.ext_rep_bool)
+        && WireInternal.equals(ext_rep_float, o.ext_rep_float)
+        && WireInternal.equals(ext_rep_double, o.ext_rep_double)
+        && WireInternal.equals(ext_rep_string, o.ext_rep_string)
+        && WireInternal.equals(ext_rep_bytes, o.ext_rep_bytes)
+        && WireInternal.equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
+        && WireInternal.equals(ext_rep_nested_message, o.ext_rep_nested_message)
+        && WireInternal.equals(ext_pack_int32, o.ext_pack_int32)
+        && WireInternal.equals(ext_pack_uint32, o.ext_pack_uint32)
+        && WireInternal.equals(ext_pack_sint32, o.ext_pack_sint32)
+        && WireInternal.equals(ext_pack_fixed32, o.ext_pack_fixed32)
+        && WireInternal.equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
+        && WireInternal.equals(ext_pack_int64, o.ext_pack_int64)
+        && WireInternal.equals(ext_pack_uint64, o.ext_pack_uint64)
+        && WireInternal.equals(ext_pack_sint64, o.ext_pack_sint64)
+        && WireInternal.equals(ext_pack_fixed64, o.ext_pack_fixed64)
+        && WireInternal.equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
+        && WireInternal.equals(ext_pack_bool, o.ext_pack_bool)
+        && WireInternal.equals(ext_pack_float, o.ext_pack_float)
+        && WireInternal.equals(ext_pack_double, o.ext_pack_double)
+        && WireInternal.equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
   }
 
   @Override
@@ -1957,68 +1958,68 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     public List<NestedEnum> ext_pack_nested_enum;
 
     public Builder() {
-      rep_int32 = newMutableList();
-      rep_uint32 = newMutableList();
-      rep_sint32 = newMutableList();
-      rep_fixed32 = newMutableList();
-      rep_sfixed32 = newMutableList();
-      rep_int64 = newMutableList();
-      rep_uint64 = newMutableList();
-      rep_sint64 = newMutableList();
-      rep_fixed64 = newMutableList();
-      rep_sfixed64 = newMutableList();
-      rep_bool = newMutableList();
-      rep_float = newMutableList();
-      rep_double = newMutableList();
-      rep_string = newMutableList();
-      rep_bytes = newMutableList();
-      rep_nested_enum = newMutableList();
-      rep_nested_message = newMutableList();
-      pack_int32 = newMutableList();
-      pack_uint32 = newMutableList();
-      pack_sint32 = newMutableList();
-      pack_fixed32 = newMutableList();
-      pack_sfixed32 = newMutableList();
-      pack_int64 = newMutableList();
-      pack_uint64 = newMutableList();
-      pack_sint64 = newMutableList();
-      pack_fixed64 = newMutableList();
-      pack_sfixed64 = newMutableList();
-      pack_bool = newMutableList();
-      pack_float = newMutableList();
-      pack_double = newMutableList();
-      pack_nested_enum = newMutableList();
-      ext_rep_int32 = newMutableList();
-      ext_rep_uint32 = newMutableList();
-      ext_rep_sint32 = newMutableList();
-      ext_rep_fixed32 = newMutableList();
-      ext_rep_sfixed32 = newMutableList();
-      ext_rep_int64 = newMutableList();
-      ext_rep_uint64 = newMutableList();
-      ext_rep_sint64 = newMutableList();
-      ext_rep_fixed64 = newMutableList();
-      ext_rep_sfixed64 = newMutableList();
-      ext_rep_bool = newMutableList();
-      ext_rep_float = newMutableList();
-      ext_rep_double = newMutableList();
-      ext_rep_string = newMutableList();
-      ext_rep_bytes = newMutableList();
-      ext_rep_nested_enum = newMutableList();
-      ext_rep_nested_message = newMutableList();
-      ext_pack_int32 = newMutableList();
-      ext_pack_uint32 = newMutableList();
-      ext_pack_sint32 = newMutableList();
-      ext_pack_fixed32 = newMutableList();
-      ext_pack_sfixed32 = newMutableList();
-      ext_pack_int64 = newMutableList();
-      ext_pack_uint64 = newMutableList();
-      ext_pack_sint64 = newMutableList();
-      ext_pack_fixed64 = newMutableList();
-      ext_pack_sfixed64 = newMutableList();
-      ext_pack_bool = newMutableList();
-      ext_pack_float = newMutableList();
-      ext_pack_double = newMutableList();
-      ext_pack_nested_enum = newMutableList();
+      rep_int32 = WireInternal.newMutableList();
+      rep_uint32 = WireInternal.newMutableList();
+      rep_sint32 = WireInternal.newMutableList();
+      rep_fixed32 = WireInternal.newMutableList();
+      rep_sfixed32 = WireInternal.newMutableList();
+      rep_int64 = WireInternal.newMutableList();
+      rep_uint64 = WireInternal.newMutableList();
+      rep_sint64 = WireInternal.newMutableList();
+      rep_fixed64 = WireInternal.newMutableList();
+      rep_sfixed64 = WireInternal.newMutableList();
+      rep_bool = WireInternal.newMutableList();
+      rep_float = WireInternal.newMutableList();
+      rep_double = WireInternal.newMutableList();
+      rep_string = WireInternal.newMutableList();
+      rep_bytes = WireInternal.newMutableList();
+      rep_nested_enum = WireInternal.newMutableList();
+      rep_nested_message = WireInternal.newMutableList();
+      pack_int32 = WireInternal.newMutableList();
+      pack_uint32 = WireInternal.newMutableList();
+      pack_sint32 = WireInternal.newMutableList();
+      pack_fixed32 = WireInternal.newMutableList();
+      pack_sfixed32 = WireInternal.newMutableList();
+      pack_int64 = WireInternal.newMutableList();
+      pack_uint64 = WireInternal.newMutableList();
+      pack_sint64 = WireInternal.newMutableList();
+      pack_fixed64 = WireInternal.newMutableList();
+      pack_sfixed64 = WireInternal.newMutableList();
+      pack_bool = WireInternal.newMutableList();
+      pack_float = WireInternal.newMutableList();
+      pack_double = WireInternal.newMutableList();
+      pack_nested_enum = WireInternal.newMutableList();
+      ext_rep_int32 = WireInternal.newMutableList();
+      ext_rep_uint32 = WireInternal.newMutableList();
+      ext_rep_sint32 = WireInternal.newMutableList();
+      ext_rep_fixed32 = WireInternal.newMutableList();
+      ext_rep_sfixed32 = WireInternal.newMutableList();
+      ext_rep_int64 = WireInternal.newMutableList();
+      ext_rep_uint64 = WireInternal.newMutableList();
+      ext_rep_sint64 = WireInternal.newMutableList();
+      ext_rep_fixed64 = WireInternal.newMutableList();
+      ext_rep_sfixed64 = WireInternal.newMutableList();
+      ext_rep_bool = WireInternal.newMutableList();
+      ext_rep_float = WireInternal.newMutableList();
+      ext_rep_double = WireInternal.newMutableList();
+      ext_rep_string = WireInternal.newMutableList();
+      ext_rep_bytes = WireInternal.newMutableList();
+      ext_rep_nested_enum = WireInternal.newMutableList();
+      ext_rep_nested_message = WireInternal.newMutableList();
+      ext_pack_int32 = WireInternal.newMutableList();
+      ext_pack_uint32 = WireInternal.newMutableList();
+      ext_pack_sint32 = WireInternal.newMutableList();
+      ext_pack_fixed32 = WireInternal.newMutableList();
+      ext_pack_sfixed32 = WireInternal.newMutableList();
+      ext_pack_int64 = WireInternal.newMutableList();
+      ext_pack_uint64 = WireInternal.newMutableList();
+      ext_pack_sint64 = WireInternal.newMutableList();
+      ext_pack_fixed64 = WireInternal.newMutableList();
+      ext_pack_sfixed64 = WireInternal.newMutableList();
+      ext_pack_bool = WireInternal.newMutableList();
+      ext_pack_float = WireInternal.newMutableList();
+      ext_pack_double = WireInternal.newMutableList();
+      ext_pack_nested_enum = WireInternal.newMutableList();
     }
 
     public Builder opt_int32(Integer opt_int32) {
@@ -2192,187 +2193,187 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
 
     public Builder rep_int32(List<Integer> rep_int32) {
-      checkElementsNotNull(rep_int32);
+      WireInternal.checkElementsNotNull(rep_int32);
       this.rep_int32 = rep_int32;
       return this;
     }
 
     public Builder rep_uint32(List<Integer> rep_uint32) {
-      checkElementsNotNull(rep_uint32);
+      WireInternal.checkElementsNotNull(rep_uint32);
       this.rep_uint32 = rep_uint32;
       return this;
     }
 
     public Builder rep_sint32(List<Integer> rep_sint32) {
-      checkElementsNotNull(rep_sint32);
+      WireInternal.checkElementsNotNull(rep_sint32);
       this.rep_sint32 = rep_sint32;
       return this;
     }
 
     public Builder rep_fixed32(List<Integer> rep_fixed32) {
-      checkElementsNotNull(rep_fixed32);
+      WireInternal.checkElementsNotNull(rep_fixed32);
       this.rep_fixed32 = rep_fixed32;
       return this;
     }
 
     public Builder rep_sfixed32(List<Integer> rep_sfixed32) {
-      checkElementsNotNull(rep_sfixed32);
+      WireInternal.checkElementsNotNull(rep_sfixed32);
       this.rep_sfixed32 = rep_sfixed32;
       return this;
     }
 
     public Builder rep_int64(List<Long> rep_int64) {
-      checkElementsNotNull(rep_int64);
+      WireInternal.checkElementsNotNull(rep_int64);
       this.rep_int64 = rep_int64;
       return this;
     }
 
     public Builder rep_uint64(List<Long> rep_uint64) {
-      checkElementsNotNull(rep_uint64);
+      WireInternal.checkElementsNotNull(rep_uint64);
       this.rep_uint64 = rep_uint64;
       return this;
     }
 
     public Builder rep_sint64(List<Long> rep_sint64) {
-      checkElementsNotNull(rep_sint64);
+      WireInternal.checkElementsNotNull(rep_sint64);
       this.rep_sint64 = rep_sint64;
       return this;
     }
 
     public Builder rep_fixed64(List<Long> rep_fixed64) {
-      checkElementsNotNull(rep_fixed64);
+      WireInternal.checkElementsNotNull(rep_fixed64);
       this.rep_fixed64 = rep_fixed64;
       return this;
     }
 
     public Builder rep_sfixed64(List<Long> rep_sfixed64) {
-      checkElementsNotNull(rep_sfixed64);
+      WireInternal.checkElementsNotNull(rep_sfixed64);
       this.rep_sfixed64 = rep_sfixed64;
       return this;
     }
 
     public Builder rep_bool(List<Boolean> rep_bool) {
-      checkElementsNotNull(rep_bool);
+      WireInternal.checkElementsNotNull(rep_bool);
       this.rep_bool = rep_bool;
       return this;
     }
 
     public Builder rep_float(List<Float> rep_float) {
-      checkElementsNotNull(rep_float);
+      WireInternal.checkElementsNotNull(rep_float);
       this.rep_float = rep_float;
       return this;
     }
 
     public Builder rep_double(List<Double> rep_double) {
-      checkElementsNotNull(rep_double);
+      WireInternal.checkElementsNotNull(rep_double);
       this.rep_double = rep_double;
       return this;
     }
 
     public Builder rep_string(List<String> rep_string) {
-      checkElementsNotNull(rep_string);
+      WireInternal.checkElementsNotNull(rep_string);
       this.rep_string = rep_string;
       return this;
     }
 
     public Builder rep_bytes(List<ByteString> rep_bytes) {
-      checkElementsNotNull(rep_bytes);
+      WireInternal.checkElementsNotNull(rep_bytes);
       this.rep_bytes = rep_bytes;
       return this;
     }
 
     public Builder rep_nested_enum(List<NestedEnum> rep_nested_enum) {
-      checkElementsNotNull(rep_nested_enum);
+      WireInternal.checkElementsNotNull(rep_nested_enum);
       this.rep_nested_enum = rep_nested_enum;
       return this;
     }
 
     public Builder rep_nested_message(List<NestedMessage> rep_nested_message) {
-      checkElementsNotNull(rep_nested_message);
+      WireInternal.checkElementsNotNull(rep_nested_message);
       this.rep_nested_message = rep_nested_message;
       return this;
     }
 
     public Builder pack_int32(List<Integer> pack_int32) {
-      checkElementsNotNull(pack_int32);
+      WireInternal.checkElementsNotNull(pack_int32);
       this.pack_int32 = pack_int32;
       return this;
     }
 
     public Builder pack_uint32(List<Integer> pack_uint32) {
-      checkElementsNotNull(pack_uint32);
+      WireInternal.checkElementsNotNull(pack_uint32);
       this.pack_uint32 = pack_uint32;
       return this;
     }
 
     public Builder pack_sint32(List<Integer> pack_sint32) {
-      checkElementsNotNull(pack_sint32);
+      WireInternal.checkElementsNotNull(pack_sint32);
       this.pack_sint32 = pack_sint32;
       return this;
     }
 
     public Builder pack_fixed32(List<Integer> pack_fixed32) {
-      checkElementsNotNull(pack_fixed32);
+      WireInternal.checkElementsNotNull(pack_fixed32);
       this.pack_fixed32 = pack_fixed32;
       return this;
     }
 
     public Builder pack_sfixed32(List<Integer> pack_sfixed32) {
-      checkElementsNotNull(pack_sfixed32);
+      WireInternal.checkElementsNotNull(pack_sfixed32);
       this.pack_sfixed32 = pack_sfixed32;
       return this;
     }
 
     public Builder pack_int64(List<Long> pack_int64) {
-      checkElementsNotNull(pack_int64);
+      WireInternal.checkElementsNotNull(pack_int64);
       this.pack_int64 = pack_int64;
       return this;
     }
 
     public Builder pack_uint64(List<Long> pack_uint64) {
-      checkElementsNotNull(pack_uint64);
+      WireInternal.checkElementsNotNull(pack_uint64);
       this.pack_uint64 = pack_uint64;
       return this;
     }
 
     public Builder pack_sint64(List<Long> pack_sint64) {
-      checkElementsNotNull(pack_sint64);
+      WireInternal.checkElementsNotNull(pack_sint64);
       this.pack_sint64 = pack_sint64;
       return this;
     }
 
     public Builder pack_fixed64(List<Long> pack_fixed64) {
-      checkElementsNotNull(pack_fixed64);
+      WireInternal.checkElementsNotNull(pack_fixed64);
       this.pack_fixed64 = pack_fixed64;
       return this;
     }
 
     public Builder pack_sfixed64(List<Long> pack_sfixed64) {
-      checkElementsNotNull(pack_sfixed64);
+      WireInternal.checkElementsNotNull(pack_sfixed64);
       this.pack_sfixed64 = pack_sfixed64;
       return this;
     }
 
     public Builder pack_bool(List<Boolean> pack_bool) {
-      checkElementsNotNull(pack_bool);
+      WireInternal.checkElementsNotNull(pack_bool);
       this.pack_bool = pack_bool;
       return this;
     }
 
     public Builder pack_float(List<Float> pack_float) {
-      checkElementsNotNull(pack_float);
+      WireInternal.checkElementsNotNull(pack_float);
       this.pack_float = pack_float;
       return this;
     }
 
     public Builder pack_double(List<Double> pack_double) {
-      checkElementsNotNull(pack_double);
+      WireInternal.checkElementsNotNull(pack_double);
       this.pack_double = pack_double;
       return this;
     }
 
     public Builder pack_nested_enum(List<NestedEnum> pack_nested_enum) {
-      checkElementsNotNull(pack_nested_enum);
+      WireInternal.checkElementsNotNull(pack_nested_enum);
       this.pack_nested_enum = pack_nested_enum;
       return this;
     }
@@ -2543,187 +2544,187 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     }
 
     public Builder ext_rep_int32(List<Integer> ext_rep_int32) {
-      checkElementsNotNull(ext_rep_int32);
+      WireInternal.checkElementsNotNull(ext_rep_int32);
       this.ext_rep_int32 = ext_rep_int32;
       return this;
     }
 
     public Builder ext_rep_uint32(List<Integer> ext_rep_uint32) {
-      checkElementsNotNull(ext_rep_uint32);
+      WireInternal.checkElementsNotNull(ext_rep_uint32);
       this.ext_rep_uint32 = ext_rep_uint32;
       return this;
     }
 
     public Builder ext_rep_sint32(List<Integer> ext_rep_sint32) {
-      checkElementsNotNull(ext_rep_sint32);
+      WireInternal.checkElementsNotNull(ext_rep_sint32);
       this.ext_rep_sint32 = ext_rep_sint32;
       return this;
     }
 
     public Builder ext_rep_fixed32(List<Integer> ext_rep_fixed32) {
-      checkElementsNotNull(ext_rep_fixed32);
+      WireInternal.checkElementsNotNull(ext_rep_fixed32);
       this.ext_rep_fixed32 = ext_rep_fixed32;
       return this;
     }
 
     public Builder ext_rep_sfixed32(List<Integer> ext_rep_sfixed32) {
-      checkElementsNotNull(ext_rep_sfixed32);
+      WireInternal.checkElementsNotNull(ext_rep_sfixed32);
       this.ext_rep_sfixed32 = ext_rep_sfixed32;
       return this;
     }
 
     public Builder ext_rep_int64(List<Long> ext_rep_int64) {
-      checkElementsNotNull(ext_rep_int64);
+      WireInternal.checkElementsNotNull(ext_rep_int64);
       this.ext_rep_int64 = ext_rep_int64;
       return this;
     }
 
     public Builder ext_rep_uint64(List<Long> ext_rep_uint64) {
-      checkElementsNotNull(ext_rep_uint64);
+      WireInternal.checkElementsNotNull(ext_rep_uint64);
       this.ext_rep_uint64 = ext_rep_uint64;
       return this;
     }
 
     public Builder ext_rep_sint64(List<Long> ext_rep_sint64) {
-      checkElementsNotNull(ext_rep_sint64);
+      WireInternal.checkElementsNotNull(ext_rep_sint64);
       this.ext_rep_sint64 = ext_rep_sint64;
       return this;
     }
 
     public Builder ext_rep_fixed64(List<Long> ext_rep_fixed64) {
-      checkElementsNotNull(ext_rep_fixed64);
+      WireInternal.checkElementsNotNull(ext_rep_fixed64);
       this.ext_rep_fixed64 = ext_rep_fixed64;
       return this;
     }
 
     public Builder ext_rep_sfixed64(List<Long> ext_rep_sfixed64) {
-      checkElementsNotNull(ext_rep_sfixed64);
+      WireInternal.checkElementsNotNull(ext_rep_sfixed64);
       this.ext_rep_sfixed64 = ext_rep_sfixed64;
       return this;
     }
 
     public Builder ext_rep_bool(List<Boolean> ext_rep_bool) {
-      checkElementsNotNull(ext_rep_bool);
+      WireInternal.checkElementsNotNull(ext_rep_bool);
       this.ext_rep_bool = ext_rep_bool;
       return this;
     }
 
     public Builder ext_rep_float(List<Float> ext_rep_float) {
-      checkElementsNotNull(ext_rep_float);
+      WireInternal.checkElementsNotNull(ext_rep_float);
       this.ext_rep_float = ext_rep_float;
       return this;
     }
 
     public Builder ext_rep_double(List<Double> ext_rep_double) {
-      checkElementsNotNull(ext_rep_double);
+      WireInternal.checkElementsNotNull(ext_rep_double);
       this.ext_rep_double = ext_rep_double;
       return this;
     }
 
     public Builder ext_rep_string(List<String> ext_rep_string) {
-      checkElementsNotNull(ext_rep_string);
+      WireInternal.checkElementsNotNull(ext_rep_string);
       this.ext_rep_string = ext_rep_string;
       return this;
     }
 
     public Builder ext_rep_bytes(List<ByteString> ext_rep_bytes) {
-      checkElementsNotNull(ext_rep_bytes);
+      WireInternal.checkElementsNotNull(ext_rep_bytes);
       this.ext_rep_bytes = ext_rep_bytes;
       return this;
     }
 
     public Builder ext_rep_nested_enum(List<NestedEnum> ext_rep_nested_enum) {
-      checkElementsNotNull(ext_rep_nested_enum);
+      WireInternal.checkElementsNotNull(ext_rep_nested_enum);
       this.ext_rep_nested_enum = ext_rep_nested_enum;
       return this;
     }
 
     public Builder ext_rep_nested_message(List<NestedMessage> ext_rep_nested_message) {
-      checkElementsNotNull(ext_rep_nested_message);
+      WireInternal.checkElementsNotNull(ext_rep_nested_message);
       this.ext_rep_nested_message = ext_rep_nested_message;
       return this;
     }
 
     public Builder ext_pack_int32(List<Integer> ext_pack_int32) {
-      checkElementsNotNull(ext_pack_int32);
+      WireInternal.checkElementsNotNull(ext_pack_int32);
       this.ext_pack_int32 = ext_pack_int32;
       return this;
     }
 
     public Builder ext_pack_uint32(List<Integer> ext_pack_uint32) {
-      checkElementsNotNull(ext_pack_uint32);
+      WireInternal.checkElementsNotNull(ext_pack_uint32);
       this.ext_pack_uint32 = ext_pack_uint32;
       return this;
     }
 
     public Builder ext_pack_sint32(List<Integer> ext_pack_sint32) {
-      checkElementsNotNull(ext_pack_sint32);
+      WireInternal.checkElementsNotNull(ext_pack_sint32);
       this.ext_pack_sint32 = ext_pack_sint32;
       return this;
     }
 
     public Builder ext_pack_fixed32(List<Integer> ext_pack_fixed32) {
-      checkElementsNotNull(ext_pack_fixed32);
+      WireInternal.checkElementsNotNull(ext_pack_fixed32);
       this.ext_pack_fixed32 = ext_pack_fixed32;
       return this;
     }
 
     public Builder ext_pack_sfixed32(List<Integer> ext_pack_sfixed32) {
-      checkElementsNotNull(ext_pack_sfixed32);
+      WireInternal.checkElementsNotNull(ext_pack_sfixed32);
       this.ext_pack_sfixed32 = ext_pack_sfixed32;
       return this;
     }
 
     public Builder ext_pack_int64(List<Long> ext_pack_int64) {
-      checkElementsNotNull(ext_pack_int64);
+      WireInternal.checkElementsNotNull(ext_pack_int64);
       this.ext_pack_int64 = ext_pack_int64;
       return this;
     }
 
     public Builder ext_pack_uint64(List<Long> ext_pack_uint64) {
-      checkElementsNotNull(ext_pack_uint64);
+      WireInternal.checkElementsNotNull(ext_pack_uint64);
       this.ext_pack_uint64 = ext_pack_uint64;
       return this;
     }
 
     public Builder ext_pack_sint64(List<Long> ext_pack_sint64) {
-      checkElementsNotNull(ext_pack_sint64);
+      WireInternal.checkElementsNotNull(ext_pack_sint64);
       this.ext_pack_sint64 = ext_pack_sint64;
       return this;
     }
 
     public Builder ext_pack_fixed64(List<Long> ext_pack_fixed64) {
-      checkElementsNotNull(ext_pack_fixed64);
+      WireInternal.checkElementsNotNull(ext_pack_fixed64);
       this.ext_pack_fixed64 = ext_pack_fixed64;
       return this;
     }
 
     public Builder ext_pack_sfixed64(List<Long> ext_pack_sfixed64) {
-      checkElementsNotNull(ext_pack_sfixed64);
+      WireInternal.checkElementsNotNull(ext_pack_sfixed64);
       this.ext_pack_sfixed64 = ext_pack_sfixed64;
       return this;
     }
 
     public Builder ext_pack_bool(List<Boolean> ext_pack_bool) {
-      checkElementsNotNull(ext_pack_bool);
+      WireInternal.checkElementsNotNull(ext_pack_bool);
       this.ext_pack_bool = ext_pack_bool;
       return this;
     }
 
     public Builder ext_pack_float(List<Float> ext_pack_float) {
-      checkElementsNotNull(ext_pack_float);
+      WireInternal.checkElementsNotNull(ext_pack_float);
       this.ext_pack_float = ext_pack_float;
       return this;
     }
 
     public Builder ext_pack_double(List<Double> ext_pack_double) {
-      checkElementsNotNull(ext_pack_double);
+      WireInternal.checkElementsNotNull(ext_pack_double);
       this.ext_pack_double = ext_pack_double;
       return this;
     }
 
     public Builder ext_pack_nested_enum(List<NestedEnum> ext_pack_nested_enum) {
-      checkElementsNotNull(ext_pack_nested_enum);
+      WireInternal.checkElementsNotNull(ext_pack_nested_enum);
       this.ext_pack_nested_enum = ext_pack_nested_enum;
       return this;
     }
@@ -2747,7 +2748,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
           || req_bytes == null
           || req_nested_enum == null
           || req_nested_message == null) {
-        throw missingRequiredFields(req_int32, "req_int32",
+        throw WireInternal.missingRequiredFields(req_int32, "req_int32",
             req_uint32, "req_uint32",
             req_sint32, "req_sint32",
             req_fixed32, "req_fixed32",
@@ -2831,8 +2832,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(a, o.a);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(a, o.a);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -11,6 +11,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Boolean;
 import java.lang.Double;
@@ -159,11 +160,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     this.bar = bar;
     this.baz = baz;
     this.qux = qux;
-    this.fred = immutableCopyOf("fred", fred);
+    this.fred = WireInternal.immutableCopyOf("fred", fred);
     this.daisy = daisy;
-    this.nested = immutableCopyOf("nested", nested);
+    this.nested = WireInternal.immutableCopyOf("nested", nested);
     this.ext = ext;
-    this.rep = immutableCopyOf("rep", rep);
+    this.rep = WireInternal.immutableCopyOf("rep", rep);
   }
 
   @Override
@@ -173,11 +174,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     builder.bar = bar;
     builder.baz = baz;
     builder.qux = qux;
-    builder.fred = copyOf("fred", fred);
+    builder.fred = WireInternal.copyOf("fred", fred);
     builder.daisy = daisy;
-    builder.nested = copyOf("nested", nested);
+    builder.nested = WireInternal.copyOf("nested", nested);
     builder.ext = ext;
-    builder.rep = copyOf("rep", rep);
+    builder.rep = WireInternal.copyOf("rep", rep);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -187,16 +188,16 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     if (other == this) return true;
     if (!(other instanceof FooBar)) return false;
     FooBar o = (FooBar) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(foo, o.foo)
-        && equals(bar, o.bar)
-        && equals(baz, o.baz)
-        && equals(qux, o.qux)
-        && equals(fred, o.fred)
-        && equals(daisy, o.daisy)
-        && equals(nested, o.nested)
-        && equals(ext, o.ext)
-        && equals(rep, o.rep);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(foo, o.foo)
+        && WireInternal.equals(bar, o.bar)
+        && WireInternal.equals(baz, o.baz)
+        && WireInternal.equals(qux, o.qux)
+        && WireInternal.equals(fred, o.fred)
+        && WireInternal.equals(daisy, o.daisy)
+        && WireInternal.equals(nested, o.nested)
+        && WireInternal.equals(ext, o.ext)
+        && WireInternal.equals(rep, o.rep);
   }
 
   @Override
@@ -253,9 +254,9 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     public List<FooBarBazEnum> rep;
 
     public Builder() {
-      fred = newMutableList();
-      nested = newMutableList();
-      rep = newMutableList();
+      fred = WireInternal.newMutableList();
+      nested = WireInternal.newMutableList();
+      rep = WireInternal.newMutableList();
     }
 
     public Builder foo(Integer foo) {
@@ -279,7 +280,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
 
     public Builder fred(List<Float> fred) {
-      checkElementsNotNull(fred);
+      WireInternal.checkElementsNotNull(fred);
       this.fred = fred;
       return this;
     }
@@ -290,7 +291,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
 
     public Builder nested(List<FooBar> nested) {
-      checkElementsNotNull(nested);
+      WireInternal.checkElementsNotNull(nested);
       this.nested = nested;
       return this;
     }
@@ -301,7 +302,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
 
     public Builder rep(List<FooBarBazEnum> rep) {
-      checkElementsNotNull(rep);
+      WireInternal.checkElementsNotNull(rep);
       this.rep = rep;
       return this;
     }
@@ -347,8 +348,8 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof Nested)) return false;
       Nested o = (Nested) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(value, o.value);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(value, o.value);
     }
 
     @Override
@@ -455,13 +456,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     public More(List<Integer> serial, ByteString unknownFields) {
       super(unknownFields);
-      this.serial = immutableCopyOf("serial", serial);
+      this.serial = WireInternal.immutableCopyOf("serial", serial);
     }
 
     @Override
     public Builder newBuilder() {
       Builder builder = new Builder();
-      builder.serial = copyOf("serial", serial);
+      builder.serial = WireInternal.copyOf("serial", serial);
       builder.addUnknownFields(unknownFields());
       return builder;
     }
@@ -471,8 +472,8 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof More)) return false;
       More o = (More) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(serial, o.serial);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(serial, o.serial);
     }
 
     @Override
@@ -497,11 +498,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       public List<Integer> serial;
 
       public Builder() {
-        serial = newMutableList();
+        serial = WireInternal.newMutableList();
       }
 
       public Builder serial(List<Integer> serial) {
-        checkElementsNotNull(serial);
+        WireInternal.checkElementsNotNull(serial);
         this.serial = serial;
         return this;
       }
@@ -683,7 +684,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     public FooBar redact(FooBar value) {
       Builder builder = value.newBuilder();
       if (builder.baz != null) builder.baz = Nested.ADAPTER.redact(builder.baz);
-      redactElements(builder.nested, FooBar.ADAPTER);
+      WireInternal.redactElements(builder.nested, FooBar.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Double;
 import java.lang.Float;
@@ -109,11 +110,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     this.bar = bar;
     this.baz = baz;
     this.qux = qux;
-    this.fred = immutableCopyOf("fred", fred);
+    this.fred = WireInternal.immutableCopyOf("fred", fred);
     this.daisy = daisy;
-    this.nested = immutableCopyOf("nested", nested);
+    this.nested = WireInternal.immutableCopyOf("nested", nested);
     this.ext = ext;
-    this.rep = immutableCopyOf("rep", rep);
+    this.rep = WireInternal.immutableCopyOf("rep", rep);
   }
 
   @Override
@@ -123,11 +124,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     builder.bar = bar;
     builder.baz = baz;
     builder.qux = qux;
-    builder.fred = copyOf("fred", fred);
+    builder.fred = WireInternal.copyOf("fred", fred);
     builder.daisy = daisy;
-    builder.nested = copyOf("nested", nested);
+    builder.nested = WireInternal.copyOf("nested", nested);
     builder.ext = ext;
-    builder.rep = copyOf("rep", rep);
+    builder.rep = WireInternal.copyOf("rep", rep);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -137,16 +138,16 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     if (other == this) return true;
     if (!(other instanceof FooBar)) return false;
     FooBar o = (FooBar) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(foo, o.foo)
-        && equals(bar, o.bar)
-        && equals(baz, o.baz)
-        && equals(qux, o.qux)
-        && equals(fred, o.fred)
-        && equals(daisy, o.daisy)
-        && equals(nested, o.nested)
-        && equals(ext, o.ext)
-        && equals(rep, o.rep);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(foo, o.foo)
+        && WireInternal.equals(bar, o.bar)
+        && WireInternal.equals(baz, o.baz)
+        && WireInternal.equals(qux, o.qux)
+        && WireInternal.equals(fred, o.fred)
+        && WireInternal.equals(daisy, o.daisy)
+        && WireInternal.equals(nested, o.nested)
+        && WireInternal.equals(ext, o.ext)
+        && WireInternal.equals(rep, o.rep);
   }
 
   @Override
@@ -203,9 +204,9 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     public List<FooBarBazEnum> rep;
 
     public Builder() {
-      fred = newMutableList();
-      nested = newMutableList();
-      rep = newMutableList();
+      fred = WireInternal.newMutableList();
+      nested = WireInternal.newMutableList();
+      rep = WireInternal.newMutableList();
     }
 
     public Builder foo(Integer foo) {
@@ -229,7 +230,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
 
     public Builder fred(List<Float> fred) {
-      checkElementsNotNull(fred);
+      WireInternal.checkElementsNotNull(fred);
       this.fred = fred;
       return this;
     }
@@ -240,7 +241,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
 
     public Builder nested(List<FooBar> nested) {
-      checkElementsNotNull(nested);
+      WireInternal.checkElementsNotNull(nested);
       this.nested = nested;
       return this;
     }
@@ -251,7 +252,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     }
 
     public Builder rep(List<FooBarBazEnum> rep) {
-      checkElementsNotNull(rep);
+      WireInternal.checkElementsNotNull(rep);
       this.rep = rep;
       return this;
     }
@@ -297,8 +298,8 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof Nested)) return false;
       Nested o = (Nested) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(value, o.value);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(value, o.value);
     }
 
     @Override
@@ -405,13 +406,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     public More(List<Integer> serial, ByteString unknownFields) {
       super(unknownFields);
-      this.serial = immutableCopyOf("serial", serial);
+      this.serial = WireInternal.immutableCopyOf("serial", serial);
     }
 
     @Override
     public Builder newBuilder() {
       Builder builder = new Builder();
-      builder.serial = copyOf("serial", serial);
+      builder.serial = WireInternal.copyOf("serial", serial);
       builder.addUnknownFields(unknownFields());
       return builder;
     }
@@ -421,8 +422,8 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof More)) return false;
       More o = (More) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(serial, o.serial);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(serial, o.serial);
     }
 
     @Override
@@ -447,11 +448,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       public List<Integer> serial;
 
       public Builder() {
-        serial = newMutableList();
+        serial = WireInternal.newMutableList();
       }
 
       public Builder serial(List<Integer> serial) {
-        checkElementsNotNull(serial);
+        WireInternal.checkElementsNotNull(serial);
         this.serial = serial;
         return this;
       }
@@ -616,7 +617,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     public FooBar redact(FooBar value) {
       Builder builder = value.newBuilder();
       if (builder.baz != null) builder.baz = Nested.ADAPTER.redact(builder.baz);
-      redactElements(builder.nested, FooBar.ADAPTER);
+      WireInternal.redactElements(builder.nested, FooBar.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class OneBytesField extends Message<OneBytesField, OneBytesField.Bu
     if (other == this) return true;
     if (!(other instanceof OneBytesField)) return false;
     OneBytesField o = (OneBytesField) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(opt_bytes, o.opt_bytes);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(opt_bytes, o.opt_bytes);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class OneField extends Message<OneField, OneField.Builder> {
     if (other == this) return true;
     if (!(other instanceof OneField)) return false;
     OneField o = (OneField) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(opt_int32, o.opt_int32);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(opt_int32, o.opt_int32);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,9 +60,9 @@ public final class Recursive extends Message<Recursive, Recursive.Builder> {
     if (other == this) return true;
     if (!(other instanceof Recursive)) return false;
     Recursive o = (Recursive) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(value, o.value)
-        && equals(recursive, o.recursive);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(value, o.value)
+        && WireInternal.equals(recursive, o.recursive);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -64,9 +65,9 @@ public final class ForeignMessage extends Message<ForeignMessage, ForeignMessage
     if (other == this) return true;
     if (!(other instanceof ForeignMessage)) return false;
     ForeignMessage o = (ForeignMessage) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i)
-        && equals(j, o.j);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i)
+        && WireInternal.equals(j, o.j);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -139,17 +140,17 @@ public final class Message extends com.squareup.wire.Message<Message, Message.Bu
     if (other_ == this) return true;
     if (!(other_ instanceof Message)) return false;
     Message o_ = (Message) other_;
-    return equals(unknownFields(), o_.unknownFields())
-        && equals(unknownFields, o_.unknownFields)
-        && equals(other, o_.other)
-        && equals(o, o_.o)
-        && equals(result, o_.result)
-        && equals(hashCode, o_.hashCode)
-        && equals(serialVersionUID_, o_.serialVersionUID_)
-        && equals(ADAPTER_, o_.ADAPTER_)
-        && equals(MESSAGE_OPTIONS_, o_.MESSAGE_OPTIONS_)
-        && equals(this_, o_.this_)
-        && equals(message, o_.message);
+    return WireInternal.equals(unknownFields(), o_.unknownFields())
+        && WireInternal.equals(unknownFields, o_.unknownFields)
+        && WireInternal.equals(other, o_.other)
+        && WireInternal.equals(o, o_.o)
+        && WireInternal.equals(result, o_.result)
+        && WireInternal.equals(hashCode, o_.hashCode)
+        && WireInternal.equals(serialVersionUID_, o_.serialVersionUID_)
+        && WireInternal.equals(ADAPTER_, o_.ADAPTER_)
+        && WireInternal.equals(MESSAGE_OPTIONS_, o_.MESSAGE_OPTIONS_)
+        && WireInternal.equals(this_, o_.this_)
+        && WireInternal.equals(message, o_.message);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -50,8 +51,8 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(bar, o.bar);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(bar, o.bar);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -61,9 +62,9 @@ public final class OneExtension extends Message<OneExtension, OneExtension.Build
     if (other == this) return true;
     if (!(other instanceof OneExtension)) return false;
     OneExtension o = (OneExtension) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(id, o.id)
-        && equals(foo, o.foo);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(id, o.id)
+        && WireInternal.equals(foo, o.foo);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -60,7 +61,7 @@ public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Build
 
   public OneOfMessage(Integer foo, String bar, String baz, ByteString unknownFields) {
     super(unknownFields);
-    if (countNonNull(foo, bar, baz) > 1) {
+    if (WireInternal.countNonNull(foo, bar, baz) > 1) {
       throw new IllegalArgumentException("at most one of foo, bar, baz may be non-null");
     }
     this.foo = foo;
@@ -83,10 +84,10 @@ public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Build
     if (other == this) return true;
     if (!(other instanceof OneOfMessage)) return false;
     OneOfMessage o = (OneOfMessage) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(foo, o.foo)
-        && equals(bar, o.bar)
-        && equals(baz, o.baz);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(foo, o.foo)
+        && WireInternal.equals(bar, o.bar)
+        && WireInternal.equals(baz, o.baz);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -77,7 +78,7 @@ public final class Person extends Message<Person, Person.Builder> {
     this.name = name;
     this.id = id;
     this.email = email;
-    this.phone = immutableCopyOf("phone", phone);
+    this.phone = WireInternal.immutableCopyOf("phone", phone);
   }
 
   @Override
@@ -86,7 +87,7 @@ public final class Person extends Message<Person, Person.Builder> {
     builder.name = name;
     builder.id = id;
     builder.email = email;
-    builder.phone = copyOf("phone", phone);
+    builder.phone = WireInternal.copyOf("phone", phone);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -96,11 +97,11 @@ public final class Person extends Message<Person, Person.Builder> {
     if (other == this) return true;
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(id, o.id)
-        && equals(email, o.email)
-        && equals(phone, o.phone);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(id, o.id)
+        && WireInternal.equals(email, o.email)
+        && WireInternal.equals(phone, o.phone);
   }
 
   @Override
@@ -137,7 +138,7 @@ public final class Person extends Message<Person, Person.Builder> {
     public List<PhoneNumber> phone;
 
     public Builder() {
-      phone = newMutableList();
+      phone = WireInternal.newMutableList();
     }
 
     /**
@@ -168,7 +169,7 @@ public final class Person extends Message<Person, Person.Builder> {
      * A list of the customer's phone numbers.
      */
     public Builder phone(List<PhoneNumber> phone) {
-      checkElementsNotNull(phone);
+      WireInternal.checkElementsNotNull(phone);
       this.phone = phone;
       return this;
     }
@@ -177,7 +178,7 @@ public final class Person extends Message<Person, Person.Builder> {
     public Person build() {
       if (name == null
           || id == null) {
-        throw missingRequiredFields(name, "name",
+        throw WireInternal.missingRequiredFields(name, "name",
             id, "id");
       }
       return new Person(name, id, email, phone, buildUnknownFields());
@@ -272,9 +273,9 @@ public final class Person extends Message<Person, Person.Builder> {
       if (other == this) return true;
       if (!(other instanceof PhoneNumber)) return false;
       PhoneNumber o = (PhoneNumber) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(number, o.number)
-          && equals(type, o.type);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(number, o.number)
+          && WireInternal.equals(type, o.type);
     }
 
     @Override
@@ -324,7 +325,7 @@ public final class Person extends Message<Person, Person.Builder> {
       @Override
       public PhoneNumber build() {
         if (number == null) {
-          throw missingRequiredFields(number, "number");
+          throw WireInternal.missingRequiredFields(number, "number");
         }
         return new PhoneNumber(number, type, buildUnknownFields());
       }
@@ -431,7 +432,7 @@ public final class Person extends Message<Person, Person.Builder> {
     @Override
     public Person redact(Person value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.phone, PhoneNumber.ADAPTER);
+      WireInternal.redactElements(builder.phone, PhoneNumber.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -12,6 +12,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -98,7 +99,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     this.name = name;
     this.id = id;
     this.email = email;
-    this.phone = immutableCopyOf("phone", phone);
+    this.phone = WireInternal.immutableCopyOf("phone", phone);
   }
 
   @Override
@@ -107,7 +108,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     builder.name = name;
     builder.id = id;
     builder.email = email;
-    builder.phone = copyOf("phone", phone);
+    builder.phone = WireInternal.copyOf("phone", phone);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -117,11 +118,11 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     if (other == this) return true;
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(name, o.name)
-        && equals(id, o.id)
-        && equals(email, o.email)
-        && equals(phone, o.phone);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(name, o.name)
+        && WireInternal.equals(id, o.id)
+        && WireInternal.equals(email, o.email)
+        && WireInternal.equals(phone, o.phone);
   }
 
   @Override
@@ -168,7 +169,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     public List<PhoneNumber> phone;
 
     public Builder() {
-      phone = newMutableList();
+      phone = WireInternal.newMutableList();
     }
 
     /**
@@ -199,7 +200,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
      * A list of the customer's phone numbers.
      */
     public Builder phone(List<PhoneNumber> phone) {
-      checkElementsNotNull(phone);
+      WireInternal.checkElementsNotNull(phone);
       this.phone = phone;
       return this;
     }
@@ -208,7 +209,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     public Person build() {
       if (name == null
           || id == null) {
-        throw missingRequiredFields(name, "name",
+        throw WireInternal.missingRequiredFields(name, "name",
             id, "id");
       }
       return new Person(name, id, email, phone, buildUnknownFields());
@@ -320,9 +321,9 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       if (other == this) return true;
       if (!(other instanceof PhoneNumber)) return false;
       PhoneNumber o = (PhoneNumber) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(number, o.number)
-          && equals(type, o.type);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(number, o.number)
+          && WireInternal.equals(type, o.type);
     }
 
     @Override
@@ -382,7 +383,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       @Override
       public PhoneNumber build() {
         if (number == null) {
-          throw missingRequiredFields(number, "number");
+          throw WireInternal.missingRequiredFields(number, "number");
         }
         return new PhoneNumber(number, type, buildUnknownFields());
       }
@@ -489,7 +490,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     @Override
     public Person redact(Person value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.phone, PhoneNumber.ADAPTER);
+      WireInternal.redactElements(builder.phone, PhoneNumber.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -60,9 +61,9 @@ public final class NotRedacted extends Message<NotRedacted, NotRedacted.Builder>
     if (other == this) return true;
     if (!(other instanceof NotRedacted)) return false;
     NotRedacted o = (NotRedacted) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(a, o.a)
-        && equals(b, o.b);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(a, o.a)
+        && WireInternal.equals(b, o.b);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -91,11 +92,11 @@ public final class Redacted extends Message<Redacted, Redacted.Builder> {
     if (other == this) return true;
     if (!(other instanceof Redacted)) return false;
     Redacted o = (Redacted) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(a, o.a)
-        && equals(b, o.b)
-        && equals(c, o.c)
-        && equals(extension, o.extension);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(a, o.a)
+        && WireInternal.equals(b, o.b)
+        && WireInternal.equals(c, o.c)
+        && WireInternal.equals(extension, o.extension);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -66,10 +67,10 @@ public final class RedactedChild extends Message<RedactedChild, RedactedChild.Bu
     if (other == this) return true;
     if (!(other instanceof RedactedChild)) return false;
     RedactedChild o = (RedactedChild) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(a, o.a)
-        && equals(b, o.b)
-        && equals(c, o.c);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(a, o.a)
+        && WireInternal.equals(b, o.b)
+        && WireInternal.equals(c, o.c);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -48,8 +49,8 @@ public final class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA
     if (other == this) return true;
     if (!(other instanceof RedactedCycleA)) return false;
     RedactedCycleA o = (RedactedCycleA) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(b, o.b);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(b, o.b);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -48,8 +49,8 @@ public final class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB
     if (other == this) return true;
     if (!(other instanceof RedactedCycleB)) return false;
     RedactedCycleB o = (RedactedCycleB) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(a, o.a);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(a, o.a);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -66,9 +67,9 @@ public final class RedactedExtension extends Message<RedactedExtension, Redacted
     if (other == this) return true;
     if (!(other instanceof RedactedExtension)) return false;
     RedactedExtension o = (RedactedExtension) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(d, o.d)
-        && equals(e, o.e);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(d, o.d)
+        && WireInternal.equals(e, o.e);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -51,15 +52,15 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
 
   public RedactedRepeated(List<String> a, List<Redacted> b, ByteString unknownFields) {
     super(unknownFields);
-    this.a = immutableCopyOf("a", a);
-    this.b = immutableCopyOf("b", b);
+    this.a = WireInternal.immutableCopyOf("a", a);
+    this.b = WireInternal.immutableCopyOf("b", b);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.a = copyOf("a", a);
-    builder.b = copyOf("b", b);
+    builder.a = WireInternal.copyOf("a", a);
+    builder.b = WireInternal.copyOf("b", b);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -69,9 +70,9 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
     if (other == this) return true;
     if (!(other instanceof RedactedRepeated)) return false;
     RedactedRepeated o = (RedactedRepeated) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(a, o.a)
-        && equals(b, o.b);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(a, o.a)
+        && WireInternal.equals(b, o.b);
   }
 
   @Override
@@ -100,12 +101,12 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
     public List<Redacted> b;
 
     public Builder() {
-      a = newMutableList();
-      b = newMutableList();
+      a = WireInternal.newMutableList();
+      b = WireInternal.newMutableList();
     }
 
     public Builder a(List<String> a) {
-      checkElementsNotNull(a);
+      WireInternal.checkElementsNotNull(a);
       this.a = a;
       return this;
     }
@@ -114,7 +115,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
      * Values in the repeated type need redacting.
      */
     public Builder b(List<Redacted> b) {
-      checkElementsNotNull(b);
+      WireInternal.checkElementsNotNull(b);
       this.b = b;
       return this;
     }
@@ -167,7 +168,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
     public RedactedRepeated redact(RedactedRepeated value) {
       Builder builder = value.newBuilder();
       builder.a = Collections.emptyList();
-      redactElements(builder.b, Redacted.ADAPTER);
+      WireInternal.redactElements(builder.b, Redacted.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,8 +59,8 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
     if (other == this) return true;
     if (!(other instanceof RedactedRequired)) return false;
     RedactedRequired o = (RedactedRequired) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(a, o.a);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(a, o.a);
   }
 
   @Override
@@ -94,7 +95,7 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
     @Override
     public RedactedRequired build() {
       if (a == null) {
-        throw missingRequiredFields(a, "a");
+        throw WireInternal.missingRequiredFields(a, "a");
       }
       return new RedactedRequired(a, buildUnknownFields());
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -71,9 +72,9 @@ public final class A extends Message<A, A.Builder> {
     if (other == this) return true;
     if (!(other instanceof A)) return false;
     A o = (A) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(c, o.c)
-        && equals(d, o.d);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(c, o.c)
+        && WireInternal.equals(d, o.d);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -63,8 +64,8 @@ public final class A extends Message<A, A.Builder> {
     if (other == this) return true;
     if (!(other instanceof A)) return false;
     A o = (A) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(d, o.d);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(d, o.d);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -49,8 +50,8 @@ public final class B extends Message<B, B.Builder> {
     if (other == this) return true;
     if (!(other instanceof B)) return false;
     B o = (B) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(c, o.c);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(c, o.c);
   }
 
   @Override
@@ -85,7 +86,7 @@ public final class B extends Message<B, B.Builder> {
     @Override
     public B build() {
       if (c == null) {
-        throw missingRequiredFields(c, "c");
+        throw WireInternal.missingRequiredFields(c, "c");
       }
       return new B(c, buildUnknownFields());
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class C extends Message<C, C.Builder> {
     if (other == this) return true;
     if (!(other instanceof C)) return false;
     C o = (C) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class D extends Message<D, D.Builder> {
     if (other == this) return true;
     if (!(other instanceof D)) return false;
     D o = (D) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class D extends Message<D, D.Builder> {
     if (other == this) return true;
     if (!(other instanceof D)) return false;
     D o = (D) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -59,9 +60,9 @@ public final class E extends Message<E, E.Builder> {
     if (other == this) return true;
     if (!(other instanceof E)) return false;
     E o = (E) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(f, o.f)
-        && equals(g, o.g);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(f, o.f)
+        && WireInternal.equals(g, o.g);
   }
 
   @Override
@@ -143,8 +144,8 @@ public final class E extends Message<E, E.Builder> {
       if (other == this) return true;
       if (!(other instanceof F)) return false;
       F o = (F) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(i, o.i);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(i, o.i);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -48,8 +49,8 @@ public final class H extends Message<H, H.Builder> {
     if (other == this) return true;
     if (!(other instanceof H)) return false;
     H o = (H) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(ef, o.ef);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(ef, o.ef);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -62,9 +63,9 @@ public final class I extends Message<I, I.Builder> {
     if (other == this) return true;
     if (!(other instanceof I)) return false;
     I o = (I) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i)
-        && equals(j, o.j);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i)
+        && WireInternal.equals(j, o.j);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -48,8 +49,8 @@ public final class J extends Message<J, J.Builder> {
     if (other == this) return true;
     if (!(other instanceof J)) return false;
     J o = (J) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(k, o.k);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(k, o.k);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class K extends Message<K, K.Builder> {
     if (other == this) return true;
     if (!(other instanceof K)) return false;
     K o = (K) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Float;
 import java.lang.Integer;
@@ -90,7 +91,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
   public ExternalMessage(Float f, List<Integer> fooext, Integer barext, Integer bazext, SimpleMessage.NestedMessage nested_message_ext, SimpleMessage.NestedEnum nested_enum_ext, ByteString unknownFields) {
     super(unknownFields);
     this.f = f;
-    this.fooext = immutableCopyOf("fooext", fooext);
+    this.fooext = WireInternal.immutableCopyOf("fooext", fooext);
     this.barext = barext;
     this.bazext = bazext;
     this.nested_message_ext = nested_message_ext;
@@ -101,7 +102,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
   public Builder newBuilder() {
     Builder builder = new Builder();
     builder.f = f;
-    builder.fooext = copyOf("fooext", fooext);
+    builder.fooext = WireInternal.copyOf("fooext", fooext);
     builder.barext = barext;
     builder.bazext = bazext;
     builder.nested_message_ext = nested_message_ext;
@@ -115,13 +116,13 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
     if (other == this) return true;
     if (!(other instanceof ExternalMessage)) return false;
     ExternalMessage o = (ExternalMessage) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(f, o.f)
-        && equals(fooext, o.fooext)
-        && equals(barext, o.barext)
-        && equals(bazext, o.bazext)
-        && equals(nested_message_ext, o.nested_message_ext)
-        && equals(nested_enum_ext, o.nested_enum_ext);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(f, o.f)
+        && WireInternal.equals(fooext, o.fooext)
+        && WireInternal.equals(barext, o.barext)
+        && WireInternal.equals(bazext, o.bazext)
+        && WireInternal.equals(nested_message_ext, o.nested_message_ext)
+        && WireInternal.equals(nested_enum_ext, o.nested_enum_ext);
   }
 
   @Override
@@ -166,7 +167,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
     public SimpleMessage.NestedEnum nested_enum_ext;
 
     public Builder() {
-      fooext = newMutableList();
+      fooext = WireInternal.newMutableList();
     }
 
     public Builder f(Float f) {
@@ -175,7 +176,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
     }
 
     public Builder fooext(List<Integer> fooext) {
-      checkElementsNotNull(fooext);
+      WireInternal.checkElementsNotNull(fooext);
       this.fooext = fooext;
       return this;
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.io.IOException;
 import java.lang.Boolean;
@@ -169,7 +170,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     this.optional_external_msg = optional_external_msg;
     this.default_nested_enum = default_nested_enum;
     this.required_int32 = required_int32;
-    this.repeated_double = immutableCopyOf("repeated_double", repeated_double);
+    this.repeated_double = WireInternal.immutableCopyOf("repeated_double", repeated_double);
     this.default_foreign_enum = default_foreign_enum;
     this.no_default_foreign_enum = no_default_foreign_enum;
     this.package_ = package_;
@@ -186,7 +187,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     builder.optional_external_msg = optional_external_msg;
     builder.default_nested_enum = default_nested_enum;
     builder.required_int32 = required_int32;
-    builder.repeated_double = copyOf("repeated_double", repeated_double);
+    builder.repeated_double = WireInternal.copyOf("repeated_double", repeated_double);
     builder.default_foreign_enum = default_foreign_enum;
     builder.no_default_foreign_enum = no_default_foreign_enum;
     builder.package_ = package_;
@@ -202,19 +203,19 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     if (other_ == this) return true;
     if (!(other_ instanceof SimpleMessage)) return false;
     SimpleMessage o_ = (SimpleMessage) other_;
-    return equals(unknownFields(), o_.unknownFields())
-        && equals(optional_int32, o_.optional_int32)
-        && equals(optional_nested_msg, o_.optional_nested_msg)
-        && equals(optional_external_msg, o_.optional_external_msg)
-        && equals(default_nested_enum, o_.default_nested_enum)
-        && equals(required_int32, o_.required_int32)
-        && equals(repeated_double, o_.repeated_double)
-        && equals(default_foreign_enum, o_.default_foreign_enum)
-        && equals(no_default_foreign_enum, o_.no_default_foreign_enum)
-        && equals(package_, o_.package_)
-        && equals(result, o_.result)
-        && equals(other, o_.other)
-        && equals(o, o_.o);
+    return WireInternal.equals(unknownFields(), o_.unknownFields())
+        && WireInternal.equals(optional_int32, o_.optional_int32)
+        && WireInternal.equals(optional_nested_msg, o_.optional_nested_msg)
+        && WireInternal.equals(optional_external_msg, o_.optional_external_msg)
+        && WireInternal.equals(default_nested_enum, o_.default_nested_enum)
+        && WireInternal.equals(required_int32, o_.required_int32)
+        && WireInternal.equals(repeated_double, o_.repeated_double)
+        && WireInternal.equals(default_foreign_enum, o_.default_foreign_enum)
+        && WireInternal.equals(no_default_foreign_enum, o_.no_default_foreign_enum)
+        && WireInternal.equals(package_, o_.package_)
+        && WireInternal.equals(result, o_.result)
+        && WireInternal.equals(other, o_.other)
+        && WireInternal.equals(o, o_.o);
   }
 
   @Override
@@ -283,7 +284,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     public String o;
 
     public Builder() {
-      repeated_double = newMutableList();
+      repeated_double = WireInternal.newMutableList();
     }
 
     /**
@@ -329,7 +330,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
      */
     @Deprecated
     public Builder repeated_double(List<Double> repeated_double) {
-      checkElementsNotNull(repeated_double);
+      WireInternal.checkElementsNotNull(repeated_double);
       this.repeated_double = repeated_double;
       return this;
     }
@@ -385,7 +386,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     @Override
     public SimpleMessage build() {
       if (required_int32 == null) {
-        throw missingRequiredFields(required_int32, "required_int32");
+        throw WireInternal.missingRequiredFields(required_int32, "required_int32");
       }
       return new SimpleMessage(optional_int32, optional_nested_msg, optional_external_msg, default_nested_enum, required_int32, repeated_double, default_foreign_enum, no_default_foreign_enum, package_, result, other, o, buildUnknownFields());
     }
@@ -429,8 +430,8 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return equals(unknownFields(), o.unknownFields())
-          && equals(bb, o.bb);
+      return WireInternal.equals(unknownFields(), o.unknownFields())
+          && WireInternal.equals(bb, o.bb);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class Bar extends Message<Bar, Bar.Builder> {
     if (other == this) return true;
     if (!(other instanceof Bar)) return false;
     Bar o = (Bar) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(baz, o.baz);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(baz, o.baz);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -34,13 +35,13 @@ public final class Bars extends Message<Bars, Bars.Builder> {
 
   public Bars(List<Bar> bars, ByteString unknownFields) {
     super(unknownFields);
-    this.bars = immutableCopyOf("bars", bars);
+    this.bars = WireInternal.immutableCopyOf("bars", bars);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.bars = copyOf("bars", bars);
+    builder.bars = WireInternal.copyOf("bars", bars);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -50,8 +51,8 @@ public final class Bars extends Message<Bars, Bars.Builder> {
     if (other == this) return true;
     if (!(other instanceof Bars)) return false;
     Bars o = (Bars) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(bars, o.bars);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(bars, o.bars);
   }
 
   @Override
@@ -76,11 +77,11 @@ public final class Bars extends Message<Bars, Bars.Builder> {
     public List<Bar> bars;
 
     public Builder() {
-      bars = newMutableList();
+      bars = WireInternal.newMutableList();
     }
 
     public Builder bars(List<Bar> bars) {
-      checkElementsNotNull(bars);
+      WireInternal.checkElementsNotNull(bars);
       this.bars = bars;
       return this;
     }
@@ -129,7 +130,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
     @Override
     public Bars redact(Bars value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.bars, Bar.ADAPTER);
+      WireInternal.redactElements(builder.bars, Bar.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(bar, o.bar);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(bar, o.bar);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -34,13 +35,13 @@ public final class Foos extends Message<Foos, Foos.Builder> {
 
   public Foos(List<Foo> foos, ByteString unknownFields) {
     super(unknownFields);
-    this.foos = immutableCopyOf("foos", foos);
+    this.foos = WireInternal.immutableCopyOf("foos", foos);
   }
 
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.foos = copyOf("foos", foos);
+    builder.foos = WireInternal.copyOf("foos", foos);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -50,8 +51,8 @@ public final class Foos extends Message<Foos, Foos.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foos)) return false;
     Foos o = (Foos) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(foos, o.foos);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(foos, o.foos);
   }
 
   @Override
@@ -76,11 +77,11 @@ public final class Foos extends Message<Foos, Foos.Builder> {
     public List<Foo> foos;
 
     public Builder() {
-      foos = newMutableList();
+      foos = WireInternal.newMutableList();
     }
 
     public Builder foos(List<Foo> foos) {
-      checkElementsNotNull(foos);
+      WireInternal.checkElementsNotNull(foos);
       this.foos = foos;
       return this;
     }
@@ -129,7 +130,7 @@ public final class Foos extends Message<Foos, Foos.Builder> {
     @Override
     public Foos redact(Foos value) {
       Builder builder = value.newBuilder();
-      redactElements(builder.foos, Foo.ADAPTER);
+      WireInternal.redactElements(builder.foos, Foo.ADAPTER);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
@@ -51,8 +52,8 @@ public final class VersionOne extends Message<VersionOne, VersionOne.Builder> {
     if (other == this) return true;
     if (!(other instanceof VersionOne)) return false;
     VersionOne o = (VersionOne) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i);
   }
 
   @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -8,6 +8,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Long;
@@ -81,7 +82,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     this.v2_s = v2_s;
     this.v2_f32 = v2_f32;
     this.v2_f64 = v2_f64;
-    this.v2_rs = immutableCopyOf("v2_rs", v2_rs);
+    this.v2_rs = WireInternal.immutableCopyOf("v2_rs", v2_rs);
   }
 
   @Override
@@ -92,7 +93,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     builder.v2_s = v2_s;
     builder.v2_f32 = v2_f32;
     builder.v2_f64 = v2_f64;
-    builder.v2_rs = copyOf("v2_rs", v2_rs);
+    builder.v2_rs = WireInternal.copyOf("v2_rs", v2_rs);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -102,13 +103,13 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     if (other == this) return true;
     if (!(other instanceof VersionTwo)) return false;
     VersionTwo o = (VersionTwo) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(i, o.i)
-        && equals(v2_i, o.v2_i)
-        && equals(v2_s, o.v2_s)
-        && equals(v2_f32, o.v2_f32)
-        && equals(v2_f64, o.v2_f64)
-        && equals(v2_rs, o.v2_rs);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(i, o.i)
+        && WireInternal.equals(v2_i, o.v2_i)
+        && WireInternal.equals(v2_s, o.v2_s)
+        && WireInternal.equals(v2_f32, o.v2_f32)
+        && WireInternal.equals(v2_f64, o.v2_f64)
+        && WireInternal.equals(v2_rs, o.v2_rs);
   }
 
   @Override
@@ -153,7 +154,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     public List<String> v2_rs;
 
     public Builder() {
-      v2_rs = newMutableList();
+      v2_rs = WireInternal.newMutableList();
     }
 
     public Builder i(Integer i) {
@@ -182,7 +183,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     }
 
     public Builder v2_rs(List<String> v2_rs) {
-      checkElementsNotNull(v2_rs);
+      WireInternal.checkElementsNotNull(v2_rs);
       this.v2_rs = v2_rs;
       return this;
     }

--- a/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.ProtoReader;
 import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
+import com.squareup.wire.WireInternal;
 import java.io.IOException;
 import java.lang.Object;
 import java.lang.Override;
@@ -58,8 +59,8 @@ public final class CollisionSubject extends Message<CollisionSubject, CollisionS
     if (other == this) return true;
     if (!(other instanceof CollisionSubject)) return false;
     CollisionSubject o = (CollisionSubject) other;
-    return equals(unknownFields(), o.unknownFields())
-        && equals(f, o.f);
+    return WireInternal.equals(unknownFields(), o.unknownFields())
+        && WireInternal.equals(f, o.f);
   }
 
   @Override


### PR DESCRIPTION
These methods are called from Message.Builder and ProtoAdapter subclasses which are defined inside a Message subclass. Since neither is directly a Message subclass synthetic accessor methods needed to be generated on the enclosing types. By making these public they can be called from anywhere.