### PR TITLE
Add support for Android annotations without Parcelable

### DIFF
--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -187,27 +187,37 @@ public final class JavaGenerator {
   private final ImmutableMap<ProtoType, ClassName> nameToJavaName;
   private final Profile profile;
   private final boolean emitAndroid;
+  private final boolean emitAndroidAnnotations;
   private final boolean emitCompact;
 
   private JavaGenerator(Schema schema, Map<ProtoType, ClassName> nameToJavaName, Profile profile,
-      boolean emitAndroid, boolean emitCompact) {
+      boolean emitAndroid, boolean emitAndroidAnnotations, boolean emitCompact) {
     this.schema = schema;
     this.nameToJavaName = ImmutableMap.copyOf(nameToJavaName);
     this.profile = profile;
     this.emitAndroid = emitAndroid;
+    this.emitAndroidAnnotations = emitAndroidAnnotations || emitAndroid;
     this.emitCompact = emitCompact;
   }
 
   public JavaGenerator withAndroid(boolean emitAndroid) {
-    return new JavaGenerator(schema, nameToJavaName, profile, emitAndroid, emitCompact);
+    return new JavaGenerator(schema, nameToJavaName, profile, emitAndroid, emitAndroidAnnotations,
+        emitCompact);
+  }
+
+  public JavaGenerator withAndroidAnnotations(boolean emitAndroidAnnotations) {
+    return new JavaGenerator(schema, nameToJavaName, profile, emitAndroid, emitAndroidAnnotations,
+        emitCompact);
   }
 
   public JavaGenerator withCompact(boolean emitCompact) {
-    return new JavaGenerator(schema, nameToJavaName, profile, emitAndroid, emitCompact);
+    return new JavaGenerator(schema, nameToJavaName, profile, emitAndroid, emitAndroidAnnotations,
+        emitCompact);
   }
 
   public JavaGenerator withProfile(Profile profile) {
-    return new JavaGenerator(schema, nameToJavaName, profile, emitAndroid, emitCompact);
+    return new JavaGenerator(schema, nameToJavaName, profile, emitAndroid, emitAndroidAnnotations,
+        emitCompact);
   }
 
   public static JavaGenerator get(Schema schema) {
@@ -223,7 +233,7 @@ public final class JavaGenerator {
       }
     }
 
-    return new JavaGenerator(schema, nameToJavaName, new Profile(), false, false);
+    return new JavaGenerator(schema, nameToJavaName, new Profile(), false, false, false);
   }
 
   private static void putAll(Map<ProtoType, ClassName> wireToJava, String javaPackage,
@@ -578,7 +588,7 @@ public final class JavaGenerator {
       if (field.isDeprecated()) {
         fieldBuilder.addAnnotation(Deprecated.class);
       }
-      if (emitAndroid && field.isOptional()) {
+      if (emitAndroidAnnotations && field.isOptional()) {
         fieldBuilder.addAnnotation(NULLABLE);
       }
       builder.addField(fieldBuilder.build());
@@ -1210,7 +1220,7 @@ public final class JavaGenerator {
       TypeName javaType = fieldType(field);
       String fieldName = nameAllocator.get(field);
       ParameterSpec.Builder param = ParameterSpec.builder(javaType, fieldName);
-      if (emitAndroid && field.isOptional()) {
+      if (emitAndroidAnnotations && field.isOptional()) {
         param.addAnnotation(NULLABLE);
       }
       result.addParameter(param.build());
@@ -1257,7 +1267,7 @@ public final class JavaGenerator {
       TypeName javaType = fieldType(field);
       String fieldName = localNameAllocator.get(field);
       ParameterSpec.Builder param = ParameterSpec.builder(javaType, fieldName);
-      if (emitAndroid && field.isOptional()) {
+      if (emitAndroidAnnotations && field.isOptional()) {
         param.addAnnotation(NULLABLE);
       }
       result.addParameter(param.build());


### PR DESCRIPTION
This PR adds support for a flag that includes Android annotations only (no
parcelable support). This is to enable folks to benefit from useful static
analysis (https://github.com/uber/NullAway, for instance) without incurring
dependencies on the wider Android framework. Decided to forgo more generalized
annotation support for now.

A couple of notes:

- Didn't catch where the Android functionality was unit tested previously, so I
  added small tests with and without this flag.
- The approach of adding more flags in this way won't scale well forever, and I
  don't love flags implying each other, but in this case, I think it's
  reasonably straightforward and hard to be surprised.
- I'm not attached to the awkward but descriptive flag name - happy to change
  the semantics.

Fixes #693.