### PR TITLE
Implement groups at the element level, throw at model level.

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
@@ -249,6 +249,9 @@ public final class MessageType extends Type {
 
   static MessageType fromElement(String packageName, ProtoType protoType,
       MessageElement messageElement) {
+    if (!messageElement.groups().isEmpty()) {
+      throw new IllegalStateException("'group' is not supported");
+    }
 
     ImmutableList<Field> declaredFields =
         Field.fromElements(packageName, messageElement.fields(), false);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/OneOf.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/OneOf.java
@@ -63,6 +63,9 @@ public final class OneOf {
       ImmutableList<OneOfElement> elements, boolean extension) {
     ImmutableList.Builder<OneOf> oneOfs = ImmutableList.builder();
     for (OneOfElement oneOf : elements) {
+      if (!oneOf.groups().isEmpty()) {
+        throw new IllegalStateException("'group' is not supported");
+      }
       oneOfs.add(new OneOf(oneOf.name(), oneOf.documentation(),
           Field.fromElements(packageName, oneOf.fields(), extension)));
     }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/GroupElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/GroupElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014 Square, Inc.
+ * Copyright (C) 2016 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,38 +17,41 @@ package com.squareup.wire.schema.internal.parser;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
+import com.squareup.wire.schema.Field;
+import java.util.Locale;
 
 import static com.squareup.wire.schema.internal.Util.appendDocumentation;
 import static com.squareup.wire.schema.internal.Util.appendIndented;
 
 @AutoValue
-public abstract class OneOfElement {
+public abstract class GroupElement {
   public static Builder builder() {
-    return new AutoValue_OneOfElement.Builder()
+    return new AutoValue_GroupElement.Builder()
         .documentation("")
-        .fields(ImmutableList.<FieldElement>of())
-        .groups(ImmutableList.<GroupElement>of());
+        .fields(ImmutableList.<FieldElement>of());
   }
 
+  @Nullable public abstract Field.Label label();
   public abstract String name();
+  public abstract int tag();
   public abstract String documentation();
   public abstract ImmutableList<FieldElement> fields();
-  public abstract ImmutableList<GroupElement> groups();
 
   public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
-    builder.append("oneof ").append(name()).append(" {");
+    if (label() != null) {
+      builder.append(label().name().toLowerCase(Locale.US)).append(' ');
+    }
+    builder.append("group ")
+        .append(name())
+        .append(" = ")
+        .append(tag())
+        .append(" {");
     if (!fields().isEmpty()) {
       builder.append('\n');
       for (FieldElement field : fields()) {
         appendIndented(builder, field.toSchema());
-      }
-    }
-    if (!groups().isEmpty()) {
-      builder.append('\n');
-      for (GroupElement group : groups()) {
-        appendIndented(builder, group.toSchema());
       }
     }
     return builder.append("}\n").toString();
@@ -56,10 +59,11 @@ public abstract class OneOfElement {
 
   @AutoValue.Builder
   public interface Builder {
+    Builder label(Field.Label label);
     Builder name(String name);
+    Builder tag(int value);
     Builder documentation(String documentation);
     Builder fields(ImmutableList<FieldElement> fields);
-    Builder groups(ImmutableList<GroupElement> groups);
-    OneOfElement build();
+    GroupElement build();
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/MessageElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/MessageElement.java
@@ -33,7 +33,8 @@ public abstract class MessageElement implements TypeElement {
         .nestedTypes(ImmutableList.<TypeElement>of())
         .extensions(ImmutableList.<ExtensionsElement>of())
         .options(ImmutableList.<OptionElement>of())
-        .reserveds(ImmutableList.<ReservedElement>of());
+        .reserveds(ImmutableList.<ReservedElement>of())
+        .groups(ImmutableList.<GroupElement>of());
   }
 
   @Override public abstract Location location();
@@ -45,6 +46,7 @@ public abstract class MessageElement implements TypeElement {
   public abstract ImmutableList<FieldElement> fields();
   public abstract ImmutableList<OneOfElement> oneOfs();
   public abstract ImmutableList<ExtensionsElement> extensions();
+  public abstract ImmutableList<GroupElement> groups();
 
   @Override public final String toSchema() {
     StringBuilder builder = new StringBuilder();
@@ -76,6 +78,12 @@ public abstract class MessageElement implements TypeElement {
         appendIndented(builder, oneOf.toSchema());
       }
     }
+    if (!groups().isEmpty()) {
+      builder.append('\n');
+      for (GroupElement group : groups()) {
+        appendIndented(builder, group.toSchema());
+      }
+    }
     if (!extensions().isEmpty()) {
       builder.append('\n');
       for (ExtensionsElement extension : extensions()) {
@@ -102,6 +110,7 @@ public abstract class MessageElement implements TypeElement {
     Builder extensions(ImmutableList<ExtensionsElement> extensions);
     Builder options(ImmutableList<OptionElement> options);
     Builder reserveds(ImmutableList<ReservedElement> reserveds);
+    Builder groups(ImmutableList<GroupElement> groups);
     MessageElement build();
   }
 }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/SchemaTest.java
@@ -1041,10 +1041,50 @@ public final class SchemaTest {
               + "  optional .b.MessageB message_b = 1;\n"
               + "}\n")
           .build();
+      fail();
     } catch (SchemaException expected) {
       assertThat(expected).hasMessage("unable to resolve .b.MessageB\n"
           + "  for field message_b (a_b_c.proto at 6:3)\n"
           + "  in message a.b.c.MessageC (a_b_c.proto at 5:1)");
+    }
+  }
+
+  @Test public void groupsThrow() throws Exception {
+    try {
+      new SchemaBuilder()
+          .add("test.proto", ""
+              + "message SearchResponse {\n"
+              + "  repeated group Result = 1 {\n"
+              + "    required string url = 2;\n"
+              + "    optional string title = 3;\n"
+              + "    repeated string snippets = 4;\n"
+              + "  }\n"
+              + "}\n")
+          .build();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage("'group' is not supported");
+    }
+  }
+
+  @Test public void oneOfGroupsThrow() throws Exception {
+    try {
+      new SchemaBuilder()
+          .add("test.proto", ""
+              + "message Message {\n"
+              + "  oneof hi {\n"
+              + "    string name = 1;\n"
+              + "  \n"
+              + "    group Stuff = 3 {\n"
+              + "      optional int32 result_per_page = 4;\n"
+              + "      optional int32 page_count = 5;\n"
+              + "    }\n"
+              + "  }\n"
+              + "}\n")
+          .build();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage("'group' is not supported");
     }
   }
 }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.java
@@ -21,6 +21,8 @@ import com.squareup.wire.schema.internal.parser.OptionElement.Kind;
 import com.squareup.wire.schema.Location;
 import org.junit.Test;
 
+import static com.squareup.wire.schema.Field.Label.OPTIONAL;
+import static com.squareup.wire.schema.Field.Label.REPEATED;
 import static com.squareup.wire.schema.Field.Label.REQUIRED;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -239,6 +241,52 @@ public final class MessageElementTest {
     assertThat(element.toSchema()).isEqualTo(expected);
   }
 
+  @Test public void oneOfWithGroupToSchema() {
+    TypeElement element = MessageElement.builder(location)
+        .name("Message")
+        .oneOfs(ImmutableList.of(
+            OneOfElement.builder()
+                .name("hi")
+                .fields(ImmutableList.of(
+                    FieldElement.builder(location)
+                        .type("string")
+                        .name("name")
+                        .tag(1)
+                        .build()))
+            .groups(ImmutableList.of(GroupElement.builder()
+                .name("Stuff")
+                .tag(3)
+                .fields(ImmutableList.of(
+                    FieldElement.builder(location.at(6, 7))
+                        .label(OPTIONAL)
+                        .type("int32")
+                        .name("result_per_page")
+                        .tag(4)
+                        .build(),
+                    FieldElement.builder(location.at(7, 7))
+                        .label(OPTIONAL)
+                        .type("int32")
+                        .name("page_count")
+                        .tag(5)
+                        .build()
+                ))
+                .build()))
+            .build()))
+        .build();
+    String expected = ""
+        + "message Message {\n"
+        + "  oneof hi {\n"
+        + "    string name = 1;\n"
+        + "  \n"
+        + "    group Stuff = 3 {\n"
+        + "      optional int32 result_per_page = 4;\n"
+        + "      optional int32 page_count = 5;\n"
+        + "    }\n"
+        + "  }\n"
+        + "}\n";
+    assertThat(element.toSchema()).isEqualTo(expected);
+  }
+
   @Test public void addMultipleOneOfs() {
     OneOfElement hi = OneOfElement.builder()
         .name("hi")
@@ -280,6 +328,48 @@ public final class MessageElementTest {
         + "  reserved 10;\n"
         + "  reserved 12 to 14;\n"
         + "  reserved \"foo\";\n"
+        + "}\n";
+    assertThat(element.toSchema()).isEqualTo(expected);
+  }
+
+  @Test public void groupToSchema() {
+    TypeElement element = MessageElement.builder(location.at(1, 1))
+        .name("SearchResponse")
+        .groups(ImmutableList.of(
+            GroupElement.builder()
+                .label(REPEATED)
+                .name("Result")
+                .tag(1)
+                .fields(ImmutableList.of(
+                    FieldElement.builder(location.at(3, 5))
+                        .label(REQUIRED)
+                        .type("string")
+                        .name("url")
+                        .tag(2)
+                        .build(),
+                    FieldElement.builder(location.at(4, 5))
+                        .label(OPTIONAL)
+                        .type("string")
+                        .name("title")
+                        .tag(3)
+                        .build(),
+                    FieldElement.builder(location.at(5, 5))
+                        .label(REPEATED)
+                        .type("string")
+                        .name("snippets")
+                        .tag(4)
+                        .build()
+                ))
+                .build()
+        ))
+        .build();
+    String expected = ""
+        + "message SearchResponse {\n"
+        + "  repeated group Result = 1 {\n"
+        + "    required string url = 2;\n"
+        + "    optional string title = 3;\n"
+        + "    repeated string snippets = 4;\n"
+        + "  }\n"
         + "}\n";
     assertThat(element.toSchema()).isEqualTo(expected);
   }


### PR DESCRIPTION
This lets us test parsing against any valid syntax, but not implement in the linker/schema.