### PR TITLE
Make ProtoReader non-final

### DIFF
--- a/wire-runtime/src/main/java/com/squareup/wire/ProtoReader.java
+++ b/wire-runtime/src/main/java/com/squareup/wire/ProtoReader.java
@@ -42,9 +42,9 @@ import okio.ByteString;
 /**
  * Reads and decodes protocol message fields.
  */
-public final class ProtoReader {
+public class ProtoReader {
   /** The standard number of levels of message nesting to allow. */
-  private static final int RECURSION_LIMIT = 65;
+  protected static final int RECURSION_LIMIT = 65;
 
   private static final int FIELD_ENCODING_MASK = 0x7;
   static final int TAG_FIELD_ENCODING_BITS = 3;


### PR DESCRIPTION
My specific use-case for this is a `FilteringProtoReader` that overrides `nextTag` and delegates to a policy to decide whether to process or `skip()` each value. This is can speed up reading of large protos from persistent storage quite dramatically if only a subset of the data is required.

Another option would be to extract the public API into a `ProtoSource` interface which `ProtoReader` implements, but that's of course a much larger change.