### PR TITLE
Do not use reflection for enum in non-compact mode.

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/EnumAdapter.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire;
+
+import java.io.IOException;
+
+/**
+ * An abstract {@link ProtoAdapter} that converts values of an enum to and from integers.
+ */
+public abstract class EnumAdapter<E extends WireEnum> extends ProtoAdapter<E> {
+  protected EnumAdapter(Class<E> type) {
+    super(FieldEncoding.VARINT, type);
+  }
+
+  @Override public final int encodedSize(E value) {
+    return ProtoWriter.varint32Size(value.getValue());
+  }
+
+  @Override public final void encode(ProtoWriter writer, E value) throws IOException {
+    writer.writeVarint32(value.getValue());
+  }
+
+  @Override public final E decode(ProtoReader reader) throws IOException {
+    int value = reader.readVarint32();
+    E constant = fromValue(value);
+    if (constant == null) {
+      throw new EnumConstantNotFoundException(value, javaType);
+    }
+    return constant;
+  }
+
+  /**
+   * Converts an integer to an enum.
+   * Returns null if there is no corresponding enum.
+   */
+  protected abstract E fromValue(int value);
+}

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldDescriptorProto.java
@@ -2,6 +2,7 @@
 // Source file: google/protobuf/descriptor.proto at 125:1
 package com.google.protobuf;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -369,7 +370,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
      */
     TYPE_SINT64(18);
 
-    public static final ProtoAdapter<Type> ADAPTER = ProtoAdapter.newEnumAdapter(Type.class);
+    public static final ProtoAdapter<Type> ADAPTER = new ProtoAdapter_Type();
 
     private final int value;
 
@@ -408,6 +409,17 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
     public int getValue() {
       return value;
     }
