### PR TITLE
Write a new .proto file loader that will work as WireRun prescribes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
       'okio': '2.1.0',
       'moshi': '1.6.0',
       'junit': '4.12',
-      'assertj': '1.7.0',
+      'assertj': '3.11.0',
       'jimfs': '1.0',
       'animalSniffer': '1.16',
       'animalSnifferGradle': '1.4.3',

--- a/wire-compiler/src/main/java/com/squareup/wire/schema/LocationAndPath.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/LocationAndPath.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.squareup.wire.schema.internal.parser.ProtoParser
+import okio.buffer
+import okio.source
+import java.io.IOException
+import java.nio.file.Path
+
+/**
+ * A logical location (the base location and path to the file), plus the physical path to load.
+ * These will be different if the file is loaded from a .zip archive.
+ */
+internal data class LocationAndPath(val location: Location, val path: Path) {
+  fun parse(): ProtoFile {
+    try {
+      path.source().buffer().use { source ->
+        val data = source.readUtf8()
+        val element = ProtoParser.parse(location, data)
+        return ProtoFile.get(element)
+      }
+    } catch (e: IOException) {
+      throw IOException("Failed to load $path", e)
+    }
+  }
+}

--- a/wire-compiler/src/main/java/com/squareup/wire/schema/NewSchemaLoader.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/NewSchemaLoader.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.google.common.io.Closer
+import java.io.Closeable
+import java.io.IOException
+import java.nio.file.FileSystem
+import java.util.ArrayDeque
+
+/**
+ * Load proto files and their transitive dependencies and parse them. Keep track of which files were
+ * loaded from where so that we can use that information later when deciding what to generate.
+ */
+class NewSchemaLoader(
+  private val fs: FileSystem,
+
+  /** See [com.squareup.wire.WireRun.sourcePath]. */
+  private val sourcePath: List<String>,
+
+  /** See [com.squareup.wire.WireRun.protoPath]. */
+  private val protoPath: List<String> = listOf()
+) : Closeable {
+  private val closer = Closer.create()
+
+  /** Errors accumulated by this load. */
+  private val errors = mutableListOf<String>()
+
+  /** Files loaded by their relative paths. This is the same path that we use in imports! */
+  private val loaded = mutableMapOf<String, ProtoFile>()
+
+  /** Source files that were loaded. Used to differentiate sources from protoPath elements. */
+  lateinit var sourceLocationPaths: Set<String>
+
+  /** Working backlog of imported .proto files to load. */
+  private val imports = ArrayDeque<String>()
+
+  @Throws(IOException::class)
+  fun load(): List<ProtoFile> {
+    check(loaded.isEmpty()) { "do not reuse instances of this class" }
+
+    // Load all of the sources, discovering imports as we go.
+    val mutableSourceLocationPaths = mutableSetOf<String>()
+    val sourceRoots = allRoots(closer, sourcePath)
+    for (sourceRoot in sourceRoots) {
+      for (locationAndPath in sourceRoot.allProtoFiles()) {
+        load(locationAndPath)
+        mutableSourceLocationPaths += locationAndPath.location.path()
+      }
+    }
+    if (mutableSourceLocationPaths.isEmpty()) {
+      errors += "no sources"
+    }
+    sourceLocationPaths = mutableSourceLocationPaths.toSet()
+
+    // Load the imported files next.
+    val protoPathRoots = allRoots(closer, protoPath)
+    while (true) {
+      val import = imports.poll() ?: break
+      if (loaded[import] != null) continue // Already loaded.
+
+      for (protoPathRoot in protoPathRoots) {
+        val locationAndPath = protoPathRoot.resolve(import) ?: continue
+        load(locationAndPath)
+      }
+    }
+
+    if (errors.isNotEmpty()) {
+      throw IllegalArgumentException(errors.joinToString(separator = "\n"))
+    }
+
+    return loaded.values.toList()
+  }
+
+  private fun load(locationAndPath: LocationAndPath) {
+    val protoFile = locationAndPath.parse()
+    val importPath = protoFile.importPath()
+
+    if (locationAndPath.location.path() != importPath
+        && !locationAndPath.location.path().endsWith("/$importPath")) {
+      errors += "expected ${locationAndPath.path} to have a path ending with $importPath"
+    }
+
+    loaded[importPath] = protoFile
+    imports.addAll(protoFile.imports())
+  }
+
+  /** Convert `pathStrings` into roots that can be searched. */
+  private fun allRoots(closer: Closer, pathStrings: List<String>): List<Root> {
+    val result = mutableListOf<Root>()
+    for (pathString in pathStrings) {
+      val path = fs.getPath(pathString)
+      try {
+        result += path.roots(closer)
+      } catch (e: IllegalArgumentException) {
+        errors += e.message!!
+      }
+    }
+    return result
+  }
+
+  override fun close() {
+    return closer.close()
+  }
+}
+
+/**
+ * Returns a path like `squareup/dinosaurs/Dinosaur.proto` for a file based on its package name
+ * (like `squareup.dinosaurs`) and its file name (like `Dinosaur.proto`).
+ */
+internal fun ProtoFile.importPath() : String {
+  val filename = location().path().substringAfterLast('/')
+  return packageName().replace('.', '/') + "/" + filename
+}

