### PR TITLE
Eliminate null checks for repeated fields.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
       <dependency>
         <groupId>com.squareup</groupId>
         <artifactId>javapoet</artifactId>
-        <version>1.4.0</version>
+        <version>1.7.0</version>
       </dependency>
       <dependency>
         <groupId>com.google.auto.value</groupId>

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -61,9 +61,9 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
     if (other == this) return true;
     if (!(other instanceof RepeatedAndPacked)) return false;
     RepeatedAndPacked o = (RepeatedAndPacked) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(rep_int32, o.rep_int32)
-        && Internal.equals(pack_int32, o.pack_int32);
+    return unknownFields().equals(o.unknownFields())
+        && rep_int32.equals(o.rep_int32)
+        && pack_int32.equals(o.pack_int32);
   }
 
   @Override
@@ -71,8 +71,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (rep_int32 != null ? rep_int32.hashCode() : 1);
-      result = result * 37 + (pack_int32 != null ? pack_int32.hashCode() : 1);
+      result = result * 37 + rep_int32.hashCode();
+      result = result * 37 + pack_int32.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -81,8 +81,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (rep_int32 != null) builder.append(", rep_int32=").append(rep_int32);
-    if (pack_int32 != null) builder.append(", pack_int32=").append(pack_int32);
+    if (!rep_int32.isEmpty()) builder.append(", rep_int32=").append(rep_int32);
+    if (!pack_int32.isEmpty()) builder.append(", pack_int32=").append(pack_int32);
     return builder.replace(0, 2, "RepeatedAndPacked{").append('}').toString();
   }
 
@@ -128,8 +128,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
 
     @Override
     public void encode(ProtoWriter writer, RepeatedAndPacked value) throws IOException {
-      if (value.rep_int32 != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32);
-      if (value.pack_int32 != null) ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 301, value.pack_int32);
+      ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32);
+      ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 301, value.pack_int32);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1427,7 +1427,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(opt_int32, o.opt_int32)
         && Internal.equals(opt_uint32, o.opt_uint32)
         && Internal.equals(opt_sint32, o.opt_sint32)
@@ -1445,54 +1445,54 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
         && Internal.equals(opt_bytes, o.opt_bytes)
         && Internal.equals(opt_nested_enum, o.opt_nested_enum)
         && Internal.equals(opt_nested_message, o.opt_nested_message)
-        && Internal.equals(req_int32, o.req_int32)
-        && Internal.equals(req_uint32, o.req_uint32)
-        && Internal.equals(req_sint32, o.req_sint32)
-        && Internal.equals(req_fixed32, o.req_fixed32)
-        && Internal.equals(req_sfixed32, o.req_sfixed32)
-        && Internal.equals(req_int64, o.req_int64)
-        && Internal.equals(req_uint64, o.req_uint64)
-        && Internal.equals(req_sint64, o.req_sint64)
-        && Internal.equals(req_fixed64, o.req_fixed64)
-        && Internal.equals(req_sfixed64, o.req_sfixed64)
-        && Internal.equals(req_bool, o.req_bool)
-        && Internal.equals(req_float, o.req_float)
-        && Internal.equals(req_double, o.req_double)
-        && Internal.equals(req_string, o.req_string)
-        && Internal.equals(req_bytes, o.req_bytes)
-        && Internal.equals(req_nested_enum, o.req_nested_enum)
-        && Internal.equals(req_nested_message, o.req_nested_message)
-        && Internal.equals(rep_int32, o.rep_int32)
-        && Internal.equals(rep_uint32, o.rep_uint32)
-        && Internal.equals(rep_sint32, o.rep_sint32)
-        && Internal.equals(rep_fixed32, o.rep_fixed32)
-        && Internal.equals(rep_sfixed32, o.rep_sfixed32)
-        && Internal.equals(rep_int64, o.rep_int64)
-        && Internal.equals(rep_uint64, o.rep_uint64)
-        && Internal.equals(rep_sint64, o.rep_sint64)
-        && Internal.equals(rep_fixed64, o.rep_fixed64)
-        && Internal.equals(rep_sfixed64, o.rep_sfixed64)
-        && Internal.equals(rep_bool, o.rep_bool)
-        && Internal.equals(rep_float, o.rep_float)
-        && Internal.equals(rep_double, o.rep_double)
-        && Internal.equals(rep_string, o.rep_string)
-        && Internal.equals(rep_bytes, o.rep_bytes)
-        && Internal.equals(rep_nested_enum, o.rep_nested_enum)
-        && Internal.equals(rep_nested_message, o.rep_nested_message)
-        && Internal.equals(pack_int32, o.pack_int32)
-        && Internal.equals(pack_uint32, o.pack_uint32)
-        && Internal.equals(pack_sint32, o.pack_sint32)
-        && Internal.equals(pack_fixed32, o.pack_fixed32)
-        && Internal.equals(pack_sfixed32, o.pack_sfixed32)
-        && Internal.equals(pack_int64, o.pack_int64)
-        && Internal.equals(pack_uint64, o.pack_uint64)
-        && Internal.equals(pack_sint64, o.pack_sint64)
-        && Internal.equals(pack_fixed64, o.pack_fixed64)
-        && Internal.equals(pack_sfixed64, o.pack_sfixed64)
-        && Internal.equals(pack_bool, o.pack_bool)
-        && Internal.equals(pack_float, o.pack_float)
-        && Internal.equals(pack_double, o.pack_double)
-        && Internal.equals(pack_nested_enum, o.pack_nested_enum)
+        && req_int32.equals(o.req_int32)
+        && req_uint32.equals(o.req_uint32)
+        && req_sint32.equals(o.req_sint32)
+        && req_fixed32.equals(o.req_fixed32)
+        && req_sfixed32.equals(o.req_sfixed32)
+        && req_int64.equals(o.req_int64)
+        && req_uint64.equals(o.req_uint64)
+        && req_sint64.equals(o.req_sint64)
+        && req_fixed64.equals(o.req_fixed64)
+        && req_sfixed64.equals(o.req_sfixed64)
+        && req_bool.equals(o.req_bool)
+        && req_float.equals(o.req_float)
+        && req_double.equals(o.req_double)
+        && req_string.equals(o.req_string)
+        && req_bytes.equals(o.req_bytes)
+        && req_nested_enum.equals(o.req_nested_enum)
+        && req_nested_message.equals(o.req_nested_message)
+        && rep_int32.equals(o.rep_int32)
+        && rep_uint32.equals(o.rep_uint32)
+        && rep_sint32.equals(o.rep_sint32)
+        && rep_fixed32.equals(o.rep_fixed32)
+        && rep_sfixed32.equals(o.rep_sfixed32)
+        && rep_int64.equals(o.rep_int64)
+        && rep_uint64.equals(o.rep_uint64)
+        && rep_sint64.equals(o.rep_sint64)
+        && rep_fixed64.equals(o.rep_fixed64)
+        && rep_sfixed64.equals(o.rep_sfixed64)
+        && rep_bool.equals(o.rep_bool)
+        && rep_float.equals(o.rep_float)
+        && rep_double.equals(o.rep_double)
+        && rep_string.equals(o.rep_string)
+        && rep_bytes.equals(o.rep_bytes)
+        && rep_nested_enum.equals(o.rep_nested_enum)
+        && rep_nested_message.equals(o.rep_nested_message)
+        && pack_int32.equals(o.pack_int32)
+        && pack_uint32.equals(o.pack_uint32)
+        && pack_sint32.equals(o.pack_sint32)
+        && pack_fixed32.equals(o.pack_fixed32)
+        && pack_sfixed32.equals(o.pack_sfixed32)
+        && pack_int64.equals(o.pack_int64)
+        && pack_uint64.equals(o.pack_uint64)
+        && pack_sint64.equals(o.pack_sint64)
+        && pack_fixed64.equals(o.pack_fixed64)
+        && pack_sfixed64.equals(o.pack_sfixed64)
+        && pack_bool.equals(o.pack_bool)
+        && pack_float.equals(o.pack_float)
+        && pack_double.equals(o.pack_double)
+        && pack_nested_enum.equals(o.pack_nested_enum)
         && Internal.equals(default_int32, o.default_int32)
         && Internal.equals(default_uint32, o.default_uint32)
         && Internal.equals(default_sint32, o.default_sint32)
@@ -1526,37 +1526,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
         && Internal.equals(ext_opt_bytes, o.ext_opt_bytes)
         && Internal.equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
         && Internal.equals(ext_opt_nested_message, o.ext_opt_nested_message)
-        && Internal.equals(ext_rep_int32, o.ext_rep_int32)
-        && Internal.equals(ext_rep_uint32, o.ext_rep_uint32)
-        && Internal.equals(ext_rep_sint32, o.ext_rep_sint32)
-        && Internal.equals(ext_rep_fixed32, o.ext_rep_fixed32)
-        && Internal.equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
-        && Internal.equals(ext_rep_int64, o.ext_rep_int64)
-        && Internal.equals(ext_rep_uint64, o.ext_rep_uint64)
-        && Internal.equals(ext_rep_sint64, o.ext_rep_sint64)
-        && Internal.equals(ext_rep_fixed64, o.ext_rep_fixed64)
-        && Internal.equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
-        && Internal.equals(ext_rep_bool, o.ext_rep_bool)
-        && Internal.equals(ext_rep_float, o.ext_rep_float)
-        && Internal.equals(ext_rep_double, o.ext_rep_double)
-        && Internal.equals(ext_rep_string, o.ext_rep_string)
-        && Internal.equals(ext_rep_bytes, o.ext_rep_bytes)
-        && Internal.equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
-        && Internal.equals(ext_rep_nested_message, o.ext_rep_nested_message)
-        && Internal.equals(ext_pack_int32, o.ext_pack_int32)
-        && Internal.equals(ext_pack_uint32, o.ext_pack_uint32)
-        && Internal.equals(ext_pack_sint32, o.ext_pack_sint32)
-        && Internal.equals(ext_pack_fixed32, o.ext_pack_fixed32)
-        && Internal.equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
-        && Internal.equals(ext_pack_int64, o.ext_pack_int64)
-        && Internal.equals(ext_pack_uint64, o.ext_pack_uint64)
-        && Internal.equals(ext_pack_sint64, o.ext_pack_sint64)
-        && Internal.equals(ext_pack_fixed64, o.ext_pack_fixed64)
-        && Internal.equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
-        && Internal.equals(ext_pack_bool, o.ext_pack_bool)
-        && Internal.equals(ext_pack_float, o.ext_pack_float)
-        && Internal.equals(ext_pack_double, o.ext_pack_double)
-        && Internal.equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
+        && ext_rep_int32.equals(o.ext_rep_int32)
+        && ext_rep_uint32.equals(o.ext_rep_uint32)
+        && ext_rep_sint32.equals(o.ext_rep_sint32)
+        && ext_rep_fixed32.equals(o.ext_rep_fixed32)
+        && ext_rep_sfixed32.equals(o.ext_rep_sfixed32)
+        && ext_rep_int64.equals(o.ext_rep_int64)
+        && ext_rep_uint64.equals(o.ext_rep_uint64)
+        && ext_rep_sint64.equals(o.ext_rep_sint64)
+        && ext_rep_fixed64.equals(o.ext_rep_fixed64)
+        && ext_rep_sfixed64.equals(o.ext_rep_sfixed64)
+        && ext_rep_bool.equals(o.ext_rep_bool)
+        && ext_rep_float.equals(o.ext_rep_float)
+        && ext_rep_double.equals(o.ext_rep_double)
+        && ext_rep_string.equals(o.ext_rep_string)
+        && ext_rep_bytes.equals(o.ext_rep_bytes)
+        && ext_rep_nested_enum.equals(o.ext_rep_nested_enum)
+        && ext_rep_nested_message.equals(o.ext_rep_nested_message)
+        && ext_pack_int32.equals(o.ext_pack_int32)
+        && ext_pack_uint32.equals(o.ext_pack_uint32)
+        && ext_pack_sint32.equals(o.ext_pack_sint32)
+        && ext_pack_fixed32.equals(o.ext_pack_fixed32)
+        && ext_pack_sfixed32.equals(o.ext_pack_sfixed32)
+        && ext_pack_int64.equals(o.ext_pack_int64)
+        && ext_pack_uint64.equals(o.ext_pack_uint64)
+        && ext_pack_sint64.equals(o.ext_pack_sint64)
+        && ext_pack_fixed64.equals(o.ext_pack_fixed64)
+        && ext_pack_sfixed64.equals(o.ext_pack_sfixed64)
+        && ext_pack_bool.equals(o.ext_pack_bool)
+        && ext_pack_float.equals(o.ext_pack_float)
+        && ext_pack_double.equals(o.ext_pack_double)
+        && ext_pack_nested_enum.equals(o.ext_pack_nested_enum);
   }
 
   @Override
@@ -1581,54 +1581,54 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       result = result * 37 + (opt_bytes != null ? opt_bytes.hashCode() : 0);
       result = result * 37 + (opt_nested_enum != null ? opt_nested_enum.hashCode() : 0);
       result = result * 37 + (opt_nested_message != null ? opt_nested_message.hashCode() : 0);
-      result = result * 37 + (req_int32 != null ? req_int32.hashCode() : 0);
-      result = result * 37 + (req_uint32 != null ? req_uint32.hashCode() : 0);
-      result = result * 37 + (req_sint32 != null ? req_sint32.hashCode() : 0);
-      result = result * 37 + (req_fixed32 != null ? req_fixed32.hashCode() : 0);
-      result = result * 37 + (req_sfixed32 != null ? req_sfixed32.hashCode() : 0);
-      result = result * 37 + (req_int64 != null ? req_int64.hashCode() : 0);
-      result = result * 37 + (req_uint64 != null ? req_uint64.hashCode() : 0);
-      result = result * 37 + (req_sint64 != null ? req_sint64.hashCode() : 0);
-      result = result * 37 + (req_fixed64 != null ? req_fixed64.hashCode() : 0);
-      result = result * 37 + (req_sfixed64 != null ? req_sfixed64.hashCode() : 0);
-      result = result * 37 + (req_bool != null ? req_bool.hashCode() : 0);
-      result = result * 37 + (req_float != null ? req_float.hashCode() : 0);
-      result = result * 37 + (req_double != null ? req_double.hashCode() : 0);
-      result = result * 37 + (req_string != null ? req_string.hashCode() : 0);
-      result = result * 37 + (req_bytes != null ? req_bytes.hashCode() : 0);
-      result = result * 37 + (req_nested_enum != null ? req_nested_enum.hashCode() : 0);
-      result = result * 37 + (req_nested_message != null ? req_nested_message.hashCode() : 0);
-      result = result * 37 + (rep_int32 != null ? rep_int32.hashCode() : 1);
-      result = result * 37 + (rep_uint32 != null ? rep_uint32.hashCode() : 1);
-      result = result * 37 + (rep_sint32 != null ? rep_sint32.hashCode() : 1);
-      result = result * 37 + (rep_fixed32 != null ? rep_fixed32.hashCode() : 1);
-      result = result * 37 + (rep_sfixed32 != null ? rep_sfixed32.hashCode() : 1);
-      result = result * 37 + (rep_int64 != null ? rep_int64.hashCode() : 1);
-      result = result * 37 + (rep_uint64 != null ? rep_uint64.hashCode() : 1);
-      result = result * 37 + (rep_sint64 != null ? rep_sint64.hashCode() : 1);
-      result = result * 37 + (rep_fixed64 != null ? rep_fixed64.hashCode() : 1);
-      result = result * 37 + (rep_sfixed64 != null ? rep_sfixed64.hashCode() : 1);
-      result = result * 37 + (rep_bool != null ? rep_bool.hashCode() : 1);
-      result = result * 37 + (rep_float != null ? rep_float.hashCode() : 1);
-      result = result * 37 + (rep_double != null ? rep_double.hashCode() : 1);
-      result = result * 37 + (rep_string != null ? rep_string.hashCode() : 1);
-      result = result * 37 + (rep_bytes != null ? rep_bytes.hashCode() : 1);
-      result = result * 37 + (rep_nested_enum != null ? rep_nested_enum.hashCode() : 1);
-      result = result * 37 + (rep_nested_message != null ? rep_nested_message.hashCode() : 1);
-      result = result * 37 + (pack_int32 != null ? pack_int32.hashCode() : 1);
-      result = result * 37 + (pack_uint32 != null ? pack_uint32.hashCode() : 1);
-      result = result * 37 + (pack_sint32 != null ? pack_sint32.hashCode() : 1);
-      result = result * 37 + (pack_fixed32 != null ? pack_fixed32.hashCode() : 1);
-      result = result * 37 + (pack_sfixed32 != null ? pack_sfixed32.hashCode() : 1);
-      result = result * 37 + (pack_int64 != null ? pack_int64.hashCode() : 1);
-      result = result * 37 + (pack_uint64 != null ? pack_uint64.hashCode() : 1);
-      result = result * 37 + (pack_sint64 != null ? pack_sint64.hashCode() : 1);
-      result = result * 37 + (pack_fixed64 != null ? pack_fixed64.hashCode() : 1);
-      result = result * 37 + (pack_sfixed64 != null ? pack_sfixed64.hashCode() : 1);
-      result = result * 37 + (pack_bool != null ? pack_bool.hashCode() : 1);
-      result = result * 37 + (pack_float != null ? pack_float.hashCode() : 1);
-      result = result * 37 + (pack_double != null ? pack_double.hashCode() : 1);
-      result = result * 37 + (pack_nested_enum != null ? pack_nested_enum.hashCode() : 1);
+      result = result * 37 + req_int32.hashCode();
+      result = result * 37 + req_uint32.hashCode();
+      result = result * 37 + req_sint32.hashCode();
+      result = result * 37 + req_fixed32.hashCode();
+      result = result * 37 + req_sfixed32.hashCode();
+      result = result * 37 + req_int64.hashCode();
+      result = result * 37 + req_uint64.hashCode();
+      result = result * 37 + req_sint64.hashCode();
+      result = result * 37 + req_fixed64.hashCode();
+      result = result * 37 + req_sfixed64.hashCode();
+      result = result * 37 + req_bool.hashCode();
+      result = result * 37 + req_float.hashCode();
+      result = result * 37 + req_double.hashCode();
+      result = result * 37 + req_string.hashCode();
+      result = result * 37 + req_bytes.hashCode();
+      result = result * 37 + req_nested_enum.hashCode();
+      result = result * 37 + req_nested_message.hashCode();
+      result = result * 37 + rep_int32.hashCode();
+      result = result * 37 + rep_uint32.hashCode();
+      result = result * 37 + rep_sint32.hashCode();
+      result = result * 37 + rep_fixed32.hashCode();
+      result = result * 37 + rep_sfixed32.hashCode();
+      result = result * 37 + rep_int64.hashCode();
+      result = result * 37 + rep_uint64.hashCode();
+      result = result * 37 + rep_sint64.hashCode();
+      result = result * 37 + rep_fixed64.hashCode();
+      result = result * 37 + rep_sfixed64.hashCode();
+      result = result * 37 + rep_bool.hashCode();
+      result = result * 37 + rep_float.hashCode();
+      result = result * 37 + rep_double.hashCode();
+      result = result * 37 + rep_string.hashCode();
+      result = result * 37 + rep_bytes.hashCode();
+      result = result * 37 + rep_nested_enum.hashCode();
+      result = result * 37 + rep_nested_message.hashCode();
+      result = result * 37 + pack_int32.hashCode();
+      result = result * 37 + pack_uint32.hashCode();
+      result = result * 37 + pack_sint32.hashCode();
+      result = result * 37 + pack_fixed32.hashCode();
+      result = result * 37 + pack_sfixed32.hashCode();
+      result = result * 37 + pack_int64.hashCode();
+      result = result * 37 + pack_uint64.hashCode();
+      result = result * 37 + pack_sint64.hashCode();
+      result = result * 37 + pack_fixed64.hashCode();
+      result = result * 37 + pack_sfixed64.hashCode();
+      result = result * 37 + pack_bool.hashCode();
+      result = result * 37 + pack_float.hashCode();
+      result = result * 37 + pack_double.hashCode();
+      result = result * 37 + pack_nested_enum.hashCode();
       result = result * 37 + (default_int32 != null ? default_int32.hashCode() : 0);
       result = result * 37 + (default_uint32 != null ? default_uint32.hashCode() : 0);
       result = result * 37 + (default_sint32 != null ? default_sint32.hashCode() : 0);
@@ -1662,37 +1662,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       result = result * 37 + (ext_opt_bytes != null ? ext_opt_bytes.hashCode() : 0);
       result = result * 37 + (ext_opt_nested_enum != null ? ext_opt_nested_enum.hashCode() : 0);
       result = result * 37 + (ext_opt_nested_message != null ? ext_opt_nested_message.hashCode() : 0);
-      result = result * 37 + (ext_rep_int32 != null ? ext_rep_int32.hashCode() : 1);
-      result = result * 37 + (ext_rep_uint32 != null ? ext_rep_uint32.hashCode() : 1);
-      result = result * 37 + (ext_rep_sint32 != null ? ext_rep_sint32.hashCode() : 1);
-      result = result * 37 + (ext_rep_fixed32 != null ? ext_rep_fixed32.hashCode() : 1);
-      result = result * 37 + (ext_rep_sfixed32 != null ? ext_rep_sfixed32.hashCode() : 1);
-      result = result * 37 + (ext_rep_int64 != null ? ext_rep_int64.hashCode() : 1);
-      result = result * 37 + (ext_rep_uint64 != null ? ext_rep_uint64.hashCode() : 1);
-      result = result * 37 + (ext_rep_sint64 != null ? ext_rep_sint64.hashCode() : 1);
-      result = result * 37 + (ext_rep_fixed64 != null ? ext_rep_fixed64.hashCode() : 1);
-      result = result * 37 + (ext_rep_sfixed64 != null ? ext_rep_sfixed64.hashCode() : 1);
-      result = result * 37 + (ext_rep_bool != null ? ext_rep_bool.hashCode() : 1);
-      result = result * 37 + (ext_rep_float != null ? ext_rep_float.hashCode() : 1);
-      result = result * 37 + (ext_rep_double != null ? ext_rep_double.hashCode() : 1);
-      result = result * 37 + (ext_rep_string != null ? ext_rep_string.hashCode() : 1);
-      result = result * 37 + (ext_rep_bytes != null ? ext_rep_bytes.hashCode() : 1);
-      result = result * 37 + (ext_rep_nested_enum != null ? ext_rep_nested_enum.hashCode() : 1);
-      result = result * 37 + (ext_rep_nested_message != null ? ext_rep_nested_message.hashCode() : 1);
-      result = result * 37 + (ext_pack_int32 != null ? ext_pack_int32.hashCode() : 1);
-      result = result * 37 + (ext_pack_uint32 != null ? ext_pack_uint32.hashCode() : 1);
-      result = result * 37 + (ext_pack_sint32 != null ? ext_pack_sint32.hashCode() : 1);
-      result = result * 37 + (ext_pack_fixed32 != null ? ext_pack_fixed32.hashCode() : 1);
-      result = result * 37 + (ext_pack_sfixed32 != null ? ext_pack_sfixed32.hashCode() : 1);
-      result = result * 37 + (ext_pack_int64 != null ? ext_pack_int64.hashCode() : 1);
-      result = result * 37 + (ext_pack_uint64 != null ? ext_pack_uint64.hashCode() : 1);
-      result = result * 37 + (ext_pack_sint64 != null ? ext_pack_sint64.hashCode() : 1);
-      result = result * 37 + (ext_pack_fixed64 != null ? ext_pack_fixed64.hashCode() : 1);
-      result = result * 37 + (ext_pack_sfixed64 != null ? ext_pack_sfixed64.hashCode() : 1);
-      result = result * 37 + (ext_pack_bool != null ? ext_pack_bool.hashCode() : 1);
-      result = result * 37 + (ext_pack_float != null ? ext_pack_float.hashCode() : 1);
-      result = result * 37 + (ext_pack_double != null ? ext_pack_double.hashCode() : 1);
-      result = result * 37 + (ext_pack_nested_enum != null ? ext_pack_nested_enum.hashCode() : 1);
+      result = result * 37 + ext_rep_int32.hashCode();
+      result = result * 37 + ext_rep_uint32.hashCode();
+      result = result * 37 + ext_rep_sint32.hashCode();
+      result = result * 37 + ext_rep_fixed32.hashCode();
+      result = result * 37 + ext_rep_sfixed32.hashCode();
+      result = result * 37 + ext_rep_int64.hashCode();
+      result = result * 37 + ext_rep_uint64.hashCode();
+      result = result * 37 + ext_rep_sint64.hashCode();
+      result = result * 37 + ext_rep_fixed64.hashCode();
+      result = result * 37 + ext_rep_sfixed64.hashCode();
+      result = result * 37 + ext_rep_bool.hashCode();
+      result = result * 37 + ext_rep_float.hashCode();
+      result = result * 37 + ext_rep_double.hashCode();
+      result = result * 37 + ext_rep_string.hashCode();
+      result = result * 37 + ext_rep_bytes.hashCode();
+      result = result * 37 + ext_rep_nested_enum.hashCode();
+      result = result * 37 + ext_rep_nested_message.hashCode();
+      result = result * 37 + ext_pack_int32.hashCode();
+      result = result * 37 + ext_pack_uint32.hashCode();
+      result = result * 37 + ext_pack_sint32.hashCode();
+      result = result * 37 + ext_pack_fixed32.hashCode();
+      result = result * 37 + ext_pack_sfixed32.hashCode();
+      result = result * 37 + ext_pack_int64.hashCode();
+      result = result * 37 + ext_pack_uint64.hashCode();
+      result = result * 37 + ext_pack_sint64.hashCode();
+      result = result * 37 + ext_pack_fixed64.hashCode();
+      result = result * 37 + ext_pack_sfixed64.hashCode();
+      result = result * 37 + ext_pack_bool.hashCode();
+      result = result * 37 + ext_pack_float.hashCode();
+      result = result * 37 + ext_pack_double.hashCode();
+      result = result * 37 + ext_pack_nested_enum.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -2832,7 +2832,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(a, o.a);
     }
 

