### PR TITLE
Do not generate describeContents() method on every Android message.

### DIFF
--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -494,13 +494,6 @@ public final class JavaGenerator {
           .addStatement("out.writeByteArray($N.encode(this))", adapterName)
           .build());
 
-      builder.addMethod(MethodSpec.methodBuilder("describeContents")
-          .addAnnotation(Override.class)
-          .addModifiers(PUBLIC)
-          .returns(int.class)
-          .addStatement("return 0")
-          .build());
-
       TypeName creatorType = creatorOf(javaType);
       builder.addField(
           FieldSpec.builder(creatorType, nameAllocator.get("CREATOR"), PUBLIC, STATIC, FINAL)

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -98,6 +98,14 @@ public abstract class Message<M extends Message<M, B>, B extends Message.Builder
     adapter.encode(stream, (M) this);
   }
 
+  /** Flags used by Android's Parcelable implementation. Always returns 0. */
+  @SuppressWarnings("unused") //
+  public final int describeContents() {
+    // This method overrides one defined in Android's Parcelable interface. By defining it here we
+    // save having to generate it on every Parcelable message which saves methods.
+    return 0;
+  }
+
   /**
    * Superclass for protocol buffer message builders.
    */

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -145,11 +145,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
   }
 
   @Override
-  public int describeContents() {
-    return 0;
-  }
-
-  @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
     if (name != null) builder.append(", name=").append(name);
@@ -341,11 +336,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     @Override
     public void writeToParcel(Parcel out, int flags) {
       out.writeByteArray(ADAPTER.encode(this));
-    }
-
-    @Override
-    public int describeContents() {
-      return 0;
     }
 
     @Override


### PR DESCRIPTION
Saves us 250 methods for free!
```
$ grep -r 'describeContents()' app/src/protos/java | wc -l
     245
```