### PR TITLE
Consolidate all Android-related support into a dedicated base class.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>com.google.android</groupId>
+        <artifactId>android</artifactId>
+        <version>4.1.1.4</version>
+      </dependency>
+      <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
         <version>18.0</version>

--- a/wire-runtime/pom.xml
+++ b/wire-runtime/pom.xml
@@ -18,6 +18,12 @@
     </dependency>
 
     <dependency>
+      <groupId>com.google.android</groupId>
+      <artifactId>android</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/wire-runtime/src/main/java/com/squareup/wire/AndroidMessage.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/AndroidMessage.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2016 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import java.io.IOException;
+import java.lang.reflect.Array;
+import okio.ByteString;
+
+/** An Android-specific {@link Message} which adds support for {@link Parcelable}. */
+public abstract class AndroidMessage<M extends Message<M, B>, B extends Message.Builder<M, B>>
+    extends Message<M, B> implements Parcelable {
+  /** Creates a new {@link Parcelable.Creator} using {@code adapter} for serialization. */
+  public static <E> Parcelable.Creator<E> newCreator(ProtoAdapter<E> adapter) {
+    return new ProtoAdapterCreator<>(adapter);
+  }
+
+  protected AndroidMessage(ProtoAdapter<M> adapter, ByteString unknownFields) {
+    super(adapter, unknownFields);
+  }
+
+  @Override public final void writeToParcel(Parcel dest, int flags) {
+    dest.writeByteArray(encode());
+  }
+
+  @Override public final int describeContents() {
+    return 0;
+  }
+
+  private static final class ProtoAdapterCreator<M> implements Creator<M> {
+    private final ProtoAdapter<M> adapter;
+
+    ProtoAdapterCreator(ProtoAdapter<M> adapter) {
+      this.adapter = adapter;
+    }
+
+    @Override public M createFromParcel(Parcel in) {
+      try {
+        return adapter.decode(in.createByteArray());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override public M[] newArray(int size) {
+      //noinspection unchecked
+      return (M[]) Array.newInstance(adapter.javaType, size);
+    }
+  }
+}

--- a/wire-runtime/src/main/java/com/squareup/wire/Message.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/Message.java
@@ -98,14 +98,6 @@ public abstract class Message<M extends Message<M, B>, B extends Message.Builder
     adapter.encode(stream, (M) this);
   }
 
-  /** Flags used by Android's Parcelable implementation. Always returns 0. */
-  @SuppressWarnings("unused") //
-  public final int describeContents() {
-    // This method overrides one defined in Android's Parcelable interface. By defining it here we
-    // save having to generate it on every Parcelable message which saves methods.
-    return 0;
-  }
-
   /**
    * Superclass for protocol buffer message builders.
    */

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -2,9 +2,9 @@
 // Source file: person.proto at 21:1
 package com.squareup.wire.protos.person;
 
-import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
+import com.squareup.wire.AndroidMessage;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -17,14 +17,15 @@ import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
-import java.lang.RuntimeException;
 import java.lang.String;
 import java.lang.StringBuilder;
 import java.util.List;
 import okio.ByteString;
 
-public final class Person extends Message<Person, Person.Builder> implements Parcelable {
+public final class Person extends AndroidMessage<Person, Person.Builder> {
   public static final ProtoAdapter<Person> ADAPTER = new ProtoAdapter_Person();
+
+  public static final Parcelable.Creator<Person> CREATOR = AndroidMessage.newCreator(ADAPTER);
 
   private static final long serialVersionUID = 0L;
 
@@ -33,22 +34,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
   public static final Integer DEFAULT_ID = 0;
 
   public static final String DEFAULT_EMAIL = "";
-
-  public static final Parcelable.Creator<Person> CREATOR = new Parcelable.Creator<Person>() {
-    @Override
-    public Person createFromParcel(Parcel in) {
-      try {
-        return ADAPTER.decode(in.createByteArray());
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    @Override
-    public Person[] newArray(int size) {
-      return new Person[size];
-    }
-  };
 
   /**
    * The customer's full name.
@@ -137,11 +122,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       super.hashCode = result;
     }
     return result;
-  }
-
-  @Override
-  public void writeToParcel(Parcel out, int flags) {
-    out.writeByteArray(ADAPTER.encode(this));
   }
 
   @Override
@@ -247,30 +227,16 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     }
   }
 
-  public static final class PhoneNumber extends Message<PhoneNumber, PhoneNumber.Builder> implements Parcelable {
+  public static final class PhoneNumber extends AndroidMessage<PhoneNumber, PhoneNumber.Builder> {
     public static final ProtoAdapter<PhoneNumber> ADAPTER = new ProtoAdapter_PhoneNumber();
+
+    public static final Parcelable.Creator<PhoneNumber> CREATOR = AndroidMessage.newCreator(ADAPTER);
 
     private static final long serialVersionUID = 0L;
 
     public static final String DEFAULT_NUMBER = "";
 
     public static final PhoneType DEFAULT_TYPE = PhoneType.HOME;
-
-    public static final Parcelable.Creator<PhoneNumber> CREATOR = new Parcelable.Creator<PhoneNumber>() {
-      @Override
-      public PhoneNumber createFromParcel(Parcel in) {
-        try {
-          return ADAPTER.decode(in.createByteArray());
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override
-      public PhoneNumber[] newArray(int size) {
-        return new PhoneNumber[size];
-      }
-    };
 
     /**
      * The customer's phone number.
@@ -331,11 +297,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
         super.hashCode = result;
       }
       return result;
-    }
-
-    @Override
-    public void writeToParcel(Parcel out, int flags) {
-      out.writeByteArray(ADAPTER.encode(this));
     }
 
     @Override

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android.compact
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android.compact
@@ -2,25 +2,25 @@
 // Source file: person.proto at 21:1
 package com.squareup.wire.protos.person;
 
-import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
+import com.squareup.wire.AndroidMessage;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.WireEnum;
 import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
-import java.io.IOException;
 import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
-import java.lang.RuntimeException;
 import java.lang.String;
 import java.util.List;
 import okio.ByteString;
 
-public final class Person extends Message<Person, Person.Builder> implements Parcelable {
+public final class Person extends AndroidMessage<Person, Person.Builder> {
   public static final ProtoAdapter<Person> ADAPTER = ProtoAdapter.newMessageAdapter(Person.class);
+
+  public static final Parcelable.Creator<Person> CREATOR = AndroidMessage.newCreator(ADAPTER);
 
   private static final long serialVersionUID = 0L;
 
@@ -29,22 +29,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
   public static final Integer DEFAULT_ID = 0;
 
   public static final String DEFAULT_EMAIL = "";
-
-  public static final Parcelable.Creator<Person> CREATOR = new Parcelable.Creator<Person>() {
-    @Override
-    public Person createFromParcel(Parcel in) {
-      try {
-        return ADAPTER.decode(in.createByteArray());
-      } catch (IOException e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    @Override
-    public Person[] newArray(int size) {
-      return new Person[size];
-    }
-  };
 
   /**
    * The customer's full name.
@@ -133,11 +117,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
       super.hashCode = result;
     }
     return result;
-  }
-
-  @Override
-  public void writeToParcel(Parcel out, int flags) {
-    out.writeByteArray(ADAPTER.encode(this));
   }
 
   public static final class Builder extends Message.Builder<Person, Builder> {
@@ -233,30 +212,16 @@ public final class Person extends Message<Person, Person.Builder> implements Par
     }
   }
 
-  public static final class PhoneNumber extends Message<PhoneNumber, PhoneNumber.Builder> implements Parcelable {
+  public static final class PhoneNumber extends AndroidMessage<PhoneNumber, PhoneNumber.Builder> {
     public static final ProtoAdapter<PhoneNumber> ADAPTER = ProtoAdapter.newMessageAdapter(PhoneNumber.class);
+
+    public static final Parcelable.Creator<PhoneNumber> CREATOR = AndroidMessage.newCreator(ADAPTER);
 
     private static final long serialVersionUID = 0L;
 
     public static final String DEFAULT_NUMBER = "";
 
     public static final PhoneType DEFAULT_TYPE = PhoneType.HOME;
-
-    public static final Parcelable.Creator<PhoneNumber> CREATOR = new Parcelable.Creator<PhoneNumber>() {
-      @Override
-      public PhoneNumber createFromParcel(Parcel in) {
-        try {
-          return ADAPTER.decode(in.createByteArray());
-        } catch (IOException e) {
-          throw new RuntimeException(e);
-        }
-      }
-
-      @Override
-      public PhoneNumber[] newArray(int size) {
-        return new PhoneNumber[size];
-      }
-    };
 
     /**
      * The customer's phone number.
@@ -317,11 +282,6 @@ public final class Person extends Message<Person, Person.Builder> implements Par
         super.hashCode = result;
       }
       return result;
-    }
-
-    @Override
-    public void writeToParcel(Parcel out, int flags) {
-      out.writeByteArray(ADAPTER.encode(this));
     }
 
     public static final class Builder extends Message.Builder<PhoneNumber, Builder> {


### PR DESCRIPTION
There's two primary benefits here which ultimately have the same effect: method reduction.

1. Switching from a per-message generated `Creator` implementation to one implementation which can work for all types by leveraging their `ProtoAdapter`.
2. Consolidating the two `Parcelable` methods onto this class which also uses the available `ProtoAdpater` for its implementation.