### PR TITLE
Pipe map support through the schema.

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
@@ -181,6 +181,9 @@ public final class Field {
   }
 
   Field retainAll(Schema schema, MarkSet markSet) {
+    // For map types only the value can participate in pruning as the key will always be scalar.
+    if (type.isMap() && !markSet.contains(type.valueType())) return null;
+
     if (!markSet.contains(type)) return null;
 
     Field result = new Field(packageName, location, label, name, documentation, tag, defaultValue,

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
@@ -175,6 +175,9 @@ final class Pruner {
   }
 
   private void mark(ProtoType type) {
+    // Map key type is always scalar. No need to mark it.
+    if (type.isMap()) type = type.valueType();
+
     if (marks.mark(type)) {
       queue.add(type); // The transitive dependencies of this type must be visited.
     }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/SchemaProtoAdapterFactory.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/SchemaProtoAdapterFactory.java
@@ -56,6 +56,8 @@ final class SchemaProtoAdapterFactory {
   }
 
   public ProtoAdapter<Object> get(ProtoType protoType) {
+    if (protoType.isMap()) throw new UnsupportedOperationException("map types not supported");
+
     ProtoAdapter<?> result = adapterMap.get(protoType);
     if (result != null) {
       return (ProtoAdapter<Object>) result;

--- a/wire-schema/src/test/java/com/squareup/wire/schema/ProtoTypeTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/ProtoTypeTest.java
@@ -52,6 +52,46 @@ public final class ProtoTypeTest {
     }
   }
 
+  @Test public void mapsCannotNest() throws Exception {
+    try {
+      ProtoType.get("map<string, string>").nestedType("PhoneType");
+      fail();
+    } catch (UnsupportedOperationException expected) {
+    }
+  }
+
+  @Test public void mapFormat() throws Exception {
+    try {
+      ProtoType.get("map<string>");
+      fail();
+    } catch (IllegalArgumentException e) {
+      assertThat(e).hasMessage("expected ',' in map type: map<string>");
+    }
+  }
+
+  @Test public void mapKeyScalarType() throws Exception {
+    try {
+      ProtoType.get("map<bytes, string>");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      ProtoType.get("map<double, string>");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      ProtoType.get("map<float, string>");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+    try {
+      ProtoType.get("map<some.Message, string>");
+      fail();
+    } catch (IllegalArgumentException expected) {
+    }
+  }
+
   @Test public void messageToString() throws Exception {
     ProtoType person = ProtoType.get("squareup.protos.person.Person");
     assertThat(person.toString()).isEqualTo("squareup.protos.person.Person");

--- a/wire-schema/src/test/java/com/squareup/wire/schema/PrunerTest.java
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/PrunerTest.java
@@ -68,7 +68,7 @@ public final class PrunerTest {
             + "  optional MessageB b = 1;\n"
             + "}\n"
             + "message MessageB {\n"
-            + "  optional MessageC c = 1;\n"
+            + "  map<string, MessageC> c = 1;\n"
             + "}\n"
             + "message MessageC {\n"
             + "}\n"
@@ -116,7 +116,7 @@ public final class PrunerTest {
         .add("service.proto", ""
             + "message MessageA {\n"
             + "  optional string b = 1;\n"
-            + "  optional string c = 2;\n"
+            + "  map<string, string> c = 2;\n"
             + "}\n"
             + "message MessageB {\n"
             + "}\n")
@@ -426,7 +426,7 @@ public final class PrunerTest {
         .add("service.proto", ""
             + "message MessageA {\n"
             + "  optional MessageB b = 1;\n"
-            + "  optional MessageC c = 2;\n"
+            + "  map<string, MessageC> c = 2;\n"
             + "}\n"
             + "message MessageB {\n"
             + "}\n"
@@ -493,20 +493,26 @@ public final class PrunerTest {
             + "message MessageA {\n"
             + "  optional MessageB b = 1;\n"
             + "  optional MessageC c = 2;\n"
+            + "  map<string, MessageD> d = 3;\n"
             + "}\n"
             + "message MessageB {\n"
             + "}\n"
             + "message MessageC {\n"
+            + "}\n"
+            + "message MessageD {\n"
             + "}\n")
         .build();
     Schema pruned = schema.prune(new IdentifierSet.Builder()
         .include("MessageA")
         .exclude("MessageA#c")
+        .exclude("MessageA#d")
         .build());
     assertThat(((MessageType) pruned.getType("MessageA")).field("b")).isNotNull();
     assertThat(pruned.getType("MessageB")).isNotNull();
     assertThat(((MessageType) pruned.getType("MessageA")).field("c")).isNull();
     assertThat(pruned.getType("MessageC")).isNull();
+    assertThat(((MessageType) pruned.getType("MessageA")).field("d")).isNull();
+    assertThat(pruned.getType("MessageD")).isNull();
   }
 
   @Test public void excludeEnumExcludesOptions() throws Exception {


### PR DESCRIPTION
This allows for linking and pruning. The schema-based proto adapter and code generation are not supported.

Refs #279.