### PR TITLE
Begin to parse build.wire configuration files.

### DIFF
--- a/wire-java-generator/pom.xml
+++ b/wire-java-generator/pom.xml
@@ -34,6 +34,11 @@
       <groupId>com.squareup</groupId>
       <artifactId>javapoet</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.auto.value</groupId>
+      <artifactId>auto-value</artifactId>
+      <scope>provided</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.squareup.wire</groupId>

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/internal/BuildConfigFileElement.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/internal/BuildConfigFileElement.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.java.internal;
+
+import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
+import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.parser.Nullable;
+
+/**
+ * A single {@code build.wire} file. This file is structured similarly to a {@code .proto} file, but
+ * with different elements.
+ *
+ * <h3>File Structure</h3>
+ *
+ * A project may have 0 or more {@code build.wire} files. These files should be in the same
+ * directory as the {@code .proto} files so they may be automatically discovered by Wire.
+ *
+ * <p>Each file starts with a syntax declaration. The syntax must be "wire2". This is followed by an
+ * optional package declaration, which should match to the package declarations of the {@code
+ * .proto} files in the directory.
+ *
+ * <p>Build configs may import any number of proto files. Note that it is an error to import {@code
+ * build.wire} files. These imports are used to resolve types specified later in the file.
+ *
+ * <p>Build configs may specify any number of type configurations. These specify a fully qualified
+ * type, its target Java type, and an adapter to do the encoding and decoding.
+ *
+ * <pre>   {@code
+ *
+ *   syntax = "wire2";
+ *   package squareup.dinosaurs;
+ *
+ *   import "squareup/geology/period.proto";
+ *
+ *   // Roar!
+ *   type squareup.dinosaurs.Dinosaur {
+ *     target com.squareup.dino.Dinosaur using com.squareup.dino.Dinosaurs#DINO_ADAPTER;
+ *   }
+ * }</pre>
+ */
+@AutoValue
+public abstract class BuildConfigFileElement {
+  public static Builder builder(Location location) {
+    return new AutoValue_BuildConfigFileElement.Builder()
+        .location(location)
+        .imports(ImmutableList.<String>of())
+        .typeConfigs(ImmutableList.<TypeConfigElement>of());
+  }
+
+  public abstract Location location();
+  @Nullable public abstract String packageName();
+  public abstract ImmutableList<String> imports();
+  public abstract ImmutableList<TypeConfigElement> typeConfigs();
+
+  public final String toSchema() {
+    StringBuilder builder = new StringBuilder();
+    builder.append("// ").append(location()).append('\n');
+    builder.append("syntax \"wire2\";\n");
+    if (packageName() != null) {
+      builder.append("package ").append(packageName()).append(";\n");
+    }
+    if (!imports().isEmpty()) {
+      builder.append('\n');
+      for (String file : imports()) {
+        builder.append("import \"").append(file).append("\";\n");
+      }
+    }
+    if (!typeConfigs().isEmpty()) {
+      builder.append('\n');
+      for (TypeConfigElement typeConfigElement : typeConfigs()) {
+        builder.append(typeConfigElement.toSchema());
+      }
+    }
+    return builder.toString();
+  }
+
+  @AutoValue.Builder
+  public interface Builder {
+    Builder location(Location location);
+    Builder packageName(@Nullable String packageName);
+    Builder imports(ImmutableList<String> imports);
+    Builder typeConfigs(ImmutableList<TypeConfigElement> typeConfigs);
+    BuildConfigFileElement build();
+  }
+}

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/internal/BuildConfigParser.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/internal/BuildConfigParser.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.java.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.parser.SyntaxReader;
+
+/** Parses {@code build.wire} files. */
+public final class BuildConfigParser {
+  private final SyntaxReader reader;
+
+  private final BuildConfigFileElement.Builder fileBuilder;
+  private final ImmutableList.Builder<String> imports = ImmutableList.builder();
+  private final ImmutableList.Builder<TypeConfigElement> typeConfigs = ImmutableList.builder();
+
+  /** Output package name, or null if none yet encountered. */
+  private String packageName;
+
+  BuildConfigParser(Location location, char[] data) {
+    this.reader = new SyntaxReader(data, location);
+    this.fileBuilder = BuildConfigFileElement.builder(location);
+  }
+
+  BuildConfigFileElement read() {
+    String label = reader.readWord();
+    if (!label.equals("syntax")) throw reader.unexpected("expected 'syntax'");
+    reader.require('=');
+    String syntaxString = reader.readQuotedString();
+    if (!syntaxString.equals("wire2")) throw reader.unexpected("expected 'wire2'");
+    reader.require(';');
+
+    while (true) {
+      String documentation = reader.readDocumentation();
+      if (reader.exhausted()) {
+        return fileBuilder.packageName(packageName)
+            .imports(imports.build())
+            .typeConfigs(typeConfigs.build())
+            .build();
+      }
+
+      readDeclaration(documentation);
+    }
+  }
+
+  private void readDeclaration(String documentation) {
+    Location location = reader.location();
+    String label = reader.readWord();
+
+    if (label.equals("package")) {
+      if (packageName != null) throw reader.unexpected(location, "too many package names");
+      packageName = reader.readName();
+      reader.require(';');
+    } else if (label.equals("import")) {
+      String importString = reader.readString();
+      imports.add(importString);
+      reader.require(';');
+    } else if (label.equals("type")) {
+      typeConfigs.add(readTypeConfig(location, documentation));
+    } else {
+      throw reader.unexpected(location, "unexpected label: " + label);
+    }
+  }
+
+  /** Reads a type config and returns it. */
+  private TypeConfigElement readTypeConfig(Location location, String documentation) {
+    String name = reader.readDataType();
+    String target = null;
+    String adapter = null;
+
+    reader.require('{');
+    while (!reader.peekChar('}')) {
+      Location wordLocation = reader.location();
+      String word = reader.readWord();
+      switch (word) {
+        case "target":
+          if (target != null) throw reader.unexpected(wordLocation, "too many targets");
+          target = reader.readWord();
+          if (!reader.readWord().equals("using")) throw reader.unexpected("expected 'using'");
+          String adapterType = reader.readWord();
+          reader.require('#');
+          String adapterConstant = reader.readWord();
+          reader.require(';');
+          adapter = adapterType + '#' + adapterConstant;
+          break;
+
+        default:
+          throw reader.unexpected(wordLocation, "unexpected label: " + word);
+      }
+    }
+
+    return TypeConfigElement.builder(location)
+        .type(name)
+        .documentation(documentation)
+        .target(target)
+        .adapter(adapter)
+        .build();
+  }
+}

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/internal/TypeConfigElement.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/internal/TypeConfigElement.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.java.internal;
+
+import com.google.auto.value.AutoValue;
+import com.squareup.wire.schema.Location;
+
+import static com.squareup.wire.schema.internal.Util.appendDocumentation;
+
+/**
+ * Configures how Wire will generate code for a specific type. This configuration belongs in a
+ * {@code build.wire} file that is in the same directory as the configured type.
+ */
+@AutoValue
+public abstract class TypeConfigElement {
+  public static Builder builder(Location location) {
+    return new AutoValue_TypeConfigElement.Builder()
+        .location(location)
+        .documentation("");
+  }
+
+  public abstract Location location();
+  public abstract String type();
+  public abstract String documentation();
+  public abstract String target();
+  public abstract String adapter();
+
+  public final String toSchema() {
+    StringBuilder builder = new StringBuilder();
+    appendDocumentation(builder, documentation());
+    builder.append("type ").append(type()).append(" {\n");
+    builder.append("  target ").append(target()).append(" using ").append(adapter()).append("\n");
+    builder.append("}\n");
+    return builder.toString();
+  }
+
+  @AutoValue.Builder
+  public interface Builder {
+    Builder location(Location location);
+    Builder type(String type);
+    Builder documentation(String documentation);
+    Builder target(String target);
+    Builder adapter(String adapter);
+    TypeConfigElement build();
+  }
+}