--- a/wire-runtime/src/test/java/com/squareup/wire/TestAllTypesData.java
+++ b/wire-runtime/src/test/java/com/squareup/wire/TestAllTypesData.java
@@ -36,14 +36,7 @@ class TestAllTypesData {
       + "ed32=[114, 114], pack_sfixed32=[115, 115], pack_int64=[116, 116], pack_uint64=[117, 117], "
       + "pack_sint64=[118, 118], pack_fixed64=[119, 119], pack_sfixed64=[120, 120], pack_bool=[true"
       + ", true], pack_float=[122.0, 122.0], pack_double=[123.0, 123.0], pack_nested_enum=[A, A], e"
-      + "xt_opt_bool=true, ext_rep_int32=[], ext_rep_uint32=[], ext_rep_sint32=[], ext_rep_fixed32="
-      + "[], ext_rep_sfixed32=[], ext_rep_int64=[], ext_rep_uint64=[], ext_rep_sint64=[], ext_rep_f"
-      + "ixed64=[], ext_rep_sfixed64=[], ext_rep_bool=[true, true], ext_rep_float=[], ext_rep_doubl"
-      + "e=[], ext_rep_string=[], ext_rep_bytes=[], ext_rep_nested_enum=[], ext_rep_nested_message="
-      + "[], ext_pack_int32=[], ext_pack_uint32=[], ext_pack_sint32=[], ext_pack_fixed32=[], ext_pa"
-      + "ck_sfixed32=[], ext_pack_int64=[], ext_pack_uint64=[], ext_pack_sint64=[], ext_pack_fixed6"
-      + "4=[], ext_pack_sfixed64=[], ext_pack_bool=[true, true], ext_pack_float=[], ext_pack_double"
-      + "=[], ext_pack_nested_enum=[]}";
+      + "xt_opt_bool=true, ext_rep_bool=[true, true], ext_pack_bool=[true, true]}";
     public static final ByteString expectedOutput = ByteString.decodeHex(""
       // optional
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
@@ -140,17 +140,17 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     if (other == this) return true;
     if (!(other instanceof DescriptorProto)) return false;
     DescriptorProto o = (DescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name)
-        && Internal.equals(field, o.field)
-        && Internal.equals(extension, o.extension)
-        && Internal.equals(nested_type, o.nested_type)
-        && Internal.equals(enum_type, o.enum_type)
-        && Internal.equals(extension_range, o.extension_range)
-        && Internal.equals(oneof_decl, o.oneof_decl)
+        && field.equals(o.field)
+        && extension.equals(o.extension)
+        && nested_type.equals(o.nested_type)
+        && enum_type.equals(o.enum_type)
+        && extension_range.equals(o.extension_range)
+        && oneof_decl.equals(o.oneof_decl)
         && Internal.equals(options, o.options)
-        && Internal.equals(reserved_range, o.reserved_range)
-        && Internal.equals(reserved_name, o.reserved_name);
+        && reserved_range.equals(o.reserved_range)
+        && reserved_name.equals(o.reserved_name);
   }
 
   @Override
@@ -159,15 +159,15 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     if (result == 0) {
       result = unknownFields().hashCode();
       result = result * 37 + (name != null ? name.hashCode() : 0);
-      result = result * 37 + (field != null ? field.hashCode() : 1);
-      result = result * 37 + (extension != null ? extension.hashCode() : 1);
-      result = result * 37 + (nested_type != null ? nested_type.hashCode() : 1);
-      result = result * 37 + (enum_type != null ? enum_type.hashCode() : 1);
-      result = result * 37 + (extension_range != null ? extension_range.hashCode() : 1);
-      result = result * 37 + (oneof_decl != null ? oneof_decl.hashCode() : 1);
+      result = result * 37 + field.hashCode();
+      result = result * 37 + extension.hashCode();
+      result = result * 37 + nested_type.hashCode();
+      result = result * 37 + enum_type.hashCode();
+      result = result * 37 + extension_range.hashCode();
+      result = result * 37 + oneof_decl.hashCode();
       result = result * 37 + (options != null ? options.hashCode() : 0);
-      result = result * 37 + (reserved_range != null ? reserved_range.hashCode() : 1);
-      result = result * 37 + (reserved_name != null ? reserved_name.hashCode() : 1);
+      result = result * 37 + reserved_range.hashCode();
+      result = result * 37 + reserved_name.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -177,15 +177,15 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (name != null) builder.append(", name=").append(name);
-    if (field != null) builder.append(", field=").append(field);
-    if (extension != null) builder.append(", extension=").append(extension);
-    if (nested_type != null) builder.append(", nested_type=").append(nested_type);
-    if (enum_type != null) builder.append(", enum_type=").append(enum_type);
-    if (extension_range != null) builder.append(", extension_range=").append(extension_range);
-    if (oneof_decl != null) builder.append(", oneof_decl=").append(oneof_decl);
+    if (!field.isEmpty()) builder.append(", field=").append(field);
+    if (!extension.isEmpty()) builder.append(", extension=").append(extension);
+    if (!nested_type.isEmpty()) builder.append(", nested_type=").append(nested_type);
+    if (!enum_type.isEmpty()) builder.append(", enum_type=").append(enum_type);
+    if (!extension_range.isEmpty()) builder.append(", extension_range=").append(extension_range);
+    if (!oneof_decl.isEmpty()) builder.append(", oneof_decl=").append(oneof_decl);
     if (options != null) builder.append(", options=").append(options);
-    if (reserved_range != null) builder.append(", reserved_range=").append(reserved_range);
-    if (reserved_name != null) builder.append(", reserved_name=").append(reserved_name);
+    if (!reserved_range.isEmpty()) builder.append(", reserved_range=").append(reserved_range);
+    if (!reserved_name.isEmpty()) builder.append(", reserved_name=").append(reserved_name);
     return builder.replace(0, 2, "DescriptorProto{").append('}').toString();
   }
 
@@ -334,7 +334,7 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
       if (other == this) return true;
       if (!(other instanceof ExtensionRange)) return false;
       ExtensionRange o = (ExtensionRange) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(start, o.start)
           && Internal.equals(end, o.end);
     }
@@ -486,7 +486,7 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
       if (other == this) return true;
       if (!(other instanceof ReservedRange)) return false;
       ReservedRange o = (ReservedRange) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(start, o.start)
           && Internal.equals(end, o.end);
     }
@@ -611,15 +611,15 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
     @Override
     public void encode(ProtoWriter writer, DescriptorProto value) throws IOException {
       if (value.name != null) ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
-      if (value.field != null) FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.field);
-      if (value.extension != null) FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 6, value.extension);
-      if (value.nested_type != null) DescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.nested_type);
-      if (value.enum_type != null) EnumDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.enum_type);
-      if (value.extension_range != null) ExtensionRange.ADAPTER.asRepeated().encodeWithTag(writer, 5, value.extension_range);
-      if (value.oneof_decl != null) OneofDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 8, value.oneof_decl);
+      FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.field);
+      FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 6, value.extension);
+      DescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.nested_type);
+      EnumDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.enum_type);
+      ExtensionRange.ADAPTER.asRepeated().encodeWithTag(writer, 5, value.extension_range);
+      OneofDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 8, value.oneof_decl);
       if (value.options != null) MessageOptions.ADAPTER.encodeWithTag(writer, 7, value.options);
-      if (value.reserved_range != null) ReservedRange.ADAPTER.asRepeated().encodeWithTag(writer, 9, value.reserved_range);
-      if (value.reserved_name != null) ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 10, value.reserved_name);
+      ReservedRange.ADAPTER.asRepeated().encodeWithTag(writer, 9, value.reserved_range);
+      ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 10, value.reserved_name);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumDescriptorProto.java
@@ -72,9 +72,9 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     if (other == this) return true;
     if (!(other instanceof EnumDescriptorProto)) return false;
     EnumDescriptorProto o = (EnumDescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name)
-        && Internal.equals(value, o.value)
+        && value.equals(o.value)
         && Internal.equals(options, o.options);
   }
 
@@ -84,7 +84,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     if (result == 0) {
       result = unknownFields().hashCode();
       result = result * 37 + (name != null ? name.hashCode() : 0);
-      result = result * 37 + (value != null ? value.hashCode() : 1);
+      result = result * 37 + value.hashCode();
       result = result * 37 + (options != null ? options.hashCode() : 0);
       super.hashCode = result;
     }
@@ -95,7 +95,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (name != null) builder.append(", name=").append(name);
-    if (value != null) builder.append(", value=").append(value);
+    if (!value.isEmpty()) builder.append(", value=").append(value);
     if (options != null) builder.append(", options=").append(options);
     return builder.replace(0, 2, "EnumDescriptorProto{").append('}').toString();
   }
@@ -149,7 +149,7 @@ public final class EnumDescriptorProto extends Message<EnumDescriptorProto, Enum
     @Override
     public void encode(ProtoWriter writer, EnumDescriptorProto value) throws IOException {
       if (value.name != null) ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
-      if (value.value != null) EnumValueDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.value);
+      EnumValueDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.value);
       if (value.options != null) EnumOptions.ADAPTER.encodeWithTag(writer, 3, value.options);
       writer.writeBytes(value.unknownFields());
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumOptions.java
@@ -98,10 +98,10 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     if (other == this) return true;
     if (!(other instanceof EnumOptions)) return false;
     EnumOptions o = (EnumOptions) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(allow_alias, o.allow_alias)
         && Internal.equals(deprecated, o.deprecated)
-        && Internal.equals(uninterpreted_option, o.uninterpreted_option)
+        && uninterpreted_option.equals(o.uninterpreted_option)
         && Internal.equals(enum_option, o.enum_option);
   }
 
@@ -112,7 +112,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
       result = unknownFields().hashCode();
       result = result * 37 + (allow_alias != null ? allow_alias.hashCode() : 0);
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
-      result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
+      result = result * 37 + uninterpreted_option.hashCode();
       result = result * 37 + (enum_option != null ? enum_option.hashCode() : 0);
       super.hashCode = result;
     }
@@ -124,7 +124,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     StringBuilder builder = new StringBuilder();
     if (allow_alias != null) builder.append(", allow_alias=").append(allow_alias);
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
-    if (uninterpreted_option != null) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
     if (enum_option != null) builder.append(", enum_option=").append(enum_option);
     return builder.replace(0, 2, "EnumOptions{").append('}').toString();
   }
@@ -200,7 +200,7 @@ public final class EnumOptions extends Message<EnumOptions, EnumOptions.Builder>
     public void encode(ProtoWriter writer, EnumOptions value) throws IOException {
       if (value.allow_alias != null) ProtoAdapter.BOOL.encodeWithTag(writer, 2, value.allow_alias);
       if (value.deprecated != null) ProtoAdapter.BOOL.encodeWithTag(writer, 3, value.deprecated);
-      if (value.uninterpreted_option != null) UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
       if (value.enum_option != null) ProtoAdapter.BOOL.encodeWithTag(writer, 71000, value.enum_option);
       writer.writeBytes(value.unknownFields());
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueDescriptorProto.java
@@ -73,7 +73,7 @@ public final class EnumValueDescriptorProto extends Message<EnumValueDescriptorP
     if (other == this) return true;
     if (!(other instanceof EnumValueDescriptorProto)) return false;
     EnumValueDescriptorProto o = (EnumValueDescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name)
         && Internal.equals(number, o.number)
         && Internal.equals(options, o.options);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/EnumValueOptions.java
@@ -110,9 +110,9 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
     if (other == this) return true;
     if (!(other instanceof EnumValueOptions)) return false;
     EnumValueOptions o = (EnumValueOptions) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(deprecated, o.deprecated)
-        && Internal.equals(uninterpreted_option, o.uninterpreted_option)
+        && uninterpreted_option.equals(o.uninterpreted_option)
         && Internal.equals(enum_value_option, o.enum_value_option)
         && Internal.equals(complex_enum_value_option, o.complex_enum_value_option)
         && Internal.equals(foreign_enum_value_option, o.foreign_enum_value_option);
@@ -124,7 +124,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
     if (result == 0) {
       result = unknownFields().hashCode();
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
-      result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
+      result = result * 37 + uninterpreted_option.hashCode();
       result = result * 37 + (enum_value_option != null ? enum_value_option.hashCode() : 0);
       result = result * 37 + (complex_enum_value_option != null ? complex_enum_value_option.hashCode() : 0);
       result = result * 37 + (foreign_enum_value_option != null ? foreign_enum_value_option.hashCode() : 0);
@@ -137,7 +137,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
-    if (uninterpreted_option != null) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
     if (enum_value_option != null) builder.append(", enum_value_option=").append(enum_value_option);
     if (complex_enum_value_option != null) builder.append(", complex_enum_value_option=").append(complex_enum_value_option);
     if (foreign_enum_value_option != null) builder.append(", foreign_enum_value_option=").append(foreign_enum_value_option);
@@ -218,7 +218,7 @@ public final class EnumValueOptions extends Message<EnumValueOptions, EnumValueO
     @Override
     public void encode(ProtoWriter writer, EnumValueOptions value) throws IOException {
       if (value.deprecated != null) ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.deprecated);
-      if (value.uninterpreted_option != null) UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
       if (value.enum_value_option != null) ProtoAdapter.INT32.encodeWithTag(writer, 70000, value.enum_value_option);
       if (value.complex_enum_value_option != null) FooBar.More.ADAPTER.encodeWithTag(writer, 70001, value.complex_enum_value_option);
       if (value.foreign_enum_value_option != null) ProtoAdapter.BOOL.encodeWithTag(writer, 70002, value.foreign_enum_value_option);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
@@ -160,7 +160,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
     if (other == this) return true;
     if (!(other instanceof FieldDescriptorProto)) return false;
     FieldDescriptorProto o = (FieldDescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name)
         && Internal.equals(number, o.number)
         && Internal.equals(label, o.label)

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
@@ -298,14 +298,14 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     if (other == this) return true;
     if (!(other instanceof FieldOptions)) return false;
     FieldOptions o = (FieldOptions) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(ctype, o.ctype)
         && Internal.equals(packed, o.packed)
         && Internal.equals(jstype, o.jstype)
         && Internal.equals(lazy, o.lazy)
         && Internal.equals(deprecated, o.deprecated)
         && Internal.equals(weak, o.weak)
-        && Internal.equals(uninterpreted_option, o.uninterpreted_option)
+        && uninterpreted_option.equals(o.uninterpreted_option)
         && Internal.equals(my_field_option_one, o.my_field_option_one)
         && Internal.equals(my_field_option_two, o.my_field_option_two)
         && Internal.equals(my_field_option_three, o.my_field_option_three)
@@ -328,7 +328,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
       result = result * 37 + (lazy != null ? lazy.hashCode() : 0);
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
       result = result * 37 + (weak != null ? weak.hashCode() : 0);
-      result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
+      result = result * 37 + uninterpreted_option.hashCode();
       result = result * 37 + (my_field_option_one != null ? my_field_option_one.hashCode() : 0);
       result = result * 37 + (my_field_option_two != null ? my_field_option_two.hashCode() : 0);
       result = result * 37 + (my_field_option_three != null ? my_field_option_three.hashCode() : 0);
@@ -352,7 +352,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     if (lazy != null) builder.append(", lazy=").append(lazy);
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
     if (weak != null) builder.append(", weak=").append(weak);
-    if (uninterpreted_option != null) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
     if (my_field_option_one != null) builder.append(", my_field_option_one=").append(my_field_option_one);
     if (my_field_option_two != null) builder.append(", my_field_option_two=").append(my_field_option_two);
     if (my_field_option_three != null) builder.append(", my_field_option_three=").append(my_field_option_three);
@@ -670,7 +670,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
       if (value.lazy != null) ProtoAdapter.BOOL.encodeWithTag(writer, 5, value.lazy);
       if (value.deprecated != null) ProtoAdapter.BOOL.encodeWithTag(writer, 3, value.deprecated);
       if (value.weak != null) ProtoAdapter.BOOL.encodeWithTag(writer, 10, value.weak);
-      if (value.uninterpreted_option != null) UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
       if (value.my_field_option_one != null) ProtoAdapter.INT32.encodeWithTag(writer, 60001, value.my_field_option_one);
       if (value.my_field_option_two != null) ProtoAdapter.FLOAT.encodeWithTag(writer, 60002, value.my_field_option_two);
       if (value.my_field_option_three != null) FooBar.FooBarBazEnum.ADAPTER.encodeWithTag(writer, 60003, value.my_field_option_three);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
@@ -184,16 +184,16 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     if (other == this) return true;
     if (!(other instanceof FileDescriptorProto)) return false;
     FileDescriptorProto o = (FileDescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name)
         && Internal.equals(package_, o.package_)
-        && Internal.equals(dependency, o.dependency)
-        && Internal.equals(public_dependency, o.public_dependency)
-        && Internal.equals(weak_dependency, o.weak_dependency)
-        && Internal.equals(message_type, o.message_type)
-        && Internal.equals(enum_type, o.enum_type)
-        && Internal.equals(service, o.service)
-        && Internal.equals(extension, o.extension)
+        && dependency.equals(o.dependency)
+        && public_dependency.equals(o.public_dependency)
+        && weak_dependency.equals(o.weak_dependency)
+        && message_type.equals(o.message_type)
+        && enum_type.equals(o.enum_type)
+        && service.equals(o.service)
+        && extension.equals(o.extension)
         && Internal.equals(options, o.options)
         && Internal.equals(source_code_info, o.source_code_info)
         && Internal.equals(syntax, o.syntax);
@@ -206,13 +206,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
       result = unknownFields().hashCode();
       result = result * 37 + (name != null ? name.hashCode() : 0);
       result = result * 37 + (package_ != null ? package_.hashCode() : 0);
-      result = result * 37 + (dependency != null ? dependency.hashCode() : 1);
-      result = result * 37 + (public_dependency != null ? public_dependency.hashCode() : 1);
-      result = result * 37 + (weak_dependency != null ? weak_dependency.hashCode() : 1);
-      result = result * 37 + (message_type != null ? message_type.hashCode() : 1);
-      result = result * 37 + (enum_type != null ? enum_type.hashCode() : 1);
-      result = result * 37 + (service != null ? service.hashCode() : 1);
-      result = result * 37 + (extension != null ? extension.hashCode() : 1);
+      result = result * 37 + dependency.hashCode();
+      result = result * 37 + public_dependency.hashCode();
+      result = result * 37 + weak_dependency.hashCode();
+      result = result * 37 + message_type.hashCode();
+      result = result * 37 + enum_type.hashCode();
+      result = result * 37 + service.hashCode();
+      result = result * 37 + extension.hashCode();
       result = result * 37 + (options != null ? options.hashCode() : 0);
       result = result * 37 + (source_code_info != null ? source_code_info.hashCode() : 0);
       result = result * 37 + (syntax != null ? syntax.hashCode() : 0);
@@ -226,13 +226,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     StringBuilder builder = new StringBuilder();
     if (name != null) builder.append(", name=").append(name);
     if (package_ != null) builder.append(", package=").append(package_);
-    if (dependency != null) builder.append(", dependency=").append(dependency);
-    if (public_dependency != null) builder.append(", public_dependency=").append(public_dependency);
-    if (weak_dependency != null) builder.append(", weak_dependency=").append(weak_dependency);
-    if (message_type != null) builder.append(", message_type=").append(message_type);
-    if (enum_type != null) builder.append(", enum_type=").append(enum_type);
-    if (service != null) builder.append(", service=").append(service);
-    if (extension != null) builder.append(", extension=").append(extension);
+    if (!dependency.isEmpty()) builder.append(", dependency=").append(dependency);
+    if (!public_dependency.isEmpty()) builder.append(", public_dependency=").append(public_dependency);
+    if (!weak_dependency.isEmpty()) builder.append(", weak_dependency=").append(weak_dependency);
+    if (!message_type.isEmpty()) builder.append(", message_type=").append(message_type);
+    if (!enum_type.isEmpty()) builder.append(", enum_type=").append(enum_type);
+    if (!service.isEmpty()) builder.append(", service=").append(service);
+    if (!extension.isEmpty()) builder.append(", extension=").append(extension);
     if (options != null) builder.append(", options=").append(options);
     if (source_code_info != null) builder.append(", source_code_info=").append(source_code_info);
     if (syntax != null) builder.append(", syntax=").append(syntax);
@@ -402,13 +402,13 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
     public void encode(ProtoWriter writer, FileDescriptorProto value) throws IOException {
       if (value.name != null) ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       if (value.package_ != null) ProtoAdapter.STRING.encodeWithTag(writer, 2, value.package_);
-      if (value.dependency != null) ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 3, value.dependency);
-      if (value.public_dependency != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 10, value.public_dependency);
-      if (value.weak_dependency != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 11, value.weak_dependency);
-      if (value.message_type != null) DescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.message_type);
-      if (value.enum_type != null) EnumDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 5, value.enum_type);
-      if (value.service != null) ServiceDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 6, value.service);
-      if (value.extension != null) FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 7, value.extension);
+      ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 3, value.dependency);
+      ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 10, value.public_dependency);
+      ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 11, value.weak_dependency);
+      DescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.message_type);
+      EnumDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 5, value.enum_type);
+      ServiceDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 6, value.service);
+      FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 7, value.extension);
       if (value.options != null) FileOptions.ADAPTER.encodeWithTag(writer, 8, value.options);
       if (value.source_code_info != null) SourceCodeInfo.ADAPTER.encodeWithTag(writer, 9, value.source_code_info);
       if (value.syntax != null) ProtoAdapter.STRING.encodeWithTag(writer, 12, value.syntax);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorSet.java
