### PR TITLE
Allow custom types to be constrained with a 'with' clause.

### DIFF
--- a/wire-java-generator/src/main/java/com/squareup/wire/java/internal/ProfileParser.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/internal/ProfileParser.java
@@ -17,6 +17,8 @@ package com.squareup.wire.java.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.parser.OptionElement;
+import com.squareup.wire.schema.internal.parser.OptionReader;
 import com.squareup.wire.schema.internal.parser.SyntaxReader;
 
 /** Parses {@code .wire} files. */
@@ -78,6 +80,7 @@ public final class ProfileParser {
   /** Reads a type config and returns it. */
   private TypeConfigElement readTypeConfig(Location location, String documentation) {
     String name = reader.readDataType();
+    ImmutableList.Builder<OptionElement> withOptions = ImmutableList.builder();
     String target = null;
     String adapter = null;
 
@@ -97,6 +100,11 @@ public final class ProfileParser {
           adapter = adapterType + '#' + adapterConstant;
           break;
 
+        case "with":
+          withOptions.add(new OptionReader(reader).readOption('='));
+          reader.require(';');
+          break;
+
         default:
           throw reader.unexpected(wordLocation, "unexpected label: " + word);
       }
@@ -105,6 +113,7 @@ public final class ProfileParser {
     return TypeConfigElement.builder(location)
         .type(name)
         .documentation(documentation)
+        .with(withOptions.build())
         .target(target)
         .adapter(adapter)
         .build();

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/internal/TypeConfigElement.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/internal/TypeConfigElement.java
@@ -16,9 +16,12 @@
 package com.squareup.wire.java.internal;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.ImmutableList;
 import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.parser.OptionElement;
 
 import static com.squareup.wire.schema.internal.Util.appendDocumentation;
+import static com.squareup.wire.schema.internal.Util.appendIndented;
 
 /**
  * Configures how Wire will generate code for a specific type. This configuration belongs in a
@@ -29,12 +32,14 @@ public abstract class TypeConfigElement {
   public static Builder builder(Location location) {
     return new AutoValue_TypeConfigElement.Builder()
         .location(location)
-        .documentation("");
+        .documentation("")
+        .with(ImmutableList.<OptionElement>of());
   }
 
   public abstract Location location();
   public abstract String type();
   public abstract String documentation();
+  public abstract ImmutableList<OptionElement> with();
   public abstract String target();
   public abstract String adapter();
 
@@ -42,6 +47,9 @@ public abstract class TypeConfigElement {
     StringBuilder builder = new StringBuilder();
     appendDocumentation(builder, documentation());
     builder.append("type ").append(type()).append(" {\n");
+    for (OptionElement option : with()) {
+      appendIndented(builder, "with " + option.toSchema() + ";\n");
+    }
     builder.append("  target ").append(target()).append(" using ").append(adapter()).append(";\n");
     builder.append("}\n");
     return builder.toString();
@@ -52,6 +60,7 @@ public abstract class TypeConfigElement {
     Builder location(Location location);
     Builder type(String type);
     Builder documentation(String documentation);
+    Builder with(ImmutableList<OptionElement> options);
     Builder target(String target);
     Builder adapter(String adapter);
     TypeConfigElement build();

--- a/wire-java-generator/src/test/java/com/squareup/wire/java/internal/ProfileParserTest.java
+++ b/wire-java-generator/src/test/java/com/squareup/wire/java/internal/ProfileParserTest.java
@@ -17,6 +17,7 @@ package com.squareup.wire.java.internal;
 
 import com.google.common.collect.ImmutableList;
 import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.parser.OptionElement;
 import org.junit.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -38,6 +39,7 @@ public final class ProfileParserTest {
         + "}\n"
         + "\n"
         + "type squareup.geology.Period {\n"
+        + "  with custom_type = \"duration\";\n"
         + "  target java.time.Period using com.squareup.time.Time#PERIOD_ADAPTER;\n"
         + "}\n";
     ProfileFileElement expected = ProfileFileElement.builder(location)
@@ -52,6 +54,8 @@ public final class ProfileParserTest {
                 .build(),
             TypeConfigElement.builder(location.at(11, 1))
                 .type("squareup.geology.Period")
+                .with(ImmutableList.of(OptionElement.create(
+                    "custom_type", OptionElement.Kind.STRING, "duration")))
                 .target("java.time.Period")
                 .adapter("com.squareup.time.Time#PERIOD_ADAPTER")
                 .build()))
@@ -106,6 +110,7 @@ public final class ProfileParserTest {
         + "  target com.squareup.dino.Dinosaur using com.squareup.dino.Dinosaurs#DINO_ADAPTER;\n"
         + "}\n"
         + "type squareup.geology.Period {\n"
+        + "  with custom_type = \"duration\";\n"
         + "  target java.time.Period using com.squareup.time.Time#PERIOD_ADAPTER;\n"
         + "}\n";
     ProfileParser parser = new ProfileParser(location, proto);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/Util.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/Util.java
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema.internal;
 
 import com.google.common.collect.ImmutableList;
+import com.squareup.wire.schema.internal.parser.OptionElement;
 import java.util.List;
 
 public final class Util {
@@ -31,6 +32,15 @@ public final class Util {
     for (String line : documentation.split("\n")) {
       builder.append("// ").append(line).append('\n');
     }
+  }
+
+  public static void appendOptions(StringBuilder builder, List<OptionElement> options) {
+    builder.append("[\n");
+    for (int i = 0, count = options.size(); i < count; i++) {
+      String endl = (i < count - 1) ? "," : "";
+      appendIndented(builder, options.get(i).toSchema() + endl);
+    }
+    builder.append(']');
   }
 
   public static void appendIndented(StringBuilder builder, String value) {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/EnumConstantElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/EnumConstantElement.java
@@ -18,9 +18,9 @@ package com.squareup.wire.schema.internal.parser;
 import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.Util;
 
 import static com.squareup.wire.schema.internal.Util.appendDocumentation;
-import static com.squareup.wire.schema.internal.parser.OptionElement.formatOptionList;
 
 @AutoValue
 public abstract class EnumConstantElement {
@@ -44,9 +44,8 @@ public abstract class EnumConstantElement {
         .append(" = ")
         .append(tag());
     if (!options().isEmpty()) {
-      builder.append(" [\n");
-      formatOptionList(builder, options());
-      builder.append(']');
+      builder.append(" ");
+      Util.appendOptions(builder, options());
     }
     return builder.append(";\n").toString();
   }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/FieldElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/FieldElement.java
@@ -19,10 +19,10 @@ import com.google.auto.value.AutoValue;
 import com.google.common.collect.ImmutableList;
 import com.squareup.wire.schema.Field;
 import com.squareup.wire.schema.Location;
+import com.squareup.wire.schema.internal.Util;
 import java.util.Locale;
 
 import static com.squareup.wire.schema.internal.Util.appendDocumentation;
-import static com.squareup.wire.schema.internal.Util.appendIndented;
 
 @AutoValue
 public abstract class FieldElement {
@@ -54,11 +54,8 @@ public abstract class FieldElement {
         .append(" = ")
         .append(tag());
     if (!options().isEmpty()) {
-      builder.append(" [\n");
-      for (OptionElement option : options()) {
-        appendIndented(builder, option.toSchema());
-      }
-      builder.append(']');
+      builder.append(" ");
+      Util.appendOptions(builder, options());
     }
     return builder.append(";\n").toString();
   }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/OptionElement.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/OptionElement.java
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema.internal.parser;
 
 import com.google.auto.value.AutoValue;
+import com.squareup.wire.schema.internal.Util;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -78,11 +79,10 @@ public abstract class OptionElement {
       }
       case LIST: {
         StringBuilder builder = new StringBuilder();
-        builder.append(formatName()).append(" = [\n");
+        builder.append(formatName()).append(" = ");
         //noinspection unchecked
         List<OptionElement> optionList = (List<OptionElement>) value;
-        formatOptionList(builder, optionList);
-        builder.append(']');
+        Util.appendOptions(builder, optionList);
         return builder.toString();
       }
       default:
@@ -92,13 +92,6 @@ public abstract class OptionElement {
 
   public final String toSchemaDeclaration() {
     return "option " + toSchema() + ";\n";
-  }
-
-  static void formatOptionList(StringBuilder builder, List<OptionElement> optionList) {
-    for (int i = 0, count = optionList.size(); i < count; i++) {
-      String endl = (i < count - 1) ? "," : "";
-      appendIndented(builder, optionList.get(i).toSchema() + endl);
-    }
   }
 
   static void formatOptionMap(StringBuilder builder, Map<String, ?> valueMap) {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/OptionReader.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/OptionReader.java
@@ -30,10 +30,10 @@ import static com.squareup.wire.schema.internal.parser.OptionElement.Kind.MAP;
 import static com.squareup.wire.schema.internal.parser.OptionElement.Kind.NUMBER;
 import static com.squareup.wire.schema.internal.parser.OptionElement.Kind.STRING;
 
-final class OptionReader {
+public final class OptionReader {
   final SyntaxReader reader;
 
-  OptionReader(SyntaxReader reader) {
+  public OptionReader(SyntaxReader reader) {
     this.reader = reader;
   }
 


### PR DESCRIPTION
This will be used to target fields like 'int64 created_at' that carry
extra type information in options '[is_date = true]' to be matched for
custom types.