### PR TITLE
Implement groups at the element level, throw at model level.

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
@@ -249,6 +249,9 @@ public final class MessageType extends Type {
 
   static MessageType fromElement(String packageName, ProtoType protoType,
       MessageElement messageElement) {
+    if (!messageElement.groups().isEmpty()) {
+      throw new IllegalStateException("'group' is not supported");
+    }
 
     ImmutableList<Field> declaredFields =
         Field.fromElements(packageName, messageElement.fields(), false);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/GroupElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/GroupElement.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema.internal.parser;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.squareup.wire.schema.Field;
+import java.util.Locale;
+
+import static com.squareup.wire.schema.internal.Util.appendDocumentation;
+import static com.squareup.wire.schema.internal.Util.appendIndented;
+
+@AutoValue
+public abstract class GroupElement {
+  public static Builder builder() {
+    return new AutoValue_GroupElement.Builder()
+        .documentation("")
+        .fields(ImmutableList.<FieldElement>of());
+  }
+
+  public abstract Field.Label label();
+  public abstract String name();
+  public abstract int tag();
+  public abstract String documentation();
+  public abstract ImmutableList<FieldElement> fields();
+
+  public final String toSchema() {
+    StringBuilder builder = new StringBuilder();
+    appendDocumentation(builder, documentation());
+    builder.append(label().name().toLowerCase(Locale.US))
+        .append(" group ")
+        .append(name())
+        .append(" = ")
+        .append(tag())
+        .append(" {");
+    if (!fields().isEmpty()) {
+      builder.append('\n');
+      for (FieldElement field : fields()) {
+        appendIndented(builder, field.toSchema());
+      }
+    }
+    return builder.append("}\n").toString();
+  }
+
+  @AutoValue.Builder
+  public interface Builder {
+    Builder label(Field.Label label);
+    Builder name(String name);
+    Builder tag(int value);
+    Builder documentation(String documentation);
+    Builder fields(ImmutableList<FieldElement> fields);
+    GroupElement build();
+  }
+}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/MessageElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/MessageElement.java
@@ -33,7 +33,8 @@ public abstract class MessageElement implements TypeElement {
         .nestedTypes(ImmutableList.<TypeElement>of())
         .extensions(ImmutableList.<ExtensionsElement>of())
         .options(ImmutableList.<OptionElement>of())
-        .reserveds(ImmutableList.<ReservedElement>of());
+        .reserveds(ImmutableList.<ReservedElement>of())
+        .groups(ImmutableList.<GroupElement>of());
   }
 
   @Override public abstract Location location();
@@ -45,6 +46,7 @@ public abstract class MessageElement implements TypeElement {
   public abstract ImmutableList<FieldElement> fields();
   public abstract ImmutableList<OneOfElement> oneOfs();
   public abstract ImmutableList<ExtensionsElement> extensions();
+  public abstract ImmutableList<GroupElement> groups();
 
   @Override public final String toSchema() {
     StringBuilder builder = new StringBuilder();
@@ -76,6 +78,12 @@ public abstract class MessageElement implements TypeElement {
         appendIndented(builder, oneOf.toSchema());
       }
     }
+    if (!groups().isEmpty()) {
+      builder.append('\n');
+      for (GroupElement group : groups()) {
+        appendIndented(builder, group.toSchema());
+      }
+    }
     if (!extensions().isEmpty()) {
       builder.append('\n');
       for (ExtensionsElement extension : extensions()) {
@@ -102,6 +110,7 @@ public abstract class MessageElement implements TypeElement {
     Builder extensions(ImmutableList<ExtensionsElement> extensions);
     Builder options(ImmutableList<OptionElement> options);
     Builder reserveds(ImmutableList<ReservedElement> reserveds);
+    Builder groups(ImmutableList<GroupElement> groups);
     MessageElement build();
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoParser.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoParser.java
@@ -211,6 +211,7 @@ public final class ProtoParser {
     ImmutableList.Builder<ExtensionsElement> extensions = ImmutableList.builder();
     ImmutableList.Builder<OptionElement> options = ImmutableList.builder();
     ImmutableList.Builder<ReservedElement> reserveds = ImmutableList.builder();
+    ImmutableList.Builder<GroupElement> groups = ImmutableList.builder();
 
     if (readChar() != '{') throw unexpected("expected '{'");
     while (true) {
@@ -224,6 +225,8 @@ public final class ProtoParser {
         fields.add((FieldElement) declared);
       } else if (declared instanceof OneOfElement) {
         oneOfs.add((OneOfElement) declared);
+      } else if (declared instanceof GroupElement) {
+        groups.add((GroupElement) declared);
       } else if (declared instanceof TypeElement) {
         nestedTypes.add((TypeElement) declared);
       } else if (declared instanceof ExtensionsElement) {
@@ -245,6 +248,7 @@ public final class ProtoParser {
         .extensions(extensions.build())
         .options(options.build())
         .reserveds(reserveds.build())
+        .groups(groups.build())
         .build();
   }
 
@@ -362,6 +366,10 @@ public final class ProtoParser {
         break;
     }
 
+    if (type.equals("group")) {
+      return readGroup(documentation, label);
+    }
+
     return readField(location, documentation, label, type);
   }
 
@@ -425,6 +433,40 @@ public final class ProtoParser {
       String type = readDataType();
       fields.add(readField(location, nestedDocumentation, null, type));
     }
+    return builder.fields(fields.build())
+        .build();
+  }
+
+  private GroupElement readGroup(String documentation, Field.Label label) {
+    String name = readWord();
+    if (readChar() != '=') {
+      throw unexpected("expected '='");
+    }
+    int tag = readInt();
+
+    GroupElement.Builder builder = GroupElement.builder()
+        .label(label)
+        .name(name)
+        .tag(tag)
+        .documentation(documentation);
+    ImmutableList.Builder<FieldElement> fields = ImmutableList.builder();
+
+    if (readChar() != '{') throw unexpected("expected '{'");
+    while (true) {
+      String nestedDocumentation = readDocumentation();
+      if (peekChar() == '}') {
+        pos++;
+        break;
+      }
+      Location location = location();
+      String fieldLabel = readWord();
+      Object field = readField(nestedDocumentation, location, fieldLabel);
+      if (!(field instanceof FieldElement)) {
+        throw unexpected("expected field declaration, was " + field);
+      }
+      fields.add((FieldElement) field);
+    }
+
     return builder.fields(fields.build())
         .build();
   }
@@ -778,9 +820,6 @@ public final class ProtoParser {
   /** Reads a scalar, map, or type name. */
   private String readDataType() {
     String name = readWord();
-    if (name.equals("group")) {
-      throw unexpected("'group' is not supported");
-    }
     return readDataType(name);
   }
 

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
@@ -1047,4 +1047,21 @@ public final class SchemaTest {
           + "  in message a.b.c.MessageC (a_b_c.proto at 5:1)");
     }
   }
+
+  @Test public void groupsThrow() throws Exception {
+    try {
+      new SchemaBuilder()
+          .add("test.proto", ""
+              + "message SearchResponse {\n"
+              + "  repeated group Result = 1 {\n"
+              + "    required string url = 2;\n"
+              + "    optional string title = 3;\n"
+              + "    repeated string snippets = 4;\n"
+              + "  }\n"
+              + "}\n")
+          .build();
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage("'group' is not supported");
+    }
+  }
 }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.java
@@ -21,6 +21,8 @@ import com.squareup.wire.schema.internal.parser.OptionElement.Kind;
 import com.squareup.wire.schema.Location;
 import org.junit.Test;
 
+import static com.squareup.wire.schema.Field.Label.OPTIONAL;
+import static com.squareup.wire.schema.Field.Label.REPEATED;
 import static com.squareup.wire.schema.Field.Label.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -280,6 +282,48 @@ public final class MessageElementTest {
         + "  reserved 10;\n"
         + "  reserved 12 to 14;\n"
         + "  reserved \"foo\";\n"
+        + "}\n";
+    assertThat(element.toSchema()).isEqualTo(expected);
+  }
+
+  @Test public void groupToSchema() {
+    TypeElement element = MessageElement.builder(location.at(1, 1))
+        .name("SearchResponse")
+        .groups(ImmutableList.of(
+            GroupElement.builder()
+                .label(REPEATED)
+                .name("Result")
+                .tag(1)
+                .fields(ImmutableList.of(
+                    FieldElement.builder(location.at(3, 5))
+                        .label(REQUIRED)
+                        .type("string")
+                        .name("url")
+                        .tag(2)
+                        .build(),
+                    FieldElement.builder(location.at(4, 5))
+                        .label(OPTIONAL)
+                        .type("string")
+                        .name("title")
+                        .tag(3)
+                        .build(),
+                    FieldElement.builder(location.at(5, 5))
+                        .label(REPEATED)
+                        .type("string")
+                        .name("snippets")
+                        .tag(4)
+                        .build()
+                ))
+                .build()
+        ))
+        .build();
+    String expected = ""
+        + "message SearchResponse {\n"
+        + "  repeated group Result = 1 {\n"
+        + "    required string url = 2;\n"
+        + "    optional string title = 3;\n"
+        + "    repeated string snippets = 4;\n"
+        + "  }\n"
         + "}\n";
     assertThat(element.toSchema()).isEqualTo(expected);
   }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/ProtoParserTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/ProtoParserTest.java
@@ -732,21 +732,49 @@ public final class ProtoParserTest {
     assertThat(ProtoParser.parse(location, proto)).isEqualTo(expected);
   }
 
-  @Test public void groupThrows() throws Exception {
+  @Test public void group() throws Exception {
     String proto = ""
-        + "message SearchRequest {\n"
+        + "message SearchResponse {\n"
         + "  repeated group Result = 1 {\n"
         + "    required string url = 2;\n"
         + "    optional string title = 3;\n"
         + "    repeated string snippets = 4;\n"
         + "  }\n"
         + "}";
-    try {
-      ProtoParser.parse(location, proto);
-      fail();
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessage("Syntax error in file.proto at 2:17: 'group' is not supported");
-    }
+    TypeElement message = MessageElement.builder(location.at(1, 1))
+        .name("SearchResponse")
+        .groups(ImmutableList.of(
+            GroupElement.builder()
+                .label(REPEATED)
+                .name("Result")
+                .tag(1)
+                .fields(ImmutableList.of(
+                    FieldElement.builder(location.at(3, 5))
+                        .label(REQUIRED)
+                        .type("string")
+                        .name("url")
+                        .tag(2)
+                        .build(),
+                    FieldElement.builder(location.at(4, 5))
+                        .label(OPTIONAL)
+                        .type("string")
+                        .name("title")
+                        .tag(3)
+                        .build(),
+                    FieldElement.builder(location.at(5, 5))
+                        .label(REPEATED)
+                        .type("string")
+                        .name("snippets")
+                        .tag(4)
+                        .build()
+                ))
+                .build()
+        ))
+        .build();
+    ProtoFileElement expected = ProtoFileElement.builder(location)
+        .types(ImmutableList.of(message))
+        .build();
+    assertThat(ProtoParser.parse(location, proto)).isEqualTo(expected);
   }
 
   @Test public void parseMessageAndOneOf() throws Exception {


### PR DESCRIPTION
This lets us test parsing against any valid syntax, but not implement in the linker/schema.