@@ -55,8 +55,8 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
     if (other == this) return true;
     if (!(other instanceof FileDescriptorSet)) return false;
     FileDescriptorSet o = (FileDescriptorSet) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(file, o.file);
+    return unknownFields().equals(o.unknownFields())
+        && file.equals(o.file);
   }
 
   @Override
@@ -64,7 +64,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (file != null ? file.hashCode() : 1);
+      result = result * 37 + file.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -73,7 +73,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (file != null) builder.append(", file=").append(file);
+    if (!file.isEmpty()) builder.append(", file=").append(file);
     return builder.replace(0, 2, "FileDescriptorSet{").append('}').toString();
   }
 
@@ -109,7 +109,7 @@ public final class FileDescriptorSet extends Message<FileDescriptorSet, FileDesc
 
     @Override
     public void encode(ProtoWriter writer, FileDescriptorSet value) throws IOException {
-      if (value.file != null) FileDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.file);
+      FileDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.file);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
@@ -305,7 +305,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     if (other == this) return true;
     if (!(other instanceof FileOptions)) return false;
     FileOptions o = (FileOptions) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(java_package, o.java_package)
         && Internal.equals(java_outer_classname, o.java_outer_classname)
         && Internal.equals(java_multiple_files, o.java_multiple_files)
@@ -320,7 +320,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
         && Internal.equals(cc_enable_arenas, o.cc_enable_arenas)
         && Internal.equals(objc_class_prefix, o.objc_class_prefix)
         && Internal.equals(csharp_namespace, o.csharp_namespace)
-        && Internal.equals(uninterpreted_option, o.uninterpreted_option);
+        && uninterpreted_option.equals(o.uninterpreted_option);
   }
 
   @Override
@@ -342,7 +342,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
       result = result * 37 + (cc_enable_arenas != null ? cc_enable_arenas.hashCode() : 0);
       result = result * 37 + (objc_class_prefix != null ? objc_class_prefix.hashCode() : 0);
       result = result * 37 + (csharp_namespace != null ? csharp_namespace.hashCode() : 0);
-      result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
+      result = result * 37 + uninterpreted_option.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -365,7 +365,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     if (cc_enable_arenas != null) builder.append(", cc_enable_arenas=").append(cc_enable_arenas);
     if (objc_class_prefix != null) builder.append(", objc_class_prefix=").append(objc_class_prefix);
     if (csharp_namespace != null) builder.append(", csharp_namespace=").append(csharp_namespace);
-    if (uninterpreted_option != null) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
     return builder.replace(0, 2, "FileOptions{").append('}').toString();
   }
 
@@ -653,7 +653,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
       if (value.cc_enable_arenas != null) ProtoAdapter.BOOL.encodeWithTag(writer, 31, value.cc_enable_arenas);
       if (value.objc_class_prefix != null) ProtoAdapter.STRING.encodeWithTag(writer, 36, value.objc_class_prefix);
       if (value.csharp_namespace != null) ProtoAdapter.STRING.encodeWithTag(writer, 37, value.csharp_namespace);
-      if (value.uninterpreted_option != null) UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MessageOptions.java
@@ -233,12 +233,12 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     if (other == this) return true;
     if (!(other instanceof MessageOptions)) return false;
     MessageOptions o = (MessageOptions) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(message_set_wire_format, o.message_set_wire_format)
         && Internal.equals(no_standard_descriptor_accessor, o.no_standard_descriptor_accessor)
         && Internal.equals(deprecated, o.deprecated)
         && Internal.equals(map_entry, o.map_entry)
-        && Internal.equals(uninterpreted_option, o.uninterpreted_option)
+        && uninterpreted_option.equals(o.uninterpreted_option)
         && Internal.equals(my_message_option_one, o.my_message_option_one)
         && Internal.equals(my_message_option_two, o.my_message_option_two)
         && Internal.equals(my_message_option_three, o.my_message_option_three)
@@ -257,7 +257,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
       result = result * 37 + (no_standard_descriptor_accessor != null ? no_standard_descriptor_accessor.hashCode() : 0);
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
       result = result * 37 + (map_entry != null ? map_entry.hashCode() : 0);
-      result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
+      result = result * 37 + uninterpreted_option.hashCode();
       result = result * 37 + (my_message_option_one != null ? my_message_option_one.hashCode() : 0);
       result = result * 37 + (my_message_option_two != null ? my_message_option_two.hashCode() : 0);
       result = result * 37 + (my_message_option_three != null ? my_message_option_three.hashCode() : 0);
@@ -277,7 +277,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
     if (no_standard_descriptor_accessor != null) builder.append(", no_standard_descriptor_accessor=").append(no_standard_descriptor_accessor);
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
     if (map_entry != null) builder.append(", map_entry=").append(map_entry);
-    if (uninterpreted_option != null) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
     if (my_message_option_one != null) builder.append(", my_message_option_one=").append(my_message_option_one);
     if (my_message_option_two != null) builder.append(", my_message_option_two=").append(my_message_option_two);
     if (my_message_option_three != null) builder.append(", my_message_option_three=").append(my_message_option_three);
@@ -469,7 +469,7 @@ public final class MessageOptions extends Message<MessageOptions, MessageOptions
       if (value.no_standard_descriptor_accessor != null) ProtoAdapter.BOOL.encodeWithTag(writer, 2, value.no_standard_descriptor_accessor);
       if (value.deprecated != null) ProtoAdapter.BOOL.encodeWithTag(writer, 3, value.deprecated);
       if (value.map_entry != null) ProtoAdapter.BOOL.encodeWithTag(writer, 7, value.map_entry);
-      if (value.uninterpreted_option != null) UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
       if (value.my_message_option_one != null) FooBar.ADAPTER.encodeWithTag(writer, 50001, value.my_message_option_one);
       if (value.my_message_option_two != null) ProtoAdapter.FLOAT.encodeWithTag(writer, 50002, value.my_message_option_two);
       if (value.my_message_option_three != null) FooBar.ADAPTER.encodeWithTag(writer, 50003, value.my_message_option_three);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodDescriptorProto.java
@@ -113,7 +113,7 @@ public final class MethodDescriptorProto extends Message<MethodDescriptorProto, 
     if (other == this) return true;
     if (!(other instanceof MethodDescriptorProto)) return false;
     MethodDescriptorProto o = (MethodDescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name)
         && Internal.equals(input_type, o.input_type)
         && Internal.equals(output_type, o.output_type)

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/MethodOptions.java
@@ -75,9 +75,9 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     if (other == this) return true;
     if (!(other instanceof MethodOptions)) return false;
     MethodOptions o = (MethodOptions) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(deprecated, o.deprecated)
-        && Internal.equals(uninterpreted_option, o.uninterpreted_option);
+        && uninterpreted_option.equals(o.uninterpreted_option);
   }
 
   @Override
@@ -86,7 +86,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     if (result == 0) {
       result = unknownFields().hashCode();
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
-      result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
+      result = result * 37 + uninterpreted_option.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -96,7 +96,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
-    if (uninterpreted_option != null) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
     return builder.replace(0, 2, "MethodOptions{").append('}').toString();
   }
 
@@ -154,7 +154,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     @Override
     public void encode(ProtoWriter writer, MethodOptions value) throws IOException {
       if (value.deprecated != null) ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated);
-      if (value.uninterpreted_option != null) UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/OneofDescriptorProto.java
@@ -54,7 +54,7 @@ public final class OneofDescriptorProto extends Message<OneofDescriptorProto, On
     if (other == this) return true;
     if (!(other instanceof OneofDescriptorProto)) return false;
     OneofDescriptorProto o = (OneofDescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name);
   }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceDescriptorProto.java
@@ -72,9 +72,9 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     if (other == this) return true;
     if (!(other instanceof ServiceDescriptorProto)) return false;
     ServiceDescriptorProto o = (ServiceDescriptorProto) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(name, o.name)
-        && Internal.equals(method, o.method)
+        && method.equals(o.method)
         && Internal.equals(options, o.options);
   }
 
@@ -84,7 +84,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     if (result == 0) {
       result = unknownFields().hashCode();
       result = result * 37 + (name != null ? name.hashCode() : 0);
-      result = result * 37 + (method != null ? method.hashCode() : 1);
+      result = result * 37 + method.hashCode();
       result = result * 37 + (options != null ? options.hashCode() : 0);
       super.hashCode = result;
     }
@@ -95,7 +95,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (name != null) builder.append(", name=").append(name);
-    if (method != null) builder.append(", method=").append(method);
+    if (!method.isEmpty()) builder.append(", method=").append(method);
     if (options != null) builder.append(", options=").append(options);
     return builder.replace(0, 2, "ServiceDescriptorProto{").append('}').toString();
   }
@@ -149,7 +149,7 @@ public final class ServiceDescriptorProto extends Message<ServiceDescriptorProto
     @Override
     public void encode(ProtoWriter writer, ServiceDescriptorProto value) throws IOException {
       if (value.name != null) ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
-      if (value.method != null) MethodDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.method);
+      MethodDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.method);
       if (value.options != null) ServiceOptions.ADAPTER.encodeWithTag(writer, 3, value.options);
       writer.writeBytes(value.unknownFields());
     }

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/ServiceOptions.java
@@ -75,9 +75,9 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     if (other == this) return true;
     if (!(other instanceof ServiceOptions)) return false;
     ServiceOptions o = (ServiceOptions) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(deprecated, o.deprecated)
-        && Internal.equals(uninterpreted_option, o.uninterpreted_option);
+        && uninterpreted_option.equals(o.uninterpreted_option);
   }
 
   @Override
@@ -86,7 +86,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     if (result == 0) {
       result = unknownFields().hashCode();
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
-      result = result * 37 + (uninterpreted_option != null ? uninterpreted_option.hashCode() : 1);
+      result = result * 37 + uninterpreted_option.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -96,7 +96,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
-    if (uninterpreted_option != null) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
     return builder.replace(0, 2, "ServiceOptions{").append('}').toString();
   }
 
@@ -154,7 +154,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     @Override
     public void encode(ProtoWriter writer, ServiceOptions value) throws IOException {
       if (value.deprecated != null) ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated);
-      if (value.uninterpreted_option != null) UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/SourceCodeInfo.java
@@ -103,8 +103,8 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     if (other == this) return true;
     if (!(other instanceof SourceCodeInfo)) return false;
     SourceCodeInfo o = (SourceCodeInfo) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(location, o.location);
+    return unknownFields().equals(o.unknownFields())
+        && location.equals(o.location);
   }
 
   @Override
@@ -112,7 +112,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (location != null ? location.hashCode() : 1);
+      result = result * 37 + location.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -121,7 +121,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (location != null) builder.append(", location=").append(location);
+    if (!location.isEmpty()) builder.append(", location=").append(location);
     return builder.replace(0, 2, "SourceCodeInfo{").append('}').toString();
   }
 
@@ -342,12 +342,12 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
       if (other == this) return true;
       if (!(other instanceof Location)) return false;
       Location o = (Location) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
-          && Internal.equals(path, o.path)
-          && Internal.equals(span, o.span)
+      return unknownFields().equals(o.unknownFields())
+          && path.equals(o.path)
+          && span.equals(o.span)
           && Internal.equals(leading_comments, o.leading_comments)
           && Internal.equals(trailing_comments, o.trailing_comments)
-          && Internal.equals(leading_detached_comments, o.leading_detached_comments);
+          && leading_detached_comments.equals(o.leading_detached_comments);
     }
 
     @Override
@@ -355,11 +355,11 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
       int result = super.hashCode;
       if (result == 0) {
         result = unknownFields().hashCode();
-        result = result * 37 + (path != null ? path.hashCode() : 1);
-        result = result * 37 + (span != null ? span.hashCode() : 1);
+        result = result * 37 + path.hashCode();
+        result = result * 37 + span.hashCode();
         result = result * 37 + (leading_comments != null ? leading_comments.hashCode() : 0);
         result = result * 37 + (trailing_comments != null ? trailing_comments.hashCode() : 0);
-        result = result * 37 + (leading_detached_comments != null ? leading_detached_comments.hashCode() : 1);
+        result = result * 37 + leading_detached_comments.hashCode();
         super.hashCode = result;
       }
       return result;
@@ -368,11 +368,11 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      if (path != null) builder.append(", path=").append(path);
-      if (span != null) builder.append(", span=").append(span);
+      if (!path.isEmpty()) builder.append(", path=").append(path);
+      if (!span.isEmpty()) builder.append(", span=").append(span);
       if (leading_comments != null) builder.append(", leading_comments=").append(leading_comments);
       if (trailing_comments != null) builder.append(", trailing_comments=").append(trailing_comments);
-      if (leading_detached_comments != null) builder.append(", leading_detached_comments=").append(leading_detached_comments);
+      if (!leading_detached_comments.isEmpty()) builder.append(", leading_detached_comments=").append(leading_detached_comments);
       return builder.replace(0, 2, "Location{").append('}').toString();
     }
 
@@ -525,11 +525,11 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
 
       @Override
       public void encode(ProtoWriter writer, Location value) throws IOException {
-        if (value.path != null) ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.path);
-        if (value.span != null) ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 2, value.span);
+        ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.path);
+        ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 2, value.span);
         if (value.leading_comments != null) ProtoAdapter.STRING.encodeWithTag(writer, 3, value.leading_comments);
         if (value.trailing_comments != null) ProtoAdapter.STRING.encodeWithTag(writer, 4, value.trailing_comments);
-        if (value.leading_detached_comments != null) ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 6, value.leading_detached_comments);
+        ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 6, value.leading_detached_comments);
         writer.writeBytes(value.unknownFields());
       }
 
@@ -577,7 +577,7 @@ public final class SourceCodeInfo extends Message<SourceCodeInfo, SourceCodeInfo
 
     @Override
     public void encode(ProtoWriter writer, SourceCodeInfo value) throws IOException {
-      if (value.location != null) Location.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.location);
+      Location.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.location);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/UninterpretedOption.java
@@ -126,8 +126,8 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
     if (other == this) return true;
     if (!(other instanceof UninterpretedOption)) return false;
     UninterpretedOption o = (UninterpretedOption) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(name, o.name)
+    return unknownFields().equals(o.unknownFields())
+        && name.equals(o.name)
         && Internal.equals(identifier_value, o.identifier_value)
         && Internal.equals(positive_int_value, o.positive_int_value)
         && Internal.equals(negative_int_value, o.negative_int_value)
@@ -141,7 +141,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (name != null ? name.hashCode() : 1);
+      result = result * 37 + name.hashCode();
       result = result * 37 + (identifier_value != null ? identifier_value.hashCode() : 0);
       result = result * 37 + (positive_int_value != null ? positive_int_value.hashCode() : 0);
       result = result * 37 + (negative_int_value != null ? negative_int_value.hashCode() : 0);
@@ -156,7 +156,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (name != null) builder.append(", name=").append(name);
+    if (!name.isEmpty()) builder.append(", name=").append(name);
     if (identifier_value != null) builder.append(", identifier_value=").append(identifier_value);
     if (positive_int_value != null) builder.append(", positive_int_value=").append(positive_int_value);
     if (negative_int_value != null) builder.append(", negative_int_value=").append(negative_int_value);
@@ -285,9 +285,9 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
       if (other == this) return true;
       if (!(other instanceof NamePart)) return false;
       NamePart o = (NamePart) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
-          && Internal.equals(name_part, o.name_part)
-          && Internal.equals(is_extension, o.is_extension);
+      return unknownFields().equals(o.unknownFields())
+          && name_part.equals(o.name_part)
+          && is_extension.equals(o.is_extension);
     }
 
     @Override
@@ -295,8 +295,8 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
       int result = super.hashCode;
       if (result == 0) {
         result = unknownFields().hashCode();
-        result = result * 37 + (name_part != null ? name_part.hashCode() : 0);
-        result = result * 37 + (is_extension != null ? is_extension.hashCode() : 0);
+        result = result * 37 + name_part.hashCode();
+        result = result * 37 + is_extension.hashCode();
         super.hashCode = result;
       }
       return result;
@@ -305,8 +305,8 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      if (name_part != null) builder.append(", name_part=").append(name_part);
-      if (is_extension != null) builder.append(", is_extension=").append(is_extension);
+      builder.append(", name_part=").append(name_part);
+      builder.append(", is_extension=").append(is_extension);
       return builder.replace(0, 2, "NamePart{").append('}').toString();
     }
 
@@ -405,7 +405,7 @@ public final class UninterpretedOption extends Message<UninterpretedOption, Unin
 
     @Override
     public void encode(ProtoWriter writer, UninterpretedOption value) throws IOException {
-      if (value.name != null) NamePart.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.name);
+      NamePart.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.name);
       if (value.identifier_value != null) ProtoAdapter.STRING.encodeWithTag(writer, 3, value.identifier_value);
       if (value.positive_int_value != null) ProtoAdapter.UINT64.encodeWithTag(writer, 4, value.positive_int_value);
       if (value.negative_int_value != null) ProtoAdapter.INT64.encodeWithTag(writer, 5, value.negative_int_value);

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -143,7 +143,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
         if (other == this) return true;
         if (!(other instanceof Moo)) return false;
         Moo o = (Moo) other;
-        return Internal.equals(unknownFields(), o.unknownFields())
+        return unknownFields().equals(o.unknownFields())
             && Internal.equals(boo, o.boo);
       }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -50,7 +50,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(moo, o.moo);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/bar/Bar.java
@@ -143,7 +143,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
         if (other == this) return true;
         if (!(other instanceof Moo)) return false;
         Moo o = (Moo) other;
-        return Internal.equals(unknownFields(), o.unknownFields())
+        return unknownFields().equals(o.unknownFields())
             && Internal.equals(boo, o.boo);
       }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/foobar/protos/foo/Foo.java
@@ -50,7 +50,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(moo, o.moo);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataRequest.java
@@ -51,7 +51,7 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
     if (other == this) return true;
     if (!(other instanceof HeresAllTheDataRequest)) return false;
     HeresAllTheDataRequest o = (HeresAllTheDataRequest) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(data, o.data);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/HeresAllTheDataResponse.java
@@ -51,7 +51,7 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
     if (other == this) return true;
     if (!(other instanceof HeresAllTheDataResponse)) return false;
     HeresAllTheDataResponse o = (HeresAllTheDataResponse) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(data, o.data);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataRequest.java
@@ -51,7 +51,7 @@ public final class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequ
     if (other == this) return true;
     if (!(other instanceof LetsDataRequest)) return false;
     LetsDataRequest o = (LetsDataRequest) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(data, o.data);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/LetsDataResponse.java
@@ -51,7 +51,7 @@ public final class LetsDataResponse extends Message<LetsDataResponse, LetsDataRe
     if (other == this) return true;
     if (!(other instanceof LetsDataResponse)) return false;
     LetsDataResponse o = (LetsDataResponse) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(data, o.data);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -51,7 +51,7 @@ public final class SendDataRequest extends Message<SendDataRequest, SendDataRequ
     if (other == this) return true;
     if (!(other instanceof SendDataRequest)) return false;
     SendDataRequest o = (SendDataRequest) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(data, o.data);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -51,7 +51,7 @@ public final class SendDataResponse extends Message<SendDataResponse, SendDataRe
     if (other == this) return true;
     if (!(other instanceof SendDataResponse)) return false;
     SendDataResponse o = (SendDataResponse) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(data, o.data);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/ChildPackage.java
@@ -52,7 +52,7 @@ public final class ChildPackage extends Message<ChildPackage, ChildPackage.Build
     if (other == this) return true;
     if (!(other instanceof ChildPackage)) return false;
     ChildPackage o = (ChildPackage) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(inner_foreign_enum, o.inner_foreign_enum);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/RepeatedAndPacked.java
@@ -61,9 +61,9 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
     if (other == this) return true;
     if (!(other instanceof RepeatedAndPacked)) return false;
     RepeatedAndPacked o = (RepeatedAndPacked) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(rep_int32, o.rep_int32)
-        && Internal.equals(pack_int32, o.pack_int32);
+    return unknownFields().equals(o.unknownFields())
+        && rep_int32.equals(o.rep_int32)
+        && pack_int32.equals(o.pack_int32);
   }
 
   @Override
@@ -71,8 +71,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (rep_int32 != null ? rep_int32.hashCode() : 1);
-      result = result * 37 + (pack_int32 != null ? pack_int32.hashCode() : 1);
+      result = result * 37 + rep_int32.hashCode();
+      result = result * 37 + pack_int32.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -81,8 +81,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (rep_int32 != null) builder.append(", rep_int32=").append(rep_int32);
-    if (pack_int32 != null) builder.append(", pack_int32=").append(pack_int32);
+    if (!rep_int32.isEmpty()) builder.append(", rep_int32=").append(rep_int32);
+    if (!pack_int32.isEmpty()) builder.append(", pack_int32=").append(pack_int32);
     return builder.replace(0, 2, "RepeatedAndPacked{").append('}').toString();
   }
 
@@ -128,8 +128,8 @@ public final class RepeatedAndPacked extends Message<RepeatedAndPacked, Repeated
 
     @Override
     public void encode(ProtoWriter writer, RepeatedAndPacked value) throws IOException {
-      if (value.rep_int32 != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32);
-      if (value.pack_int32 != null) ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 301, value.pack_int32);
+      ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32);
+      ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 301, value.pack_int32);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -1432,7 +1432,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(opt_int32, o.opt_int32)
         && Internal.equals(opt_uint32, o.opt_uint32)
         && Internal.equals(opt_sint32, o.opt_sint32)
@@ -1450,54 +1450,54 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
         && Internal.equals(opt_bytes, o.opt_bytes)
         && Internal.equals(opt_nested_enum, o.opt_nested_enum)
         && Internal.equals(opt_nested_message, o.opt_nested_message)
