### PR TITLE
Fix KotlinGenerator issue where optional was not always nullable

### DIFF
--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -43,10 +43,10 @@ class KotlinGeneratorTest {
         |  optional int64 d = 4 [default = 0x21 ];
         |}""".trimMargin())
     val code = repoBuilder.generateKotlin("Message")
-    assertTrue(code.contains("val a: Int = 10"))
-    assertTrue(code.contains("val b: Int = 0x20"))
-    assertTrue(code.contains("val c: Long = 11"))
-    assertTrue(code.contains("val d: Long = 0x21"))
+    assertTrue(code.contains("val a: Int? = 10"))
+    assertTrue(code.contains("val b: Int? = 0x20"))
+    assertTrue(code.contains("val c: Long? = 11"))
+    assertTrue(code.contains("val d: Long? = 0x21"))
   }
 
   @Test fun nameAllocatorIsUsed() {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -119,7 +119,7 @@ data class Person(
     data class PhoneNumber(
         @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter.STRING") val number:
                 String,
-        @field:WireField(tag = 2, adapter = "PhoneType.ADAPTER") val type: PhoneType =
+        @field:WireField(tag = 2, adapter = "PhoneType.ADAPTER") val type: PhoneType? =
                 PhoneType.HOME,
         val unknownFields: ByteString = ByteString.EMPTY
     ) : Message<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
@@ -124,7 +124,7 @@ data class Person(
     data class PhoneNumber(
         @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter.STRING") val number:
                 String,
-        @field:WireField(tag = 2, adapter = "PhoneType.ADAPTER") val type: PhoneType =
+        @field:WireField(tag = 2, adapter = "PhoneType.ADAPTER") val type: PhoneType? =
                 PhoneType.HOME,
         val unknownFields: ByteString = ByteString.EMPTY
     ) : AndroidMessage<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
@@ -45,7 +45,7 @@ data class Person(
 
         internal var email: String? = null
 
-        internal var phone: List<PhoneNumber> = Internal.newMutableList()
+        internal var phone: List<PhoneNumber> = emptyList()
 
         /**
          * The customer's full name.
@@ -168,7 +168,7 @@ data class Person(
     data class PhoneNumber(
         @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter.STRING") val number:
                 String,
-        @field:WireField(tag = 2, adapter = "PhoneType.ADAPTER") val type: PhoneType =
+        @field:WireField(tag = 2, adapter = "PhoneType.ADAPTER") val type: PhoneType? =
                 PhoneType.HOME,
         val unknownFields: ByteString = ByteString.EMPTY
     ) : Message<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {


### PR DESCRIPTION
Check out the second commit to see the actual changes this makes. The first one is in a separate PR, but this commit depends on that refactoring work.