### PR TITLE
allow inline multiline comments

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/SyntaxReader.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/SyntaxReader.java
@@ -324,8 +324,8 @@ public final class SyntaxReader {
     if (isStar) {
       // Consume star comment until it closes on the same line.
       while (true) {
-        if (pos == data.length || data[pos] == '\n') {
-          throw unexpected("trailing comment must be closed on the same line");
+        if (pos == data.length) {
+          throw unexpected("trailing comment must be closed");
         }
         if (data[pos] == '*' && pos + 1 < data.length && data[pos + 1] == '/') {
           end = pos - 1; // The character before '*'.

--- a/wire-tests/src/test/java/com/squareup/wire/schema/internal/parser/ProtoParserTest.java
+++ b/wire-tests/src/test/java/com/squareup/wire/schema/internal/parser/ProtoParserTest.java
@@ -391,7 +391,7 @@ public final class ProtoParserTest {
     assertThat(value.documentation()).isEqualTo("Test all the things!");
   }
 
-  @Test public void trailingMultilineComment() {
+  @Test public void trailingSinglelineComment() {
     String proto = ""
         + "enum Test {\n"
         + "  FOO = 1; /* Test all the things!  */  \n"
@@ -405,17 +405,16 @@ public final class ProtoParserTest {
     assertThat(bar.documentation()).isEqualTo("Test all the things!");
   }
 
-  @Test public void trailingUnclosedMultilineCommentThrows() {
+  @Test public void trailingMultilineComment() {
     String proto = ""
         + "enum Test {\n"
-        + "  FOO = 1; /* Test all the things!   \n"
+        + "  FOO = 1; /* Test all the\n"
+        + "things! */ \n"
         + "}";
-    try {
-      ProtoParser.parse(location, proto);
-    } catch (IllegalStateException e) {
-      assertThat(e).hasMessage(
-          "Syntax error in file.proto at 2:38: trailing comment must be closed on the same line");
-    }
+    ProtoFileElement parsed = ProtoParser.parse(location, proto);
+    EnumElement enumElement = (EnumElement) parsed.types().get(0);
+    EnumConstantElement value = enumElement.constants().get(0);
+    assertThat(value.documentation()).isEqualTo("Test all the\nthings!");
   }
 
   @Test public void trailingMultilineCommentMustBeLastOnLineThrows() {


### PR DESCRIPTION
This PR addresses #651.
The parser should allow inline multiline start comment.