-        && Internal.equals(req_int32, o.req_int32)
-        && Internal.equals(req_uint32, o.req_uint32)
-        && Internal.equals(req_sint32, o.req_sint32)
-        && Internal.equals(req_fixed32, o.req_fixed32)
-        && Internal.equals(req_sfixed32, o.req_sfixed32)
-        && Internal.equals(req_int64, o.req_int64)
-        && Internal.equals(req_uint64, o.req_uint64)
-        && Internal.equals(req_sint64, o.req_sint64)
-        && Internal.equals(req_fixed64, o.req_fixed64)
-        && Internal.equals(req_sfixed64, o.req_sfixed64)
-        && Internal.equals(req_bool, o.req_bool)
-        && Internal.equals(req_float, o.req_float)
-        && Internal.equals(req_double, o.req_double)
-        && Internal.equals(req_string, o.req_string)
-        && Internal.equals(req_bytes, o.req_bytes)
-        && Internal.equals(req_nested_enum, o.req_nested_enum)
-        && Internal.equals(req_nested_message, o.req_nested_message)
-        && Internal.equals(rep_int32, o.rep_int32)
-        && Internal.equals(rep_uint32, o.rep_uint32)
-        && Internal.equals(rep_sint32, o.rep_sint32)
-        && Internal.equals(rep_fixed32, o.rep_fixed32)
-        && Internal.equals(rep_sfixed32, o.rep_sfixed32)
-        && Internal.equals(rep_int64, o.rep_int64)
-        && Internal.equals(rep_uint64, o.rep_uint64)
-        && Internal.equals(rep_sint64, o.rep_sint64)
-        && Internal.equals(rep_fixed64, o.rep_fixed64)
-        && Internal.equals(rep_sfixed64, o.rep_sfixed64)
-        && Internal.equals(rep_bool, o.rep_bool)
-        && Internal.equals(rep_float, o.rep_float)
-        && Internal.equals(rep_double, o.rep_double)
-        && Internal.equals(rep_string, o.rep_string)
-        && Internal.equals(rep_bytes, o.rep_bytes)
-        && Internal.equals(rep_nested_enum, o.rep_nested_enum)
-        && Internal.equals(rep_nested_message, o.rep_nested_message)
-        && Internal.equals(pack_int32, o.pack_int32)
-        && Internal.equals(pack_uint32, o.pack_uint32)
-        && Internal.equals(pack_sint32, o.pack_sint32)
-        && Internal.equals(pack_fixed32, o.pack_fixed32)
-        && Internal.equals(pack_sfixed32, o.pack_sfixed32)
-        && Internal.equals(pack_int64, o.pack_int64)
-        && Internal.equals(pack_uint64, o.pack_uint64)
-        && Internal.equals(pack_sint64, o.pack_sint64)
-        && Internal.equals(pack_fixed64, o.pack_fixed64)
-        && Internal.equals(pack_sfixed64, o.pack_sfixed64)
-        && Internal.equals(pack_bool, o.pack_bool)
-        && Internal.equals(pack_float, o.pack_float)
-        && Internal.equals(pack_double, o.pack_double)
-        && Internal.equals(pack_nested_enum, o.pack_nested_enum)
+        && req_int32.equals(o.req_int32)
+        && req_uint32.equals(o.req_uint32)
+        && req_sint32.equals(o.req_sint32)
+        && req_fixed32.equals(o.req_fixed32)
+        && req_sfixed32.equals(o.req_sfixed32)
+        && req_int64.equals(o.req_int64)
+        && req_uint64.equals(o.req_uint64)
+        && req_sint64.equals(o.req_sint64)
+        && req_fixed64.equals(o.req_fixed64)
+        && req_sfixed64.equals(o.req_sfixed64)
+        && req_bool.equals(o.req_bool)
+        && req_float.equals(o.req_float)
+        && req_double.equals(o.req_double)
+        && req_string.equals(o.req_string)
+        && req_bytes.equals(o.req_bytes)
+        && req_nested_enum.equals(o.req_nested_enum)
+        && req_nested_message.equals(o.req_nested_message)
+        && rep_int32.equals(o.rep_int32)
+        && rep_uint32.equals(o.rep_uint32)
+        && rep_sint32.equals(o.rep_sint32)
+        && rep_fixed32.equals(o.rep_fixed32)
+        && rep_sfixed32.equals(o.rep_sfixed32)
+        && rep_int64.equals(o.rep_int64)
+        && rep_uint64.equals(o.rep_uint64)
+        && rep_sint64.equals(o.rep_sint64)
+        && rep_fixed64.equals(o.rep_fixed64)
+        && rep_sfixed64.equals(o.rep_sfixed64)
+        && rep_bool.equals(o.rep_bool)
+        && rep_float.equals(o.rep_float)
+        && rep_double.equals(o.rep_double)
+        && rep_string.equals(o.rep_string)
+        && rep_bytes.equals(o.rep_bytes)
+        && rep_nested_enum.equals(o.rep_nested_enum)
+        && rep_nested_message.equals(o.rep_nested_message)
+        && pack_int32.equals(o.pack_int32)
+        && pack_uint32.equals(o.pack_uint32)
+        && pack_sint32.equals(o.pack_sint32)
+        && pack_fixed32.equals(o.pack_fixed32)
+        && pack_sfixed32.equals(o.pack_sfixed32)
+        && pack_int64.equals(o.pack_int64)
+        && pack_uint64.equals(o.pack_uint64)
+        && pack_sint64.equals(o.pack_sint64)
+        && pack_fixed64.equals(o.pack_fixed64)
+        && pack_sfixed64.equals(o.pack_sfixed64)
+        && pack_bool.equals(o.pack_bool)
+        && pack_float.equals(o.pack_float)
+        && pack_double.equals(o.pack_double)
+        && pack_nested_enum.equals(o.pack_nested_enum)
         && Internal.equals(default_int32, o.default_int32)
         && Internal.equals(default_uint32, o.default_uint32)
         && Internal.equals(default_sint32, o.default_sint32)
@@ -1531,37 +1531,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
         && Internal.equals(ext_opt_bytes, o.ext_opt_bytes)
         && Internal.equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
         && Internal.equals(ext_opt_nested_message, o.ext_opt_nested_message)
-        && Internal.equals(ext_rep_int32, o.ext_rep_int32)
-        && Internal.equals(ext_rep_uint32, o.ext_rep_uint32)
-        && Internal.equals(ext_rep_sint32, o.ext_rep_sint32)
-        && Internal.equals(ext_rep_fixed32, o.ext_rep_fixed32)
-        && Internal.equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
-        && Internal.equals(ext_rep_int64, o.ext_rep_int64)
-        && Internal.equals(ext_rep_uint64, o.ext_rep_uint64)
-        && Internal.equals(ext_rep_sint64, o.ext_rep_sint64)
-        && Internal.equals(ext_rep_fixed64, o.ext_rep_fixed64)
-        && Internal.equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
-        && Internal.equals(ext_rep_bool, o.ext_rep_bool)
-        && Internal.equals(ext_rep_float, o.ext_rep_float)
-        && Internal.equals(ext_rep_double, o.ext_rep_double)
-        && Internal.equals(ext_rep_string, o.ext_rep_string)
-        && Internal.equals(ext_rep_bytes, o.ext_rep_bytes)
-        && Internal.equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
-        && Internal.equals(ext_rep_nested_message, o.ext_rep_nested_message)
-        && Internal.equals(ext_pack_int32, o.ext_pack_int32)
-        && Internal.equals(ext_pack_uint32, o.ext_pack_uint32)
-        && Internal.equals(ext_pack_sint32, o.ext_pack_sint32)
-        && Internal.equals(ext_pack_fixed32, o.ext_pack_fixed32)
-        && Internal.equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
-        && Internal.equals(ext_pack_int64, o.ext_pack_int64)
-        && Internal.equals(ext_pack_uint64, o.ext_pack_uint64)
-        && Internal.equals(ext_pack_sint64, o.ext_pack_sint64)
-        && Internal.equals(ext_pack_fixed64, o.ext_pack_fixed64)
-        && Internal.equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
-        && Internal.equals(ext_pack_bool, o.ext_pack_bool)
-        && Internal.equals(ext_pack_float, o.ext_pack_float)
-        && Internal.equals(ext_pack_double, o.ext_pack_double)
-        && Internal.equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
+        && ext_rep_int32.equals(o.ext_rep_int32)
+        && ext_rep_uint32.equals(o.ext_rep_uint32)
+        && ext_rep_sint32.equals(o.ext_rep_sint32)
+        && ext_rep_fixed32.equals(o.ext_rep_fixed32)
+        && ext_rep_sfixed32.equals(o.ext_rep_sfixed32)
+        && ext_rep_int64.equals(o.ext_rep_int64)
+        && ext_rep_uint64.equals(o.ext_rep_uint64)
+        && ext_rep_sint64.equals(o.ext_rep_sint64)
+        && ext_rep_fixed64.equals(o.ext_rep_fixed64)
+        && ext_rep_sfixed64.equals(o.ext_rep_sfixed64)
+        && ext_rep_bool.equals(o.ext_rep_bool)
+        && ext_rep_float.equals(o.ext_rep_float)
+        && ext_rep_double.equals(o.ext_rep_double)
+        && ext_rep_string.equals(o.ext_rep_string)
+        && ext_rep_bytes.equals(o.ext_rep_bytes)
+        && ext_rep_nested_enum.equals(o.ext_rep_nested_enum)
+        && ext_rep_nested_message.equals(o.ext_rep_nested_message)
+        && ext_pack_int32.equals(o.ext_pack_int32)
+        && ext_pack_uint32.equals(o.ext_pack_uint32)
+        && ext_pack_sint32.equals(o.ext_pack_sint32)
+        && ext_pack_fixed32.equals(o.ext_pack_fixed32)
+        && ext_pack_sfixed32.equals(o.ext_pack_sfixed32)
+        && ext_pack_int64.equals(o.ext_pack_int64)
+        && ext_pack_uint64.equals(o.ext_pack_uint64)
+        && ext_pack_sint64.equals(o.ext_pack_sint64)
+        && ext_pack_fixed64.equals(o.ext_pack_fixed64)
+        && ext_pack_sfixed64.equals(o.ext_pack_sfixed64)
+        && ext_pack_bool.equals(o.ext_pack_bool)
+        && ext_pack_float.equals(o.ext_pack_float)
+        && ext_pack_double.equals(o.ext_pack_double)
+        && ext_pack_nested_enum.equals(o.ext_pack_nested_enum);
   }
 
   @Override
@@ -1586,54 +1586,54 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       result = result * 37 + (opt_bytes != null ? opt_bytes.hashCode() : 0);
       result = result * 37 + (opt_nested_enum != null ? opt_nested_enum.hashCode() : 0);
       result = result * 37 + (opt_nested_message != null ? opt_nested_message.hashCode() : 0);
-      result = result * 37 + (req_int32 != null ? req_int32.hashCode() : 0);
-      result = result * 37 + (req_uint32 != null ? req_uint32.hashCode() : 0);
-      result = result * 37 + (req_sint32 != null ? req_sint32.hashCode() : 0);
-      result = result * 37 + (req_fixed32 != null ? req_fixed32.hashCode() : 0);
-      result = result * 37 + (req_sfixed32 != null ? req_sfixed32.hashCode() : 0);
-      result = result * 37 + (req_int64 != null ? req_int64.hashCode() : 0);
-      result = result * 37 + (req_uint64 != null ? req_uint64.hashCode() : 0);
-      result = result * 37 + (req_sint64 != null ? req_sint64.hashCode() : 0);
-      result = result * 37 + (req_fixed64 != null ? req_fixed64.hashCode() : 0);
-      result = result * 37 + (req_sfixed64 != null ? req_sfixed64.hashCode() : 0);
-      result = result * 37 + (req_bool != null ? req_bool.hashCode() : 0);
-      result = result * 37 + (req_float != null ? req_float.hashCode() : 0);
-      result = result * 37 + (req_double != null ? req_double.hashCode() : 0);
-      result = result * 37 + (req_string != null ? req_string.hashCode() : 0);
-      result = result * 37 + (req_bytes != null ? req_bytes.hashCode() : 0);
-      result = result * 37 + (req_nested_enum != null ? req_nested_enum.hashCode() : 0);
-      result = result * 37 + (req_nested_message != null ? req_nested_message.hashCode() : 0);
-      result = result * 37 + (rep_int32 != null ? rep_int32.hashCode() : 1);
-      result = result * 37 + (rep_uint32 != null ? rep_uint32.hashCode() : 1);
-      result = result * 37 + (rep_sint32 != null ? rep_sint32.hashCode() : 1);
-      result = result * 37 + (rep_fixed32 != null ? rep_fixed32.hashCode() : 1);
-      result = result * 37 + (rep_sfixed32 != null ? rep_sfixed32.hashCode() : 1);
-      result = result * 37 + (rep_int64 != null ? rep_int64.hashCode() : 1);
-      result = result * 37 + (rep_uint64 != null ? rep_uint64.hashCode() : 1);
-      result = result * 37 + (rep_sint64 != null ? rep_sint64.hashCode() : 1);
-      result = result * 37 + (rep_fixed64 != null ? rep_fixed64.hashCode() : 1);
-      result = result * 37 + (rep_sfixed64 != null ? rep_sfixed64.hashCode() : 1);
-      result = result * 37 + (rep_bool != null ? rep_bool.hashCode() : 1);
-      result = result * 37 + (rep_float != null ? rep_float.hashCode() : 1);
-      result = result * 37 + (rep_double != null ? rep_double.hashCode() : 1);
-      result = result * 37 + (rep_string != null ? rep_string.hashCode() : 1);
-      result = result * 37 + (rep_bytes != null ? rep_bytes.hashCode() : 1);
-      result = result * 37 + (rep_nested_enum != null ? rep_nested_enum.hashCode() : 1);
-      result = result * 37 + (rep_nested_message != null ? rep_nested_message.hashCode() : 1);
-      result = result * 37 + (pack_int32 != null ? pack_int32.hashCode() : 1);
-      result = result * 37 + (pack_uint32 != null ? pack_uint32.hashCode() : 1);
-      result = result * 37 + (pack_sint32 != null ? pack_sint32.hashCode() : 1);
-      result = result * 37 + (pack_fixed32 != null ? pack_fixed32.hashCode() : 1);
-      result = result * 37 + (pack_sfixed32 != null ? pack_sfixed32.hashCode() : 1);
-      result = result * 37 + (pack_int64 != null ? pack_int64.hashCode() : 1);
-      result = result * 37 + (pack_uint64 != null ? pack_uint64.hashCode() : 1);
-      result = result * 37 + (pack_sint64 != null ? pack_sint64.hashCode() : 1);
-      result = result * 37 + (pack_fixed64 != null ? pack_fixed64.hashCode() : 1);
-      result = result * 37 + (pack_sfixed64 != null ? pack_sfixed64.hashCode() : 1);
-      result = result * 37 + (pack_bool != null ? pack_bool.hashCode() : 1);
-      result = result * 37 + (pack_float != null ? pack_float.hashCode() : 1);
-      result = result * 37 + (pack_double != null ? pack_double.hashCode() : 1);
-      result = result * 37 + (pack_nested_enum != null ? pack_nested_enum.hashCode() : 1);
+      result = result * 37 + req_int32.hashCode();
+      result = result * 37 + req_uint32.hashCode();
+      result = result * 37 + req_sint32.hashCode();
+      result = result * 37 + req_fixed32.hashCode();
+      result = result * 37 + req_sfixed32.hashCode();
+      result = result * 37 + req_int64.hashCode();
+      result = result * 37 + req_uint64.hashCode();
+      result = result * 37 + req_sint64.hashCode();
+      result = result * 37 + req_fixed64.hashCode();
+      result = result * 37 + req_sfixed64.hashCode();
+      result = result * 37 + req_bool.hashCode();
+      result = result * 37 + req_float.hashCode();
+      result = result * 37 + req_double.hashCode();
+      result = result * 37 + req_string.hashCode();
+      result = result * 37 + req_bytes.hashCode();
+      result = result * 37 + req_nested_enum.hashCode();
+      result = result * 37 + req_nested_message.hashCode();
+      result = result * 37 + rep_int32.hashCode();
+      result = result * 37 + rep_uint32.hashCode();
+      result = result * 37 + rep_sint32.hashCode();
+      result = result * 37 + rep_fixed32.hashCode();
+      result = result * 37 + rep_sfixed32.hashCode();
+      result = result * 37 + rep_int64.hashCode();
+      result = result * 37 + rep_uint64.hashCode();
+      result = result * 37 + rep_sint64.hashCode();
+      result = result * 37 + rep_fixed64.hashCode();
+      result = result * 37 + rep_sfixed64.hashCode();
+      result = result * 37 + rep_bool.hashCode();
+      result = result * 37 + rep_float.hashCode();
+      result = result * 37 + rep_double.hashCode();
+      result = result * 37 + rep_string.hashCode();
+      result = result * 37 + rep_bytes.hashCode();
+      result = result * 37 + rep_nested_enum.hashCode();
+      result = result * 37 + rep_nested_message.hashCode();
+      result = result * 37 + pack_int32.hashCode();
+      result = result * 37 + pack_uint32.hashCode();
+      result = result * 37 + pack_sint32.hashCode();
+      result = result * 37 + pack_fixed32.hashCode();
+      result = result * 37 + pack_sfixed32.hashCode();
+      result = result * 37 + pack_int64.hashCode();
+      result = result * 37 + pack_uint64.hashCode();
+      result = result * 37 + pack_sint64.hashCode();
+      result = result * 37 + pack_fixed64.hashCode();
+      result = result * 37 + pack_sfixed64.hashCode();
+      result = result * 37 + pack_bool.hashCode();
+      result = result * 37 + pack_float.hashCode();
+      result = result * 37 + pack_double.hashCode();
+      result = result * 37 + pack_nested_enum.hashCode();
       result = result * 37 + (default_int32 != null ? default_int32.hashCode() : 0);
       result = result * 37 + (default_uint32 != null ? default_uint32.hashCode() : 0);
       result = result * 37 + (default_sint32 != null ? default_sint32.hashCode() : 0);
@@ -1667,37 +1667,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       result = result * 37 + (ext_opt_bytes != null ? ext_opt_bytes.hashCode() : 0);
       result = result * 37 + (ext_opt_nested_enum != null ? ext_opt_nested_enum.hashCode() : 0);
       result = result * 37 + (ext_opt_nested_message != null ? ext_opt_nested_message.hashCode() : 0);
-      result = result * 37 + (ext_rep_int32 != null ? ext_rep_int32.hashCode() : 1);
-      result = result * 37 + (ext_rep_uint32 != null ? ext_rep_uint32.hashCode() : 1);
-      result = result * 37 + (ext_rep_sint32 != null ? ext_rep_sint32.hashCode() : 1);
-      result = result * 37 + (ext_rep_fixed32 != null ? ext_rep_fixed32.hashCode() : 1);
-      result = result * 37 + (ext_rep_sfixed32 != null ? ext_rep_sfixed32.hashCode() : 1);
-      result = result * 37 + (ext_rep_int64 != null ? ext_rep_int64.hashCode() : 1);
-      result = result * 37 + (ext_rep_uint64 != null ? ext_rep_uint64.hashCode() : 1);
-      result = result * 37 + (ext_rep_sint64 != null ? ext_rep_sint64.hashCode() : 1);
-      result = result * 37 + (ext_rep_fixed64 != null ? ext_rep_fixed64.hashCode() : 1);
-      result = result * 37 + (ext_rep_sfixed64 != null ? ext_rep_sfixed64.hashCode() : 1);
-      result = result * 37 + (ext_rep_bool != null ? ext_rep_bool.hashCode() : 1);
-      result = result * 37 + (ext_rep_float != null ? ext_rep_float.hashCode() : 1);
-      result = result * 37 + (ext_rep_double != null ? ext_rep_double.hashCode() : 1);
-      result = result * 37 + (ext_rep_string != null ? ext_rep_string.hashCode() : 1);
-      result = result * 37 + (ext_rep_bytes != null ? ext_rep_bytes.hashCode() : 1);
-      result = result * 37 + (ext_rep_nested_enum != null ? ext_rep_nested_enum.hashCode() : 1);
-      result = result * 37 + (ext_rep_nested_message != null ? ext_rep_nested_message.hashCode() : 1);
-      result = result * 37 + (ext_pack_int32 != null ? ext_pack_int32.hashCode() : 1);
-      result = result * 37 + (ext_pack_uint32 != null ? ext_pack_uint32.hashCode() : 1);
-      result = result * 37 + (ext_pack_sint32 != null ? ext_pack_sint32.hashCode() : 1);
-      result = result * 37 + (ext_pack_fixed32 != null ? ext_pack_fixed32.hashCode() : 1);
-      result = result * 37 + (ext_pack_sfixed32 != null ? ext_pack_sfixed32.hashCode() : 1);
-      result = result * 37 + (ext_pack_int64 != null ? ext_pack_int64.hashCode() : 1);
-      result = result * 37 + (ext_pack_uint64 != null ? ext_pack_uint64.hashCode() : 1);
-      result = result * 37 + (ext_pack_sint64 != null ? ext_pack_sint64.hashCode() : 1);
-      result = result * 37 + (ext_pack_fixed64 != null ? ext_pack_fixed64.hashCode() : 1);
-      result = result * 37 + (ext_pack_sfixed64 != null ? ext_pack_sfixed64.hashCode() : 1);
-      result = result * 37 + (ext_pack_bool != null ? ext_pack_bool.hashCode() : 1);
-      result = result * 37 + (ext_pack_float != null ? ext_pack_float.hashCode() : 1);
-      result = result * 37 + (ext_pack_double != null ? ext_pack_double.hashCode() : 1);
-      result = result * 37 + (ext_pack_nested_enum != null ? ext_pack_nested_enum.hashCode() : 1);
+      result = result * 37 + ext_rep_int32.hashCode();
+      result = result * 37 + ext_rep_uint32.hashCode();
+      result = result * 37 + ext_rep_sint32.hashCode();
+      result = result * 37 + ext_rep_fixed32.hashCode();
+      result = result * 37 + ext_rep_sfixed32.hashCode();
+      result = result * 37 + ext_rep_int64.hashCode();
+      result = result * 37 + ext_rep_uint64.hashCode();
+      result = result * 37 + ext_rep_sint64.hashCode();
+      result = result * 37 + ext_rep_fixed64.hashCode();
+      result = result * 37 + ext_rep_sfixed64.hashCode();
+      result = result * 37 + ext_rep_bool.hashCode();
+      result = result * 37 + ext_rep_float.hashCode();
+      result = result * 37 + ext_rep_double.hashCode();
+      result = result * 37 + ext_rep_string.hashCode();
+      result = result * 37 + ext_rep_bytes.hashCode();
+      result = result * 37 + ext_rep_nested_enum.hashCode();
+      result = result * 37 + ext_rep_nested_message.hashCode();
+      result = result * 37 + ext_pack_int32.hashCode();
+      result = result * 37 + ext_pack_uint32.hashCode();
+      result = result * 37 + ext_pack_sint32.hashCode();
+      result = result * 37 + ext_pack_fixed32.hashCode();
+      result = result * 37 + ext_pack_sfixed32.hashCode();
+      result = result * 37 + ext_pack_int64.hashCode();
+      result = result * 37 + ext_pack_uint64.hashCode();
+      result = result * 37 + ext_pack_sint64.hashCode();
+      result = result * 37 + ext_pack_fixed64.hashCode();
+      result = result * 37 + ext_pack_sfixed64.hashCode();
+      result = result * 37 + ext_pack_bool.hashCode();
+      result = result * 37 + ext_pack_float.hashCode();
+      result = result * 37 + ext_pack_double.hashCode();
+      result = result * 37 + ext_pack_nested_enum.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -1723,54 +1723,54 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (opt_bytes != null) builder.append(", opt_bytes=").append(opt_bytes);
     if (opt_nested_enum != null) builder.append(", opt_nested_enum=").append(opt_nested_enum);
     if (opt_nested_message != null) builder.append(", opt_nested_message=").append(opt_nested_message);
