### PR TITLE
Make Okio an api dependency in wire-runtime

### DIFF
--- a/wire-runtime/build.gradle
+++ b/wire-runtime/build.gradle
@@ -22,7 +22,7 @@ animalsniffer {
 }
 
 dependencies {
-  implementation deps.okio
+  api deps.okio
   compileOnly deps.android
   compileOnly deps.jsr305
   testImplementation deps.kotlin.stdlib.jdk6


### PR DESCRIPTION
Generated code has `val unknownFields: ByteString`, hence Okio should be declared as `api`.