--- a/wire-java-generator/src/test/java/com/squareup/wire/java/internal/BuildConfigParserTest.java
+++ b/wire-java-generator/src/test/java/com/squareup/wire/java/internal/BuildConfigParserTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.java.internal;
+
+import com.google.common.collect.ImmutableList;
+import com.squareup.wire.schema.Location;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+public final class BuildConfigParserTest {
+  Location location = Location.get("build.wire");
+
+  @Test public void parseType() {
+    String proto = ""
+        + "syntax = \"wire2\";\n"
+        + "package squareup.dinosaurs;\n"
+        + "\n"
+        + "import \"squareup/geology/period.proto\";\n"
+        + "\n"
+        + "/* Roar! */\n"
+        + "type squareup.dinosaurs.Dinosaur {\n"
+        + "  target com.squareup.dino.Dinosaur using com.squareup.dino.Dinosaurs#DINO_ADAPTER;\n"
+        + "}\n"
+        + "\n"
+        + "type squareup.geology.Period {\n"
+        + "  target java.time.Period using com.squareup.time.Time#PERIOD_ADAPTER;\n"
+        + "}\n";
+    BuildConfigFileElement expected = BuildConfigFileElement.builder(location)
+        .packageName("squareup.dinosaurs")
+        .imports(ImmutableList.of("squareup/geology/period.proto"))
+        .typeConfigs(ImmutableList.of(
+            TypeConfigElement.builder(location.at(7, 1))
+                .documentation("Roar!")
+                .type("squareup.dinosaurs.Dinosaur")
+                .target("com.squareup.dino.Dinosaur")
+                .adapter("com.squareup.dino.Dinosaurs#DINO_ADAPTER")
+                .build(),
+            TypeConfigElement.builder(location.at(11, 1))
+                .type("squareup.geology.Period")
+                .target("java.time.Period")
+                .adapter("com.squareup.time.Time#PERIOD_ADAPTER")
+                .build()))
+        .build();
+    BuildConfigParser parser = new BuildConfigParser(location, proto.toCharArray());
+    assertThat(parser.read()).isEqualTo(expected);
+  }
+
+  @Test public void invalidSyntax() {
+    String proto = ""
+        + "syntax = \"proto2\";\n"
+        + "\n"
+        + "type squareup.dinosaurs.Dinosaur {\n"
+        + "  target com.squareup.dino.Dinosaur using com.squareup.dino.Dinosaurs#DINO_ADAPTER;\n"
+        + "}\n";
+    BuildConfigParser parser = new BuildConfigParser(location, proto.toCharArray());
+    try {
+      parser.read();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage("Syntax error in build.wire at 1:18: expected 'wire2'");
+    }
+  }
+
+  @Test public void tooManyTargets() {
+    String proto = ""
+        + "syntax = \"wire2\";\n"
+        + "\n"
+        + "type squareup.dinosaurs.Dinosaur {\n"
+        + "  target com.squareup.dino.Herbivore using com.squareup.dino.Dinosaurs#PLANT_ADAPTER;\n"
+        + "  target com.squareup.dino.Carnivore using com.squareup.dino.Dinosaurs#MEAT_ADAPTER;\n"
+        + "}\n";
+    BuildConfigParser parser = new BuildConfigParser(location, proto.toCharArray());
+    try {
+      parser.read();
+      fail();
+    } catch (IllegalStateException expected) {
+      assertThat(expected).hasMessage("Syntax error in build.wire at 5:3: too many targets");
+    }
+  }
+}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/Nullable.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/Nullable.java
@@ -20,5 +20,5 @@ import java.lang.annotation.Retention;
 import static java.lang.annotation.RetentionPolicy.SOURCE;
 
 @Retention(SOURCE)