-    if (req_int32 != null) builder.append(", req_int32=").append(req_int32);
-    if (req_uint32 != null) builder.append(", req_uint32=").append(req_uint32);
-    if (req_sint32 != null) builder.append(", req_sint32=").append(req_sint32);
-    if (req_fixed32 != null) builder.append(", req_fixed32=").append(req_fixed32);
-    if (req_sfixed32 != null) builder.append(", req_sfixed32=").append(req_sfixed32);
-    if (req_int64 != null) builder.append(", req_int64=").append(req_int64);
-    if (req_uint64 != null) builder.append(", req_uint64=").append(req_uint64);
-    if (req_sint64 != null) builder.append(", req_sint64=").append(req_sint64);
-    if (req_fixed64 != null) builder.append(", req_fixed64=").append(req_fixed64);
-    if (req_sfixed64 != null) builder.append(", req_sfixed64=").append(req_sfixed64);
-    if (req_bool != null) builder.append(", req_bool=").append(req_bool);
-    if (req_float != null) builder.append(", req_float=").append(req_float);
-    if (req_double != null) builder.append(", req_double=").append(req_double);
-    if (req_string != null) builder.append(", req_string=").append(req_string);
-    if (req_bytes != null) builder.append(", req_bytes=").append(req_bytes);
-    if (req_nested_enum != null) builder.append(", req_nested_enum=").append(req_nested_enum);
-    if (req_nested_message != null) builder.append(", req_nested_message=").append(req_nested_message);
-    if (rep_int32 != null) builder.append(", rep_int32=").append(rep_int32);
-    if (rep_uint32 != null) builder.append(", rep_uint32=").append(rep_uint32);
-    if (rep_sint32 != null) builder.append(", rep_sint32=").append(rep_sint32);
-    if (rep_fixed32 != null) builder.append(", rep_fixed32=").append(rep_fixed32);
-    if (rep_sfixed32 != null) builder.append(", rep_sfixed32=").append(rep_sfixed32);
-    if (rep_int64 != null) builder.append(", rep_int64=").append(rep_int64);
-    if (rep_uint64 != null) builder.append(", rep_uint64=").append(rep_uint64);
-    if (rep_sint64 != null) builder.append(", rep_sint64=").append(rep_sint64);
-    if (rep_fixed64 != null) builder.append(", rep_fixed64=").append(rep_fixed64);
-    if (rep_sfixed64 != null) builder.append(", rep_sfixed64=").append(rep_sfixed64);
-    if (rep_bool != null) builder.append(", rep_bool=").append(rep_bool);
-    if (rep_float != null) builder.append(", rep_float=").append(rep_float);
-    if (rep_double != null) builder.append(", rep_double=").append(rep_double);
-    if (rep_string != null) builder.append(", rep_string=").append(rep_string);
-    if (rep_bytes != null) builder.append(", rep_bytes=").append(rep_bytes);
-    if (rep_nested_enum != null) builder.append(", rep_nested_enum=").append(rep_nested_enum);
-    if (rep_nested_message != null) builder.append(", rep_nested_message=").append(rep_nested_message);
-    if (pack_int32 != null) builder.append(", pack_int32=").append(pack_int32);
-    if (pack_uint32 != null) builder.append(", pack_uint32=").append(pack_uint32);
-    if (pack_sint32 != null) builder.append(", pack_sint32=").append(pack_sint32);
-    if (pack_fixed32 != null) builder.append(", pack_fixed32=").append(pack_fixed32);
-    if (pack_sfixed32 != null) builder.append(", pack_sfixed32=").append(pack_sfixed32);
-    if (pack_int64 != null) builder.append(", pack_int64=").append(pack_int64);
-    if (pack_uint64 != null) builder.append(", pack_uint64=").append(pack_uint64);
-    if (pack_sint64 != null) builder.append(", pack_sint64=").append(pack_sint64);
-    if (pack_fixed64 != null) builder.append(", pack_fixed64=").append(pack_fixed64);
-    if (pack_sfixed64 != null) builder.append(", pack_sfixed64=").append(pack_sfixed64);
-    if (pack_bool != null) builder.append(", pack_bool=").append(pack_bool);
-    if (pack_float != null) builder.append(", pack_float=").append(pack_float);
-    if (pack_double != null) builder.append(", pack_double=").append(pack_double);
-    if (pack_nested_enum != null) builder.append(", pack_nested_enum=").append(pack_nested_enum);
+    builder.append(", req_int32=").append(req_int32);
+    builder.append(", req_uint32=").append(req_uint32);
+    builder.append(", req_sint32=").append(req_sint32);
+    builder.append(", req_fixed32=").append(req_fixed32);
+    builder.append(", req_sfixed32=").append(req_sfixed32);
+    builder.append(", req_int64=").append(req_int64);
+    builder.append(", req_uint64=").append(req_uint64);
+    builder.append(", req_sint64=").append(req_sint64);
+    builder.append(", req_fixed64=").append(req_fixed64);
+    builder.append(", req_sfixed64=").append(req_sfixed64);
+    builder.append(", req_bool=").append(req_bool);
+    builder.append(", req_float=").append(req_float);
+    builder.append(", req_double=").append(req_double);
+    builder.append(", req_string=").append(req_string);
+    builder.append(", req_bytes=").append(req_bytes);
+    builder.append(", req_nested_enum=").append(req_nested_enum);
+    builder.append(", req_nested_message=").append(req_nested_message);
+    if (!rep_int32.isEmpty()) builder.append(", rep_int32=").append(rep_int32);
+    if (!rep_uint32.isEmpty()) builder.append(", rep_uint32=").append(rep_uint32);
+    if (!rep_sint32.isEmpty()) builder.append(", rep_sint32=").append(rep_sint32);
+    if (!rep_fixed32.isEmpty()) builder.append(", rep_fixed32=").append(rep_fixed32);
+    if (!rep_sfixed32.isEmpty()) builder.append(", rep_sfixed32=").append(rep_sfixed32);
+    if (!rep_int64.isEmpty()) builder.append(", rep_int64=").append(rep_int64);
+    if (!rep_uint64.isEmpty()) builder.append(", rep_uint64=").append(rep_uint64);
+    if (!rep_sint64.isEmpty()) builder.append(", rep_sint64=").append(rep_sint64);
+    if (!rep_fixed64.isEmpty()) builder.append(", rep_fixed64=").append(rep_fixed64);
+    if (!rep_sfixed64.isEmpty()) builder.append(", rep_sfixed64=").append(rep_sfixed64);
+    if (!rep_bool.isEmpty()) builder.append(", rep_bool=").append(rep_bool);
+    if (!rep_float.isEmpty()) builder.append(", rep_float=").append(rep_float);
+    if (!rep_double.isEmpty()) builder.append(", rep_double=").append(rep_double);
+    if (!rep_string.isEmpty()) builder.append(", rep_string=").append(rep_string);
+    if (!rep_bytes.isEmpty()) builder.append(", rep_bytes=").append(rep_bytes);
+    if (!rep_nested_enum.isEmpty()) builder.append(", rep_nested_enum=").append(rep_nested_enum);
+    if (!rep_nested_message.isEmpty()) builder.append(", rep_nested_message=").append(rep_nested_message);
+    if (!pack_int32.isEmpty()) builder.append(", pack_int32=").append(pack_int32);
+    if (!pack_uint32.isEmpty()) builder.append(", pack_uint32=").append(pack_uint32);
+    if (!pack_sint32.isEmpty()) builder.append(", pack_sint32=").append(pack_sint32);
+    if (!pack_fixed32.isEmpty()) builder.append(", pack_fixed32=").append(pack_fixed32);
+    if (!pack_sfixed32.isEmpty()) builder.append(", pack_sfixed32=").append(pack_sfixed32);
+    if (!pack_int64.isEmpty()) builder.append(", pack_int64=").append(pack_int64);
+    if (!pack_uint64.isEmpty()) builder.append(", pack_uint64=").append(pack_uint64);
+    if (!pack_sint64.isEmpty()) builder.append(", pack_sint64=").append(pack_sint64);
+    if (!pack_fixed64.isEmpty()) builder.append(", pack_fixed64=").append(pack_fixed64);
+    if (!pack_sfixed64.isEmpty()) builder.append(", pack_sfixed64=").append(pack_sfixed64);
+    if (!pack_bool.isEmpty()) builder.append(", pack_bool=").append(pack_bool);
+    if (!pack_float.isEmpty()) builder.append(", pack_float=").append(pack_float);
+    if (!pack_double.isEmpty()) builder.append(", pack_double=").append(pack_double);
+    if (!pack_nested_enum.isEmpty()) builder.append(", pack_nested_enum=").append(pack_nested_enum);
     if (default_int32 != null) builder.append(", default_int32=").append(default_int32);
     if (default_uint32 != null) builder.append(", default_uint32=").append(default_uint32);
     if (default_sint32 != null) builder.append(", default_sint32=").append(default_sint32);
@@ -1804,37 +1804,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (ext_opt_bytes != null) builder.append(", ext_opt_bytes=").append(ext_opt_bytes);
     if (ext_opt_nested_enum != null) builder.append(", ext_opt_nested_enum=").append(ext_opt_nested_enum);
     if (ext_opt_nested_message != null) builder.append(", ext_opt_nested_message=").append(ext_opt_nested_message);
-    if (ext_rep_int32 != null) builder.append(", ext_rep_int32=").append(ext_rep_int32);
-    if (ext_rep_uint32 != null) builder.append(", ext_rep_uint32=").append(ext_rep_uint32);
-    if (ext_rep_sint32 != null) builder.append(", ext_rep_sint32=").append(ext_rep_sint32);
-    if (ext_rep_fixed32 != null) builder.append(", ext_rep_fixed32=").append(ext_rep_fixed32);
-    if (ext_rep_sfixed32 != null) builder.append(", ext_rep_sfixed32=").append(ext_rep_sfixed32);
-    if (ext_rep_int64 != null) builder.append(", ext_rep_int64=").append(ext_rep_int64);
-    if (ext_rep_uint64 != null) builder.append(", ext_rep_uint64=").append(ext_rep_uint64);
-    if (ext_rep_sint64 != null) builder.append(", ext_rep_sint64=").append(ext_rep_sint64);
-    if (ext_rep_fixed64 != null) builder.append(", ext_rep_fixed64=").append(ext_rep_fixed64);
-    if (ext_rep_sfixed64 != null) builder.append(", ext_rep_sfixed64=").append(ext_rep_sfixed64);
-    if (ext_rep_bool != null) builder.append(", ext_rep_bool=").append(ext_rep_bool);
-    if (ext_rep_float != null) builder.append(", ext_rep_float=").append(ext_rep_float);
-    if (ext_rep_double != null) builder.append(", ext_rep_double=").append(ext_rep_double);
-    if (ext_rep_string != null) builder.append(", ext_rep_string=").append(ext_rep_string);
-    if (ext_rep_bytes != null) builder.append(", ext_rep_bytes=").append(ext_rep_bytes);
-    if (ext_rep_nested_enum != null) builder.append(", ext_rep_nested_enum=").append(ext_rep_nested_enum);
-    if (ext_rep_nested_message != null) builder.append(", ext_rep_nested_message=").append(ext_rep_nested_message);
-    if (ext_pack_int32 != null) builder.append(", ext_pack_int32=").append(ext_pack_int32);
-    if (ext_pack_uint32 != null) builder.append(", ext_pack_uint32=").append(ext_pack_uint32);
-    if (ext_pack_sint32 != null) builder.append(", ext_pack_sint32=").append(ext_pack_sint32);
-    if (ext_pack_fixed32 != null) builder.append(", ext_pack_fixed32=").append(ext_pack_fixed32);
-    if (ext_pack_sfixed32 != null) builder.append(", ext_pack_sfixed32=").append(ext_pack_sfixed32);
-    if (ext_pack_int64 != null) builder.append(", ext_pack_int64=").append(ext_pack_int64);
-    if (ext_pack_uint64 != null) builder.append(", ext_pack_uint64=").append(ext_pack_uint64);
-    if (ext_pack_sint64 != null) builder.append(", ext_pack_sint64=").append(ext_pack_sint64);
-    if (ext_pack_fixed64 != null) builder.append(", ext_pack_fixed64=").append(ext_pack_fixed64);
-    if (ext_pack_sfixed64 != null) builder.append(", ext_pack_sfixed64=").append(ext_pack_sfixed64);
-    if (ext_pack_bool != null) builder.append(", ext_pack_bool=").append(ext_pack_bool);
-    if (ext_pack_float != null) builder.append(", ext_pack_float=").append(ext_pack_float);
-    if (ext_pack_double != null) builder.append(", ext_pack_double=").append(ext_pack_double);
-    if (ext_pack_nested_enum != null) builder.append(", ext_pack_nested_enum=").append(ext_pack_nested_enum);
+    if (!ext_rep_int32.isEmpty()) builder.append(", ext_rep_int32=").append(ext_rep_int32);
+    if (!ext_rep_uint32.isEmpty()) builder.append(", ext_rep_uint32=").append(ext_rep_uint32);
+    if (!ext_rep_sint32.isEmpty()) builder.append(", ext_rep_sint32=").append(ext_rep_sint32);
+    if (!ext_rep_fixed32.isEmpty()) builder.append(", ext_rep_fixed32=").append(ext_rep_fixed32);
+    if (!ext_rep_sfixed32.isEmpty()) builder.append(", ext_rep_sfixed32=").append(ext_rep_sfixed32);
+    if (!ext_rep_int64.isEmpty()) builder.append(", ext_rep_int64=").append(ext_rep_int64);
+    if (!ext_rep_uint64.isEmpty()) builder.append(", ext_rep_uint64=").append(ext_rep_uint64);
+    if (!ext_rep_sint64.isEmpty()) builder.append(", ext_rep_sint64=").append(ext_rep_sint64);
+    if (!ext_rep_fixed64.isEmpty()) builder.append(", ext_rep_fixed64=").append(ext_rep_fixed64);
+    if (!ext_rep_sfixed64.isEmpty()) builder.append(", ext_rep_sfixed64=").append(ext_rep_sfixed64);
+    if (!ext_rep_bool.isEmpty()) builder.append(", ext_rep_bool=").append(ext_rep_bool);
+    if (!ext_rep_float.isEmpty()) builder.append(", ext_rep_float=").append(ext_rep_float);
+    if (!ext_rep_double.isEmpty()) builder.append(", ext_rep_double=").append(ext_rep_double);
+    if (!ext_rep_string.isEmpty()) builder.append(", ext_rep_string=").append(ext_rep_string);
+    if (!ext_rep_bytes.isEmpty()) builder.append(", ext_rep_bytes=").append(ext_rep_bytes);
+    if (!ext_rep_nested_enum.isEmpty()) builder.append(", ext_rep_nested_enum=").append(ext_rep_nested_enum);
+    if (!ext_rep_nested_message.isEmpty()) builder.append(", ext_rep_nested_message=").append(ext_rep_nested_message);
+    if (!ext_pack_int32.isEmpty()) builder.append(", ext_pack_int32=").append(ext_pack_int32);
+    if (!ext_pack_uint32.isEmpty()) builder.append(", ext_pack_uint32=").append(ext_pack_uint32);
+    if (!ext_pack_sint32.isEmpty()) builder.append(", ext_pack_sint32=").append(ext_pack_sint32);
+    if (!ext_pack_fixed32.isEmpty()) builder.append(", ext_pack_fixed32=").append(ext_pack_fixed32);
+    if (!ext_pack_sfixed32.isEmpty()) builder.append(", ext_pack_sfixed32=").append(ext_pack_sfixed32);
+    if (!ext_pack_int64.isEmpty()) builder.append(", ext_pack_int64=").append(ext_pack_int64);
+    if (!ext_pack_uint64.isEmpty()) builder.append(", ext_pack_uint64=").append(ext_pack_uint64);
+    if (!ext_pack_sint64.isEmpty()) builder.append(", ext_pack_sint64=").append(ext_pack_sint64);
+    if (!ext_pack_fixed64.isEmpty()) builder.append(", ext_pack_fixed64=").append(ext_pack_fixed64);
+    if (!ext_pack_sfixed64.isEmpty()) builder.append(", ext_pack_sfixed64=").append(ext_pack_sfixed64);
+    if (!ext_pack_bool.isEmpty()) builder.append(", ext_pack_bool=").append(ext_pack_bool);
+    if (!ext_pack_float.isEmpty()) builder.append(", ext_pack_float=").append(ext_pack_float);
+    if (!ext_pack_double.isEmpty()) builder.append(", ext_pack_double=").append(ext_pack_double);
+    if (!ext_pack_nested_enum.isEmpty()) builder.append(", ext_pack_nested_enum=").append(ext_pack_nested_enum);
     return builder.replace(0, 2, "AllTypes{").append('}').toString();
   }
 
@@ -2972,7 +2972,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(a, o.a);
     }
 
@@ -3230,37 +3230,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       ProtoAdapter.BYTES.encodeWithTag(writer, 115, value.req_bytes);
       NestedEnum.ADAPTER.encodeWithTag(writer, 116, value.req_nested_enum);
       NestedMessage.ADAPTER.encodeWithTag(writer, 117, value.req_nested_message);
-      if (value.rep_int32 != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32);
-      if (value.rep_uint32 != null) ProtoAdapter.UINT32.asRepeated().encodeWithTag(writer, 202, value.rep_uint32);
-      if (value.rep_sint32 != null) ProtoAdapter.SINT32.asRepeated().encodeWithTag(writer, 203, value.rep_sint32);
-      if (value.rep_fixed32 != null) ProtoAdapter.FIXED32.asRepeated().encodeWithTag(writer, 204, value.rep_fixed32);
-      if (value.rep_sfixed32 != null) ProtoAdapter.SFIXED32.asRepeated().encodeWithTag(writer, 205, value.rep_sfixed32);
-      if (value.rep_int64 != null) ProtoAdapter.INT64.asRepeated().encodeWithTag(writer, 206, value.rep_int64);
-      if (value.rep_uint64 != null) ProtoAdapter.UINT64.asRepeated().encodeWithTag(writer, 207, value.rep_uint64);
-      if (value.rep_sint64 != null) ProtoAdapter.SINT64.asRepeated().encodeWithTag(writer, 208, value.rep_sint64);
-      if (value.rep_fixed64 != null) ProtoAdapter.FIXED64.asRepeated().encodeWithTag(writer, 209, value.rep_fixed64);
-      if (value.rep_sfixed64 != null) ProtoAdapter.SFIXED64.asRepeated().encodeWithTag(writer, 210, value.rep_sfixed64);
-      if (value.rep_bool != null) ProtoAdapter.BOOL.asRepeated().encodeWithTag(writer, 211, value.rep_bool);
-      if (value.rep_float != null) ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 212, value.rep_float);
-      if (value.rep_double != null) ProtoAdapter.DOUBLE.asRepeated().encodeWithTag(writer, 213, value.rep_double);
-      if (value.rep_string != null) ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 214, value.rep_string);
-      if (value.rep_bytes != null) ProtoAdapter.BYTES.asRepeated().encodeWithTag(writer, 215, value.rep_bytes);
-      if (value.rep_nested_enum != null) NestedEnum.ADAPTER.asRepeated().encodeWithTag(writer, 216, value.rep_nested_enum);
-      if (value.rep_nested_message != null) NestedMessage.ADAPTER.asRepeated().encodeWithTag(writer, 217, value.rep_nested_message);
-      if (value.pack_int32 != null) ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 301, value.pack_int32);
-      if (value.pack_uint32 != null) ProtoAdapter.UINT32.asPacked().encodeWithTag(writer, 302, value.pack_uint32);
-      if (value.pack_sint32 != null) ProtoAdapter.SINT32.asPacked().encodeWithTag(writer, 303, value.pack_sint32);
-      if (value.pack_fixed32 != null) ProtoAdapter.FIXED32.asPacked().encodeWithTag(writer, 304, value.pack_fixed32);
-      if (value.pack_sfixed32 != null) ProtoAdapter.SFIXED32.asPacked().encodeWithTag(writer, 305, value.pack_sfixed32);
-      if (value.pack_int64 != null) ProtoAdapter.INT64.asPacked().encodeWithTag(writer, 306, value.pack_int64);
-      if (value.pack_uint64 != null) ProtoAdapter.UINT64.asPacked().encodeWithTag(writer, 307, value.pack_uint64);
-      if (value.pack_sint64 != null) ProtoAdapter.SINT64.asPacked().encodeWithTag(writer, 308, value.pack_sint64);
-      if (value.pack_fixed64 != null) ProtoAdapter.FIXED64.asPacked().encodeWithTag(writer, 309, value.pack_fixed64);
-      if (value.pack_sfixed64 != null) ProtoAdapter.SFIXED64.asPacked().encodeWithTag(writer, 310, value.pack_sfixed64);
-      if (value.pack_bool != null) ProtoAdapter.BOOL.asPacked().encodeWithTag(writer, 311, value.pack_bool);
-      if (value.pack_float != null) ProtoAdapter.FLOAT.asPacked().encodeWithTag(writer, 312, value.pack_float);
-      if (value.pack_double != null) ProtoAdapter.DOUBLE.asPacked().encodeWithTag(writer, 313, value.pack_double);
-      if (value.pack_nested_enum != null) NestedEnum.ADAPTER.asPacked().encodeWithTag(writer, 316, value.pack_nested_enum);
+      ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32);
+      ProtoAdapter.UINT32.asRepeated().encodeWithTag(writer, 202, value.rep_uint32);
+      ProtoAdapter.SINT32.asRepeated().encodeWithTag(writer, 203, value.rep_sint32);
+      ProtoAdapter.FIXED32.asRepeated().encodeWithTag(writer, 204, value.rep_fixed32);
+      ProtoAdapter.SFIXED32.asRepeated().encodeWithTag(writer, 205, value.rep_sfixed32);
+      ProtoAdapter.INT64.asRepeated().encodeWithTag(writer, 206, value.rep_int64);
+      ProtoAdapter.UINT64.asRepeated().encodeWithTag(writer, 207, value.rep_uint64);
+      ProtoAdapter.SINT64.asRepeated().encodeWithTag(writer, 208, value.rep_sint64);
+      ProtoAdapter.FIXED64.asRepeated().encodeWithTag(writer, 209, value.rep_fixed64);
+      ProtoAdapter.SFIXED64.asRepeated().encodeWithTag(writer, 210, value.rep_sfixed64);
+      ProtoAdapter.BOOL.asRepeated().encodeWithTag(writer, 211, value.rep_bool);
+      ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 212, value.rep_float);
+      ProtoAdapter.DOUBLE.asRepeated().encodeWithTag(writer, 213, value.rep_double);
+      ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 214, value.rep_string);
+      ProtoAdapter.BYTES.asRepeated().encodeWithTag(writer, 215, value.rep_bytes);
+      NestedEnum.ADAPTER.asRepeated().encodeWithTag(writer, 216, value.rep_nested_enum);
+      NestedMessage.ADAPTER.asRepeated().encodeWithTag(writer, 217, value.rep_nested_message);
+      ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 301, value.pack_int32);
+      ProtoAdapter.UINT32.asPacked().encodeWithTag(writer, 302, value.pack_uint32);
+      ProtoAdapter.SINT32.asPacked().encodeWithTag(writer, 303, value.pack_sint32);
+      ProtoAdapter.FIXED32.asPacked().encodeWithTag(writer, 304, value.pack_fixed32);
+      ProtoAdapter.SFIXED32.asPacked().encodeWithTag(writer, 305, value.pack_sfixed32);
+      ProtoAdapter.INT64.asPacked().encodeWithTag(writer, 306, value.pack_int64);
+      ProtoAdapter.UINT64.asPacked().encodeWithTag(writer, 307, value.pack_uint64);
+      ProtoAdapter.SINT64.asPacked().encodeWithTag(writer, 308, value.pack_sint64);
+      ProtoAdapter.FIXED64.asPacked().encodeWithTag(writer, 309, value.pack_fixed64);
+      ProtoAdapter.SFIXED64.asPacked().encodeWithTag(writer, 310, value.pack_sfixed64);
+      ProtoAdapter.BOOL.asPacked().encodeWithTag(writer, 311, value.pack_bool);
+      ProtoAdapter.FLOAT.asPacked().encodeWithTag(writer, 312, value.pack_float);
+      ProtoAdapter.DOUBLE.asPacked().encodeWithTag(writer, 313, value.pack_double);
+      NestedEnum.ADAPTER.asPacked().encodeWithTag(writer, 316, value.pack_nested_enum);
       if (value.default_int32 != null) ProtoAdapter.INT32.encodeWithTag(writer, 401, value.default_int32);
       if (value.default_uint32 != null) ProtoAdapter.UINT32.encodeWithTag(writer, 402, value.default_uint32);
       if (value.default_sint32 != null) ProtoAdapter.SINT32.encodeWithTag(writer, 403, value.default_sint32);
@@ -3294,37 +3294,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       if (value.ext_opt_bytes != null) ProtoAdapter.BYTES.encodeWithTag(writer, 1015, value.ext_opt_bytes);
       if (value.ext_opt_nested_enum != null) NestedEnum.ADAPTER.encodeWithTag(writer, 1016, value.ext_opt_nested_enum);
       if (value.ext_opt_nested_message != null) NestedMessage.ADAPTER.encodeWithTag(writer, 1017, value.ext_opt_nested_message);
