### PR TITLE
Explicitly order decode switch by tag.

### DIFF
--- a/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/DescriptorProto.java
@@ -631,12 +631,12 @@ public final class DescriptorProto extends Message<DescriptorProto, DescriptorPr
         switch (tag) {
           case 1: builder.name(ProtoAdapter.STRING.decode(reader)); break;
           case 2: builder.field.add(FieldDescriptorProto.ADAPTER.decode(reader)); break;
-          case 6: builder.extension.add(FieldDescriptorProto.ADAPTER.decode(reader)); break;
           case 3: builder.nested_type.add(DescriptorProto.ADAPTER.decode(reader)); break;
           case 4: builder.enum_type.add(EnumDescriptorProto.ADAPTER.decode(reader)); break;
           case 5: builder.extension_range.add(ExtensionRange.ADAPTER.decode(reader)); break;
-          case 8: builder.oneof_decl.add(OneofDescriptorProto.ADAPTER.decode(reader)); break;
+          case 6: builder.extension.add(FieldDescriptorProto.ADAPTER.decode(reader)); break;
           case 7: builder.options(MessageOptions.ADAPTER.decode(reader)); break;
+          case 8: builder.oneof_decl.add(OneofDescriptorProto.ADAPTER.decode(reader)); break;
           case 9: builder.reserved_range.add(ReservedRange.ADAPTER.decode(reader)); break;
           case 10: builder.reserved_name.add(ProtoAdapter.STRING.decode(reader)); break;
           default: {

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
@@ -486,6 +486,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
       for (int tag; (tag = reader.nextTag()) != -1;) {
         switch (tag) {
           case 1: builder.name(ProtoAdapter.STRING.decode(reader)); break;
+          case 2: builder.extendee(ProtoAdapter.STRING.decode(reader)); break;
           case 3: builder.number(ProtoAdapter.INT32.decode(reader)); break;
           case 4: {
             try {
@@ -504,10 +505,9 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
             break;
           }
           case 6: builder.type_name(ProtoAdapter.STRING.decode(reader)); break;
-          case 2: builder.extendee(ProtoAdapter.STRING.decode(reader)); break;
           case 7: builder.default_value(ProtoAdapter.STRING.decode(reader)); break;
-          case 9: builder.oneof_index(ProtoAdapter.INT32.decode(reader)); break;
           case 8: builder.options(FieldOptions.ADAPTER.decode(reader)); break;
+          case 9: builder.oneof_index(ProtoAdapter.INT32.decode(reader)); break;
           default: {
             FieldEncoding fieldEncoding = reader.peekFieldEncoding();
             Object value = fieldEncoding.rawProtoAdapter().decode(reader);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
@@ -698,6 +698,8 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
             break;
           }
           case 2: builder.packed(ProtoAdapter.BOOL.decode(reader)); break;
+          case 3: builder.deprecated(ProtoAdapter.BOOL.decode(reader)); break;
+          case 5: builder.lazy(ProtoAdapter.BOOL.decode(reader)); break;
           case 6: {
             try {
               builder.jstype(JSType.ADAPTER.decode(reader));
@@ -706,10 +708,13 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
             }
             break;
           }
-          case 5: builder.lazy(ProtoAdapter.BOOL.decode(reader)); break;
-          case 3: builder.deprecated(ProtoAdapter.BOOL.decode(reader)); break;
           case 10: builder.weak(ProtoAdapter.BOOL.decode(reader)); break;
           case 999: builder.uninterpreted_option.add(UninterpretedOption.ADAPTER.decode(reader)); break;
+          case 22101: builder.squareup_protos_extension_collision_1_a(ProtoAdapter.STRING.decode(reader)); break;
+          case 22102: builder.b(ProtoAdapter.STRING.decode(reader)); break;
+          case 22103: builder.squareup_protos_extension_collision_2_a(ProtoAdapter.STRING.decode(reader)); break;
+          case 22104: builder.c(ProtoAdapter.STRING.decode(reader)); break;
+          case 22200: builder.redacted(ProtoAdapter.BOOL.decode(reader)); break;
           case 60001: builder.my_field_option_one(ProtoAdapter.INT32.decode(reader)); break;
           case 60002: builder.my_field_option_two(ProtoAdapter.FLOAT.decode(reader)); break;
           case 60003: {
@@ -721,11 +726,6 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
             break;
           }
           case 60004: builder.my_field_option_four(FooBar.ADAPTER.decode(reader)); break;
-          case 22101: builder.squareup_protos_extension_collision_1_a(ProtoAdapter.STRING.decode(reader)); break;
-          case 22102: builder.b(ProtoAdapter.STRING.decode(reader)); break;
-          case 22103: builder.squareup_protos_extension_collision_2_a(ProtoAdapter.STRING.decode(reader)); break;
-          case 22104: builder.c(ProtoAdapter.STRING.decode(reader)); break;
-          case 22200: builder.redacted(ProtoAdapter.BOOL.decode(reader)); break;
           default: {
             FieldEncoding fieldEncoding = reader.peekFieldEncoding();
             Object value = fieldEncoding.rawProtoAdapter().decode(reader);

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileDescriptorProto.java
@@ -424,14 +424,14 @@ public final class FileDescriptorProto extends Message<FileDescriptorProto, File
           case 1: builder.name(ProtoAdapter.STRING.decode(reader)); break;
           case 2: builder.package_(ProtoAdapter.STRING.decode(reader)); break;
           case 3: builder.dependency.add(ProtoAdapter.STRING.decode(reader)); break;
-          case 10: builder.public_dependency.add(ProtoAdapter.INT32.decode(reader)); break;
-          case 11: builder.weak_dependency.add(ProtoAdapter.INT32.decode(reader)); break;
           case 4: builder.message_type.add(DescriptorProto.ADAPTER.decode(reader)); break;
           case 5: builder.enum_type.add(EnumDescriptorProto.ADAPTER.decode(reader)); break;
           case 6: builder.service.add(ServiceDescriptorProto.ADAPTER.decode(reader)); break;
           case 7: builder.extension.add(FieldDescriptorProto.ADAPTER.decode(reader)); break;
           case 8: builder.options(FileOptions.ADAPTER.decode(reader)); break;
           case 9: builder.source_code_info(SourceCodeInfo.ADAPTER.decode(reader)); break;
+          case 10: builder.public_dependency.add(ProtoAdapter.INT32.decode(reader)); break;
+          case 11: builder.weak_dependency.add(ProtoAdapter.INT32.decode(reader)); break;
           case 12: builder.syntax(ProtoAdapter.STRING.decode(reader)); break;
           default: {
             FieldEncoding fieldEncoding = reader.peekFieldEncoding();

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
@@ -665,9 +665,6 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
         switch (tag) {
           case 1: builder.java_package(ProtoAdapter.STRING.decode(reader)); break;
           case 8: builder.java_outer_classname(ProtoAdapter.STRING.decode(reader)); break;
-          case 10: builder.java_multiple_files(ProtoAdapter.BOOL.decode(reader)); break;
-          case 20: builder.java_generate_equals_and_hash(ProtoAdapter.BOOL.decode(reader)); break;
-          case 27: builder.java_string_check_utf8(ProtoAdapter.BOOL.decode(reader)); break;
           case 9: {
             try {
               builder.optimize_for(OptimizeMode.ADAPTER.decode(reader));
@@ -676,11 +673,14 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
             }
             break;
           }
+          case 10: builder.java_multiple_files(ProtoAdapter.BOOL.decode(reader)); break;
           case 11: builder.go_package(ProtoAdapter.STRING.decode(reader)); break;
           case 16: builder.cc_generic_services(ProtoAdapter.BOOL.decode(reader)); break;
           case 17: builder.java_generic_services(ProtoAdapter.BOOL.decode(reader)); break;
           case 18: builder.py_generic_services(ProtoAdapter.BOOL.decode(reader)); break;
+          case 20: builder.java_generate_equals_and_hash(ProtoAdapter.BOOL.decode(reader)); break;
           case 23: builder.deprecated(ProtoAdapter.BOOL.decode(reader)); break;
+          case 27: builder.java_string_check_utf8(ProtoAdapter.BOOL.decode(reader)); break;
           case 31: builder.cc_enable_arenas(ProtoAdapter.BOOL.decode(reader)); break;
           case 36: builder.objc_class_prefix(ProtoAdapter.STRING.decode(reader)); break;
           case 37: builder.csharp_namespace(ProtoAdapter.STRING.decode(reader)); break;


### PR DESCRIPTION
While the rest of the methods read better ordered by declaration order from the schema, because decode is a switch on int it makes more sense to have it ordered ascending by tag.