--- a/wire-compiler/src/main/java/com/squareup/wire/schema/Root.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/Root.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.google.common.io.Closer
+import java.nio.file.FileSystems
+import java.nio.file.FileVisitResult
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.ProviderNotFoundException
+import java.nio.file.SimpleFileVisitor
+import java.nio.file.attribute.BasicFileAttributes
+
+internal sealed class Root {
+  /** Returns all proto files within this root. */
+  abstract fun allProtoFiles(): Set<LocationAndPath>
+
+  /** Returns the proto file if it's in this root, or null if it isn't. */
+  abstract fun resolve(import: String): LocationAndPath?
+}
+
+internal fun Path.roots(closer: Closer): List<Root> {
+  return when {
+    Files.isDirectory(this) -> listOf(DirectoryRoot(this, this))
+
+    endsWithDotProto() -> listOf(StandaloneFileRoot(this))
+
+    // Handle a .zip or .jar file by adding all .proto files within.
+    else -> {
+      try {
+        val sourceFs = FileSystems.newFileSystem(this, javaClass.classLoader)
+        closer.register(sourceFs)
+        sourceFs.rootDirectories.map { inZipDirectory -> DirectoryRoot(this, inZipDirectory) }
+      } catch (e: ProviderNotFoundException) {
+        throw IllegalArgumentException(
+            "expected a directory, archive (.zip / .jar / etc.), or .proto: $this")
+      }
+    }
+  }
+}
+
+internal class StandaloneFileRoot(path: Path) : Root() {
+  private val locationAndPath = LocationAndPath(Location.get("$path"), path)
+
+  override fun allProtoFiles() = setOf(locationAndPath)
+
+  override fun resolve(import: String): LocationAndPath? = null
+}
+
+internal class DirectoryRoot(
+  /** The path to either a directory or .zip file. */
+  val path: Path,
+
+  /** The root to search. If this is a .zip file this is within its internal file system. */
+  val rootDirectory: Path
+) : Root() {
+  override fun allProtoFiles(): Set<LocationAndPath> {
+    val result = mutableSetOf<LocationAndPath>()
+    Files.walkFileTree(rootDirectory, object : SimpleFileVisitor<Path>() {
+      override fun visitFile(descendant: Path, attrs: BasicFileAttributes): FileVisitResult {
+        if (descendant.endsWithDotProto()) {
+          val location = Location.get("$path", "${rootDirectory.relativize(descendant)}")
+          result.add(LocationAndPath(location, descendant))
+        }
+        return FileVisitResult.CONTINUE
+      }
+    })
+    return result
+  }
+
+  override fun resolve(import: String): LocationAndPath? {
+    val resolved = rootDirectory.resolve(import)
+    if (!Files.exists(resolved)) return null
+    return LocationAndPath(Location.get("$path", import), resolved)
+  }
+}
+
+private fun Path.endsWithDotProto() = fileName.toString().endsWith(".proto")

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/NewSchemaLoaderTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/NewSchemaLoaderTest.kt
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import kotlin.test.assertFailsWith
+
+class NewSchemaLoaderTest {
+  private val fs = Jimfs.newFileSystem(Configuration.unix())
+
+  @Test
+  fun happyPath() {
+    // Dependency graph:
+    //   - blue
+    //     - circle
+    //       - triangle
+    //   - red
+    //     - oval
+    //     - triangle
+    // Note that the protoPath element octagon.proto is not imported!
+    fs.add("colors/src/main/proto/squareup/colors/blue.proto", """
+        |syntax = "proto2";
+        |package squareup.colors;
+        |import "squareup/curves/circle.proto";
+        |message Blue {
+        |}
+        """.trimMargin())
+    fs.add("colors/src/main/proto/squareup/colors/red.proto", """
+        |syntax = "proto2";
+        |package squareup.colors;
+        |import "squareup/curves/oval.proto";
+        |import "squareup/polygons/triangle.proto";
+        |message Red {
+        |}
+        """.trimMargin())
+    fs.add("polygons/src/main/proto/squareup/polygons/octagon.proto", """
+        |syntax = "proto2";
+        |package squareup.polygons;
+        |message Octagon {
+        |}
+        """.trimMargin())
+    fs.add("polygons/src/main/proto/squareup/polygons/triangle.proto", """
+        |syntax = "proto2";
+        |package squareup.polygons;
+        |message Triangle {
+        |}
+        """.trimMargin())
+    fs.addZip("lib/curves.zip",
+        "squareup/curves/circle.proto" to """
+        |syntax = "proto2";
+        |package squareup.curves;
+        |import "squareup/polygons/triangle.proto";
+        |message Circle {
+        |}
+        """.trimMargin(),
+        "squareup/curves/oval.proto" to """
+        |syntax = "proto2";
+        |package squareup.curves;
+        |message Oval {
+        |}
+        """.trimMargin())
+
+    val sourcePath = listOf("colors/src/main/proto")
+    val protoPath = listOf("polygons/src/main/proto", "lib/curves.zip")
+    val loader = NewSchemaLoader(fs, sourcePath, protoPath)
+    val protoFiles = loader.use { it.load() }
+    assertThat(protoFiles.map { it.location().path() }).containsExactlyInAnyOrder(
+        "squareup/colors/blue.proto",
+        "squareup/colors/red.proto",
+        "squareup/curves/circle.proto",
+        "squareup/curves/oval.proto",
+        "squareup/polygons/triangle.proto"
+    )
+    assertThat(loader.sourceLocationPaths).containsExactlyInAnyOrder(
+        "squareup/colors/blue.proto",
+        "squareup/colors/red.proto"
+    )
+  }
+
+  @Test
+  fun noSourcesFound() {
+    val sourcePath = listOf<String>()
+    val exception = assertFailsWith<IllegalArgumentException> {
+      NewSchemaLoader(fs, sourcePath).use { it.load() }
+    }
+    assertThat(exception).hasMessage("no sources")
+  }
+
+  @Test
+  fun packageDoesNotMatchFileSystem() {
+    fs.add("colors/src/main/proto/squareup/shapes/blue.proto", """
+        |syntax = "proto2";
+        |package squareup.colors;
+        |message Blue {
+        |}
+        """.trimMargin())
+
+    val sourcePath = listOf("colors/src/main/proto")
+    val exception = assertFailsWith<IllegalArgumentException> {
+      NewSchemaLoader(fs, sourcePath).use { it.load() }
+    }
+    assertThat(exception).hasMessage("expected colors/src/main/proto/squareup/shapes/blue.proto " +
+        "to have a path ending with squareup/colors/blue.proto")
+  }
+}

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/RootTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/RootTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.google.common.io.Closer
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import okio.buffer
+import okio.sink
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
+import org.junit.Test
+import java.nio.file.FileSystem
+import java.nio.file.Files
+import java.util.zip.ZipEntry
+import java.util.zip.ZipOutputStream
+import kotlin.test.assertFailsWith
+import kotlin.text.Charsets.UTF_8
+
+class RootTest {
+  private val fs = Jimfs.newFileSystem(Configuration.unix())
+  private val closer = Closer.create()
+
+  @After fun tearDown() {
+    closer.close()
+  }
+
+  @Test fun standaloneFile() {
+    fs.add("sample/src/main/proto/squareup/dinosaurs/dinosaur.proto", "/* dinosaur.proto */")
+
+    val onlyFile = fs.getPath("sample/src/main/proto/squareup/dinosaurs/dinosaur.proto")
+    val roots = onlyFile.roots(closer)
+    assertThat(roots.size == 1)
+
+    // Standalone files don't resolve because we don't know what base directory to use.
+    assertThat(roots[0].resolve("squareup/dinosaurs/dinosaur.proto")).isNull()
+    assertThat(roots[0].resolve("sample/src/main/proto/squareup/dinosaurs/dinosaur.proto")).isNull()
+
+    // But we can enumerate their contents.
+    assertThat(roots[0].allProtoFiles().map { it.location })
+        .containsOnly(Location.get("sample/src/main/proto/squareup/dinosaurs/dinosaur.proto"))
+  }
+
+  @Test fun directory() {
+    fs.add("sample/src/main/proto/squareup/dinosaurs/dinosaur.proto", "/* dinosaur.proto */")
+    fs.add("sample/src/main/proto/squareup/dinosaurs/geology.proto", "/* geology.proto */")
+
+    val sourceDir = fs.getPath("sample/src/main/proto")
+    val roots = sourceDir.roots(closer)
+    assertThat(roots.size == 1)
+
+    assertThat(roots[0].resolve("squareup/dinosaurs/dinosaur.proto")?.location)
+        .isEqualTo(Location.get(sourceDir.toString(), "squareup/dinosaurs/dinosaur.proto"))
+
+    assertThat(roots[0].resolve("squareup/dinosaurs/unknown.proto")).isNull()
+
+    assertThat(roots[0].allProtoFiles().map { it.location }).containsExactlyInAnyOrder(
+        Location.get(sourceDir.toString(), "squareup/dinosaurs/dinosaur.proto"),
+        Location.get(sourceDir.toString(), "squareup/dinosaurs/geology.proto")
+    )
+  }
+
+  @Test fun zip() {
+    fs.addZip(
+        "lib/dinosaurs.zip",
+        "squareup/dinosaurs/dinosaur.proto" to "/* dinosaur.proto */",
+        "squareup/dinosaurs/geology.proto" to "/* geology.proto */")
+
+    val sourceZip = fs.getPath("lib/dinosaurs.zip")
+    val roots = sourceZip.roots(closer)
+    assertThat(roots.size == 1)
+
+    assertThat(roots[0].resolve("squareup/dinosaurs/dinosaur.proto")?.location)
+        .isEqualTo(Location.get(sourceZip.toString(), "squareup/dinosaurs/dinosaur.proto"))
+
+    assertThat(roots[0].resolve("squareup/dinosaurs/unknown.proto")).isNull()
+
+    assertThat(roots[0].allProtoFiles().map { it.location }).containsExactlyInAnyOrder(
+        Location.get(sourceZip.toString(), "squareup/dinosaurs/dinosaur.proto"),
+        Location.get(sourceZip.toString(), "squareup/dinosaurs/geology.proto")
+    )
+  }
+
+  @Test fun zipProtoFilesOnly() {
+    fs.addZip(
+        "lib/dinosaurs.zip",
+        "squareup/dinosaurs/raptor.proto" to "/* raptor.proto */",
+        "squareup/dinosaurs/raptor.nba" to "/* raptor.nba */")
+
+    val sourceZip = fs.getPath("lib/dinosaurs.zip")
+    val roots = sourceZip.roots(closer)
+    assertThat(roots.size == 1)
+    assertThat(roots[0].allProtoFiles().map { it.location })
+        .containsOnly(Location.get(sourceZip.toString(), "squareup/dinosaurs/raptor.proto"))
+  }
+
+  @Test fun directoryProtoFilesOnly() {
+    fs.add("sample/src/main/proto/squareup/dinosaurs/raptor.proto", "/* raptor.proto */")
+    fs.add("sample/src/main/proto/squareup/dinosaurs/raptor.nba", "/* raptor.nba */")
+
+    val sourceDir = fs.getPath("sample/src/main/proto")
+    val roots = sourceDir.roots(closer)
+    assertThat(roots.size == 1)
+    assertThat(roots[0].allProtoFiles().map { it.location })
+        .containsOnly(Location.get(sourceDir.toString(), "squareup/dinosaurs/raptor.proto"))
+  }
+
+  @Test fun standaloneFileMustBeProtoOrZip() {
+    fs.add("sample/src/main/proto/squareup/dinosaurs/raptor.nba", "/* raptor.nba */")
+
+    val onlyFile = fs.getPath("sample/src/main/proto/squareup/dinosaurs/raptor.nba")
+    val exception = assertFailsWith<IllegalArgumentException> {
+      onlyFile.roots(closer)
+    }
+    assertThat(exception)
+        .hasMessage("expected a directory, archive (.zip / .jar / etc.), or .proto: $onlyFile")
+  }
+}
+
+fun FileSystem.add(pathString: String, contents: String) {
+  val path = getPath(pathString)
+  if (path.parent != null) {
+    Files.createDirectories(path.parent)
+  }
+  Files.write(path, contents.toByteArray(UTF_8))
+}
+
+fun FileSystem.addZip(pathString: String, vararg contents: Pair<String, String>) {
+  val path = getPath(pathString)
+  if (path.parent != null) {
+    Files.createDirectories(path.parent)
+  }
+
+  ZipOutputStream(Files.newOutputStream(path)).use { zipOut ->
+    val zipSink = zipOut.sink().buffer()
+    for ((elementPath, elementContents) in contents) {
+      zipOut.putNextEntry(ZipEntry(elementPath))
+      zipSink.writeUtf8(elementContents)
+      zipSink.flush()
+    }
+  }
+}


### PR DESCRIPTION
It's more flexible in how inputs are provided - fully-qualified paths,
directories, or .zips. And it validates that the parsed paths are in
the expected directories.

The Root class keeps track of a user-provided directory where .proto
files are loaded.

The NewSchemaLoader loads the user's provided sources, and the protos
they import.