-      if (value.ext_rep_int32 != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1101, value.ext_rep_int32);
-      if (value.ext_rep_uint32 != null) ProtoAdapter.UINT32.asRepeated().encodeWithTag(writer, 1102, value.ext_rep_uint32);
-      if (value.ext_rep_sint32 != null) ProtoAdapter.SINT32.asRepeated().encodeWithTag(writer, 1103, value.ext_rep_sint32);
-      if (value.ext_rep_fixed32 != null) ProtoAdapter.FIXED32.asRepeated().encodeWithTag(writer, 1104, value.ext_rep_fixed32);
-      if (value.ext_rep_sfixed32 != null) ProtoAdapter.SFIXED32.asRepeated().encodeWithTag(writer, 1105, value.ext_rep_sfixed32);
-      if (value.ext_rep_int64 != null) ProtoAdapter.INT64.asRepeated().encodeWithTag(writer, 1106, value.ext_rep_int64);
-      if (value.ext_rep_uint64 != null) ProtoAdapter.UINT64.asRepeated().encodeWithTag(writer, 1107, value.ext_rep_uint64);
-      if (value.ext_rep_sint64 != null) ProtoAdapter.SINT64.asRepeated().encodeWithTag(writer, 1108, value.ext_rep_sint64);
-      if (value.ext_rep_fixed64 != null) ProtoAdapter.FIXED64.asRepeated().encodeWithTag(writer, 1109, value.ext_rep_fixed64);
-      if (value.ext_rep_sfixed64 != null) ProtoAdapter.SFIXED64.asRepeated().encodeWithTag(writer, 1110, value.ext_rep_sfixed64);
-      if (value.ext_rep_bool != null) ProtoAdapter.BOOL.asRepeated().encodeWithTag(writer, 1111, value.ext_rep_bool);
-      if (value.ext_rep_float != null) ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 1112, value.ext_rep_float);
-      if (value.ext_rep_double != null) ProtoAdapter.DOUBLE.asRepeated().encodeWithTag(writer, 1113, value.ext_rep_double);
-      if (value.ext_rep_string != null) ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 1114, value.ext_rep_string);
-      if (value.ext_rep_bytes != null) ProtoAdapter.BYTES.asRepeated().encodeWithTag(writer, 1115, value.ext_rep_bytes);
-      if (value.ext_rep_nested_enum != null) NestedEnum.ADAPTER.asRepeated().encodeWithTag(writer, 1116, value.ext_rep_nested_enum);
-      if (value.ext_rep_nested_message != null) NestedMessage.ADAPTER.asRepeated().encodeWithTag(writer, 1117, value.ext_rep_nested_message);
-      if (value.ext_pack_int32 != null) ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1201, value.ext_pack_int32);
-      if (value.ext_pack_uint32 != null) ProtoAdapter.UINT32.asPacked().encodeWithTag(writer, 1202, value.ext_pack_uint32);
-      if (value.ext_pack_sint32 != null) ProtoAdapter.SINT32.asPacked().encodeWithTag(writer, 1203, value.ext_pack_sint32);
-      if (value.ext_pack_fixed32 != null) ProtoAdapter.FIXED32.asPacked().encodeWithTag(writer, 1204, value.ext_pack_fixed32);
-      if (value.ext_pack_sfixed32 != null) ProtoAdapter.SFIXED32.asPacked().encodeWithTag(writer, 1205, value.ext_pack_sfixed32);
-      if (value.ext_pack_int64 != null) ProtoAdapter.INT64.asPacked().encodeWithTag(writer, 1206, value.ext_pack_int64);
-      if (value.ext_pack_uint64 != null) ProtoAdapter.UINT64.asPacked().encodeWithTag(writer, 1207, value.ext_pack_uint64);
-      if (value.ext_pack_sint64 != null) ProtoAdapter.SINT64.asPacked().encodeWithTag(writer, 1208, value.ext_pack_sint64);
-      if (value.ext_pack_fixed64 != null) ProtoAdapter.FIXED64.asPacked().encodeWithTag(writer, 1209, value.ext_pack_fixed64);
-      if (value.ext_pack_sfixed64 != null) ProtoAdapter.SFIXED64.asPacked().encodeWithTag(writer, 1210, value.ext_pack_sfixed64);
-      if (value.ext_pack_bool != null) ProtoAdapter.BOOL.asPacked().encodeWithTag(writer, 1211, value.ext_pack_bool);
-      if (value.ext_pack_float != null) ProtoAdapter.FLOAT.asPacked().encodeWithTag(writer, 1212, value.ext_pack_float);
-      if (value.ext_pack_double != null) ProtoAdapter.DOUBLE.asPacked().encodeWithTag(writer, 1213, value.ext_pack_double);
-      if (value.ext_pack_nested_enum != null) NestedEnum.ADAPTER.asPacked().encodeWithTag(writer, 1216, value.ext_pack_nested_enum);
+      ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1101, value.ext_rep_int32);
+      ProtoAdapter.UINT32.asRepeated().encodeWithTag(writer, 1102, value.ext_rep_uint32);
+      ProtoAdapter.SINT32.asRepeated().encodeWithTag(writer, 1103, value.ext_rep_sint32);
+      ProtoAdapter.FIXED32.asRepeated().encodeWithTag(writer, 1104, value.ext_rep_fixed32);
+      ProtoAdapter.SFIXED32.asRepeated().encodeWithTag(writer, 1105, value.ext_rep_sfixed32);
+      ProtoAdapter.INT64.asRepeated().encodeWithTag(writer, 1106, value.ext_rep_int64);
+      ProtoAdapter.UINT64.asRepeated().encodeWithTag(writer, 1107, value.ext_rep_uint64);
+      ProtoAdapter.SINT64.asRepeated().encodeWithTag(writer, 1108, value.ext_rep_sint64);
+      ProtoAdapter.FIXED64.asRepeated().encodeWithTag(writer, 1109, value.ext_rep_fixed64);
+      ProtoAdapter.SFIXED64.asRepeated().encodeWithTag(writer, 1110, value.ext_rep_sfixed64);
+      ProtoAdapter.BOOL.asRepeated().encodeWithTag(writer, 1111, value.ext_rep_bool);
+      ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 1112, value.ext_rep_float);
+      ProtoAdapter.DOUBLE.asRepeated().encodeWithTag(writer, 1113, value.ext_rep_double);
+      ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 1114, value.ext_rep_string);
+      ProtoAdapter.BYTES.asRepeated().encodeWithTag(writer, 1115, value.ext_rep_bytes);
+      NestedEnum.ADAPTER.asRepeated().encodeWithTag(writer, 1116, value.ext_rep_nested_enum);
+      NestedMessage.ADAPTER.asRepeated().encodeWithTag(writer, 1117, value.ext_rep_nested_message);
+      ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1201, value.ext_pack_int32);
+      ProtoAdapter.UINT32.asPacked().encodeWithTag(writer, 1202, value.ext_pack_uint32);
+      ProtoAdapter.SINT32.asPacked().encodeWithTag(writer, 1203, value.ext_pack_sint32);
+      ProtoAdapter.FIXED32.asPacked().encodeWithTag(writer, 1204, value.ext_pack_fixed32);
+      ProtoAdapter.SFIXED32.asPacked().encodeWithTag(writer, 1205, value.ext_pack_sfixed32);
+      ProtoAdapter.INT64.asPacked().encodeWithTag(writer, 1206, value.ext_pack_int64);
+      ProtoAdapter.UINT64.asPacked().encodeWithTag(writer, 1207, value.ext_pack_uint64);
+      ProtoAdapter.SINT64.asPacked().encodeWithTag(writer, 1208, value.ext_pack_sint64);
+      ProtoAdapter.FIXED64.asPacked().encodeWithTag(writer, 1209, value.ext_pack_fixed64);
+      ProtoAdapter.SFIXED64.asPacked().encodeWithTag(writer, 1210, value.ext_pack_sfixed64);
+      ProtoAdapter.BOOL.asPacked().encodeWithTag(writer, 1211, value.ext_pack_bool);
+      ProtoAdapter.FLOAT.asPacked().encodeWithTag(writer, 1212, value.ext_pack_float);
+      ProtoAdapter.DOUBLE.asPacked().encodeWithTag(writer, 1213, value.ext_pack_double);
+      NestedEnum.ADAPTER.asPacked().encodeWithTag(writer, 1216, value.ext_pack_nested_enum);
       writer.writeBytes(value.unknownFields());
     }
 
@@ -3534,7 +3534,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     public AllTypes redact(AllTypes value) {
       Builder builder = value.newBuilder();
       if (builder.opt_nested_message != null) builder.opt_nested_message = NestedMessage.ADAPTER.redact(builder.opt_nested_message);
-      if (builder.req_nested_message != null) builder.req_nested_message = NestedMessage.ADAPTER.redact(builder.req_nested_message);
+      builder.req_nested_message = NestedMessage.ADAPTER.redact(builder.req_nested_message);
       Internal.redactElements(builder.rep_nested_message, NestedMessage.ADAPTER);
       if (builder.ext_opt_nested_message != null) builder.ext_opt_nested_message = NestedMessage.ADAPTER.redact(builder.ext_opt_nested_message);
       Internal.redactElements(builder.ext_rep_nested_message, NestedMessage.ADAPTER);

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java.compact
@@ -1427,7 +1427,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     if (other == this) return true;
     if (!(other instanceof AllTypes)) return false;
     AllTypes o = (AllTypes) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(opt_int32, o.opt_int32)
         && Internal.equals(opt_uint32, o.opt_uint32)
         && Internal.equals(opt_sint32, o.opt_sint32)
@@ -1445,54 +1445,54 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
         && Internal.equals(opt_bytes, o.opt_bytes)
         && Internal.equals(opt_nested_enum, o.opt_nested_enum)
         && Internal.equals(opt_nested_message, o.opt_nested_message)
-        && Internal.equals(req_int32, o.req_int32)
-        && Internal.equals(req_uint32, o.req_uint32)
-        && Internal.equals(req_sint32, o.req_sint32)
-        && Internal.equals(req_fixed32, o.req_fixed32)
-        && Internal.equals(req_sfixed32, o.req_sfixed32)
-        && Internal.equals(req_int64, o.req_int64)
-        && Internal.equals(req_uint64, o.req_uint64)
-        && Internal.equals(req_sint64, o.req_sint64)
-        && Internal.equals(req_fixed64, o.req_fixed64)
-        && Internal.equals(req_sfixed64, o.req_sfixed64)
-        && Internal.equals(req_bool, o.req_bool)
-        && Internal.equals(req_float, o.req_float)
-        && Internal.equals(req_double, o.req_double)
-        && Internal.equals(req_string, o.req_string)
-        && Internal.equals(req_bytes, o.req_bytes)
-        && Internal.equals(req_nested_enum, o.req_nested_enum)
-        && Internal.equals(req_nested_message, o.req_nested_message)
-        && Internal.equals(rep_int32, o.rep_int32)
-        && Internal.equals(rep_uint32, o.rep_uint32)
-        && Internal.equals(rep_sint32, o.rep_sint32)
-        && Internal.equals(rep_fixed32, o.rep_fixed32)
-        && Internal.equals(rep_sfixed32, o.rep_sfixed32)
-        && Internal.equals(rep_int64, o.rep_int64)
-        && Internal.equals(rep_uint64, o.rep_uint64)
-        && Internal.equals(rep_sint64, o.rep_sint64)
-        && Internal.equals(rep_fixed64, o.rep_fixed64)
-        && Internal.equals(rep_sfixed64, o.rep_sfixed64)
-        && Internal.equals(rep_bool, o.rep_bool)
-        && Internal.equals(rep_float, o.rep_float)
-        && Internal.equals(rep_double, o.rep_double)
-        && Internal.equals(rep_string, o.rep_string)
-        && Internal.equals(rep_bytes, o.rep_bytes)
-        && Internal.equals(rep_nested_enum, o.rep_nested_enum)
-        && Internal.equals(rep_nested_message, o.rep_nested_message)
-        && Internal.equals(pack_int32, o.pack_int32)
-        && Internal.equals(pack_uint32, o.pack_uint32)
-        && Internal.equals(pack_sint32, o.pack_sint32)
-        && Internal.equals(pack_fixed32, o.pack_fixed32)
-        && Internal.equals(pack_sfixed32, o.pack_sfixed32)
-        && Internal.equals(pack_int64, o.pack_int64)
-        && Internal.equals(pack_uint64, o.pack_uint64)
-        && Internal.equals(pack_sint64, o.pack_sint64)
-        && Internal.equals(pack_fixed64, o.pack_fixed64)
-        && Internal.equals(pack_sfixed64, o.pack_sfixed64)
-        && Internal.equals(pack_bool, o.pack_bool)
-        && Internal.equals(pack_float, o.pack_float)
-        && Internal.equals(pack_double, o.pack_double)
-        && Internal.equals(pack_nested_enum, o.pack_nested_enum)
+        && req_int32.equals(o.req_int32)
+        && req_uint32.equals(o.req_uint32)
+        && req_sint32.equals(o.req_sint32)
+        && req_fixed32.equals(o.req_fixed32)
+        && req_sfixed32.equals(o.req_sfixed32)
+        && req_int64.equals(o.req_int64)
+        && req_uint64.equals(o.req_uint64)
+        && req_sint64.equals(o.req_sint64)
+        && req_fixed64.equals(o.req_fixed64)
+        && req_sfixed64.equals(o.req_sfixed64)
+        && req_bool.equals(o.req_bool)
+        && req_float.equals(o.req_float)
+        && req_double.equals(o.req_double)
+        && req_string.equals(o.req_string)
+        && req_bytes.equals(o.req_bytes)
+        && req_nested_enum.equals(o.req_nested_enum)
+        && req_nested_message.equals(o.req_nested_message)
+        && rep_int32.equals(o.rep_int32)
+        && rep_uint32.equals(o.rep_uint32)
+        && rep_sint32.equals(o.rep_sint32)
+        && rep_fixed32.equals(o.rep_fixed32)
+        && rep_sfixed32.equals(o.rep_sfixed32)
+        && rep_int64.equals(o.rep_int64)
+        && rep_uint64.equals(o.rep_uint64)
+        && rep_sint64.equals(o.rep_sint64)
+        && rep_fixed64.equals(o.rep_fixed64)
+        && rep_sfixed64.equals(o.rep_sfixed64)
+        && rep_bool.equals(o.rep_bool)
+        && rep_float.equals(o.rep_float)
+        && rep_double.equals(o.rep_double)
+        && rep_string.equals(o.rep_string)
+        && rep_bytes.equals(o.rep_bytes)
+        && rep_nested_enum.equals(o.rep_nested_enum)
+        && rep_nested_message.equals(o.rep_nested_message)
+        && pack_int32.equals(o.pack_int32)
+        && pack_uint32.equals(o.pack_uint32)
+        && pack_sint32.equals(o.pack_sint32)
+        && pack_fixed32.equals(o.pack_fixed32)
+        && pack_sfixed32.equals(o.pack_sfixed32)
+        && pack_int64.equals(o.pack_int64)
+        && pack_uint64.equals(o.pack_uint64)
+        && pack_sint64.equals(o.pack_sint64)
+        && pack_fixed64.equals(o.pack_fixed64)
+        && pack_sfixed64.equals(o.pack_sfixed64)
+        && pack_bool.equals(o.pack_bool)
+        && pack_float.equals(o.pack_float)
+        && pack_double.equals(o.pack_double)
+        && pack_nested_enum.equals(o.pack_nested_enum)
         && Internal.equals(default_int32, o.default_int32)
         && Internal.equals(default_uint32, o.default_uint32)
         && Internal.equals(default_sint32, o.default_sint32)
@@ -1526,37 +1526,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
         && Internal.equals(ext_opt_bytes, o.ext_opt_bytes)
         && Internal.equals(ext_opt_nested_enum, o.ext_opt_nested_enum)
         && Internal.equals(ext_opt_nested_message, o.ext_opt_nested_message)
-        && Internal.equals(ext_rep_int32, o.ext_rep_int32)
-        && Internal.equals(ext_rep_uint32, o.ext_rep_uint32)
-        && Internal.equals(ext_rep_sint32, o.ext_rep_sint32)
-        && Internal.equals(ext_rep_fixed32, o.ext_rep_fixed32)
-        && Internal.equals(ext_rep_sfixed32, o.ext_rep_sfixed32)
-        && Internal.equals(ext_rep_int64, o.ext_rep_int64)
-        && Internal.equals(ext_rep_uint64, o.ext_rep_uint64)
-        && Internal.equals(ext_rep_sint64, o.ext_rep_sint64)
-        && Internal.equals(ext_rep_fixed64, o.ext_rep_fixed64)
-        && Internal.equals(ext_rep_sfixed64, o.ext_rep_sfixed64)
-        && Internal.equals(ext_rep_bool, o.ext_rep_bool)
-        && Internal.equals(ext_rep_float, o.ext_rep_float)
-        && Internal.equals(ext_rep_double, o.ext_rep_double)
-        && Internal.equals(ext_rep_string, o.ext_rep_string)
-        && Internal.equals(ext_rep_bytes, o.ext_rep_bytes)
-        && Internal.equals(ext_rep_nested_enum, o.ext_rep_nested_enum)
-        && Internal.equals(ext_rep_nested_message, o.ext_rep_nested_message)
-        && Internal.equals(ext_pack_int32, o.ext_pack_int32)
-        && Internal.equals(ext_pack_uint32, o.ext_pack_uint32)
-        && Internal.equals(ext_pack_sint32, o.ext_pack_sint32)
-        && Internal.equals(ext_pack_fixed32, o.ext_pack_fixed32)
-        && Internal.equals(ext_pack_sfixed32, o.ext_pack_sfixed32)
-        && Internal.equals(ext_pack_int64, o.ext_pack_int64)
-        && Internal.equals(ext_pack_uint64, o.ext_pack_uint64)
-        && Internal.equals(ext_pack_sint64, o.ext_pack_sint64)
-        && Internal.equals(ext_pack_fixed64, o.ext_pack_fixed64)
-        && Internal.equals(ext_pack_sfixed64, o.ext_pack_sfixed64)
-        && Internal.equals(ext_pack_bool, o.ext_pack_bool)
-        && Internal.equals(ext_pack_float, o.ext_pack_float)
-        && Internal.equals(ext_pack_double, o.ext_pack_double)
-        && Internal.equals(ext_pack_nested_enum, o.ext_pack_nested_enum);
+        && ext_rep_int32.equals(o.ext_rep_int32)
+        && ext_rep_uint32.equals(o.ext_rep_uint32)
+        && ext_rep_sint32.equals(o.ext_rep_sint32)
+        && ext_rep_fixed32.equals(o.ext_rep_fixed32)
+        && ext_rep_sfixed32.equals(o.ext_rep_sfixed32)
+        && ext_rep_int64.equals(o.ext_rep_int64)
+        && ext_rep_uint64.equals(o.ext_rep_uint64)
+        && ext_rep_sint64.equals(o.ext_rep_sint64)
+        && ext_rep_fixed64.equals(o.ext_rep_fixed64)
+        && ext_rep_sfixed64.equals(o.ext_rep_sfixed64)
+        && ext_rep_bool.equals(o.ext_rep_bool)
+        && ext_rep_float.equals(o.ext_rep_float)
+        && ext_rep_double.equals(o.ext_rep_double)
+        && ext_rep_string.equals(o.ext_rep_string)
+        && ext_rep_bytes.equals(o.ext_rep_bytes)
+        && ext_rep_nested_enum.equals(o.ext_rep_nested_enum)
+        && ext_rep_nested_message.equals(o.ext_rep_nested_message)
+        && ext_pack_int32.equals(o.ext_pack_int32)
+        && ext_pack_uint32.equals(o.ext_pack_uint32)
+        && ext_pack_sint32.equals(o.ext_pack_sint32)
+        && ext_pack_fixed32.equals(o.ext_pack_fixed32)
+        && ext_pack_sfixed32.equals(o.ext_pack_sfixed32)
+        && ext_pack_int64.equals(o.ext_pack_int64)
+        && ext_pack_uint64.equals(o.ext_pack_uint64)
+        && ext_pack_sint64.equals(o.ext_pack_sint64)
+        && ext_pack_fixed64.equals(o.ext_pack_fixed64)
+        && ext_pack_sfixed64.equals(o.ext_pack_sfixed64)
+        && ext_pack_bool.equals(o.ext_pack_bool)
+        && ext_pack_float.equals(o.ext_pack_float)
+        && ext_pack_double.equals(o.ext_pack_double)
+        && ext_pack_nested_enum.equals(o.ext_pack_nested_enum);
   }
 
   @Override
@@ -1581,54 +1581,54 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       result = result * 37 + (opt_bytes != null ? opt_bytes.hashCode() : 0);
       result = result * 37 + (opt_nested_enum != null ? opt_nested_enum.hashCode() : 0);
       result = result * 37 + (opt_nested_message != null ? opt_nested_message.hashCode() : 0);