+
+    private static final class ProtoAdapter_Type extends EnumAdapter<Type> {
+      ProtoAdapter_Type() {
+        super(Type.class);
+      }
+
+      @Override
+      protected Type fromValue(int value) {
+        return Type.fromValue(value);
+      }
+    }
   }
 
   public enum Label implements WireEnum {
@@ -420,7 +432,7 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
 
     LABEL_REPEATED(3);
 
-    public static final ProtoAdapter<Label> ADAPTER = ProtoAdapter.newEnumAdapter(Label.class);
+    public static final ProtoAdapter<Label> ADAPTER = new ProtoAdapter_Label();
 
     private final int value;
 
@@ -443,6 +455,17 @@ public final class FieldDescriptorProto extends Message<FieldDescriptorProto, Fi
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_Label extends EnumAdapter<Label> {
+      ProtoAdapter_Label() {
+        super(Label.class);
+      }
+
+      @Override
+      protected Label fromValue(int value) {
+        return Label.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FieldOptions.java
@@ -2,6 +2,7 @@
 // Source file: google/protobuf/descriptor.proto at 441:1
 package com.google.protobuf;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -568,7 +569,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
 
     STRING_PIECE(2);
 
-    public static final ProtoAdapter<CType> ADAPTER = ProtoAdapter.newEnumAdapter(CType.class);
+    public static final ProtoAdapter<CType> ADAPTER = new ProtoAdapter_CType();
 
     private final int value;
 
@@ -592,6 +593,17 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     public int getValue() {
       return value;
     }
+
+    private static final class ProtoAdapter_CType extends EnumAdapter<CType> {
+      ProtoAdapter_CType() {
+        super(CType.class);
+      }
+
+      @Override
+      protected CType fromValue(int value) {
+        return CType.fromValue(value);
+      }
+    }
   }
 
   public enum JSType implements WireEnum {
@@ -610,7 +622,7 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
      */
     JS_NUMBER(2);
 
-    public static final ProtoAdapter<JSType> ADAPTER = ProtoAdapter.newEnumAdapter(JSType.class);
+    public static final ProtoAdapter<JSType> ADAPTER = new ProtoAdapter_JSType();
 
     private final int value;
 
@@ -633,6 +645,17 @@ public final class FieldOptions extends Message<FieldOptions, FieldOptions.Build
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_JSType extends EnumAdapter<JSType> {
+      ProtoAdapter_JSType() {
+        super(JSType.class);
+      }
+
+      @Override
+      protected JSType fromValue(int value) {
+        return JSType.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
+++ b/wire-runtime/src/test/proto-java/com/google/protobuf/FileOptions.java
@@ -2,6 +2,7 @@
 // Source file: google/protobuf/descriptor.proto at 277:1
 package com.google.protobuf;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -586,7 +587,7 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
      */
     LITE_RUNTIME(3);
 
-    public static final ProtoAdapter<OptimizeMode> ADAPTER = ProtoAdapter.newEnumAdapter(OptimizeMode.class);
+    public static final ProtoAdapter<OptimizeMode> ADAPTER = new ProtoAdapter_OptimizeMode();
 
     private final int value;
 
@@ -609,6 +610,17 @@ public final class FileOptions extends Message<FileOptions, FileOptions.Builder>
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_OptimizeMode extends EnumAdapter<OptimizeMode> {
+      ProtoAdapter_OptimizeMode() {
+        super(OptimizeMode.class);
+      }
+
+      @Override
+      protected OptimizeMode fromValue(int value) {
+        return OptimizeMode.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -2,6 +2,7 @@
 // Source file: all_types.proto at 21:1
 package com.squareup.wire.protos.alltypes;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -3094,7 +3095,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   public enum NestedEnum implements WireEnum {
     A(1);
 
-    public static final ProtoAdapter<NestedEnum> ADAPTER = ProtoAdapter.newEnumAdapter(NestedEnum.class);
+    public static final ProtoAdapter<NestedEnum> ADAPTER = new ProtoAdapter_NestedEnum();
 
     private final int value;
 
@@ -3115,6 +3116,17 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_NestedEnum extends EnumAdapter<NestedEnum> {
+      ProtoAdapter_NestedEnum() {
+        super(NestedEnum.class);
+      }
+
+      @Override
+      protected NestedEnum fromValue(int value) {
+        return NestedEnum.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -4,6 +4,7 @@ package com.squareup.wire.protos.custom_options;
 
 import com.google.protobuf.EnumOptions;
 import com.google.protobuf.FieldOptions;
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -574,7 +575,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     BAZ(3, 18, null, false);
 
-    public static final ProtoAdapter<FooBarBazEnum> ADAPTER = ProtoAdapter.newEnumAdapter(FooBarBazEnum.class);
+    public static final ProtoAdapter<FooBarBazEnum> ADAPTER = new ProtoAdapter_FooBarBazEnum();
 
     public static final EnumOptions ENUM_OPTIONS = new EnumOptions.Builder()
         .enum_option(true)
@@ -610,6 +611,17 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_FooBarBazEnum extends EnumAdapter<FooBarBazEnum> {
+      ProtoAdapter_FooBarBazEnum() {
+        super(FooBarBazEnum.class);
+      }
+
+      @Override
+      protected FooBarBazEnum fromValue(int value) {
+        return FooBarBazEnum.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/custom_options/FooBar.java.noOptions
@@ -2,6 +2,7 @@
 // Source file: custom_options.proto at 24:1
 package com.squareup.wire.protos.custom_options;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -516,7 +517,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     BAZ(3);
 
-    public static final ProtoAdapter<FooBarBazEnum> ADAPTER = ProtoAdapter.newEnumAdapter(FooBarBazEnum.class);
+    public static final ProtoAdapter<FooBarBazEnum> ADAPTER = new ProtoAdapter_FooBarBazEnum();
 
     private final int value;
 
@@ -539,6 +540,17 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_FooBarBazEnum extends EnumAdapter<FooBarBazEnum> {
+      ProtoAdapter_FooBarBazEnum() {
+        super(FooBarBazEnum.class);
+      }
+
+      @Override
+      protected FooBarBazEnum fromValue(int value) {
+        return FooBarBazEnum.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignEnum.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/foreign/ForeignEnum.java
@@ -2,6 +2,7 @@
 // Source file: foreign.proto at 23:1
 package com.squareup.wire.protos.foreign;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.WireEnum;
 import java.lang.Override;
@@ -11,7 +12,7 @@ public enum ForeignEnum implements WireEnum {
 
   BAX(1);
 
-  public static final ProtoAdapter<ForeignEnum> ADAPTER = ProtoAdapter.newEnumAdapter(ForeignEnum.class);
+  public static final ProtoAdapter<ForeignEnum> ADAPTER = new ProtoAdapter_ForeignEnum();
 
   private final int value;
 
@@ -33,5 +34,16 @@ public enum ForeignEnum implements WireEnum {
   @Override
   public int getValue() {
     return value;
+  }
+
+  private static final class ProtoAdapter_ForeignEnum extends EnumAdapter<ForeignEnum> {
+    ProtoAdapter_ForeignEnum() {
+      super(ForeignEnum.class);
+    }
+
+    @Override
+    protected ForeignEnum fromValue(int value) {
+      return ForeignEnum.fromValue(value);
+    }
   }
 }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java
@@ -2,6 +2,7 @@
 // Source file: person.proto at 21:1
 package com.squareup.wire.protos.person;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -195,7 +196,7 @@ public final class Person extends Message<Person, Person.Builder> {
      */
     WORK(2);
 
-    public static final ProtoAdapter<PhoneType> ADAPTER = ProtoAdapter.newEnumAdapter(PhoneType.class);
+    public static final ProtoAdapter<PhoneType> ADAPTER = new ProtoAdapter_PhoneType();
 
     private final int value;
 
@@ -218,6 +219,17 @@ public final class Person extends Message<Person, Person.Builder> {
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_PhoneType extends EnumAdapter<PhoneType> {
+      ProtoAdapter_PhoneType() {
+        super(PhoneType.class);
+      }
+
+      @Override
+      protected PhoneType fromValue(int value) {
+        return PhoneType.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/person/Person.java.android
@@ -5,6 +5,7 @@ package com.squareup.wire.protos.person;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import com.squareup.wire.AndroidMessage;
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -201,7 +202,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
      */
     WORK(2);
 
-    public static final ProtoAdapter<PhoneType> ADAPTER = ProtoAdapter.newEnumAdapter(PhoneType.class);
+    public static final ProtoAdapter<PhoneType> ADAPTER = new ProtoAdapter_PhoneType();
 
     private final int value;
 
@@ -224,6 +225,17 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_PhoneType extends EnumAdapter<PhoneType> {
+      ProtoAdapter_PhoneType() {
+        super(PhoneType.class);
+      }
+
+      @Override
+      protected PhoneType fromValue(int value) {
+        return PhoneType.fromValue(value);
+      }
     }
   }
 

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/G.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/roots/G.java
@@ -2,6 +2,7 @@
 // Source file: roots.proto at 60:1
 package com.squareup.wire.protos.roots;
 
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.ProtoAdapter;
 import com.squareup.wire.WireEnum;
 import java.lang.Override;
@@ -11,7 +12,7 @@ public enum G implements WireEnum {
 
   BAR(2);
 
-  public static final ProtoAdapter<G> ADAPTER = ProtoAdapter.newEnumAdapter(G.class);
+  public static final ProtoAdapter<G> ADAPTER = new ProtoAdapter_G();
 
   private final int value;
 
@@ -33,5 +34,16 @@ public enum G implements WireEnum {
   @Override
   public int getValue() {
     return value;
+  }
+
+  private static final class ProtoAdapter_G extends EnumAdapter<G> {
+    ProtoAdapter_G() {
+      super(G.class);
+    }
+
+    @Override
+    protected G fromValue(int value) {
+      return G.fromValue(value);
+    }
   }
 }

--- a/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-runtime/src/test/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -3,6 +3,7 @@
 package com.squareup.wire.protos.simple;
 
 import com.google.protobuf.EnumOptions;
+import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -526,7 +527,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     @Deprecated
     BUZ(3, true);
 
-    public static final ProtoAdapter<NestedEnum> ADAPTER = ProtoAdapter.newEnumAdapter(NestedEnum.class);
+    public static final ProtoAdapter<NestedEnum> ADAPTER = new ProtoAdapter_NestedEnum();
 
     public static final EnumOptions ENUM_OPTIONS = new EnumOptions.Builder()
         .allow_alias(true)
@@ -556,6 +557,17 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
     @Override
     public int getValue() {
       return value;
+    }
+
+    private static final class ProtoAdapter_NestedEnum extends EnumAdapter<NestedEnum> {
+      ProtoAdapter_NestedEnum() {
+        super(NestedEnum.class);
+      }
+
+      @Override
+      protected NestedEnum fromValue(int value) {
+        return NestedEnum.fromValue(value);
+      }
     }
   }
 


### PR DESCRIPTION
Making wire protos j2objc-friendly. 

CC @swankjesse