-@interface Nullable {
+public @interface Nullable {
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoFileElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoFileElement.java
@@ -48,11 +48,11 @@ public abstract class ProtoFileElement {
   public final String toSchema() {
     StringBuilder builder = new StringBuilder();
     builder.append("// ").append(location()).append('\n');
-    if (packageName() != null) {
-      builder.append("package ").append(packageName()).append(";\n");
-    }
     if (syntax() != null) {
       builder.append("syntax \"").append(syntax()).append("\";\n");
+    }
+    if (packageName() != null) {
+      builder.append("package ").append(packageName()).append(";\n");
     }
     if (!imports().isEmpty() || !publicImports().isEmpty()) {
       builder.append('\n');

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/SyntaxReader.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/SyntaxReader.java
@@ -1,0 +1,415 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema.internal.parser;
+
+import com.squareup.wire.schema.Location;
+
+/** A general purpose reader for formats like {@code .proto}. */
+public final class SyntaxReader {
+  private final Location location;
+
+  private final char[] data;
+  /** Our cursor within the document. {@code data[pos]} is the next character to be read. */
+  private int pos;
+  /** The number of newline characters encountered thus far. */
+  private int line;
+  /** The index of the most recent newline character. */
+  private int lineStart;
+
+  public SyntaxReader(char[] data, Location location) {
+    this.data = data;
+    this.location = location;
+  }
+
+  public boolean exhausted() {
+    return pos == data.length;
+  }
+
+  /** Reads a non-whitespace character and returns it. */
+  public char readChar() {
+    char result = peekChar();
+    pos++;
+    return result;
+  }
+
+  /** Reads a non-whitespace character 'c', or throws an exception. */
+  public void require(char c) {
+    if (readChar() != c) throw unexpected("expected '" + c + "'");
+  }
+
+  /**
+   * Peeks a non-whitespace character and returns it. The only difference
+   * between this and {@code readChar} is that this doesn't consume the char.
+   */
+  public char peekChar() {
+    skipWhitespace(true);
+    if (pos == data.length) throw unexpected("unexpected end of file");
+    return data[pos];
+  }
+
+  public boolean peekChar(char c) {
+    if (peekChar() == c) {
+      pos++;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  /** Push back the most recently read character. */
+  public void pushBack(char c) {
+    if (data[pos - 1] != c) throw new IllegalArgumentException();
+    pos--;
+  }
+
+  /** Reads a quoted or unquoted string and returns it. */
+  public String readString() {
+    skipWhitespace(true);
+    char c = peekChar();
+    return c == '"' || c == '\'' ? readQuotedString() : readWord();
+  }
+
+  public String readQuotedString() {
+    char startQuote = readChar();
+    if (startQuote != '"' && startQuote != '\'') throw new AssertionError();
+    StringBuilder result = new StringBuilder();
+    while (pos < data.length) {
+      char c = data[pos++];
+      if (c == startQuote) {
+        if (peekChar() == '"' || peekChar() == '\'') {
+          // Adjacent strings are concatenated. Consume new quote and continue reading.
+          startQuote = readChar();
+          continue;
+        }
+        return result.toString();
+      }
+
+      if (c == '\\') {
+        if (pos == data.length) throw unexpected("unexpected end of file");
+        c = data[pos++];
+        switch (c) {
+          case 'a': c = 0x7; break;
+          case 'b': c = '\b'; break;
+          case 'f': c = '\f'; break;
+          case 'n': c = '\n'; break;
+          case 'r': c = '\r'; break;
+          case 't': c = '\t'; break;
+          case 'v': c = 0xb; break;
+          case 'x':case 'X':
+            c = readNumericEscape(16, 2);
+            break;
+          case '0':case '1':case '2':case '3':case '4':case '5':case '6':case '7':
+            --pos;
+            c = readNumericEscape(8, 3);
+            break;
+          default:
+            // use char as-is
+            break;
+        }
+      }
+
+      result.append(c);
+      if (c == '\n') newline();
+    }
+    throw unexpected("unterminated string");
+  }
+
+  private char readNumericEscape(int radix, int len) {
+    int value = -1;
+    for (int endPos = Math.min(pos + len, data.length); pos < endPos; pos++) {
+      int digit = hexDigit(data[pos]);
+      if (digit == -1 || digit >= radix) break;
+      if (value < 0) {
+        value = digit;
+      } else {
+        value = value * radix + digit;
+      }
+    }
+    if (value < 0) throw unexpected("expected a digit after \\x or \\X");
+    return (char) value;
+  }
+
+  private int hexDigit(char c) {
+    if (c >= '0' && c <= '9') return c - '0';
+    else if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    else if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    else return -1;
+  }
+
+  /** Reads a (paren-wrapped), [square-wrapped] or naked symbol name. */
+  public String readName() {
+    String optionName;
+    char c = peekChar();
+    if (c == '(') {
+      pos++;
+      optionName = readWord();
+      if (readChar() != ')') throw unexpected("expected ')'");
+    } else if (c == '[') {
+      pos++;
+      optionName = readWord();
+      if (readChar() != ']') throw unexpected("expected ']'");
+    } else {
+      optionName = readWord();
+    }
+    return optionName;
+  }
+
+  /** Reads a scalar, map, or type name. */
+  public String readDataType() {
+    String name = readWord();
+    return readDataType(name);
+  }
+
+  /** Reads a scalar, map, or type name with {@code name} as a prefix word. */
+  public String readDataType(String name) {
+    if (name.equals("map")) {
+      if (readChar() != '<') throw unexpected("expected '<'");
+      String keyType = readDataType();
+      if (readChar() != ',') throw unexpected("expected ','");
+      String valueType = readDataType();
+      if (readChar() != '>') throw unexpected("expected '>'");
+      return String.format("map<%s, %s>", keyType, valueType);
+    } else {
+      return name;
+    }
+  }
+
+  /** Reads a non-empty word and returns it. */
+  public String readWord() {
+    skipWhitespace(true);
+    int start = pos;
+    while (pos < data.length) {
+      char c = data[pos];
+      if ((c >= 'a' && c <= 'z')
+          || (c >= 'A' && c <= 'Z')
+          || (c >= '0' && c <= '9')
+          || (c == '_')
+          || (c == '-')
+          || (c == '.')) {
+        pos++;
+      } else {
+        break;
+      }
+    }
+    if (start == pos) {
+      throw unexpected("expected a word");
+    }
+    return new String(data, start, pos - start);
+  }
+
+  /** Reads an integer and returns it. */
+  public int readInt() {
+    String tag = readWord();
+    try {
+      int radix = 10;
+      if (tag.startsWith("0x") || tag.startsWith("0X")) {
+        tag = tag.substring("0x".length());
+        radix = 16;
+      }
+      return Integer.valueOf(tag, radix);
+    } catch (Exception e) {
+      throw unexpected("expected an integer but was " + tag);
+    }
+  }
+
+  /**
+   * Like {@link #skipWhitespace}, but this returns a string containing all
+   * comment text. By convention, comments before a declaration document that
+   * declaration.
+   */
+  public String readDocumentation() {
+    String result = null;
+    while (true) {
+      skipWhitespace(false);
+      if (pos == data.length || data[pos] != '/') {
+        return result != null ? result : "";
+      }
+      String comment = readComment();
+      result = (result == null) ? comment : (result + "\n" + comment);
+    }
+  }
+
+  /** Reads a comment and returns its body. */
+  private String readComment() {
+    if (pos == data.length || data[pos] != '/') throw new AssertionError();
+    pos++;
+    int commentType = pos < data.length ? data[pos++] : -1;
+    if (commentType == '*') {
+      StringBuilder result = new StringBuilder();
+      boolean startOfLine = true;
+
+      for (; pos + 1 < data.length; pos++) {
+        char c = data[pos];
+        if (c == '*' && data[pos + 1] == '/') {
+          pos += 2;
+          return result.toString().trim();
+        }
+        if (c == '\n') {
+          result.append('\n');
+          newline();
+          startOfLine = true;
+        } else if (!startOfLine) {
+          result.append(c);
+        } else if (c == '*') {
+          if (data[pos + 1] == ' ') {
+            pos += 1; // Skip a single leading space, if present.
+          }
+          startOfLine = false;
+        } else if (!Character.isWhitespace(c)) {
+          result.append(c);
+          startOfLine = false;
+        }
+      }
+      throw unexpected("unterminated comment");
+    } else if (commentType == '/') {
+      if (pos < data.length && data[pos] == ' ') {
+        pos += 1; // Skip a single leading space, if present.
+      }
+      int start = pos;
+      while (pos < data.length) {
+        char c = data[pos++];
+        if (c == '\n') {
+          newline();
+          break;
+        }
+      }
+      return new String(data, start, pos - 1 - start);
+    } else {
+      throw unexpected("unexpected '/'");
+    }
+  }
+
+  public String tryAppendTrailingDocumentation(String documentation) {
+    // Search for a '/' character ignoring spaces and tabs.
+    while (pos < data.length) {
+      char c = data[pos];
+      if (c == ' ' || c == '\t') {
+        pos++;
+      } else if (c == '/') {
+        pos++;
+        break;
+      } else {
+        // Not a whitespace or comment-starting character. Return original documentation.
+        return documentation;
+      }
+    }
+
+    if (pos == data.length || (data[pos] != '/' && data[pos] != '*')) {
+      pos--; // Backtrack to start of comment.
+      throw unexpected("expected '//' or '/*'");
+    }
+    boolean isStar = data[pos] == '*';
+    pos++;
+
+    if (pos < data.length && data[pos] == ' ') {
+      pos++; // Skip a single leading space, if present.
+    }
+
+    int start = pos;
+    int end;
+
+    if (isStar) {
+      // Consume star comment until it closes on the same line.
+      while (true) {
+        if (pos == data.length || data[pos] == '\n') {
+          throw unexpected("trailing comment must be closed on the same line");
+        }
+        if (data[pos] == '*' && pos + 1 < data.length && data[pos + 1] == '/') {
+          end = pos - 1; // The character before '*'.
+          pos += 2; // Skip to the character after '/'.
+          break;
+        }
+        pos++;
+      }
+      // Ensure nothing follows a trailing star comment.
+      while (pos < data.length) {
+        char c = data[pos++];
+        if (c == '\n') {
+          newline();
+          break;
+        }
+        if (c != ' ' && c != '\t') {
+          throw unexpected("no syntax may follow trailing comment");
+        }
+      }
+    } else {
+      // Consume comment until newline.
+      while (true) {
+        if (pos == data.length) {
+          end = pos - 1;
+          break;
+        }
+        char c = data[pos++];
+        if (c == '\n') {
+          newline();
+          end = pos - 2; // Account for stepping past the newline.
+          break;
+        }
+      }
+    }
+
+    // Remove trailing whitespace.
+    while (end > start && (data[end] == ' ' || data[end] == '\t')) {
+      end--;
+    }
+
+    if (end == start) {
+      return documentation;
+    }
+
+    String trailingDocumentation = new String(data, start, end - start + 1);
+
+    return documentation.isEmpty()
+        ? trailingDocumentation
+        : documentation + '\n' + trailingDocumentation;
+  }
+
+  /**
+   * Skips whitespace characters and optionally comments. When this returns,
+   * either {@code pos == data.length} or a non-whitespace character.
+   */
+  private void skipWhitespace(boolean skipComments) {
+    while (pos < data.length) {
+      char c = data[pos];
+      if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+        pos++;
+        if (c == '\n') newline();
+      } else if (skipComments && c == '/') {
+        readComment();
+      } else {
+        break;
+      }
+    }
+  }
+
+  /** Call this every time a '\n' is encountered. */
+  private void newline() {
+    line++;
+    lineStart = pos;
+  }
+
+  public Location location() {
+    return location.at(line + 1, pos - lineStart + 1);
+  }
+
+  public RuntimeException unexpected(String message) {
+    return unexpected(location(), message);
+  }
+
+  public RuntimeException unexpected(Location location, String message) {
+    throw new IllegalStateException(String.format("Syntax error in %s: %s", location, message));
+  }
+}


### PR DESCRIPTION
This extracts the general-purpose parts of the parser out of ProtoParser
and into a standalone file, Parser.java.

It then uses that file to build a new parser for build.wire files, which
currently only support type configs. The type configs do not yet support
any deep validation; that will come in a follow up that will hook these
up to SchemaLoader.