-      result = result * 37 + (req_int32 != null ? req_int32.hashCode() : 0);
-      result = result * 37 + (req_uint32 != null ? req_uint32.hashCode() : 0);
-      result = result * 37 + (req_sint32 != null ? req_sint32.hashCode() : 0);
-      result = result * 37 + (req_fixed32 != null ? req_fixed32.hashCode() : 0);
-      result = result * 37 + (req_sfixed32 != null ? req_sfixed32.hashCode() : 0);
-      result = result * 37 + (req_int64 != null ? req_int64.hashCode() : 0);
-      result = result * 37 + (req_uint64 != null ? req_uint64.hashCode() : 0);
-      result = result * 37 + (req_sint64 != null ? req_sint64.hashCode() : 0);
-      result = result * 37 + (req_fixed64 != null ? req_fixed64.hashCode() : 0);
-      result = result * 37 + (req_sfixed64 != null ? req_sfixed64.hashCode() : 0);
-      result = result * 37 + (req_bool != null ? req_bool.hashCode() : 0);
-      result = result * 37 + (req_float != null ? req_float.hashCode() : 0);
-      result = result * 37 + (req_double != null ? req_double.hashCode() : 0);
-      result = result * 37 + (req_string != null ? req_string.hashCode() : 0);
-      result = result * 37 + (req_bytes != null ? req_bytes.hashCode() : 0);
-      result = result * 37 + (req_nested_enum != null ? req_nested_enum.hashCode() : 0);
-      result = result * 37 + (req_nested_message != null ? req_nested_message.hashCode() : 0);
-      result = result * 37 + (rep_int32 != null ? rep_int32.hashCode() : 1);
-      result = result * 37 + (rep_uint32 != null ? rep_uint32.hashCode() : 1);
-      result = result * 37 + (rep_sint32 != null ? rep_sint32.hashCode() : 1);
-      result = result * 37 + (rep_fixed32 != null ? rep_fixed32.hashCode() : 1);
-      result = result * 37 + (rep_sfixed32 != null ? rep_sfixed32.hashCode() : 1);
-      result = result * 37 + (rep_int64 != null ? rep_int64.hashCode() : 1);
-      result = result * 37 + (rep_uint64 != null ? rep_uint64.hashCode() : 1);
-      result = result * 37 + (rep_sint64 != null ? rep_sint64.hashCode() : 1);
-      result = result * 37 + (rep_fixed64 != null ? rep_fixed64.hashCode() : 1);
-      result = result * 37 + (rep_sfixed64 != null ? rep_sfixed64.hashCode() : 1);
-      result = result * 37 + (rep_bool != null ? rep_bool.hashCode() : 1);
-      result = result * 37 + (rep_float != null ? rep_float.hashCode() : 1);
-      result = result * 37 + (rep_double != null ? rep_double.hashCode() : 1);
-      result = result * 37 + (rep_string != null ? rep_string.hashCode() : 1);
-      result = result * 37 + (rep_bytes != null ? rep_bytes.hashCode() : 1);
-      result = result * 37 + (rep_nested_enum != null ? rep_nested_enum.hashCode() : 1);
-      result = result * 37 + (rep_nested_message != null ? rep_nested_message.hashCode() : 1);
-      result = result * 37 + (pack_int32 != null ? pack_int32.hashCode() : 1);
-      result = result * 37 + (pack_uint32 != null ? pack_uint32.hashCode() : 1);
-      result = result * 37 + (pack_sint32 != null ? pack_sint32.hashCode() : 1);
-      result = result * 37 + (pack_fixed32 != null ? pack_fixed32.hashCode() : 1);
-      result = result * 37 + (pack_sfixed32 != null ? pack_sfixed32.hashCode() : 1);
-      result = result * 37 + (pack_int64 != null ? pack_int64.hashCode() : 1);
-      result = result * 37 + (pack_uint64 != null ? pack_uint64.hashCode() : 1);
-      result = result * 37 + (pack_sint64 != null ? pack_sint64.hashCode() : 1);
-      result = result * 37 + (pack_fixed64 != null ? pack_fixed64.hashCode() : 1);
-      result = result * 37 + (pack_sfixed64 != null ? pack_sfixed64.hashCode() : 1);
-      result = result * 37 + (pack_bool != null ? pack_bool.hashCode() : 1);
-      result = result * 37 + (pack_float != null ? pack_float.hashCode() : 1);
-      result = result * 37 + (pack_double != null ? pack_double.hashCode() : 1);
-      result = result * 37 + (pack_nested_enum != null ? pack_nested_enum.hashCode() : 1);
+      result = result * 37 + req_int32.hashCode();
+      result = result * 37 + req_uint32.hashCode();
+      result = result * 37 + req_sint32.hashCode();
+      result = result * 37 + req_fixed32.hashCode();
+      result = result * 37 + req_sfixed32.hashCode();
+      result = result * 37 + req_int64.hashCode();
+      result = result * 37 + req_uint64.hashCode();
+      result = result * 37 + req_sint64.hashCode();
+      result = result * 37 + req_fixed64.hashCode();
+      result = result * 37 + req_sfixed64.hashCode();
+      result = result * 37 + req_bool.hashCode();
+      result = result * 37 + req_float.hashCode();
+      result = result * 37 + req_double.hashCode();
+      result = result * 37 + req_string.hashCode();
+      result = result * 37 + req_bytes.hashCode();
+      result = result * 37 + req_nested_enum.hashCode();
+      result = result * 37 + req_nested_message.hashCode();
+      result = result * 37 + rep_int32.hashCode();
+      result = result * 37 + rep_uint32.hashCode();
+      result = result * 37 + rep_sint32.hashCode();
+      result = result * 37 + rep_fixed32.hashCode();
+      result = result * 37 + rep_sfixed32.hashCode();
+      result = result * 37 + rep_int64.hashCode();
+      result = result * 37 + rep_uint64.hashCode();
+      result = result * 37 + rep_sint64.hashCode();
+      result = result * 37 + rep_fixed64.hashCode();
+      result = result * 37 + rep_sfixed64.hashCode();
+      result = result * 37 + rep_bool.hashCode();
+      result = result * 37 + rep_float.hashCode();
+      result = result * 37 + rep_double.hashCode();
+      result = result * 37 + rep_string.hashCode();
+      result = result * 37 + rep_bytes.hashCode();
+      result = result * 37 + rep_nested_enum.hashCode();
+      result = result * 37 + rep_nested_message.hashCode();
+      result = result * 37 + pack_int32.hashCode();
+      result = result * 37 + pack_uint32.hashCode();
+      result = result * 37 + pack_sint32.hashCode();
+      result = result * 37 + pack_fixed32.hashCode();
+      result = result * 37 + pack_sfixed32.hashCode();
+      result = result * 37 + pack_int64.hashCode();
+      result = result * 37 + pack_uint64.hashCode();
+      result = result * 37 + pack_sint64.hashCode();
+      result = result * 37 + pack_fixed64.hashCode();
+      result = result * 37 + pack_sfixed64.hashCode();
+      result = result * 37 + pack_bool.hashCode();
+      result = result * 37 + pack_float.hashCode();
+      result = result * 37 + pack_double.hashCode();
+      result = result * 37 + pack_nested_enum.hashCode();
       result = result * 37 + (default_int32 != null ? default_int32.hashCode() : 0);
       result = result * 37 + (default_uint32 != null ? default_uint32.hashCode() : 0);
       result = result * 37 + (default_sint32 != null ? default_sint32.hashCode() : 0);
@@ -1662,37 +1662,37 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       result = result * 37 + (ext_opt_bytes != null ? ext_opt_bytes.hashCode() : 0);
       result = result * 37 + (ext_opt_nested_enum != null ? ext_opt_nested_enum.hashCode() : 0);
       result = result * 37 + (ext_opt_nested_message != null ? ext_opt_nested_message.hashCode() : 0);
-      result = result * 37 + (ext_rep_int32 != null ? ext_rep_int32.hashCode() : 1);
-      result = result * 37 + (ext_rep_uint32 != null ? ext_rep_uint32.hashCode() : 1);
-      result = result * 37 + (ext_rep_sint32 != null ? ext_rep_sint32.hashCode() : 1);
-      result = result * 37 + (ext_rep_fixed32 != null ? ext_rep_fixed32.hashCode() : 1);
-      result = result * 37 + (ext_rep_sfixed32 != null ? ext_rep_sfixed32.hashCode() : 1);
-      result = result * 37 + (ext_rep_int64 != null ? ext_rep_int64.hashCode() : 1);
-      result = result * 37 + (ext_rep_uint64 != null ? ext_rep_uint64.hashCode() : 1);
-      result = result * 37 + (ext_rep_sint64 != null ? ext_rep_sint64.hashCode() : 1);
-      result = result * 37 + (ext_rep_fixed64 != null ? ext_rep_fixed64.hashCode() : 1);
-      result = result * 37 + (ext_rep_sfixed64 != null ? ext_rep_sfixed64.hashCode() : 1);
-      result = result * 37 + (ext_rep_bool != null ? ext_rep_bool.hashCode() : 1);
-      result = result * 37 + (ext_rep_float != null ? ext_rep_float.hashCode() : 1);
-      result = result * 37 + (ext_rep_double != null ? ext_rep_double.hashCode() : 1);
-      result = result * 37 + (ext_rep_string != null ? ext_rep_string.hashCode() : 1);
-      result = result * 37 + (ext_rep_bytes != null ? ext_rep_bytes.hashCode() : 1);
-      result = result * 37 + (ext_rep_nested_enum != null ? ext_rep_nested_enum.hashCode() : 1);
-      result = result * 37 + (ext_rep_nested_message != null ? ext_rep_nested_message.hashCode() : 1);
-      result = result * 37 + (ext_pack_int32 != null ? ext_pack_int32.hashCode() : 1);
-      result = result * 37 + (ext_pack_uint32 != null ? ext_pack_uint32.hashCode() : 1);
-      result = result * 37 + (ext_pack_sint32 != null ? ext_pack_sint32.hashCode() : 1);
-      result = result * 37 + (ext_pack_fixed32 != null ? ext_pack_fixed32.hashCode() : 1);
-      result = result * 37 + (ext_pack_sfixed32 != null ? ext_pack_sfixed32.hashCode() : 1);
-      result = result * 37 + (ext_pack_int64 != null ? ext_pack_int64.hashCode() : 1);
-      result = result * 37 + (ext_pack_uint64 != null ? ext_pack_uint64.hashCode() : 1);
-      result = result * 37 + (ext_pack_sint64 != null ? ext_pack_sint64.hashCode() : 1);
-      result = result * 37 + (ext_pack_fixed64 != null ? ext_pack_fixed64.hashCode() : 1);
-      result = result * 37 + (ext_pack_sfixed64 != null ? ext_pack_sfixed64.hashCode() : 1);
-      result = result * 37 + (ext_pack_bool != null ? ext_pack_bool.hashCode() : 1);
-      result = result * 37 + (ext_pack_float != null ? ext_pack_float.hashCode() : 1);
-      result = result * 37 + (ext_pack_double != null ? ext_pack_double.hashCode() : 1);
-      result = result * 37 + (ext_pack_nested_enum != null ? ext_pack_nested_enum.hashCode() : 1);
+      result = result * 37 + ext_rep_int32.hashCode();
+      result = result * 37 + ext_rep_uint32.hashCode();
+      result = result * 37 + ext_rep_sint32.hashCode();
+      result = result * 37 + ext_rep_fixed32.hashCode();
+      result = result * 37 + ext_rep_sfixed32.hashCode();
+      result = result * 37 + ext_rep_int64.hashCode();
+      result = result * 37 + ext_rep_uint64.hashCode();
+      result = result * 37 + ext_rep_sint64.hashCode();
+      result = result * 37 + ext_rep_fixed64.hashCode();
+      result = result * 37 + ext_rep_sfixed64.hashCode();
+      result = result * 37 + ext_rep_bool.hashCode();
+      result = result * 37 + ext_rep_float.hashCode();
+      result = result * 37 + ext_rep_double.hashCode();
+      result = result * 37 + ext_rep_string.hashCode();
+      result = result * 37 + ext_rep_bytes.hashCode();
+      result = result * 37 + ext_rep_nested_enum.hashCode();
+      result = result * 37 + ext_rep_nested_message.hashCode();
+      result = result * 37 + ext_pack_int32.hashCode();
+      result = result * 37 + ext_pack_uint32.hashCode();
+      result = result * 37 + ext_pack_sint32.hashCode();
+      result = result * 37 + ext_pack_fixed32.hashCode();
+      result = result * 37 + ext_pack_sfixed32.hashCode();
+      result = result * 37 + ext_pack_int64.hashCode();
+      result = result * 37 + ext_pack_uint64.hashCode();
+      result = result * 37 + ext_pack_sint64.hashCode();
+      result = result * 37 + ext_pack_fixed64.hashCode();
+      result = result * 37 + ext_pack_sfixed64.hashCode();
+      result = result * 37 + ext_pack_bool.hashCode();
+      result = result * 37 + ext_pack_float.hashCode();
+      result = result * 37 + ext_pack_double.hashCode();
+      result = result * 37 + ext_pack_nested_enum.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -2832,7 +2832,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(a, o.a);
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -188,16 +188,16 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     if (other == this) return true;
     if (!(other instanceof FooBar)) return false;
     FooBar o = (FooBar) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(foo, o.foo)
         && Internal.equals(bar, o.bar)
         && Internal.equals(baz, o.baz)
         && Internal.equals(qux, o.qux)
-        && Internal.equals(fred, o.fred)
+        && fred.equals(o.fred)
         && Internal.equals(daisy, o.daisy)
-        && Internal.equals(nested, o.nested)
+        && nested.equals(o.nested)
         && Internal.equals(ext, o.ext)
-        && Internal.equals(rep, o.rep);
+        && rep.equals(o.rep);
   }
 
   @Override
@@ -209,11 +209,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       result = result * 37 + (bar != null ? bar.hashCode() : 0);
       result = result * 37 + (baz != null ? baz.hashCode() : 0);
       result = result * 37 + (qux != null ? qux.hashCode() : 0);
-      result = result * 37 + (fred != null ? fred.hashCode() : 1);
+      result = result * 37 + fred.hashCode();
       result = result * 37 + (daisy != null ? daisy.hashCode() : 0);
-      result = result * 37 + (nested != null ? nested.hashCode() : 1);
+      result = result * 37 + nested.hashCode();
       result = result * 37 + (ext != null ? ext.hashCode() : 0);
-      result = result * 37 + (rep != null ? rep.hashCode() : 1);
+      result = result * 37 + rep.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -226,11 +226,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     if (bar != null) builder.append(", bar=").append(bar);
     if (baz != null) builder.append(", baz=").append(baz);
     if (qux != null) builder.append(", qux=").append(qux);
-    if (fred != null) builder.append(", fred=").append(fred);
+    if (!fred.isEmpty()) builder.append(", fred=").append(fred);
     if (daisy != null) builder.append(", daisy=").append(daisy);
-    if (nested != null) builder.append(", nested=").append(nested);
+    if (!nested.isEmpty()) builder.append(", nested=").append(nested);
     if (ext != null) builder.append(", ext=").append(ext);
-    if (rep != null) builder.append(", rep=").append(rep);
+    if (!rep.isEmpty()) builder.append(", rep=").append(rep);
     return builder.replace(0, 2, "FooBar{").append('}').toString();
   }
 
@@ -348,7 +348,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof Nested)) return false;
       Nested o = (Nested) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(value, o.value);
     }
 
@@ -472,8 +472,8 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof More)) return false;
       More o = (More) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
-          && Internal.equals(serial, o.serial);
+      return unknownFields().equals(o.unknownFields())
+          && serial.equals(o.serial);
     }
 
     @Override
@@ -481,7 +481,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       int result = super.hashCode;
       if (result == 0) {
         result = unknownFields().hashCode();
-        result = result * 37 + (serial != null ? serial.hashCode() : 1);
+        result = result * 37 + serial.hashCode();
         super.hashCode = result;
       }
       return result;
@@ -490,7 +490,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      if (serial != null) builder.append(", serial=").append(serial);
+      if (!serial.isEmpty()) builder.append(", serial=").append(serial);
       return builder.replace(0, 2, "More{").append('}').toString();
     }
 
@@ -526,7 +526,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
       @Override
       public void encode(ProtoWriter writer, More value) throws IOException {
-        if (value.serial != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1, value.serial);
+        ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1, value.serial);
         writer.writeBytes(value.unknownFields());
       }
 
@@ -632,11 +632,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (value.bar != null) ProtoAdapter.STRING.encodeWithTag(writer, 2, value.bar);
       if (value.baz != null) Nested.ADAPTER.encodeWithTag(writer, 3, value.baz);
       if (value.qux != null) ProtoAdapter.UINT64.encodeWithTag(writer, 4, value.qux);
-      if (value.fred != null) ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 5, value.fred);
+      ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 5, value.fred);
       if (value.daisy != null) ProtoAdapter.DOUBLE.encodeWithTag(writer, 6, value.daisy);
-      if (value.nested != null) FooBar.ADAPTER.asRepeated().encodeWithTag(writer, 7, value.nested);
+      FooBar.ADAPTER.asRepeated().encodeWithTag(writer, 7, value.nested);
       if (value.ext != null) FooBarBazEnum.ADAPTER.encodeWithTag(writer, 101, value.ext);
-      if (value.rep != null) FooBarBazEnum.ADAPTER.asRepeated().encodeWithTag(writer, 102, value.rep);
+      FooBarBazEnum.ADAPTER.asRepeated().encodeWithTag(writer, 102, value.rep);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -138,16 +138,16 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     if (other == this) return true;
     if (!(other instanceof FooBar)) return false;
     FooBar o = (FooBar) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(foo, o.foo)
         && Internal.equals(bar, o.bar)
         && Internal.equals(baz, o.baz)
         && Internal.equals(qux, o.qux)
-        && Internal.equals(fred, o.fred)
+        && fred.equals(o.fred)
         && Internal.equals(daisy, o.daisy)
-        && Internal.equals(nested, o.nested)
+        && nested.equals(o.nested)
         && Internal.equals(ext, o.ext)
-        && Internal.equals(rep, o.rep);
+        && rep.equals(o.rep);
   }
 
   @Override
@@ -159,11 +159,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       result = result * 37 + (bar != null ? bar.hashCode() : 0);
       result = result * 37 + (baz != null ? baz.hashCode() : 0);
       result = result * 37 + (qux != null ? qux.hashCode() : 0);
-      result = result * 37 + (fred != null ? fred.hashCode() : 1);
+      result = result * 37 + fred.hashCode();
       result = result * 37 + (daisy != null ? daisy.hashCode() : 0);
-      result = result * 37 + (nested != null ? nested.hashCode() : 1);
+      result = result * 37 + nested.hashCode();
       result = result * 37 + (ext != null ? ext.hashCode() : 0);
-      result = result * 37 + (rep != null ? rep.hashCode() : 1);
+      result = result * 37 + rep.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -176,11 +176,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     if (bar != null) builder.append(", bar=").append(bar);
     if (baz != null) builder.append(", baz=").append(baz);
     if (qux != null) builder.append(", qux=").append(qux);
-    if (fred != null) builder.append(", fred=").append(fred);
+    if (!fred.isEmpty()) builder.append(", fred=").append(fred);
     if (daisy != null) builder.append(", daisy=").append(daisy);
-    if (nested != null) builder.append(", nested=").append(nested);
+    if (!nested.isEmpty()) builder.append(", nested=").append(nested);
     if (ext != null) builder.append(", ext=").append(ext);
-    if (rep != null) builder.append(", rep=").append(rep);
+    if (!rep.isEmpty()) builder.append(", rep=").append(rep);
     return builder.replace(0, 2, "FooBar{").append('}').toString();
   }
 
@@ -298,7 +298,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof Nested)) return false;
       Nested o = (Nested) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(value, o.value);
     }
 
@@ -422,8 +422,8 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (other == this) return true;
       if (!(other instanceof More)) return false;
       More o = (More) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
-          && Internal.equals(serial, o.serial);
+      return unknownFields().equals(o.unknownFields())
+          && serial.equals(o.serial);
     }
 
     @Override
@@ -431,7 +431,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       int result = super.hashCode;
       if (result == 0) {
         result = unknownFields().hashCode();
-        result = result * 37 + (serial != null ? serial.hashCode() : 1);
+        result = result * 37 + serial.hashCode();
         super.hashCode = result;
       }
       return result;
@@ -440,7 +440,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      if (serial != null) builder.append(", serial=").append(serial);
+      if (!serial.isEmpty()) builder.append(", serial=").append(serial);
       return builder.replace(0, 2, "More{").append('}').toString();
     }
 
@@ -476,7 +476,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
       @Override
       public void encode(ProtoWriter writer, More value) throws IOException {
-        if (value.serial != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1, value.serial);
+        ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1, value.serial);
         writer.writeBytes(value.unknownFields());
       }
 
@@ -565,11 +565,11 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       if (value.bar != null) ProtoAdapter.STRING.encodeWithTag(writer, 2, value.bar);
       if (value.baz != null) Nested.ADAPTER.encodeWithTag(writer, 3, value.baz);
       if (value.qux != null) ProtoAdapter.UINT64.encodeWithTag(writer, 4, value.qux);
-      if (value.fred != null) ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 5, value.fred);
+      ProtoAdapter.FLOAT.asRepeated().encodeWithTag(writer, 5, value.fred);
       if (value.daisy != null) ProtoAdapter.DOUBLE.encodeWithTag(writer, 6, value.daisy);
-      if (value.nested != null) FooBar.ADAPTER.asRepeated().encodeWithTag(writer, 7, value.nested);
+      FooBar.ADAPTER.asRepeated().encodeWithTag(writer, 7, value.nested);
       if (value.ext != null) FooBarBazEnum.ADAPTER.encodeWithTag(writer, 101, value.ext);
-      if (value.rep != null) FooBarBazEnum.ADAPTER.asRepeated().encodeWithTag(writer, 102, value.rep);
+      FooBarBazEnum.ADAPTER.asRepeated().encodeWithTag(writer, 102, value.rep);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -51,7 +51,7 @@ public final class OneBytesField extends Message<OneBytesField, OneBytesField.Bu
     if (other == this) return true;
     if (!(other instanceof OneBytesField)) return false;
     OneBytesField o = (OneBytesField) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(opt_bytes, o.opt_bytes);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/OneField.java
@@ -52,7 +52,7 @@ public final class OneField extends Message<OneField, OneField.Builder> {
     if (other == this) return true;
     if (!(other instanceof OneField)) return false;
     OneField o = (OneField) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(opt_int32, o.opt_int32);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -60,7 +60,7 @@ public final class Recursive extends Message<Recursive, Recursive.Builder> {
     if (other == this) return true;
     if (!(other instanceof Recursive)) return false;
     Recursive o = (Recursive) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(value, o.value)
         && Internal.equals(recursive, o.recursive);
   }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -65,7 +65,7 @@ public final class ForeignMessage extends Message<ForeignMessage, ForeignMessage
     if (other == this) return true;
     if (!(other instanceof ForeignMessage)) return false;
     ForeignMessage o = (ForeignMessage) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i)
         && Internal.equals(j, o.j);
   }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/namecollisions/Message.java
@@ -140,7 +140,7 @@ public final class Message extends com.squareup.wire.Message<Message, Message.Bu
     if (other_ == this) return true;
     if (!(other_ instanceof Message)) return false;
     Message o_ = (Message) other_;
-    return Internal.equals(unknownFields(), o_.unknownFields())
+    return unknownFields().equals(o_.unknownFields())
         && Internal.equals(unknownFields, o_.unknownFields)
         && Internal.equals(other, o_.other)
         && Internal.equals(o, o_.o)

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/Foo.java
@@ -51,7 +51,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(bar, o.bar);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -62,7 +62,7 @@ public final class OneExtension extends Message<OneExtension, OneExtension.Build
     if (other == this) return true;
     if (!(other instanceof OneExtension)) return false;
     OneExtension o = (OneExtension) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(id, o.id)
         && Internal.equals(foo, o.foo);
   }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -84,7 +84,7 @@ public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Build
     if (other == this) return true;
     if (!(other instanceof OneOfMessage)) return false;
     OneOfMessage o = (OneOfMessage) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(foo, o.foo)
         && Internal.equals(bar, o.bar)
         && Internal.equals(baz, o.baz);

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
@@ -97,11 +97,11 @@ public final class Person extends Message<Person, Person.Builder> {
     if (other == this) return true;
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(name, o.name)
-        && Internal.equals(id, o.id)
+    return unknownFields().equals(o.unknownFields())
+        && name.equals(o.name)
+        && id.equals(o.id)
         && Internal.equals(email, o.email)
-        && Internal.equals(phone, o.phone);
+        && phone.equals(o.phone);
   }
 
   @Override
@@ -109,10 +109,10 @@ public final class Person extends Message<Person, Person.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (name != null ? name.hashCode() : 0);
-      result = result * 37 + (id != null ? id.hashCode() : 0);
+      result = result * 37 + name.hashCode();
+      result = result * 37 + id.hashCode();
       result = result * 37 + (email != null ? email.hashCode() : 0);
-      result = result * 37 + (phone != null ? phone.hashCode() : 1);
+      result = result * 37 + phone.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -121,10 +121,10 @@ public final class Person extends Message<Person, Person.Builder> {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (name != null) builder.append(", name=").append(name);
-    if (id != null) builder.append(", id=").append(id);
+    builder.append(", name=").append(name);
+    builder.append(", id=").append(id);
     if (email != null) builder.append(", email=").append(email);
-    if (phone != null) builder.append(", phone=").append(phone);
+    if (!phone.isEmpty()) builder.append(", phone=").append(phone);
     return builder.replace(0, 2, "Person{").append('}').toString();
   }
 
@@ -273,8 +273,8 @@ public final class Person extends Message<Person, Person.Builder> {
       if (other == this) return true;
       if (!(other instanceof PhoneNumber)) return false;
       PhoneNumber o = (PhoneNumber) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
-          && Internal.equals(number, o.number)
+      return unknownFields().equals(o.unknownFields())
+          && number.equals(o.number)
           && Internal.equals(type, o.type);
     }
 
