### PR TITLE
Use NameAllocator in Message.Builder.build()

### DIFF
--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1355,9 +1355,10 @@ public final class JavaGenerator {
       for (int i = 0; i < requiredFields.size(); i++) {
         Field requiredField = requiredFields.get(i);
         if (i > 0) conditionals.add("\n|| ");
-        conditionals.add("$L == null", requiredField.name());
+        conditionals.add("$L == null", nameAllocator.get(requiredField));
         if (i > 0) missingArgs.add(",\n");
-        missingArgs.add("$1L, $1S", requiredField.name());
+        missingArgs.add("$1L, $2S", nameAllocator.get(requiredField),
+            requiredField.name());
       }
 
       result.beginControlFlow("if ($L)", conditionals.add("$]").build())

--- a/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -48,6 +48,26 @@ public final class JavaGeneratorTest {
     assertThat(JavaGenerator.sanitizeJavadoc(input)).isEqualTo(expected);
   }
 
+  @Test public void generateTypeUsesNameAllocatorInMessageBuilderBuild() {
+    Schema schema = new SchemaBuilder()
+        .add("message.proto", ""
+            + "message Message {\n"
+            + "  required float long = 1;\n"
+            + "}\n")
+        .build();
+    MessageType message = (MessageType) schema.getType("Message");
+    JavaGenerator javaGenerator = JavaGenerator.get(schema);
+    TypeSpec typeSpec = javaGenerator.generateType(message);
+    assertThat(JavaFile.builder("com.squareup.message", typeSpec).build().toString()).contains(""
+        + "    @Override\n"
+        + "    public Message build() {\n"
+        + "      if (long_ == null) {\n"
+        + "        throw Internal.missingRequiredFields(long_, \"long\");\n"
+        + "      }\n"
+        + "      return new Message(long_, super.buildUnknownFields());\n"
+        + "    }\n");
+  }
+
   @Test public void generateProtoFields() {
     Schema schema = new SchemaBuilder()
         .add("message.proto", ""


### PR DESCRIPTION
Use the NameAllocator when inserting string literals, don't use the field
name directly.