### PR TITLE
Always create a no-arg constructor

### DIFF
--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1286,6 +1286,13 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.ext_pack_nested_enum = Internal.immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private AllTypes() {
+    this(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<String>newMutableList(), Internal.<ByteString>newMutableList(), Internal.<NestedEnum>newMutableList(), Internal.<NestedMessage>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<NestedEnum>newMutableList(), null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<String>newMutableList(), Internal.<ByteString>newMutableList(), Internal.<NestedEnum>newMutableList(), Internal.<NestedMessage>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<NestedEnum>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -2817,6 +2824,13 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     public NestedMessage(Integer a, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.a = a;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private NestedMessage() {
+      this(null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/WireTest.java
@@ -15,6 +15,8 @@
  */
 package com.squareup.wire;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.squareup.wire.protos.RepeatedAndPacked;
 import com.squareup.wire.protos.edgecases.NoFields;
 import com.squareup.wire.protos.person.Person;
@@ -371,6 +373,12 @@ public class WireTest {
     } catch (NullPointerException expected) {
       assertThat(expected).hasMessage("phone == null");
     }
+  }
+
+  @Test public void listDeserializesToNonNull() {
+    Gson gson = new GsonBuilder().create();
+    Person person = gson.fromJson("{}", Person.class);
+    assertThat(person.phone).isEmpty();
   }
 
   @Test public void listElementsMustBeNonNull() {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
@@ -118,6 +118,13 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     this.reserved_name = Internal.immutableCopyOf("reserved_name", reserved_name);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private DescriptorProto() {
+    this(null, Internal.<FieldDescriptorProto>newMutableList(), Internal.<FieldDescriptorProto>newMutableList(), Internal.<DescriptorProto>newMutableList(), Internal.<EnumDescriptorProto>newMutableList(), Internal.<ExtensionRange>newMutableList(), Internal.<OneofDescriptorProto>newMutableList(), null, Internal.<ReservedRange>newMutableList(), Internal.<String>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -320,6 +327,13 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
       this.end = end;
     }
 
+    /**
+     * Used for deserialization.
+     */
+    private ExtensionRange() {
+      this(null, null, ByteString.EMPTY);
+    }
+
     @Override
     public Builder newBuilder() {
       Builder builder = new Builder();
@@ -470,6 +484,13 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
       super(ADAPTER, unknownFields);
       this.start = start;
       this.end = end;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private ReservedRange() {
+      this(null, null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
@@ -57,6 +57,13 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     this.options = options;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private EnumDescriptorProto() {
+    this(null, Internal.<EnumValueDescriptorProto>newMutableList(), null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
@@ -82,6 +82,13 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     this.enum_option = enum_option;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private EnumOptions() {
+    this(null, null, Internal.<UninterpretedOption>newMutableList(), null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -58,6 +58,13 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
     this.options = options;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private EnumValueDescriptorProto() {
+    this(null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
@@ -93,6 +93,13 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
     this.foreign_enum_value_option = foreign_enum_value_option;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private EnumValueOptions() {
+    this(null, Internal.<UninterpretedOption>newMutableList(), null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
@@ -139,6 +139,13 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
     this.options = options;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private FieldDescriptorProto() {
+    this(null, null, null, null, null, null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
@@ -270,6 +270,13 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     this.redacted = redacted;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private FieldOptions() {
+    this(null, null, null, null, null, null, Internal.<UninterpretedOption>newMutableList(), null, null, null, null, null, null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
@@ -160,6 +160,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     this.syntax = syntax;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private FileDescriptorProto() {
+    this(null, null, Internal.<String>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<DescriptorProto>newMutableList(), Internal.<EnumDescriptorProto>newMutableList(), Internal.<ServiceDescriptorProto>newMutableList(), Internal.<FieldDescriptorProto>newMutableList(), null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
@@ -42,6 +42,13 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
     this.file = Internal.immutableCopyOf("file", file);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private FileDescriptorSet() {
+    this(Internal.<FileDescriptorProto>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
@@ -278,6 +278,13 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     this.uninterpreted_option = Internal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private FileOptions() {
+    this(null, null, null, null, null, null, null, null, null, null, null, null, null, null, Internal.<UninterpretedOption>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
@@ -209,6 +209,13 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     this.foreign_message_option = foreign_message_option;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private MessageOptions() {
+    this(null, null, null, null, Internal.<UninterpretedOption>newMutableList(), null, null, null, null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
@@ -95,6 +95,13 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto, 
     this.server_streaming = server_streaming;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private MethodDescriptorProto() {
+    this(null, null, null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
@@ -61,6 +61,13 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     this.uninterpreted_option = Internal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private MethodOptions() {
+    this(null, Internal.<UninterpretedOption>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
@@ -41,6 +41,13 @@ public final class OneofDescriptorProto extends Message<OneofDescriptorProto, On
     this.name = name;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private OneofDescriptorProto() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
@@ -57,6 +57,13 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     this.options = options;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private ServiceDescriptorProto() {
+    this(null, Internal.<MethodDescriptorProto>newMutableList(), null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
@@ -61,6 +61,13 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     this.uninterpreted_option = Internal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private ServiceOptions() {
+    this(null, Internal.<UninterpretedOption>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
@@ -90,6 +90,13 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     this.location = Internal.immutableCopyOf("location", location);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private SourceCodeInfo() {
+    this(Internal.<Location>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -323,6 +330,13 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
       this.leading_comments = leading_comments;
       this.trailing_comments = trailing_comments;
       this.leading_detached_comments = Internal.immutableCopyOf("leading_detached_comments", leading_detached_comments);
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private Location() {
+      this(Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), null, null, Internal.<String>newMutableList(), ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
@@ -107,6 +107,13 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
     this.aggregate_value = aggregate_value;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private UninterpretedOption() {
+    this(Internal.<NamePart>newMutableList(), null, null, null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -269,6 +276,13 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
       super(ADAPTER, unknownFields);
       this.name_part = name_part;
       this.is_extension = is_extension;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private NamePart() {
+      this(null, null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -130,6 +130,13 @@ public final class Bar extends Message<Bar, Bar.Builder> {
         this.boo = boo;
       }
 
+      /**
+       * Used for deserialization.
+       */
+      private Moo() {
+        this(null, ByteString.EMPTY);
+      }
+
       @Override
       public Builder newBuilder() {
         Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -37,6 +37,13 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     this.moo = moo;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Foo() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
@@ -130,6 +130,13 @@ public final class Bar extends Message<Bar, Bar.Builder> {
         this.boo = boo;
       }
 
+      /**
+       * Used for deserialization.
+       */
+      private Moo() {
+        this(null, ByteString.EMPTY);
+      }
+
       @Override
       public Builder newBuilder() {
         Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
@@ -37,6 +37,13 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     this.moo = moo;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Foo() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
@@ -38,6 +38,13 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
     this.data = data;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private HeresAllTheDataRequest() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
@@ -38,6 +38,13 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
     this.data = data;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private HeresAllTheDataResponse() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
@@ -38,6 +38,13 @@ public final class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequ
     this.data = data;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private LetsDataRequest() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
@@ -38,6 +38,13 @@ public final class LetsDataResponse extends Message<LetsDataResponse, LetsDataRe
     this.data = data;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private LetsDataResponse() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -38,6 +38,13 @@ public final class SendDataRequest extends Message<SendDataRequest, SendDataRequ
     this.data = data;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private SendDataRequest() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -38,6 +38,13 @@ public final class SendDataResponse extends Message<SendDataResponse, SendDataRe
     this.data = data;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private SendDataResponse() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
@@ -39,6 +39,13 @@ public final class ChildPackage extends Message<ChildPackage, ChildPackage.Build
     this.inner_foreign_enum = inner_foreign_enum;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private ChildPackage() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -47,6 +47,13 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
     this.pack_int32 = Internal.immutableCopyOf("pack_int32", pack_int32);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private RepeatedAndPacked() {
+    this(Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1291,6 +1291,13 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.ext_pack_nested_enum = Internal.immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private AllTypes() {
+    this(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<String>newMutableList(), Internal.<ByteString>newMutableList(), Internal.<NestedEnum>newMutableList(), Internal.<NestedMessage>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<NestedEnum>newMutableList(), null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<String>newMutableList(), Internal.<ByteString>newMutableList(), Internal.<NestedEnum>newMutableList(), Internal.<NestedMessage>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<NestedEnum>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -2957,6 +2964,13 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     public NestedMessage(Integer a, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.a = a;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private NestedMessage() {
+      this(null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
@@ -1286,6 +1286,13 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.ext_pack_nested_enum = Internal.immutableCopyOf("ext_pack_nested_enum", ext_pack_nested_enum);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private AllTypes() {
+    this(null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<String>newMutableList(), Internal.<ByteString>newMutableList(), Internal.<NestedEnum>newMutableList(), Internal.<NestedMessage>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<NestedEnum>newMutableList(), null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, null, Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<String>newMutableList(), Internal.<ByteString>newMutableList(), Internal.<NestedEnum>newMutableList(), Internal.<NestedMessage>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Integer>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Long>newMutableList(), Internal.<Boolean>newMutableList(), Internal.<Float>newMutableList(), Internal.<Double>newMutableList(), Internal.<NestedEnum>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -2817,6 +2824,13 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     public NestedMessage(Integer a, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.a = a;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private NestedMessage() {
+      this(null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -167,6 +167,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     this.rep = Internal.immutableCopyOf("rep", rep);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private FooBar() {
+    this(null, null, null, null, Internal.<Float>newMutableList(), null, Internal.<FooBar>newMutableList(), null, Internal.<FooBarBazEnum>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -335,6 +342,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       this.value = value;
     }
 
+    /**
+     * Used for deserialization.
+     */
+    private Nested() {
+      this(null, ByteString.EMPTY);
+    }
+
     @Override
     public Builder newBuilder() {
       Builder builder = new Builder();
@@ -457,6 +471,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     public More(List<Integer> serial, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.serial = Internal.immutableCopyOf("serial", serial);
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private More() {
+      this(Internal.<Integer>newMutableList(), ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -117,6 +117,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     this.rep = Internal.immutableCopyOf("rep", rep);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private FooBar() {
+    this(null, null, null, null, Internal.<Float>newMutableList(), null, Internal.<FooBar>newMutableList(), null, Internal.<FooBarBazEnum>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -285,6 +292,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       this.value = value;
     }
 
+    /**
+     * Used for deserialization.
+     */
+    private Nested() {
+      this(null, ByteString.EMPTY);
+    }
+
     @Override
     public Builder newBuilder() {
       Builder builder = new Builder();
@@ -407,6 +421,13 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     public More(List<Integer> serial, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.serial = Internal.immutableCopyOf("serial", serial);
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private More() {
+      this(Internal.<Integer>newMutableList(), ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -38,6 +38,13 @@ public final class OneBytesField extends Message<OneBytesField, OneBytesField.Bu
     this.opt_bytes = opt_bytes;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private OneBytesField() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
@@ -39,6 +39,13 @@ public final class OneField extends Message<OneField, OneField.Builder> {
     this.opt_int32 = opt_int32;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private OneField() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -46,6 +46,13 @@ public final class Recursive extends Message<Recursive, Recursive.Builder> {
     this.recursive = recursive;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Recursive() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -51,6 +51,13 @@ public final class ForeignMessage extends Message<ForeignMessage, ForeignMessage
     this.j = j;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private ForeignMessage() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
@@ -118,6 +118,13 @@ public final class Message extends com.squareup.wire.Message<Message, Message.Bu
     this.message = message;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Message() {
+    this(null, null, null, null, null, null, null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
@@ -38,6 +38,13 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     this.bar = bar;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Foo() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -48,6 +48,13 @@ public final class OneExtension extends Message<OneExtension, OneExtension.Build
     this.foo = foo;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private OneExtension() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -69,6 +69,13 @@ public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Build
     this.baz = baz;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private OneOfMessage() {
+    this(null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
@@ -81,6 +81,13 @@ public final class Person extends Message<Person, Person.Builder> {
     this.phone = Internal.immutableCopyOf("phone", phone);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Person() {
+    this(null, null, null, Internal.<PhoneNumber>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -257,6 +264,13 @@ public final class Person extends Message<Person, Person.Builder> {
       super(ADAPTER, unknownFields);
       this.number = number;
       this.type = type;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private PhoneNumber() {
+      this(null, null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -102,6 +102,13 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     this.phone = Internal.immutableCopyOf("phone", phone);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Person() {
+    this(null, null, null, Internal.<PhoneNumber>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -305,6 +312,13 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       super(ADAPTER, unknownFields);
       this.number = number;
       this.type = type;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private PhoneNumber() {
+      this(null, null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -47,6 +47,13 @@ public final class NotRedacted extends Message<NotRedacted, NotRedacted.Builder>
     this.b = b;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private NotRedacted() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
@@ -76,6 +76,13 @@ public final class Redacted extends Message<Redacted, Redacted.Builder> {
     this.extension = extension;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Redacted() {
+    this(null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -52,6 +52,13 @@ public final class RedactedChild extends Message<RedactedChild, RedactedChild.Bu
     this.c = c;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private RedactedChild() {
+    this(null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -36,6 +36,13 @@ public final class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA
     this.b = b;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private RedactedCycleA() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -36,6 +36,13 @@ public final class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB
     this.a = a;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private RedactedCycleB() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -53,6 +53,13 @@ public final class RedactedExtension extends Message<RedactedExtension, Redacted
     this.e = e;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private RedactedExtension() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -56,6 +56,13 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
     this.b = Internal.immutableCopyOf("b", b);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private RedactedRepeated() {
+    this(Internal.<String>newMutableList(), Internal.<Redacted>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -46,6 +46,13 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
     this.a = a;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private RedactedRequired() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
@@ -58,6 +58,13 @@ public final class A extends Message<A, A.Builder> {
     this.d = d;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private A() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
@@ -51,6 +51,13 @@ public final class A extends Message<A, A.Builder> {
     this.d = d;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private A() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
@@ -37,6 +37,13 @@ public final class B extends Message<B, B.Builder> {
     this.c = c;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private B() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
@@ -39,6 +39,13 @@ public final class C extends Message<C, C.Builder> {
     this.i = i;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private C() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
@@ -39,6 +39,13 @@ public final class D extends Message<D, D.Builder> {
     this.i = i;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private D() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
@@ -39,6 +39,13 @@ public final class D extends Message<D, D.Builder> {
     this.i = i;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private D() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
@@ -46,6 +46,13 @@ public final class E extends Message<E, E.Builder> {
     this.g = g;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private E() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -129,6 +136,13 @@ public final class E extends Message<E, E.Builder> {
     public F(Integer i, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.i = i;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private F() {
+      this(null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
@@ -36,6 +36,13 @@ public final class H extends Message<H, H.Builder> {
     this.ef = ef;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private H() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
@@ -49,6 +49,13 @@ public final class I extends Message<I, I.Builder> {
     this.j = j;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private I() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
@@ -36,6 +36,13 @@ public final class J extends Message<J, J.Builder> {
     this.k = k;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private J() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
@@ -39,6 +39,13 @@ public final class K extends Message<K, K.Builder> {
     this.i = i;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private K() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -98,6 +98,13 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
     this.nested_enum_ext = nested_enum_ext;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private ExternalMessage() {
+    this(null, Internal.<Integer>newMutableList(), null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -179,6 +179,13 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     this.o = o;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private SimpleMessage() {
+    this(null, null, null, null, null, Internal.<Double>newMutableList(), null, null, null, null, null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
@@ -415,6 +422,13 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     public NestedMessage(Integer bb, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.bb = bb;
+    }
+
+    /**
+     * Used for deserialization.
+     */
+    private NestedMessage() {
+      this(null, ByteString.EMPTY);
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -39,6 +39,13 @@ public final class Bar extends Message<Bar, Bar.Builder> {
     this.baz = baz;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Bar() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -38,6 +38,13 @@ public final class Bars extends Message<Bars, Bars.Builder> {
     this.bars = Internal.immutableCopyOf("bars", bars);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Bars() {
+    this(Internal.<Bar>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
@@ -39,6 +39,13 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     this.bar = bar;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Foo() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
@@ -38,6 +38,13 @@ public final class Foos extends Message<Foos, Foos.Builder> {
     this.foos = Internal.immutableCopyOf("foos", foos);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private Foos() {
+    this(Internal.<Foo>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -39,6 +39,13 @@ public final class VersionOne extends Message<VersionOne, VersionOne.Builder> {
     this.i = i;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private VersionOne() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -85,6 +85,13 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     this.v2_rs = Internal.immutableCopyOf("v2_rs", v2_rs);
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private VersionTwo() {
+    this(null, null, null, null, null, Internal.<String>newMutableList(), ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
@@ -46,6 +46,13 @@ public final class CollisionSubject extends Message<CollisionSubject, CollisionS
     this.f = f;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private CollisionSubject() {
+    this(null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
@@ -48,6 +48,13 @@ public final class EmbeddedMessage extends Message<EmbeddedMessage, EmbeddedMess
     this.inner_number_after = inner_number_after;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private EmbeddedMessage() {
+    this(Internal.<Integer>newMutableList(), null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();

--- a/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/OuterMessage.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/OuterMessage.java
@@ -46,6 +46,13 @@ public final class OuterMessage extends Message<OuterMessage, OuterMessage.Build
     this.embedded_message = embedded_message;
   }
 
+  /**
+   * Used for deserialization.
+   */
+  private OuterMessage() {
+    this(null, null, ByteString.EMPTY);
+  }
+
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();


### PR DESCRIPTION
The no-arg constructor is invoked during deserialization and ensures that fields (e.g. Lists) are initialized properly.