@@ -283,7 +283,7 @@ public final class Person extends Message<Person, Person.Builder> {
       int result = super.hashCode;
       if (result == 0) {
         result = unknownFields().hashCode();
-        result = result * 37 + (number != null ? number.hashCode() : 0);
+        result = result * 37 + number.hashCode();
         result = result * 37 + (type != null ? type.hashCode() : 0);
         super.hashCode = result;
       }
@@ -293,7 +293,7 @@ public final class Person extends Message<Person, Person.Builder> {
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      if (number != null) builder.append(", number=").append(number);
+      builder.append(", number=").append(number);
       if (type != null) builder.append(", type=").append(type);
       return builder.replace(0, 2, "PhoneNumber{").append('}').toString();
     }
@@ -404,7 +404,7 @@ public final class Person extends Message<Person, Person.Builder> {
       ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
       if (value.email != null) ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
-      if (value.phone != null) PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
+      PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -118,11 +118,11 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     if (other == this) return true;
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(name, o.name)
-        && Internal.equals(id, o.id)
+    return unknownFields().equals(o.unknownFields())
+        && name.equals(o.name)
+        && id.equals(o.id)
         && Internal.equals(email, o.email)
-        && Internal.equals(phone, o.phone);
+        && phone.equals(o.phone);
   }
 
   @Override
@@ -130,10 +130,10 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (name != null ? name.hashCode() : 0);
-      result = result * 37 + (id != null ? id.hashCode() : 0);
+      result = result * 37 + name.hashCode();
+      result = result * 37 + id.hashCode();
       result = result * 37 + (email != null ? email.hashCode() : 0);
-      result = result * 37 + (phone != null ? phone.hashCode() : 1);
+      result = result * 37 + phone.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -152,10 +152,10 @@ public final class Person extends Message<Person, Person.Builder> implements Par
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (name != null) builder.append(", name=").append(name);
-    if (id != null) builder.append(", id=").append(id);
+    builder.append(", name=").append(name);
+    builder.append(", id=").append(id);
     if (email != null) builder.append(", email=").append(email);
-    if (phone != null) builder.append(", phone=").append(phone);
+    if (!phone.isEmpty()) builder.append(", phone=").append(phone);
     return builder.replace(0, 2, "Person{").append('}').toString();
   }
 
@@ -321,8 +321,8 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       if (other == this) return true;
       if (!(other instanceof PhoneNumber)) return false;
       PhoneNumber o = (PhoneNumber) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
-          && Internal.equals(number, o.number)
+      return unknownFields().equals(o.unknownFields())
+          && number.equals(o.number)
           && Internal.equals(type, o.type);
     }
 
@@ -331,7 +331,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       int result = super.hashCode;
       if (result == 0) {
         result = unknownFields().hashCode();
-        result = result * 37 + (number != null ? number.hashCode() : 0);
+        result = result * 37 + number.hashCode();
         result = result * 37 + (type != null ? type.hashCode() : 0);
         super.hashCode = result;
       }
@@ -351,7 +351,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     @Override
     public String toString() {
       StringBuilder builder = new StringBuilder();
-      if (number != null) builder.append(", number=").append(number);
+      builder.append(", number=").append(number);
       if (type != null) builder.append(", type=").append(type);
       return builder.replace(0, 2, "PhoneNumber{").append('}').toString();
     }
@@ -462,7 +462,7 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
       if (value.email != null) ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
-      if (value.phone != null) PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
+      PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -61,7 +61,7 @@ public final class NotRedacted extends Message<NotRedacted, NotRedacted.Builder>
     if (other == this) return true;
     if (!(other instanceof NotRedacted)) return false;
     NotRedacted o = (NotRedacted) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(a, o.a)
         && Internal.equals(b, o.b);
   }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/Redacted.java
@@ -92,7 +92,7 @@ public final class Redacted extends Message<Redacted, Redacted.Builder> {
     if (other == this) return true;
     if (!(other instanceof Redacted)) return false;
     Redacted o = (Redacted) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(a, o.a)
         && Internal.equals(b, o.b)
         && Internal.equals(c, o.c)

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -67,7 +67,7 @@ public final class RedactedChild extends Message<RedactedChild, RedactedChild.Bu
     if (other == this) return true;
     if (!(other instanceof RedactedChild)) return false;
     RedactedChild o = (RedactedChild) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(a, o.a)
         && Internal.equals(b, o.b)
         && Internal.equals(c, o.c);

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -49,7 +49,7 @@ public final class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA
     if (other == this) return true;
     if (!(other instanceof RedactedCycleA)) return false;
     RedactedCycleA o = (RedactedCycleA) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(b, o.b);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -49,7 +49,7 @@ public final class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB
     if (other == this) return true;
     if (!(other instanceof RedactedCycleB)) return false;
     RedactedCycleB o = (RedactedCycleB) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(a, o.a);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -67,7 +67,7 @@ public final class RedactedExtension extends Message<RedactedExtension, Redacted
     if (other == this) return true;
     if (!(other instanceof RedactedExtension)) return false;
     RedactedExtension o = (RedactedExtension) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(d, o.d)
         && Internal.equals(e, o.e);
   }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -70,9 +70,9 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
     if (other == this) return true;
     if (!(other instanceof RedactedRepeated)) return false;
     RedactedRepeated o = (RedactedRepeated) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(a, o.a)
-        && Internal.equals(b, o.b);
+    return unknownFields().equals(o.unknownFields())
+        && a.equals(o.a)
+        && b.equals(o.b);
   }
 
   @Override
@@ -80,8 +80,8 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (a != null ? a.hashCode() : 1);
-      result = result * 37 + (b != null ? b.hashCode() : 1);
+      result = result * 37 + a.hashCode();
+      result = result * 37 + b.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -90,8 +90,8 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (a != null) builder.append(", a=██");
-    if (b != null) builder.append(", b=").append(b);
+    if (!a.isEmpty()) builder.append(", a=██");
+    if (!b.isEmpty()) builder.append(", b=").append(b);
     return builder.replace(0, 2, "RedactedRepeated{").append('}').toString();
   }
 
@@ -140,8 +140,8 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
 
     @Override
     public void encode(ProtoWriter writer, RedactedRepeated value) throws IOException {
-      if (value.a != null) ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 1, value.a);
-      if (value.b != null) Redacted.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.b);
+      ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 1, value.a);
+      Redacted.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.b);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -59,8 +59,8 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
     if (other == this) return true;
     if (!(other instanceof RedactedRequired)) return false;
     RedactedRequired o = (RedactedRequired) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(a, o.a);
+    return unknownFields().equals(o.unknownFields())
+        && a.equals(o.a);
   }
 
   @Override
@@ -68,7 +68,7 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (a != null ? a.hashCode() : 0);
+      result = result * 37 + a.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -77,7 +77,7 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (a != null) builder.append(", a=██");
+    builder.append(", a=██");
     return builder.replace(0, 2, "RedactedRequired{").append('}').toString();
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java
@@ -72,7 +72,7 @@ public final class A extends Message<A, A.Builder> {
     if (other == this) return true;
     if (!(other instanceof A)) return false;
     A o = (A) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(c, o.c)
         && Internal.equals(d, o.d);
   }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/A.java.pruned
@@ -64,7 +64,7 @@ public final class A extends Message<A, A.Builder> {
     if (other == this) return true;
     if (!(other instanceof A)) return false;
     A o = (A) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(d, o.d);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/B.java
@@ -50,8 +50,8 @@ public final class B extends Message<B, B.Builder> {
     if (other == this) return true;
     if (!(other instanceof B)) return false;
     B o = (B) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(c, o.c);
+    return unknownFields().equals(o.unknownFields())
+        && c.equals(o.c);
   }
 
   @Override
@@ -59,7 +59,7 @@ public final class B extends Message<B, B.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (c != null ? c.hashCode() : 0);
+      result = result * 37 + c.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -68,7 +68,7 @@ public final class B extends Message<B, B.Builder> {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (c != null) builder.append(", c=").append(c);
+    builder.append(", c=").append(c);
     return builder.replace(0, 2, "B{").append('}').toString();
   }
 
@@ -130,7 +130,7 @@ public final class B extends Message<B, B.Builder> {
     @Override
     public B redact(B value) {
       Builder builder = value.newBuilder();
-      if (builder.c != null) builder.c = C.ADAPTER.redact(builder.c);
+      builder.c = C.ADAPTER.redact(builder.c);
       builder.clearUnknownFields();
       return builder.build();
     }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/C.java
@@ -52,7 +52,7 @@ public final class C extends Message<C, C.Builder> {
     if (other == this) return true;
     if (!(other instanceof C)) return false;
     C o = (C) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java
@@ -52,7 +52,7 @@ public final class D extends Message<D, D.Builder> {
     if (other == this) return true;
     if (!(other instanceof D)) return false;
     D o = (D) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/D.java.pruned
@@ -52,7 +52,7 @@ public final class D extends Message<D, D.Builder> {
     if (other == this) return true;
     if (!(other instanceof D)) return false;
     D o = (D) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/E.java
@@ -60,7 +60,7 @@ public final class E extends Message<E, E.Builder> {
     if (other == this) return true;
     if (!(other instanceof E)) return false;
     E o = (E) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(f, o.f)
         && Internal.equals(g, o.g);
   }
@@ -144,7 +144,7 @@ public final class E extends Message<E, E.Builder> {
       if (other == this) return true;
       if (!(other instanceof F)) return false;
       F o = (F) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(i, o.i);
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/H.java
@@ -49,7 +49,7 @@ public final class H extends Message<H, H.Builder> {
     if (other == this) return true;
     if (!(other instanceof H)) return false;
     H o = (H) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(ef, o.ef);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/I.java
@@ -63,7 +63,7 @@ public final class I extends Message<I, I.Builder> {
     if (other == this) return true;
     if (!(other instanceof I)) return false;
     I o = (I) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i)
         && Internal.equals(j, o.j);
   }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/J.java
@@ -49,7 +49,7 @@ public final class J extends Message<J, J.Builder> {
     if (other == this) return true;
     if (!(other instanceof J)) return false;
     J o = (J) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(k, o.k);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/K.java
@@ -52,7 +52,7 @@ public final class K extends Message<K, K.Builder> {
     if (other == this) return true;
     if (!(other instanceof K)) return false;
     K o = (K) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -116,9 +116,9 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
     if (other == this) return true;
     if (!(other instanceof ExternalMessage)) return false;
     ExternalMessage o = (ExternalMessage) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(f, o.f)
-        && Internal.equals(fooext, o.fooext)
+        && fooext.equals(o.fooext)
         && Internal.equals(barext, o.barext)
         && Internal.equals(bazext, o.bazext)
         && Internal.equals(nested_message_ext, o.nested_message_ext)
@@ -131,7 +131,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
     if (result == 0) {
       result = unknownFields().hashCode();
       result = result * 37 + (f != null ? f.hashCode() : 0);
-      result = result * 37 + (fooext != null ? fooext.hashCode() : 1);
+      result = result * 37 + fooext.hashCode();
       result = result * 37 + (barext != null ? barext.hashCode() : 0);
       result = result * 37 + (bazext != null ? bazext.hashCode() : 0);
       result = result * 37 + (nested_message_ext != null ? nested_message_ext.hashCode() : 0);
@@ -145,7 +145,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (f != null) builder.append(", f=").append(f);
-    if (fooext != null) builder.append(", fooext=").append(fooext);
+    if (!fooext.isEmpty()) builder.append(", fooext=").append(fooext);
     if (barext != null) builder.append(", barext=").append(barext);
     if (bazext != null) builder.append(", bazext=").append(bazext);
     if (nested_message_ext != null) builder.append(", nested_message_ext=").append(nested_message_ext);
@@ -226,7 +226,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
     @Override
     public void encode(ProtoWriter writer, ExternalMessage value) throws IOException {
       if (value.f != null) ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.f);
-      if (value.fooext != null) ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 125, value.fooext);
+      ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 125, value.fooext);
       if (value.barext != null) ProtoAdapter.INT32.encodeWithTag(writer, 126, value.barext);
       if (value.bazext != null) ProtoAdapter.INT32.encodeWithTag(writer, 127, value.bazext);
       if (value.nested_message_ext != null) SimpleMessage.NestedMessage.ADAPTER.encodeWithTag(writer, 128, value.nested_message_ext);

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -203,13 +203,13 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     if (other_ == this) return true;
     if (!(other_ instanceof SimpleMessage)) return false;
     SimpleMessage o_ = (SimpleMessage) other_;
-    return Internal.equals(unknownFields(), o_.unknownFields())
+    return unknownFields().equals(o_.unknownFields())
         && Internal.equals(optional_int32, o_.optional_int32)
         && Internal.equals(optional_nested_msg, o_.optional_nested_msg)
         && Internal.equals(optional_external_msg, o_.optional_external_msg)
         && Internal.equals(default_nested_enum, o_.default_nested_enum)
-        && Internal.equals(required_int32, o_.required_int32)
-        && Internal.equals(repeated_double, o_.repeated_double)
+        && required_int32.equals(o_.required_int32)
+        && repeated_double.equals(o_.repeated_double)
         && Internal.equals(default_foreign_enum, o_.default_foreign_enum)
         && Internal.equals(no_default_foreign_enum, o_.no_default_foreign_enum)
         && Internal.equals(package_, o_.package_)
@@ -227,8 +227,8 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
       result_ = result_ * 37 + (optional_nested_msg != null ? optional_nested_msg.hashCode() : 0);
       result_ = result_ * 37 + (optional_external_msg != null ? optional_external_msg.hashCode() : 0);
       result_ = result_ * 37 + (default_nested_enum != null ? default_nested_enum.hashCode() : 0);
-      result_ = result_ * 37 + (required_int32 != null ? required_int32.hashCode() : 0);
-      result_ = result_ * 37 + (repeated_double != null ? repeated_double.hashCode() : 1);
+      result_ = result_ * 37 + required_int32.hashCode();
+      result_ = result_ * 37 + repeated_double.hashCode();
       result_ = result_ * 37 + (default_foreign_enum != null ? default_foreign_enum.hashCode() : 0);
       result_ = result_ * 37 + (no_default_foreign_enum != null ? no_default_foreign_enum.hashCode() : 0);
       result_ = result_ * 37 + (package_ != null ? package_.hashCode() : 0);
@@ -247,8 +247,8 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     if (optional_nested_msg != null) builder.append(", optional_nested_msg=").append(optional_nested_msg);
     if (optional_external_msg != null) builder.append(", optional_external_msg=").append(optional_external_msg);
     if (default_nested_enum != null) builder.append(", default_nested_enum=").append(default_nested_enum);
-    if (required_int32 != null) builder.append(", required_int32=").append(required_int32);
-    if (repeated_double != null) builder.append(", repeated_double=").append(repeated_double);
+    builder.append(", required_int32=").append(required_int32);
+    if (!repeated_double.isEmpty()) builder.append(", repeated_double=").append(repeated_double);
     if (default_foreign_enum != null) builder.append(", default_foreign_enum=").append(default_foreign_enum);
     if (no_default_foreign_enum != null) builder.append(", no_default_foreign_enum=").append(no_default_foreign_enum);
     if (package_ != null) builder.append(", package=").append(package_);
@@ -430,7 +430,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
       if (other == this) return true;
       if (!(other instanceof NestedMessage)) return false;
       NestedMessage o = (NestedMessage) other;
-      return Internal.equals(unknownFields(), o.unknownFields())
+      return unknownFields().equals(o.unknownFields())
           && Internal.equals(bb, o.bb);
     }
 
@@ -588,7 +588,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
       if (value.optional_external_msg != null) ExternalMessage.ADAPTER.encodeWithTag(writer, 3, value.optional_external_msg);
       if (value.default_nested_enum != null) NestedEnum.ADAPTER.encodeWithTag(writer, 4, value.default_nested_enum);
       ProtoAdapter.INT32.encodeWithTag(writer, 5, value.required_int32);
-      if (value.repeated_double != null) ProtoAdapter.DOUBLE.asRepeated().encodeWithTag(writer, 6, value.repeated_double);
+      ProtoAdapter.DOUBLE.asRepeated().encodeWithTag(writer, 6, value.repeated_double);
       if (value.default_foreign_enum != null) ForeignEnum.ADAPTER.encodeWithTag(writer, 7, value.default_foreign_enum);
       if (value.no_default_foreign_enum != null) ForeignEnum.ADAPTER.encodeWithTag(writer, 8, value.no_default_foreign_enum);
       if (value.package_ != null) ProtoAdapter.STRING.encodeWithTag(writer, 9, value.package_);

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -52,7 +52,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
     if (other == this) return true;
     if (!(other instanceof Bar)) return false;
     Bar o = (Bar) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(baz, o.baz);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -51,8 +51,8 @@ public final class Bars extends Message<Bars, Bars.Builder> {
     if (other == this) return true;
     if (!(other instanceof Bars)) return false;
     Bars o = (Bars) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(bars, o.bars);
+    return unknownFields().equals(o.unknownFields())
+        && bars.equals(o.bars);
   }
 
   @Override
@@ -60,7 +60,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (bars != null ? bars.hashCode() : 1);
+      result = result * 37 + bars.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -69,7 +69,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (bars != null) builder.append(", bars=").append(bars);
+    if (!bars.isEmpty()) builder.append(", bars=").append(bars);
     return builder.replace(0, 2, "Bars{").append('}').toString();
   }
 
@@ -105,7 +105,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
 
     @Override
     public void encode(ProtoWriter writer, Bars value) throws IOException {
-      if (value.bars != null) Bar.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.bars);
+      Bar.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.bars);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foo.java
@@ -52,7 +52,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foo)) return false;
     Foo o = (Foo) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(bar, o.bar);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/single_level/Foos.java
@@ -51,8 +51,8 @@ public final class Foos extends Message<Foos, Foos.Builder> {
     if (other == this) return true;
     if (!(other instanceof Foos)) return false;
     Foos o = (Foos) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(foos, o.foos);
+    return unknownFields().equals(o.unknownFields())
+        && foos.equals(o.foos);
   }
 
   @Override
@@ -60,7 +60,7 @@ public final class Foos extends Message<Foos, Foos.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (foos != null ? foos.hashCode() : 1);
+      result = result * 37 + foos.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -69,7 +69,7 @@ public final class Foos extends Message<Foos, Foos.Builder> {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (foos != null) builder.append(", foos=").append(foos);
+    if (!foos.isEmpty()) builder.append(", foos=").append(foos);
     return builder.replace(0, 2, "Foos{").append('}').toString();
   }
 
@@ -105,7 +105,7 @@ public final class Foos extends Message<Foos, Foos.Builder> {
 
     @Override
     public void encode(ProtoWriter writer, Foos value) throws IOException {
-      if (value.foos != null) Foo.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.foos);
+      Foo.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.foos);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -52,7 +52,7 @@ public final class VersionOne extends Message<VersionOne, VersionOne.Builder> {
     if (other == this) return true;
     if (!(other instanceof VersionOne)) return false;
     VersionOne o = (VersionOne) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i);
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -103,13 +103,13 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     if (other == this) return true;
     if (!(other instanceof VersionTwo)) return false;
     VersionTwo o = (VersionTwo) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(i, o.i)
         && Internal.equals(v2_i, o.v2_i)
         && Internal.equals(v2_s, o.v2_s)
         && Internal.equals(v2_f32, o.v2_f32)
         && Internal.equals(v2_f64, o.v2_f64)
-        && Internal.equals(v2_rs, o.v2_rs);
+        && v2_rs.equals(o.v2_rs);
   }
 
   @Override
@@ -122,7 +122,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
       result = result * 37 + (v2_s != null ? v2_s.hashCode() : 0);
       result = result * 37 + (v2_f32 != null ? v2_f32.hashCode() : 0);
       result = result * 37 + (v2_f64 != null ? v2_f64.hashCode() : 0);
-      result = result * 37 + (v2_rs != null ? v2_rs.hashCode() : 1);
+      result = result * 37 + v2_rs.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -136,7 +136,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
     if (v2_s != null) builder.append(", v2_s=").append(v2_s);
     if (v2_f32 != null) builder.append(", v2_f32=").append(v2_f32);
     if (v2_f64 != null) builder.append(", v2_f64=").append(v2_f64);
-    if (v2_rs != null) builder.append(", v2_rs=").append(v2_rs);
+    if (!v2_rs.isEmpty()) builder.append(", v2_rs=").append(v2_rs);
     return builder.replace(0, 2, "VersionTwo{").append('}').toString();
   }
 
@@ -217,7 +217,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
       if (value.v2_s != null) ProtoAdapter.STRING.encodeWithTag(writer, 3, value.v2_s);
       if (value.v2_f32 != null) ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.v2_f32);
       if (value.v2_f64 != null) ProtoAdapter.FIXED64.encodeWithTag(writer, 5, value.v2_f64);
-      if (value.v2_rs != null) ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 6, value.v2_rs);
+      ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 6, value.v2_rs);
       writer.writeBytes(value.unknownFields());
     }
 

--- a/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/extension_collision/CollisionSubject.java
@@ -59,7 +59,7 @@ public final class CollisionSubject extends Message<CollisionSubject, CollisionS
     if (other == this) return true;
     if (!(other instanceof CollisionSubject)) return false;
     CollisionSubject o = (CollisionSubject) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(f, o.f);
   }
 

--- a/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
@@ -62,8 +62,8 @@ public final class EmbeddedMessage extends Message<EmbeddedMessage, EmbeddedMess
     if (other == this) return true;
     if (!(other instanceof EmbeddedMessage)) return false;
     EmbeddedMessage o = (EmbeddedMessage) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
-        && Internal.equals(inner_repeated_number, o.inner_repeated_number)
+    return unknownFields().equals(o.unknownFields())
+        && inner_repeated_number.equals(o.inner_repeated_number)
         && Internal.equals(inner_number_after, o.inner_number_after);
   }
 
@@ -72,7 +72,7 @@ public final class EmbeddedMessage extends Message<EmbeddedMessage, EmbeddedMess
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + (inner_repeated_number != null ? inner_repeated_number.hashCode() : 1);
+      result = result * 37 + inner_repeated_number.hashCode();
       result = result * 37 + (inner_number_after != null ? inner_number_after.hashCode() : 0);
       super.hashCode = result;
     }
@@ -82,7 +82,7 @@ public final class EmbeddedMessage extends Message<EmbeddedMessage, EmbeddedMess
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    if (inner_repeated_number != null) builder.append(", inner_repeated_number=").append(inner_repeated_number);
+    if (!inner_repeated_number.isEmpty()) builder.append(", inner_repeated_number=").append(inner_repeated_number);
     if (inner_number_after != null) builder.append(", inner_number_after=").append(inner_number_after);
     return builder.replace(0, 2, "EmbeddedMessage{").append('}').toString();
   }
@@ -127,7 +127,7 @@ public final class EmbeddedMessage extends Message<EmbeddedMessage, EmbeddedMess
 
     @Override
     public void encode(ProtoWriter writer, EmbeddedMessage value) throws IOException {
-      if (value.inner_repeated_number != null) ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.inner_repeated_number);
+      ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.inner_repeated_number);
       if (value.inner_number_after != null) ProtoAdapter.INT32.encodeWithTag(writer, 2, value.inner_number_after);
       writer.writeBytes(value.unknownFields());
     }

--- a/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/OuterMessage.java
+++ b/wire-runtime/src/test/proto-java/squareup/protos/packed_encoding/OuterMessage.java
@@ -60,7 +60,7 @@ public final class OuterMessage extends Message<OuterMessage, OuterMessage.Build
     if (other == this) return true;
     if (!(other instanceof OuterMessage)) return false;
     OuterMessage o = (OuterMessage) other;
-    return Internal.equals(unknownFields(), o.unknownFields())
+    return unknownFields().equals(o.unknownFields())
         && Internal.equals(outer_number_before, o.outer_number_before)
         && Internal.equals(embedded_message, o.embedded_message);
   }


### PR DESCRIPTION
Note: There's a slight behavior change here in that empty lists are no longer included in toString output for a message.