### PR TITLE
Possible to add package prefix

### DIFF
--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -211,10 +211,17 @@ public final class JavaGenerator {
   }
 
   public static JavaGenerator get(Schema schema) {
+    return get(schema, JavaPackage.ROOT);
+  }
+
+  public static JavaGenerator get(Schema schema, JavaPackage packagePrefix) {
+    if (packagePrefix == null) {
+      throw new NullPointerException("packagePrefix");
+    }
     Map<ProtoType, ClassName> nameToJavaName = new LinkedHashMap<>(BUILT_IN_TYPES_MAP);
 
     for (ProtoFile protoFile : schema.protoFiles()) {
-      String javaPackage = javaPackage(protoFile);
+      String javaPackage = javaPackage(protoFile, packagePrefix);
       putAll(nameToJavaName, javaPackage, null, protoFile.types());
 
       for (Service service : protoFile.services()) {
@@ -303,7 +310,11 @@ public final class JavaGenerator {
     return result.build();
   }
 
-  private static String javaPackage(ProtoFile protoFile) {
+  private static String javaPackage(ProtoFile protoFile, JavaPackage packagePrefix) {
+    return packagePrefix.plus(javaPackageFromProto(protoFile)).asString();
+  }
+
+  private static String javaPackageFromProto(ProtoFile protoFile) {
     String javaPackage = protoFile.javaPackage();
     if (javaPackage != null) {
       return javaPackage;

--- a/wire-java-generator/src/main/java/com/squareup/wire/java/JavaPackage.java
+++ b/wire-java-generator/src/main/java/com/squareup/wire/java/JavaPackage.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.java;
+
+import java.util.Locale;
+import java.util.Objects;
+
+import static java.lang.String.format;
+
+public final class JavaPackage implements Comparable<JavaPackage> {
+
+  public static final JavaPackage ROOT = new JavaPackage("");
+
+  private final String javaPackage;
+
+  private JavaPackage(String javaPackage) {
+    this.javaPackage = javaPackage;
+  }
+
+  public static JavaPackage parse(String javaPackage) {
+    if (javaPackage == null) {
+      throw new NullPointerException("Java package may not be null");
+    }
+    if (!javaPackage.trim().equals(javaPackage)) {
+      throw new IllegalArgumentException("Java package may not start of end with whitespace");
+    }
+    if (javaPackage.startsWith(".")) {
+      throw new IllegalArgumentException("Java package may not start with a dot");
+    }
+    if (javaPackage.endsWith(".")) {
+      throw new IllegalArgumentException("Java package may not end with a dot");
+    }
+    return new JavaPackage(javaPackage);
+  }
+
+  public String asString() {
+    return javaPackage;
+  }
+
+  public JavaPackage plus(String otherJavaPackage) {
+    return plus(JavaPackage.parse(otherJavaPackage));
+  }
+
+  public JavaPackage plus(JavaPackage other) {
+    if (javaPackage.isEmpty() || other.javaPackage.isEmpty()) {
+      return new JavaPackage(format(Locale.ROOT, "%s%s", javaPackage, other.javaPackage));
+    }
+    return new JavaPackage(format(Locale.ROOT, "%s.%s", javaPackage, other.javaPackage));
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(this.javaPackage);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null) {
+      return false;
+    }
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+    return Objects.equals(this.javaPackage, ((JavaPackage) obj).javaPackage);
+  }
+
+  @Override
+  public int compareTo(JavaPackage other) {
+    return javaPackage.compareTo(other.javaPackage);
+  }
+
+  @Override
+  public String toString() {
+    if (javaPackage.equals("")) {
+      return "JavaPackage.ROOT";
+    }
+    return format(Locale.ROOT, "JavaPackage[%s]", javaPackage);
+  }
+
+}

--- a/wire-java-generator/src/test/java/com/squareup/wire/java/JavaPackageTest.java
+++ b/wire-java-generator/src/test/java/com/squareup/wire/java/JavaPackageTest.java
@@ -1,0 +1,64 @@
+package com.squareup.wire.java;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public final class JavaPackageTest {
+
+  @Test(expected = NullPointerException.class)
+  public void notNull() {
+    JavaPackage.parse(null);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void notBlank() {
+    JavaPackage.parse("\t");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void notTrimmed() {
+    JavaPackage.parse("  valid.but.leading.space");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void mayNotStartWithDot() {
+    JavaPackage.parse(".a.b.c");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void mayNotEndWithDot() {
+    JavaPackage.parse("a.b.c.");
+  }
+
+  @Test
+  public void someThingsAreOk() {
+    assertEquals("", JavaPackage.parse("").asString());
+    assertEquals("a", JavaPackage.parse("a").asString());
+    assertEquals("a.b", JavaPackage.parse("a.b").asString());
+  }
+
+  @Test
+  public void plussing() {
+    assertEquals("", JavaPackage.parse("").plus("").asString());
+    assertEquals("a.b", JavaPackage.parse("a.b").plus("").asString());
+    assertEquals("a.b", JavaPackage.parse("").plus("a.b").asString());
+    assertEquals("a.b", JavaPackage.parse("a").plus("b").asString());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void plusStringNull() {
+    JavaPackage.parse("").plus((String)null);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void plusJavaPackageNull() {
+    JavaPackage.parse("").plus((JavaPackage)null);
+  }
+
+  @Test
+  public void emptyStringIsRoot() {
+    assertEquals(JavaPackage.ROOT, JavaPackage.parse(""));
+  }
+
+}

--- a/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
+++ b/wire-maven-plugin/src/main/java/com/squareup/wire/mojo/WireGenerateSourcesMojo.java
@@ -5,6 +5,7 @@ import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.JavaFile;
 import com.squareup.javapoet.TypeSpec;
 import com.squareup.wire.java.JavaGenerator;
+import com.squareup.wire.java.JavaPackage;
 import com.squareup.wire.java.Profile;
 import com.squareup.wire.java.ProfileLoader;
 import com.squareup.wire.schema.IdentifierSet;
@@ -50,6 +51,9 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
   @Parameter(property = "wire.excludes")
   private String[] excludes;
 
+  @Parameter(property = "wire.packagePrefix")
+  private String packagePrefix;
+
   @Parameter(property = "wire.serviceFactory")
   private String serviceFactory;
 
@@ -85,7 +89,7 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
         schema = retainRoots(identifierSet, schema);
       }
 
-      JavaGenerator javaGenerator = JavaGenerator.get(schema)
+      JavaGenerator javaGenerator = JavaGenerator.get(schema, packagePrefix())
           .withAndroid(emitAndroid)
           .withCompact(emitCompact)
           .withProfile(profile);
@@ -106,6 +110,10 @@ public class WireGenerateSourcesMojo extends AbstractMojo {
     } catch (Exception e) {
       throw new MojoExecutionException("Wire Plugin: Failure compiling proto sources.", e);
     }
+  }
+
+  private JavaPackage packagePrefix() {
+    return packagePrefix == null ? JavaPackage.ROOT : JavaPackage.parse(packagePrefix);
   }
 
   private IdentifierSet identifierSet() {


### PR DESCRIPTION
This is needed since we need since we need to coexist with Java classes already on the class path but generated with protoc.

For example, if we want to generate code with Wire that uses google/protobuf/Timestamp we will get two com.google.protobuf.Timestamp classes on the class path were one is generated with protoc and one with wire.

With this change it is possible to generate se.vandmo.somelibrary.com.google.protobuf.Timestamp