### PR TITLE
Refactoring kotlinFileWriter for better type safety

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/JavaFileWriter.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/JavaFileWriter.kt
@@ -17,7 +17,6 @@ package com.squareup.wire
 
 import com.squareup.javapoet.JavaFile
 import com.squareup.wire.java.JavaGenerator
-import com.squareup.wire.schema.Type
 import java.io.IOException
 import java.nio.file.FileSystem
 import java.util.concurrent.Callable
@@ -26,7 +25,7 @@ import java.util.concurrent.ConcurrentLinkedQueue
 internal class JavaFileWriter(
   private val destination: String,
   private val javaGenerator: JavaGenerator,
-  private val queue: ConcurrentLinkedQueue<Type>,
+  private val queue: ConcurrentLinkedQueue<PendingTypeFileSpec>,
   private val dryRun: Boolean,
   private val fs: FileSystem,
   private val log: WireLogger
@@ -35,7 +34,8 @@ internal class JavaFileWriter(
   @Throws(IOException::class)
   override fun call() {
     while (true) {
-      val type = queue.poll() ?: return
+      val type = queue.poll()?.type ?: return
+
 
       val typeSpec = javaGenerator.generateType(type)
       val javaTypeName = javaGenerator.generatedTypeName(type)

--- a/wire-compiler/src/main/java/com/squareup/wire/PendingFileSpec.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/PendingFileSpec.kt
@@ -1,0 +1,8 @@
+package com.squareup.wire
+
+import com.squareup.wire.schema.Service
+import com.squareup.wire.schema.Type
+
+internal sealed class PendingFileSpec
+internal data class PendingTypeFileSpec(val type: Type) : PendingFileSpec()
+internal data class PendingServiceFileSpec(val service: Service) : PendingFileSpec()

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -17,54 +17,54 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class Feature(
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val name: String? =
-            null,
-    @field:WireField(tag = 2, adapter = "routeguide.Point#ADAPTER") val location: Point? = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val name: String? =
+      null,
+  @field:WireField(tag = 2, adapter = "routeguide.Point#ADAPTER") val location: Point? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Feature, Feature.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: Feature) : Message.Builder<Feature, Builder>() {
-        override fun build(): Feature = message
-    }
+  class Builder(private val message: Feature) : Message.Builder<Feature, Builder>() {
+    override fun build(): Feature = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Feature> = object : ProtoAdapter<Feature>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Feature::class.java
-        ) {
-            override fun encodedSize(value: Feature): Int = 
-                ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-                Point.ADAPTER.encodedSizeWithTag(2, value.location) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Feature> = object : ProtoAdapter<Feature>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Feature::class.java
+    ) {
+      override fun encodedSize(value: Feature): Int = 
+        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
+        Point.ADAPTER.encodedSizeWithTag(2, value.location) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: Feature) {
-                ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
-                Point.ADAPTER.encodeWithTag(writer, 2, value.location)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: Feature) {
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        Point.ADAPTER.encodeWithTag(writer, 2, value.location)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): Feature {
-                var name: String? = null
-                var location: Point? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> name = ProtoAdapter.STRING.decode(reader)
-                        2 -> location = Point.ADAPTER.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Feature(
-                    name = name,
-                    location = location,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): Feature {
+        var name: String? = null
+        var location: Point? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> name = ProtoAdapter.STRING.decode(reader)
+            2 -> location = Point.ADAPTER.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return Feature(
+          name = name,
+          location = location,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -17,47 +17,47 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class FeatureDatabase(@field:WireField(tag = 1, adapter = "routeguide.Feature#ADAPTER") val
-        feature: List<Feature> = emptyList(), val unknownFields: ByteString = ByteString.EMPTY) :
-        Message<FeatureDatabase, FeatureDatabase.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    feature: List<Feature> = emptyList(), val unknownFields: ByteString = ByteString.EMPTY) :
+    Message<FeatureDatabase, FeatureDatabase.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: FeatureDatabase) : Message.Builder<FeatureDatabase,
-            Builder>() {
-        override fun build(): FeatureDatabase = message
-    }
+  class Builder(private val message: FeatureDatabase) : Message.Builder<FeatureDatabase, Builder>()
+      {
+    override fun build(): FeatureDatabase = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<FeatureDatabase> = object : ProtoAdapter<FeatureDatabase>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            FeatureDatabase::class.java
-        ) {
-            override fun encodedSize(value: FeatureDatabase): Int = 
-                Feature.ADAPTER.asRepeated().encodedSizeWithTag(1, value.feature) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<FeatureDatabase> = object : ProtoAdapter<FeatureDatabase>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      FeatureDatabase::class.java
+    ) {
+      override fun encodedSize(value: FeatureDatabase): Int = 
+        Feature.ADAPTER.asRepeated().encodedSizeWithTag(1, value.feature) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: FeatureDatabase) {
-                Feature.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.feature)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: FeatureDatabase) {
+        Feature.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.feature)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): FeatureDatabase {
-                val feature = mutableListOf<Feature>()
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> feature.add(Feature.ADAPTER.decode(reader))
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return FeatureDatabase(
-                    feature = feature,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): FeatureDatabase {
+        val feature = mutableListOf<Feature>()
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> feature.add(Feature.ADAPTER.decode(reader))
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return FeatureDatabase(
+          feature = feature,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -16,55 +16,55 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class Point(
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") val latitude: Int? =
-            null,
-    @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val longitude: Int?
-            = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") val latitude: Int? =
+      null,
+  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val longitude: Int? =
+      null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Point, Point.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: Point) : Message.Builder<Point, Builder>() {
-        override fun build(): Point = message
-    }
+  class Builder(private val message: Point) : Message.Builder<Point, Builder>() {
+    override fun build(): Point = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Point> = object : ProtoAdapter<Point>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Point::class.java
-        ) {
-            override fun encodedSize(value: Point): Int = 
-                ProtoAdapter.INT32.encodedSizeWithTag(1, value.latitude) +
-                ProtoAdapter.INT32.encodedSizeWithTag(2, value.longitude) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Point> = object : ProtoAdapter<Point>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Point::class.java
+    ) {
+      override fun encodedSize(value: Point): Int = 
+        ProtoAdapter.INT32.encodedSizeWithTag(1, value.latitude) +
+        ProtoAdapter.INT32.encodedSizeWithTag(2, value.longitude) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: Point) {
-                ProtoAdapter.INT32.encodeWithTag(writer, 1, value.latitude)
-                ProtoAdapter.INT32.encodeWithTag(writer, 2, value.longitude)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: Point) {
+        ProtoAdapter.INT32.encodeWithTag(writer, 1, value.latitude)
+        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.longitude)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): Point {
-                var latitude: Int? = null
-                var longitude: Int? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> latitude = ProtoAdapter.INT32.decode(reader)
-                        2 -> longitude = ProtoAdapter.INT32.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Point(
-                    latitude = latitude,
-                    longitude = longitude,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): Point {
+        var latitude: Int? = null
+        var longitude: Int? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> latitude = ProtoAdapter.INT32.decode(reader)
+            2 -> longitude = ProtoAdapter.INT32.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return Point(
+          latitude = latitude,
+          longitude = longitude,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -16,53 +16,53 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class Rectangle(
-    @field:WireField(tag = 1, adapter = "routeguide.Point#ADAPTER") val lo: Point? = null,
-    @field:WireField(tag = 2, adapter = "routeguide.Point#ADAPTER") val hi: Point? = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "routeguide.Point#ADAPTER") val lo: Point? = null,
+  @field:WireField(tag = 2, adapter = "routeguide.Point#ADAPTER") val hi: Point? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Rectangle, Rectangle.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: Rectangle) : Message.Builder<Rectangle, Builder>() {
-        override fun build(): Rectangle = message
-    }
+  class Builder(private val message: Rectangle) : Message.Builder<Rectangle, Builder>() {
+    override fun build(): Rectangle = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Rectangle> = object : ProtoAdapter<Rectangle>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Rectangle::class.java
-        ) {
-            override fun encodedSize(value: Rectangle): Int = 
-                Point.ADAPTER.encodedSizeWithTag(1, value.lo) +
-                Point.ADAPTER.encodedSizeWithTag(2, value.hi) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Rectangle> = object : ProtoAdapter<Rectangle>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Rectangle::class.java
+    ) {
+      override fun encodedSize(value: Rectangle): Int = 
+        Point.ADAPTER.encodedSizeWithTag(1, value.lo) +
+        Point.ADAPTER.encodedSizeWithTag(2, value.hi) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: Rectangle) {
-                Point.ADAPTER.encodeWithTag(writer, 1, value.lo)
-                Point.ADAPTER.encodeWithTag(writer, 2, value.hi)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: Rectangle) {
+        Point.ADAPTER.encodeWithTag(writer, 1, value.lo)
+        Point.ADAPTER.encodeWithTag(writer, 2, value.hi)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): Rectangle {
-                var lo: Point? = null
-                var hi: Point? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> lo = Point.ADAPTER.decode(reader)
-                        2 -> hi = Point.ADAPTER.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Rectangle(
-                    lo = lo,
-                    hi = hi,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): Rectangle {
+        var lo: Point? = null
+        var hi: Point? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> lo = Point.ADAPTER.decode(reader)
+            2 -> hi = Point.ADAPTER.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return Rectangle(
+          lo = lo,
+          hi = hi,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -17,54 +17,54 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class RouteNote(
-    @field:WireField(tag = 1, adapter = "routeguide.Point#ADAPTER") val location: Point? = null,
-    @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#STRING") val message:
-            String? = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "routeguide.Point#ADAPTER") val location: Point? = null,
+  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#STRING") val message: String?
+      = null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RouteNote, RouteNote.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: RouteNote) : Message.Builder<RouteNote, Builder>() {
-        override fun build(): RouteNote = message
-    }
+  class Builder(private val message: RouteNote) : Message.Builder<RouteNote, Builder>() {
+    override fun build(): RouteNote = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<RouteNote> = object : ProtoAdapter<RouteNote>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            RouteNote::class.java
-        ) {
-            override fun encodedSize(value: RouteNote): Int = 
-                Point.ADAPTER.encodedSizeWithTag(1, value.location) +
-                ProtoAdapter.STRING.encodedSizeWithTag(2, value.message) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<RouteNote> = object : ProtoAdapter<RouteNote>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      RouteNote::class.java
+    ) {
+      override fun encodedSize(value: RouteNote): Int = 
+        Point.ADAPTER.encodedSizeWithTag(1, value.location) +
+        ProtoAdapter.STRING.encodedSizeWithTag(2, value.message) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: RouteNote) {
-                Point.ADAPTER.encodeWithTag(writer, 1, value.location)
-                ProtoAdapter.STRING.encodeWithTag(writer, 2, value.message)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: RouteNote) {
+        Point.ADAPTER.encodeWithTag(writer, 1, value.location)
+        ProtoAdapter.STRING.encodeWithTag(writer, 2, value.message)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): RouteNote {
-                var location: Point? = null
-                var message: String? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> location = Point.ADAPTER.decode(reader)
-                        2 -> message = ProtoAdapter.STRING.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return RouteNote(
-                    location = location,
-                    message = message,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): RouteNote {
+        var location: Point? = null
+        var message: String? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> location = Point.ADAPTER.decode(reader)
+            2 -> message = ProtoAdapter.STRING.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return RouteNote(
+          location = location,
+          message = message,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -16,69 +16,69 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class RouteSummary(
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") val point_count:
-            Int? = null,
-    @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val feature_count:
-            Int? = null,
-    @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#INT32") val distance: Int? =
-            null,
-    @field:WireField(tag = 4, adapter = "com.squareup.wire.ProtoAdapter#INT32") val elapsed_time:
-            Int? = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") val point_count: Int?
+      = null,
+  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val feature_count:
+      Int? = null,
+  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#INT32") val distance: Int? =
+      null,
+  @field:WireField(tag = 4, adapter = "com.squareup.wire.ProtoAdapter#INT32") val elapsed_time: Int?
+      = null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RouteSummary, RouteSummary.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: RouteSummary) : Message.Builder<RouteSummary, Builder>() {
-        override fun build(): RouteSummary = message
-    }
+  class Builder(private val message: RouteSummary) : Message.Builder<RouteSummary, Builder>() {
+    override fun build(): RouteSummary = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<RouteSummary> = object : ProtoAdapter<RouteSummary>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            RouteSummary::class.java
-        ) {
-            override fun encodedSize(value: RouteSummary): Int = 
-                ProtoAdapter.INT32.encodedSizeWithTag(1, value.point_count) +
-                ProtoAdapter.INT32.encodedSizeWithTag(2, value.feature_count) +
-                ProtoAdapter.INT32.encodedSizeWithTag(3, value.distance) +
-                ProtoAdapter.INT32.encodedSizeWithTag(4, value.elapsed_time) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<RouteSummary> = object : ProtoAdapter<RouteSummary>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      RouteSummary::class.java
+    ) {
+      override fun encodedSize(value: RouteSummary): Int = 
+        ProtoAdapter.INT32.encodedSizeWithTag(1, value.point_count) +
+        ProtoAdapter.INT32.encodedSizeWithTag(2, value.feature_count) +
+        ProtoAdapter.INT32.encodedSizeWithTag(3, value.distance) +
+        ProtoAdapter.INT32.encodedSizeWithTag(4, value.elapsed_time) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: RouteSummary) {
-                ProtoAdapter.INT32.encodeWithTag(writer, 1, value.point_count)
-                ProtoAdapter.INT32.encodeWithTag(writer, 2, value.feature_count)
-                ProtoAdapter.INT32.encodeWithTag(writer, 3, value.distance)
-                ProtoAdapter.INT32.encodeWithTag(writer, 4, value.elapsed_time)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: RouteSummary) {
+        ProtoAdapter.INT32.encodeWithTag(writer, 1, value.point_count)
+        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.feature_count)
+        ProtoAdapter.INT32.encodeWithTag(writer, 3, value.distance)
+        ProtoAdapter.INT32.encodeWithTag(writer, 4, value.elapsed_time)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): RouteSummary {
-                var point_count: Int? = null
-                var feature_count: Int? = null
-                var distance: Int? = null
-                var elapsed_time: Int? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> point_count = ProtoAdapter.INT32.decode(reader)
-                        2 -> feature_count = ProtoAdapter.INT32.decode(reader)
-                        3 -> distance = ProtoAdapter.INT32.decode(reader)
-                        4 -> elapsed_time = ProtoAdapter.INT32.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return RouteSummary(
-                    point_count = point_count,
-                    feature_count = feature_count,
-                    distance = distance,
-                    elapsed_time = elapsed_time,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): RouteSummary {
+        var point_count: Int? = null
+        var feature_count: Int? = null
+        var distance: Int? = null
+        var elapsed_time: Int? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> point_count = ProtoAdapter.INT32.decode(reader)
+            2 -> feature_count = ProtoAdapter.INT32.decode(reader)
+            3 -> distance = ProtoAdapter.INT32.decode(reader)
+            4 -> elapsed_time = ProtoAdapter.INT32.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return RouteSummary(
+          point_count = point_count,
+          feature_count = feature_count,
+          distance = distance,
+          elapsed_time = elapsed_time,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt.java.interop
@@ -16,60 +16,60 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class DeprecatedProto(@field:WireField(tag = 1, adapter =
-        "com.squareup.wire.ProtoAdapter#STRING") @JvmField val foo: String? = null, val
-        unknownFields: ByteString = ByteString.EMPTY) : Message<DeprecatedProto,
-        DeprecatedProto.Builder>(ADAPTER, unknownFields) {
-    override fun newBuilder(): Builder {
-        val builder = Builder()
-        builder.foo = foo
-        builder.addUnknownFields(unknownFields())
-        return builder
+    "com.squareup.wire.ProtoAdapter#STRING") @JvmField val foo: String? = null, val unknownFields:
+    ByteString = ByteString.EMPTY) : Message<DeprecatedProto, DeprecatedProto.Builder>(ADAPTER,
+    unknownFields) {
+  override fun newBuilder(): Builder {
+    val builder = Builder()
+    builder.foo = foo
+    builder.addUnknownFields(unknownFields())
+    return builder
+  }
+
+  class Builder : Message.Builder<DeprecatedProto, Builder>() {
+    @JvmField
+    var foo: String? = null
+
+    @Deprecated(message = "foo is deprecated")
+    fun foo(foo: String?): Builder {
+      this.foo = foo
+      return this
     }
 
-    class Builder : Message.Builder<DeprecatedProto, Builder>() {
-        @JvmField
+    override fun build(): DeprecatedProto = DeprecatedProto(
+      foo = foo,
+      unknownFields = buildUnknownFields()
+    )
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<DeprecatedProto> = object : ProtoAdapter<DeprecatedProto>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      DeprecatedProto::class.java
+    ) {
+      override fun encodedSize(value: DeprecatedProto): Int = 
+        ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo) +
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: DeprecatedProto) {
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): DeprecatedProto {
         var foo: String? = null
-
-        @Deprecated(message = "foo is deprecated")
-        fun foo(foo: String?): Builder {
-            this.foo = foo
-            return this
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> foo = ProtoAdapter.STRING.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
-
-        override fun build(): DeprecatedProto = DeprecatedProto(
-            foo = foo,
-            unknownFields = buildUnknownFields()
+        return DeprecatedProto(
+          foo = foo,
+          unknownFields = unknownFields
         )
+      }
     }
-
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<DeprecatedProto> = object : ProtoAdapter<DeprecatedProto>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            DeprecatedProto::class.java
-        ) {
-            override fun encodedSize(value: DeprecatedProto): Int = 
-                ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo) +
-                value.unknownFields.size
-
-            override fun encode(writer: ProtoWriter, value: DeprecatedProto) {
-                ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): DeprecatedProto {
-                var foo: String? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> foo = ProtoAdapter.STRING.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return DeprecatedProto(
-                    foo = foo,
-                    unknownFields = unknownFields
-                )
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -16,59 +16,59 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class MessageUsingMultipleEnums(
-    @field:WireField(tag = 1, adapter =
-            "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER") val a:
-            MessageWithStatus.Status? = null,
-    @field:WireField(tag = 2, adapter =
-            "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER") val b:
-            OtherMessageWithStatus.Status? = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter =
+      "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER") val a:
+      MessageWithStatus.Status? = null,
+  @field:WireField(tag = 2, adapter =
+      "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER") val b:
+      OtherMessageWithStatus.Status? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<MessageUsingMultipleEnums, MessageUsingMultipleEnums.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: MessageUsingMultipleEnums) :
-            Message.Builder<MessageUsingMultipleEnums, Builder>() {
-        override fun build(): MessageUsingMultipleEnums = message
-    }
+  class Builder(private val message: MessageUsingMultipleEnums) :
+      Message.Builder<MessageUsingMultipleEnums, Builder>() {
+    override fun build(): MessageUsingMultipleEnums = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<MessageUsingMultipleEnums> = object :
-                ProtoAdapter<MessageUsingMultipleEnums>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            MessageUsingMultipleEnums::class.java
-        ) {
-            override fun encodedSize(value: MessageUsingMultipleEnums): Int = 
-                MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a) +
-                OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<MessageUsingMultipleEnums> = object :
+        ProtoAdapter<MessageUsingMultipleEnums>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      MessageUsingMultipleEnums::class.java
+    ) {
+      override fun encodedSize(value: MessageUsingMultipleEnums): Int = 
+        MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a) +
+        OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums) {
-                MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)
-                OtherMessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 2, value.b)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums) {
+        MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)
+        OtherMessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 2, value.b)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): MessageUsingMultipleEnums {
-                var a: MessageWithStatus.Status? = null
-                var b: OtherMessageWithStatus.Status? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> a = MessageWithStatus.Status.ADAPTER.decode(reader)
-                        2 -> b = OtherMessageWithStatus.Status.ADAPTER.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return MessageUsingMultipleEnums(
-                    a = a,
-                    b = b,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): MessageUsingMultipleEnums {
+        var a: MessageWithStatus.Status? = null
+        var b: OtherMessageWithStatus.Status? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> a = MessageWithStatus.Status.ADAPTER.decode(reader)
+            2 -> b = OtherMessageWithStatus.Status.ADAPTER.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return MessageUsingMultipleEnums(
+          a = a,
+          b = b,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt.java.interop
@@ -14,80 +14,80 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class MessageUsingMultipleEnums(
-    @field:WireField(tag = 1, adapter =
-            "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER") @JvmField val a:
-            MessageWithStatus.Status? = null,
-    @field:WireField(tag = 2, adapter =
-            "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER") @JvmField val
-            b: OtherMessageWithStatus.Status? = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter =
+      "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER") @JvmField val a:
+      MessageWithStatus.Status? = null,
+  @field:WireField(tag = 2, adapter =
+      "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER") @JvmField val b:
+      OtherMessageWithStatus.Status? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<MessageUsingMultipleEnums, MessageUsingMultipleEnums.Builder>(ADAPTER, unknownFields) {
-    override fun newBuilder(): Builder {
-        val builder = Builder()
-        builder.a = a
-        builder.b = b
-        builder.addUnknownFields(unknownFields())
-        return builder
+  override fun newBuilder(): Builder {
+    val builder = Builder()
+    builder.a = a
+    builder.b = b
+    builder.addUnknownFields(unknownFields())
+    return builder
+  }
+
+  class Builder : Message.Builder<MessageUsingMultipleEnums, Builder>() {
+    @JvmField
+    var a: MessageWithStatus.Status? = null
+
+    @JvmField
+    var b: OtherMessageWithStatus.Status? = null
+
+    fun a(a: MessageWithStatus.Status?): Builder {
+      this.a = a
+      return this
     }
 
-    class Builder : Message.Builder<MessageUsingMultipleEnums, Builder>() {
-        @JvmField
+    fun b(b: OtherMessageWithStatus.Status?): Builder {
+      this.b = b
+      return this
+    }
+
+    override fun build(): MessageUsingMultipleEnums = MessageUsingMultipleEnums(
+      a = a,
+      b = b,
+      unknownFields = buildUnknownFields()
+    )
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<MessageUsingMultipleEnums> = object :
+        ProtoAdapter<MessageUsingMultipleEnums>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      MessageUsingMultipleEnums::class.java
+    ) {
+      override fun encodedSize(value: MessageUsingMultipleEnums): Int = 
+        MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a) +
+        OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b) +
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums) {
+        MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)
+        OtherMessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 2, value.b)
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): MessageUsingMultipleEnums {
         var a: MessageWithStatus.Status? = null
-
-        @JvmField
         var b: OtherMessageWithStatus.Status? = null
-
-        fun a(a: MessageWithStatus.Status?): Builder {
-            this.a = a
-            return this
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> a = MessageWithStatus.Status.ADAPTER.decode(reader)
+            2 -> b = OtherMessageWithStatus.Status.ADAPTER.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
-
-        fun b(b: OtherMessageWithStatus.Status?): Builder {
-            this.b = b
-            return this
-        }
-
-        override fun build(): MessageUsingMultipleEnums = MessageUsingMultipleEnums(
-            a = a,
-            b = b,
-            unknownFields = buildUnknownFields()
+        return MessageUsingMultipleEnums(
+          a = a,
+          b = b,
+          unknownFields = unknownFields
         )
+      }
     }
-
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<MessageUsingMultipleEnums> = object :
-                ProtoAdapter<MessageUsingMultipleEnums>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            MessageUsingMultipleEnums::class.java
-        ) {
-            override fun encodedSize(value: MessageUsingMultipleEnums): Int = 
-                MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a) +
-                OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b) +
-                value.unknownFields.size
-
-            override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums) {
-                MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)
-                OtherMessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 2, value.b)
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): MessageUsingMultipleEnums {
-                var a: MessageWithStatus.Status? = null
-                var b: OtherMessageWithStatus.Status? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> a = MessageWithStatus.Status.ADAPTER.decode(reader)
-                        2 -> b = OtherMessageWithStatus.Status.ADAPTER.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return MessageUsingMultipleEnums(
-                    a = a,
-                    b = b,
-                    unknownFields = unknownFields
-                )
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -18,62 +18,62 @@ import kotlin.jvm.JvmStatic
 import okio.ByteString
 
 data class MessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-        Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: MessageWithStatus) : Message.Builder<MessageWithStatus,
-            Builder>() {
-        override fun build(): MessageWithStatus = message
+  class Builder(private val message: MessageWithStatus) : Message.Builder<MessageWithStatus,
+      Builder>() {
+    override fun build(): MessageWithStatus = message
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<MessageWithStatus> = object : ProtoAdapter<MessageWithStatus>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      MessageWithStatus::class.java
+    ) {
+      override fun encodedSize(value: MessageWithStatus): Int = 
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: MessageWithStatus) {
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): MessageWithStatus {
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            else -> TagHandler.UNKNOWN_TAG
+          }
+        }
+        return MessageWithStatus(
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
+
+  enum class Status(private val value: Int) : WireEnum {
+    A(1);
+
+    override fun getValue(): Int = value
 
     companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<MessageWithStatus> = object : ProtoAdapter<MessageWithStatus>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            MessageWithStatus::class.java
-        ) {
-            override fun encodedSize(value: MessageWithStatus): Int = 
-                value.unknownFields.size
+      @JvmField
+      val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
+        Status::class.java
+      ) {
+        override fun fromValue(value: Int): Status = Status.fromValue(value)
+      }
 
-            override fun encode(writer: ProtoWriter, value: MessageWithStatus) {
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): MessageWithStatus {
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return MessageWithStatus(
-                    unknownFields = unknownFields
-                )
-            }
-        }
+      @JvmStatic
+      fun fromValue(value: Int): Status = when (value) {
+        1 -> A
+        else -> throw IllegalArgumentException("""Unexpected value: $value""")
+      }
     }
-
-    enum class Status(private val value: Int) : WireEnum {
-        A(1);
-
-        override fun getValue(): Int = value
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
-                Status::class.java
-            ) {
-                override fun fromValue(value: Int): Status = Status.fromValue(value)
-            }
-
-            @JvmStatic
-            fun fromValue(value: Int): Status = when (value) {
-                1 -> A
-                else -> throw IllegalArgumentException("""Unexpected value: $value""")
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt.java.interop
@@ -16,63 +16,63 @@ import kotlin.jvm.JvmStatic
 import okio.ByteString
 
 data class MessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-        Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
-    override fun newBuilder(): Builder {
-        val builder = Builder()
-        builder.addUnknownFields(unknownFields())
-        return builder
-    }
+    Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
+  override fun newBuilder(): Builder {
+    val builder = Builder()
+    builder.addUnknownFields(unknownFields())
+    return builder
+  }
 
-    class Builder : Message.Builder<MessageWithStatus, Builder>() {
-        override fun build(): MessageWithStatus = MessageWithStatus(
-            unknownFields = buildUnknownFields()
+  class Builder : Message.Builder<MessageWithStatus, Builder>() {
+    override fun build(): MessageWithStatus = MessageWithStatus(
+      unknownFields = buildUnknownFields()
+    )
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<MessageWithStatus> = object : ProtoAdapter<MessageWithStatus>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      MessageWithStatus::class.java
+    ) {
+      override fun encodedSize(value: MessageWithStatus): Int = 
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: MessageWithStatus) {
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): MessageWithStatus {
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            else -> TagHandler.UNKNOWN_TAG
+          }
+        }
+        return MessageWithStatus(
+          unknownFields = unknownFields
         )
+      }
     }
+  }
+
+  enum class Status(private val value: Int) : WireEnum {
+    A(1);
+
+    override fun getValue(): Int = value
 
     companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<MessageWithStatus> = object : ProtoAdapter<MessageWithStatus>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            MessageWithStatus::class.java
-        ) {
-            override fun encodedSize(value: MessageWithStatus): Int = 
-                value.unknownFields.size
+      @JvmField
+      val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
+        Status::class.java
+      ) {
+        override fun fromValue(value: Int): Status = Status.fromValue(value)
+      }
 
-            override fun encode(writer: ProtoWriter, value: MessageWithStatus) {
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): MessageWithStatus {
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return MessageWithStatus(
-                    unknownFields = unknownFields
-                )
-            }
-        }
+      @JvmStatic
+      fun fromValue(value: Int): Status = when (value) {
+        1 -> A
+        else -> throw IllegalArgumentException("""Unexpected value: $value""")
+      }
     }
-
-    enum class Status(private val value: Int) : WireEnum {
-        A(1);
-
-        override fun getValue(): Int = value
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
-                Status::class.java
-            ) {
-                override fun fromValue(value: Int): Status = Status.fromValue(value)
-            }
-
-            @JvmStatic
-            fun fromValue(value: Int): Status = when (value) {
-                1 -> A
-                else -> throw IllegalArgumentException("""Unexpected value: $value""")
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -16,64 +16,64 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class OneOfMessage(val choice: Choice? = null, val unknownFields: ByteString =
-        ByteString.EMPTY) : Message<OneOfMessage, OneOfMessage.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    ByteString.EMPTY) : Message<OneOfMessage, OneOfMessage.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: OneOfMessage) : Message.Builder<OneOfMessage, Builder>() {
-        override fun build(): OneOfMessage = message
-    }
+  class Builder(private val message: OneOfMessage) : Message.Builder<OneOfMessage, Builder>() {
+    override fun build(): OneOfMessage = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<OneOfMessage> = object : ProtoAdapter<OneOfMessage>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            OneOfMessage::class.java
-        ) {
-            override fun encodedSize(value: OneOfMessage): Int = 
-                when (value.choice) {
-                    is Choice.Foo -> ProtoAdapter.INT32.encodedSizeWithTag(1, value.choice.foo)
-                    is Choice.Bar -> ProtoAdapter.STRING.encodedSizeWithTag(3, value.choice.bar)
-                    is Choice.Baz -> ProtoAdapter.STRING.encodedSizeWithTag(4, value.choice.baz)
-                    else -> 0
-                } +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<OneOfMessage> = object : ProtoAdapter<OneOfMessage>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      OneOfMessage::class.java
+    ) {
+      override fun encodedSize(value: OneOfMessage): Int = 
+        when (value.choice) {
+          is Choice.Foo -> ProtoAdapter.INT32.encodedSizeWithTag(1, value.choice.foo)
+          is Choice.Bar -> ProtoAdapter.STRING.encodedSizeWithTag(3, value.choice.bar)
+          is Choice.Baz -> ProtoAdapter.STRING.encodedSizeWithTag(4, value.choice.baz)
+          else -> 0
+        } +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: OneOfMessage) {
-                when (value.choice) {
-                    is Choice.Foo -> ProtoAdapter.INT32.encodeWithTag(writer, 1, value.choice.foo)
-                    is Choice.Bar -> ProtoAdapter.STRING.encodeWithTag(writer, 3, value.choice.bar)
-                    is Choice.Baz -> ProtoAdapter.STRING.encodeWithTag(writer, 4, value.choice.baz)
-                }
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): OneOfMessage {
-                var choice: Choice? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> choice = Choice.Foo(ProtoAdapter.INT32.decode(reader))
-                        3 -> choice = Choice.Bar(ProtoAdapter.STRING.decode(reader))
-                        4 -> choice = Choice.Baz(ProtoAdapter.STRING.decode(reader))
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return OneOfMessage(
-                    choice = choice,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun encode(writer: ProtoWriter, value: OneOfMessage) {
+        when (value.choice) {
+          is Choice.Foo -> ProtoAdapter.INT32.encodeWithTag(writer, 1, value.choice.foo)
+          is Choice.Bar -> ProtoAdapter.STRING.encodeWithTag(writer, 3, value.choice.bar)
+          is Choice.Baz -> ProtoAdapter.STRING.encodeWithTag(writer, 4, value.choice.baz)
         }
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): OneOfMessage {
+        var choice: Choice? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> choice = Choice.Foo(ProtoAdapter.INT32.decode(reader))
+            3 -> choice = Choice.Bar(ProtoAdapter.STRING.decode(reader))
+            4 -> choice = Choice.Baz(ProtoAdapter.STRING.decode(reader))
+            else -> TagHandler.UNKNOWN_TAG
+          }
+        }
+        return OneOfMessage(
+          choice = choice,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 
-    sealed class Choice {
-        data class Foo(val foo: Int) : Choice()
+  sealed class Choice {
+    data class Foo(val foo: Int) : Choice()
 
-        data class Bar(val bar: String) : Choice()
+    data class Bar(val bar: String) : Choice()
 
-        data class Baz(val baz: String) : Choice()
-    }
+    data class Baz(val baz: String) : Choice()
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt.java.interop
@@ -16,109 +16,109 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class OneOfMessage(
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") @JvmField val foo:
-            Int? = null,
-    @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val bar:
-            String? = null,
-    @field:WireField(tag = 4, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val baz:
-            String? = null,
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") @JvmField val foo:
+      Int? = null,
+  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val bar:
+      String? = null,
+  @field:WireField(tag = 4, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val baz:
+      String? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<OneOfMessage, OneOfMessage.Builder>(ADAPTER, unknownFields) {
-    init {
-        require (Internal.countNonNull(foo, bar, baz) > 1) {
-            "At most one of foo, bar, baz may be non-null"
-        }
+  init {
+    require (Internal.countNonNull(foo, bar, baz) > 1) {
+      "At most one of foo, bar, baz may be non-null"
+    }
+  }
+
+  override fun newBuilder(): Builder {
+    val builder = Builder()
+    builder.foo = foo
+    builder.bar = bar
+    builder.baz = baz
+    builder.addUnknownFields(unknownFields())
+    return builder
+  }
+
+  class Builder : Message.Builder<OneOfMessage, Builder>() {
+    @JvmField
+    var foo: Int? = null
+
+    @JvmField
+    var bar: String? = null
+
+    @JvmField
+    var baz: String? = null
+
+    /**
+     * What foo.
+     */
+    fun foo(foo: Int): Builder {
+      this.foo = foo
+      return this
     }
 
-    override fun newBuilder(): Builder {
-        val builder = Builder()
-        builder.foo = foo
-        builder.bar = bar
-        builder.baz = baz
-        builder.addUnknownFields(unknownFields())
-        return builder
+    /**
+     * Such bar.
+     */
+    fun bar(bar: String): Builder {
+      this.bar = bar
+      return this
     }
 
-    class Builder : Message.Builder<OneOfMessage, Builder>() {
-        @JvmField
+    /**
+     * Nice baz.
+     */
+    fun baz(baz: String): Builder {
+      this.baz = baz
+      return this
+    }
+
+    override fun build(): OneOfMessage = OneOfMessage(
+      foo = foo,
+      bar = bar,
+      baz = baz,
+      unknownFields = buildUnknownFields()
+    )
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<OneOfMessage> = object : ProtoAdapter<OneOfMessage>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      OneOfMessage::class.java
+    ) {
+      override fun encodedSize(value: OneOfMessage): Int = 
+        ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo) +
+        ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar) +
+        ProtoAdapter.STRING.encodedSizeWithTag(4, value.baz) +
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: OneOfMessage) {
+        ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)
+        ProtoAdapter.STRING.encodeWithTag(writer, 3, value.bar)
+        ProtoAdapter.STRING.encodeWithTag(writer, 4, value.baz)
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): OneOfMessage {
         var foo: Int? = null
-
-        @JvmField
         var bar: String? = null
-
-        @JvmField
         var baz: String? = null
-
-        /**
-         * What foo.
-         */
-        fun foo(foo: Int): Builder {
-            this.foo = foo
-            return this
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> foo = ProtoAdapter.INT32.decode(reader)
+            3 -> bar = ProtoAdapter.STRING.decode(reader)
+            4 -> baz = ProtoAdapter.STRING.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
-
-        /**
-         * Such bar.
-         */
-        fun bar(bar: String): Builder {
-            this.bar = bar
-            return this
-        }
-
-        /**
-         * Nice baz.
-         */
-        fun baz(baz: String): Builder {
-            this.baz = baz
-            return this
-        }
-
-        override fun build(): OneOfMessage = OneOfMessage(
-            foo = foo,
-            bar = bar,
-            baz = baz,
-            unknownFields = buildUnknownFields()
+        return OneOfMessage(
+          foo = foo,
+          bar = bar,
+          baz = baz,
+          unknownFields = unknownFields
         )
+      }
     }
-
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<OneOfMessage> = object : ProtoAdapter<OneOfMessage>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            OneOfMessage::class.java
-        ) {
-            override fun encodedSize(value: OneOfMessage): Int = 
-                ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo) +
-                ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar) +
-                ProtoAdapter.STRING.encodedSizeWithTag(4, value.baz) +
-                value.unknownFields.size
-
-            override fun encode(writer: ProtoWriter, value: OneOfMessage) {
-                ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)
-                ProtoAdapter.STRING.encodeWithTag(writer, 3, value.bar)
-                ProtoAdapter.STRING.encodeWithTag(writer, 4, value.baz)
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): OneOfMessage {
-                var foo: Int? = null
-                var bar: String? = null
-                var baz: String? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> foo = ProtoAdapter.INT32.decode(reader)
-                        3 -> bar = ProtoAdapter.STRING.decode(reader)
-                        4 -> baz = ProtoAdapter.STRING.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return OneOfMessage(
-                    foo = foo,
-                    bar = bar,
-                    baz = baz,
-                    unknownFields = unknownFields
-                )
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -19,72 +19,72 @@ import kotlin.jvm.JvmStatic
 import okio.ByteString
 
 data class OptionalEnumUser(@field:WireField(tag = 1, adapter =
-        "com.squareup.wire.protos.kotlin.OptionalEnumUser.OptionalEnum#ADAPTER") val optional_enum:
-        OptionalEnum? = null, val unknownFields: ByteString = ByteString.EMPTY) :
-        Message<OptionalEnumUser, OptionalEnumUser.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    "com.squareup.wire.protos.kotlin.OptionalEnumUser.OptionalEnum#ADAPTER") val optional_enum:
+    OptionalEnum? = null, val unknownFields: ByteString = ByteString.EMPTY) :
+    Message<OptionalEnumUser, OptionalEnumUser.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: OptionalEnumUser) : Message.Builder<OptionalEnumUser,
-            Builder>() {
-        override fun build(): OptionalEnumUser = message
+  class Builder(private val message: OptionalEnumUser) : Message.Builder<OptionalEnumUser,
+      Builder>() {
+    override fun build(): OptionalEnumUser = message
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<OptionalEnumUser> = object : ProtoAdapter<OptionalEnumUser>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      OptionalEnumUser::class.java
+    ) {
+      override fun encodedSize(value: OptionalEnumUser): Int = 
+        OptionalEnum.ADAPTER.encodedSizeWithTag(1, value.optional_enum) +
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: OptionalEnumUser) {
+        OptionalEnum.ADAPTER.encodeWithTag(writer, 1, value.optional_enum)
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): OptionalEnumUser {
+        var optional_enum: OptionalEnum? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> optional_enum = OptionalEnum.ADAPTER.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
+        }
+        return OptionalEnumUser(
+          optional_enum = optional_enum,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
+
+  enum class OptionalEnum(private val value: Int) : WireEnum {
+    FOO(1),
+
+    BAR(2);
+
+    override fun getValue(): Int = value
 
     companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<OptionalEnumUser> = object : ProtoAdapter<OptionalEnumUser>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            OptionalEnumUser::class.java
-        ) {
-            override fun encodedSize(value: OptionalEnumUser): Int = 
-                OptionalEnum.ADAPTER.encodedSizeWithTag(1, value.optional_enum) +
-                value.unknownFields.size
+      @JvmField
+      val ADAPTER: ProtoAdapter<OptionalEnum> = object : EnumAdapter<OptionalEnum>(
+        OptionalEnum::class.java
+      ) {
+        override fun fromValue(value: Int): OptionalEnum = OptionalEnum.fromValue(value)
+      }
 
-            override fun encode(writer: ProtoWriter, value: OptionalEnumUser) {
-                OptionalEnum.ADAPTER.encodeWithTag(writer, 1, value.optional_enum)
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): OptionalEnumUser {
-                var optional_enum: OptionalEnum? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> optional_enum = OptionalEnum.ADAPTER.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return OptionalEnumUser(
-                    optional_enum = optional_enum,
-                    unknownFields = unknownFields
-                )
-            }
-        }
+      @JvmStatic
+      fun fromValue(value: Int): OptionalEnum = when (value) {
+        1 -> FOO
+        2 -> BAR
+        else -> throw IllegalArgumentException("""Unexpected value: $value""")
+      }
     }
-
-    enum class OptionalEnum(private val value: Int) : WireEnum {
-        FOO(1),
-
-        BAR(2);
-
-        override fun getValue(): Int = value
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<OptionalEnum> = object : EnumAdapter<OptionalEnum>(
-                OptionalEnum::class.java
-            ) {
-                override fun fromValue(value: Int): OptionalEnum = OptionalEnum.fromValue(value)
-            }
-
-            @JvmStatic
-            fun fromValue(value: Int): OptionalEnum = when (value) {
-                1 -> FOO
-                2 -> BAR
-                else -> throw IllegalArgumentException("""Unexpected value: $value""")
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -18,63 +18,63 @@ import kotlin.jvm.JvmStatic
 import okio.ByteString
 
 data class OtherMessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-        Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: OtherMessageWithStatus) :
-            Message.Builder<OtherMessageWithStatus, Builder>() {
-        override fun build(): OtherMessageWithStatus = message
+  class Builder(private val message: OtherMessageWithStatus) :
+      Message.Builder<OtherMessageWithStatus, Builder>() {
+    override fun build(): OtherMessageWithStatus = message
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<OtherMessageWithStatus> = object :
+        ProtoAdapter<OtherMessageWithStatus>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      OtherMessageWithStatus::class.java
+    ) {
+      override fun encodedSize(value: OtherMessageWithStatus): Int = 
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus) {
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): OtherMessageWithStatus {
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            else -> TagHandler.UNKNOWN_TAG
+          }
+        }
+        return OtherMessageWithStatus(
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
+
+  enum class Status(private val value: Int) : WireEnum {
+    A(1);
+
+    override fun getValue(): Int = value
 
     companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<OtherMessageWithStatus> = object :
-                ProtoAdapter<OtherMessageWithStatus>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            OtherMessageWithStatus::class.java
-        ) {
-            override fun encodedSize(value: OtherMessageWithStatus): Int = 
-                value.unknownFields.size
+      @JvmField
+      val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
+        Status::class.java
+      ) {
+        override fun fromValue(value: Int): Status = Status.fromValue(value)
+      }
 
-            override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus) {
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): OtherMessageWithStatus {
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return OtherMessageWithStatus(
-                    unknownFields = unknownFields
-                )
-            }
-        }
+      @JvmStatic
+      fun fromValue(value: Int): Status = when (value) {
+        1 -> A
+        else -> throw IllegalArgumentException("""Unexpected value: $value""")
+      }
     }
-
-    enum class Status(private val value: Int) : WireEnum {
-        A(1);
-
-        override fun getValue(): Int = value
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
-                Status::class.java
-            ) {
-                override fun fromValue(value: Int): Status = Status.fromValue(value)
-            }
-
-            @JvmStatic
-            fun fromValue(value: Int): Status = when (value) {
-                1 -> A
-                else -> throw IllegalArgumentException("""Unexpected value: $value""")
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt.java.interop
@@ -16,64 +16,64 @@ import kotlin.jvm.JvmStatic
 import okio.ByteString
 
 data class OtherMessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-        Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
-    override fun newBuilder(): Builder {
-        val builder = Builder()
-        builder.addUnknownFields(unknownFields())
-        return builder
-    }
+    Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
+  override fun newBuilder(): Builder {
+    val builder = Builder()
+    builder.addUnknownFields(unknownFields())
+    return builder
+  }
 
-    class Builder : Message.Builder<OtherMessageWithStatus, Builder>() {
-        override fun build(): OtherMessageWithStatus = OtherMessageWithStatus(
-            unknownFields = buildUnknownFields()
+  class Builder : Message.Builder<OtherMessageWithStatus, Builder>() {
+    override fun build(): OtherMessageWithStatus = OtherMessageWithStatus(
+      unknownFields = buildUnknownFields()
+    )
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<OtherMessageWithStatus> = object :
+        ProtoAdapter<OtherMessageWithStatus>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      OtherMessageWithStatus::class.java
+    ) {
+      override fun encodedSize(value: OtherMessageWithStatus): Int = 
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus) {
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): OtherMessageWithStatus {
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            else -> TagHandler.UNKNOWN_TAG
+          }
+        }
+        return OtherMessageWithStatus(
+          unknownFields = unknownFields
         )
+      }
     }
+  }
+
+  enum class Status(private val value: Int) : WireEnum {
+    A(1);
+
+    override fun getValue(): Int = value
 
     companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<OtherMessageWithStatus> = object :
-                ProtoAdapter<OtherMessageWithStatus>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            OtherMessageWithStatus::class.java
-        ) {
-            override fun encodedSize(value: OtherMessageWithStatus): Int = 
-                value.unknownFields.size
+      @JvmField
+      val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
+        Status::class.java
+      ) {
+        override fun fromValue(value: Int): Status = Status.fromValue(value)
+      }
 
-            override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus) {
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): OtherMessageWithStatus {
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return OtherMessageWithStatus(
-                    unknownFields = unknownFields
-                )
-            }
-        }
+      @JvmStatic
+      fun fromValue(value: Int): Status = when (value) {
+        1 -> A
+        else -> throw IllegalArgumentException("""Unexpected value: $value""")
+      }
     }
-
-    enum class Status(private val value: Int) : WireEnum {
-        A(1);
-
-        override fun getValue(): Int = value
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<Status> = object : EnumAdapter<Status>(
-                Status::class.java
-            ) {
-                override fun fromValue(value: Int): Status = Status.fromValue(value)
-            }
-
-            @JvmStatic
-            fun fromValue(value: Int): Status = when (value) {
-                1 -> A
-                else -> throw IllegalArgumentException("""Unexpected value: $value""")
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt.java.interop
@@ -15,61 +15,61 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class Percents(@field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING")
-        @JvmField val text: String? = null, val unknownFields: ByteString = ByteString.EMPTY) :
-        Message<Percents, Percents.Builder>(ADAPTER, unknownFields) {
-    override fun newBuilder(): Builder {
-        val builder = Builder()
-        builder.text = text
-        builder.addUnknownFields(unknownFields())
-        return builder
+    @JvmField val text: String? = null, val unknownFields: ByteString = ByteString.EMPTY) :
+    Message<Percents, Percents.Builder>(ADAPTER, unknownFields) {
+  override fun newBuilder(): Builder {
+    val builder = Builder()
+    builder.text = text
+    builder.addUnknownFields(unknownFields())
+    return builder
+  }
+
+  class Builder : Message.Builder<Percents, Builder>() {
+    @JvmField
+    var text: String? = null
+
+    /**
+     * e.g. "No limits, free to send and just 2.75% to receive".
+     */
+    fun text(text: String?): Builder {
+      this.text = text
+      return this
     }
 
-    class Builder : Message.Builder<Percents, Builder>() {
-        @JvmField
+    override fun build(): Percents = Percents(
+      text = text,
+      unknownFields = buildUnknownFields()
+    )
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Percents> = object : ProtoAdapter<Percents>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Percents::class.java
+    ) {
+      override fun encodedSize(value: Percents): Int = 
+        ProtoAdapter.STRING.encodedSizeWithTag(1, value.text) +
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: Percents) {
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.text)
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): Percents {
         var text: String? = null
-
-        /**
-         * e.g. "No limits, free to send and just 2.75% to receive".
-         */
-        fun text(text: String?): Builder {
-            this.text = text
-            return this
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> text = ProtoAdapter.STRING.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
-
-        override fun build(): Percents = Percents(
-            text = text,
-            unknownFields = buildUnknownFields()
+        return Percents(
+          text = text,
+          unknownFields = unknownFields
         )
+      }
     }
-
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Percents> = object : ProtoAdapter<Percents>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Percents::class.java
-        ) {
-            override fun encodedSize(value: Percents): Int = 
-                ProtoAdapter.STRING.encodedSizeWithTag(1, value.text) +
-                value.unknownFields.size
-
-            override fun encode(writer: ProtoWriter, value: Percents) {
-                ProtoAdapter.STRING.encodeWithTag(writer, 1, value.text)
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): Percents {
-                var text: String? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> text = ProtoAdapter.STRING.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Percents(
-                    text = text,
-                    unknownFields = unknownFields
-                )
-            }
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeRequest.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeRequest.kt
@@ -15,40 +15,40 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class SomeRequest(val unknownFields: ByteString = ByteString.EMPTY) : Message<SomeRequest,
-        SomeRequest.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    SomeRequest.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: SomeRequest) : Message.Builder<SomeRequest, Builder>() {
-        override fun build(): SomeRequest = message
-    }
+  class Builder(private val message: SomeRequest) : Message.Builder<SomeRequest, Builder>() {
+    override fun build(): SomeRequest = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<SomeRequest> = object : ProtoAdapter<SomeRequest>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            SomeRequest::class.java
-        ) {
-            override fun encodedSize(value: SomeRequest): Int = 
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<SomeRequest> = object : ProtoAdapter<SomeRequest>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      SomeRequest::class.java
+    ) {
+      override fun encodedSize(value: SomeRequest): Int = 
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: SomeRequest) {
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: SomeRequest) {
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): SomeRequest {
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return SomeRequest(
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): SomeRequest {
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return SomeRequest(
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeResponse.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeResponse.kt
@@ -15,40 +15,40 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class SomeResponse(val unknownFields: ByteString = ByteString.EMPTY) : Message<SomeResponse,
-        SomeResponse.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    SomeResponse.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: SomeResponse) : Message.Builder<SomeResponse, Builder>() {
-        override fun build(): SomeResponse = message
-    }
+  class Builder(private val message: SomeResponse) : Message.Builder<SomeResponse, Builder>() {
+    override fun build(): SomeResponse = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<SomeResponse> = object : ProtoAdapter<SomeResponse>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            SomeResponse::class.java
-        ) {
-            override fun encodedSize(value: SomeResponse): Int = 
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<SomeResponse> = object : ProtoAdapter<SomeResponse>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      SomeResponse::class.java
+    ) {
+      override fun encodedSize(value: SomeResponse): Int = 
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: SomeResponse) {
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: SomeResponse) {
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): SomeResponse {
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return SomeResponse(
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): SomeResponse {
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return SomeResponse(
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -18,49 +18,49 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class Mappy(@field:WireField(tag = 1, adapter = "thingsAdapter") val things: Map<String,
-        Thing>, val unknownFields: ByteString = ByteString.EMPTY) : Message<Mappy,
-        Mappy.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    Thing>, val unknownFields: ByteString = ByteString.EMPTY) : Message<Mappy,
+    Mappy.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: Mappy) : Message.Builder<Mappy, Builder>() {
-        override fun build(): Mappy = message
-    }
+  class Builder(private val message: Mappy) : Message.Builder<Mappy, Builder>() {
+    override fun build(): Mappy = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Mappy> = object : ProtoAdapter<Mappy>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Mappy::class.java
-        ) {
-            private val thingsAdapter: ProtoAdapter<Map<String, Thing>> =
-                    ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER)
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Mappy> = object : ProtoAdapter<Mappy>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Mappy::class.java
+    ) {
+      private val thingsAdapter: ProtoAdapter<Map<String, Thing>> =
+          ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER)
 
-            override fun encodedSize(value: Mappy): Int = 
-                thingsAdapter.encodedSizeWithTag(1, value.things) +
-                value.unknownFields.size
+      override fun encodedSize(value: Mappy): Int = 
+        thingsAdapter.encodedSizeWithTag(1, value.things) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: Mappy) {
-                thingsAdapter.encodeWithTag(writer, 1, value.things)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: Mappy) {
+        thingsAdapter.encodeWithTag(writer, 1, value.things)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): Mappy {
-                val things = mutableMapOf<String, Thing>()
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> things.putAll(thingsAdapter.decode(reader))
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Mappy(
-                    things = things,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): Mappy {
+        val things = mutableMapOf<String, Thing>()
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> things.putAll(thingsAdapter.decode(reader))
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return Mappy(
+          things = things,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -17,46 +17,46 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class Thing(@field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val
-        name: String? = null, val unknownFields: ByteString = ByteString.EMPTY) : Message<Thing,
-        Thing.Builder>(ADAPTER, unknownFields) {
-    @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
-    )
-    override fun newBuilder(): Builder = Builder(this.copy())
+    name: String? = null, val unknownFields: ByteString = ByteString.EMPTY) : Message<Thing,
+    Thing.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: Thing) : Message.Builder<Thing, Builder>() {
-        override fun build(): Thing = message
-    }
+  class Builder(private val message: Thing) : Message.Builder<Thing, Builder>() {
+    override fun build(): Thing = message
+  }
 
-    companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Thing> = object : ProtoAdapter<Thing>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Thing::class.java
-        ) {
-            override fun encodedSize(value: Thing): Int = 
-                ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-                value.unknownFields.size
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Thing> = object : ProtoAdapter<Thing>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Thing::class.java
+    ) {
+      override fun encodedSize(value: Thing): Int = 
+        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
+        value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: Thing) {
-                ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
-                writer.writeBytes(value.unknownFields)
-            }
+      override fun encode(writer: ProtoWriter, value: Thing) {
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        writer.writeBytes(value.unknownFields)
+      }
 
-            override fun decode(reader: ProtoReader): Thing {
-                var name: String? = null
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> name = ProtoAdapter.STRING.decode(reader)
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Thing(
-                    name = name,
-                    unknownFields = unknownFields
-                )
-            }
+      override fun decode(reader: ProtoReader): Thing {
+        var name: String? = null
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> name = ProtoAdapter.STRING.decode(reader)
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
+        return Thing(
+          name = name,
+          unknownFields = unknownFields
+        )
+      }
     }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
@@ -24,159 +24,158 @@ import kotlin.jvm.JvmStatic
 import okio.ByteString
 
 data class Person(
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val name: String,
-    @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val id: Int,
-    @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") val email: String?
-            = null,
-    @field:WireField(tag = 4, adapter =
-            "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER") val phone:
-            List<PhoneNumber> = emptyList(),
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val name: String,
+  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val id: Int,
+  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") val email: String? =
+      null,
+  @field:WireField(tag = 4, adapter =
+      "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER") val phone:
+      List<PhoneNumber> = emptyList(),
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : AndroidMessage<Person, Person.Builder>(ADAPTER, unknownFields) {
+  @Deprecated(
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
+  )
+  override fun newBuilder(): Builder = Builder(this.copy())
+
+  class Builder(private val message: Person) : Message.Builder<Person, Builder>() {
+    override fun build(): Person = message
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Person> = object : ProtoAdapter<Person>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Person::class.java
+    ) {
+      override fun encodedSize(value: Person): Int = 
+        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
+        ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
+        ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
+        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: Person) {
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
+        ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
+        PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): Person {
+        var name: String? = null
+        var id: Int? = null
+        var email: String? = null
+        val phone = mutableListOf<PhoneNumber>()
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> name = ProtoAdapter.STRING.decode(reader)
+            2 -> id = ProtoAdapter.INT32.decode(reader)
+            3 -> email = ProtoAdapter.STRING.decode(reader)
+            4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
+            else -> TagHandler.UNKNOWN_TAG
+          }
+        }
+        return Person(
+          name = name ?: throw Internal.missingRequiredFields(name, "name"),
+          id = id ?: throw Internal.missingRequiredFields(id, "id"),
+          email = email,
+          phone = phone,
+          unknownFields = unknownFields
+        )
+      }
+    }
+
+    @JvmField
+    val CREATOR: Parcelable.Creator<Person> = AndroidMessage.newCreator(ADAPTER)
+  }
+
+  enum class PhoneType(private val value: Int) : WireEnum {
+    MOBILE(0),
+
+    HOME(1),
+
+    /**
+     * Could be phone or fax.
+     */
+    WORK(2);
+
+    override fun getValue(): Int = value
+
+    companion object {
+      @JvmField
+      val ADAPTER: ProtoAdapter<PhoneType> = object : EnumAdapter<PhoneType>(
+        PhoneType::class.java
+      ) {
+        override fun fromValue(value: Int): PhoneType = PhoneType.fromValue(value)
+      }
+
+      @JvmStatic
+      fun fromValue(value: Int): PhoneType = when (value) {
+        0 -> MOBILE
+        1 -> HOME
+        2 -> WORK
+        else -> throw IllegalArgumentException("""Unexpected value: $value""")
+      }
+    }
+  }
+
+  data class PhoneNumber(
+    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val number: String,
+    @field:WireField(tag = 2, adapter =
+        "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER") val type: PhoneType? =
+        PhoneType.HOME,
+    val unknownFields: ByteString = ByteString.EMPTY
+  ) : AndroidMessage<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {
     @Deprecated(
-            message = "Shouldn't be used in Kotlin",
-            level = DeprecationLevel.HIDDEN
+        message = "Shouldn't be used in Kotlin",
+        level = DeprecationLevel.HIDDEN
     )
     override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: Person) : Message.Builder<Person, Builder>() {
-        override fun build(): Person = message
+    class Builder(private val message: PhoneNumber) : Message.Builder<PhoneNumber, Builder>() {
+      override fun build(): PhoneNumber = message
     }
 
     companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Person> = object : ProtoAdapter<Person>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Person::class.java
-        ) {
-            override fun encodedSize(value: Person): Int = 
-                ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-                ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
-                ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-                PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
-                value.unknownFields.size
+      @JvmField
+      val ADAPTER: ProtoAdapter<PhoneNumber> = object : ProtoAdapter<PhoneNumber>(
+        FieldEncoding.LENGTH_DELIMITED, 
+        PhoneNumber::class.java
+      ) {
+        override fun encodedSize(value: PhoneNumber): Int = 
+          ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
+          PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
+          value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: Person) {
-                ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
-                ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
-                ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
-                PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): Person {
-                var name: String? = null
-                var id: Int? = null
-                var email: String? = null
-                val phone = mutableListOf<PhoneNumber>()
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> name = ProtoAdapter.STRING.decode(reader)
-                        2 -> id = ProtoAdapter.INT32.decode(reader)
-                        3 -> email = ProtoAdapter.STRING.decode(reader)
-                        4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Person(
-                    name = name ?: throw Internal.missingRequiredFields(name, "name"),
-                    id = id ?: throw Internal.missingRequiredFields(id, "id"),
-                    email = email,
-                    phone = phone,
-                    unknownFields = unknownFields
-                )
-            }
+        override fun encode(writer: ProtoWriter, value: PhoneNumber) {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
+          PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
+          writer.writeBytes(value.unknownFields)
         }
 
-        @JvmField
-        val CREATOR: Parcelable.Creator<Person> = AndroidMessage.newCreator(ADAPTER)
+        override fun decode(reader: ProtoReader): PhoneNumber {
+          var number: String? = null
+          var type: PhoneType = PhoneType.HOME
+          val unknownFields = reader.forEachTag { tag ->
+            when (tag) {
+              1 -> number = ProtoAdapter.STRING.decode(reader)
+              2 -> type = PhoneType.ADAPTER.decode(reader)
+              else -> TagHandler.UNKNOWN_TAG
+            }
+          }
+          return PhoneNumber(
+            number = number ?: throw Internal.missingRequiredFields(number, "number"),
+            type = type,
+            unknownFields = unknownFields
+          )
+        }
+      }
+
+      @JvmField
+      val CREATOR: Parcelable.Creator<PhoneNumber> = AndroidMessage.newCreator(ADAPTER)
     }
-
-    enum class PhoneType(private val value: Int) : WireEnum {
-        MOBILE(0),
-
-        HOME(1),
-
-        /**
-         * Could be phone or fax.
-         */
-        WORK(2);
-
-        override fun getValue(): Int = value
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<PhoneType> = object : EnumAdapter<PhoneType>(
-                PhoneType::class.java
-            ) {
-                override fun fromValue(value: Int): PhoneType = PhoneType.fromValue(value)
-            }
-
-            @JvmStatic
-            fun fromValue(value: Int): PhoneType = when (value) {
-                0 -> MOBILE
-                1 -> HOME
-                2 -> WORK
-                else -> throw IllegalArgumentException("""Unexpected value: $value""")
-            }
-        }
-    }
-
-    data class PhoneNumber(
-        @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val number:
-                String,
-        @field:WireField(tag = 2, adapter =
-                "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER") val type:
-                PhoneType? = PhoneType.HOME,
-        val unknownFields: ByteString = ByteString.EMPTY
-    ) : AndroidMessage<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {
-        @Deprecated(
-                message = "Shouldn't be used in Kotlin",
-                level = DeprecationLevel.HIDDEN
-        )
-        override fun newBuilder(): Builder = Builder(this.copy())
-
-        class Builder(private val message: PhoneNumber) : Message.Builder<PhoneNumber, Builder>() {
-            override fun build(): PhoneNumber = message
-        }
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<PhoneNumber> = object : ProtoAdapter<PhoneNumber>(
-                FieldEncoding.LENGTH_DELIMITED, 
-                PhoneNumber::class.java
-            ) {
-                override fun encodedSize(value: PhoneNumber): Int = 
-                    ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
-                    PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-                    value.unknownFields.size
-
-                override fun encode(writer: ProtoWriter, value: PhoneNumber) {
-                    ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
-                    PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
-                    writer.writeBytes(value.unknownFields)
-                }
-
-                override fun decode(reader: ProtoReader): PhoneNumber {
-                    var number: String? = null
-                    var type: PhoneType = PhoneType.HOME
-                    val unknownFields = reader.forEachTag { tag ->
-                        when (tag) {
-                            1 -> number = ProtoAdapter.STRING.decode(reader)
-                            2 -> type = PhoneType.ADAPTER.decode(reader)
-                            else -> TagHandler.UNKNOWN_TAG
-                        }
-                    }
-                    return PhoneNumber(
-                        number = number ?: throw Internal.missingRequiredFields(number, "number"),
-                        type = type,
-                        unknownFields = unknownFields
-                    )
-                }
-            }
-
-            @JvmField
-            val CREATOR: Parcelable.Creator<PhoneNumber> = AndroidMessage.newCreator(ADAPTER)
-        }
-    }
+  }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
@@ -20,238 +20,237 @@ import kotlin.jvm.JvmStatic
 import okio.ByteString
 
 data class Person(
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val name:
-            String,
-    @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") @JvmField val id:
-            Int,
-    @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val
-            email: String? = null,
-    @field:WireField(tag = 4, adapter =
-            "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER") @JvmField val
-            phone: List<PhoneNumber> = emptyList(),
-    val unknownFields: ByteString = ByteString.EMPTY
+  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val name:
+      String,
+  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") @JvmField val id: Int,
+  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val email:
+      String? = null,
+  @field:WireField(tag = 4, adapter =
+      "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER") @JvmField val phone:
+      List<PhoneNumber> = emptyList(),
+  val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Person, Person.Builder>(ADAPTER, unknownFields) {
-    override fun newBuilder(): Builder {
-        val builder = Builder()
-        builder.name = name
-        builder.id = id
-        builder.email = email
-        builder.phone = phone
-        builder.addUnknownFields(unknownFields())
-        return builder
+  override fun newBuilder(): Builder {
+    val builder = Builder()
+    builder.name = name
+    builder.id = id
+    builder.email = email
+    builder.phone = phone
+    builder.addUnknownFields(unknownFields())
+    return builder
+  }
+
+  class Builder : Message.Builder<Person, Builder>() {
+    @JvmField
+    var name: String? = null
+
+    @JvmField
+    var id: Int? = null
+
+    @JvmField
+    var email: String? = null
+
+    @JvmField
+    var phone: List<PhoneNumber> = emptyList()
+
+    /**
+     * The customer's full name.
+     */
+    fun name(name: String): Builder {
+      this.name = name
+      return this
     }
 
-    class Builder : Message.Builder<Person, Builder>() {
-        @JvmField
+    /**
+     * The customer's ID number.
+     */
+    fun id(id: Int): Builder {
+      this.id = id
+      return this
+    }
+
+    /**
+     * Email address for the customer.
+     */
+    fun email(email: String?): Builder {
+      this.email = email
+      return this
+    }
+
+    /**
+     * A list of the customer's phone numbers.
+     */
+    fun phone(phone: List<PhoneNumber>): Builder {
+      Internal.checkElementsNotNull(phone)
+      this.phone = phone
+      return this
+    }
+
+    override fun build(): Person = Person(
+      name = name ?: throw Internal.missingRequiredFields(name, "name"),
+      id = id ?: throw Internal.missingRequiredFields(id, "id"),
+      email = email,
+      phone = phone,
+      unknownFields = buildUnknownFields()
+    )
+  }
+
+  companion object {
+    @JvmField
+    val ADAPTER: ProtoAdapter<Person> = object : ProtoAdapter<Person>(
+      FieldEncoding.LENGTH_DELIMITED, 
+      Person::class.java
+    ) {
+      override fun encodedSize(value: Person): Int = 
+        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
+        ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
+        ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
+        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
+        value.unknownFields.size
+
+      override fun encode(writer: ProtoWriter, value: Person) {
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
+        ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
+        PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
+        writer.writeBytes(value.unknownFields)
+      }
+
+      override fun decode(reader: ProtoReader): Person {
         var name: String? = null
-
-        @JvmField
         var id: Int? = null
-
-        @JvmField
         var email: String? = null
-
-        @JvmField
-        var phone: List<PhoneNumber> = emptyList()
-
-        /**
-         * The customer's full name.
-         */
-        fun name(name: String): Builder {
-            this.name = name
-            return this
+        val phone = mutableListOf<PhoneNumber>()
+        val unknownFields = reader.forEachTag { tag ->
+          when (tag) {
+            1 -> name = ProtoAdapter.STRING.decode(reader)
+            2 -> id = ProtoAdapter.INT32.decode(reader)
+            3 -> email = ProtoAdapter.STRING.decode(reader)
+            4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
+            else -> TagHandler.UNKNOWN_TAG
+          }
         }
-
-        /**
-         * The customer's ID number.
-         */
-        fun id(id: Int): Builder {
-            this.id = id
-            return this
-        }
-
-        /**
-         * Email address for the customer.
-         */
-        fun email(email: String?): Builder {
-            this.email = email
-            return this
-        }
-
-        /**
-         * A list of the customer's phone numbers.
-         */
-        fun phone(phone: List<PhoneNumber>): Builder {
-            Internal.checkElementsNotNull(phone)
-            this.phone = phone
-            return this
-        }
-
-        override fun build(): Person = Person(
-            name = name ?: throw Internal.missingRequiredFields(name, "name"),
-            id = id ?: throw Internal.missingRequiredFields(id, "id"),
-            email = email,
-            phone = phone,
-            unknownFields = buildUnknownFields()
+        return Person(
+          name = name ?: throw Internal.missingRequiredFields(name, "name"),
+          id = id ?: throw Internal.missingRequiredFields(id, "id"),
+          email = email,
+          phone = phone,
+          unknownFields = unknownFields
         )
+      }
+    }
+  }
+
+  enum class PhoneType(private val value: Int) : WireEnum {
+    MOBILE(0),
+
+    HOME(1),
+
+    /**
+     * Could be phone or fax.
+     */
+    WORK(2);
+
+    override fun getValue(): Int = value
+
+    companion object {
+      @JvmField
+      val ADAPTER: ProtoAdapter<PhoneType> = object : EnumAdapter<PhoneType>(
+        PhoneType::class.java
+      ) {
+        override fun fromValue(value: Int): PhoneType = PhoneType.fromValue(value)
+      }
+
+      @JvmStatic
+      fun fromValue(value: Int): PhoneType = when (value) {
+        0 -> MOBILE
+        1 -> HOME
+        2 -> WORK
+        else -> throw IllegalArgumentException("""Unexpected value: $value""")
+      }
+    }
+  }
+
+  data class PhoneNumber(
+    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val
+        number: String,
+    @field:WireField(tag = 2, adapter =
+        "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER") @JvmField val type:
+        PhoneType? = PhoneType.HOME,
+    val unknownFields: ByteString = ByteString.EMPTY
+  ) : Message<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {
+    override fun newBuilder(): Builder {
+      val builder = Builder()
+      builder.number = number
+      builder.type = type
+      builder.addUnknownFields(unknownFields())
+      return builder
+    }
+
+    class Builder : Message.Builder<PhoneNumber, Builder>() {
+      @JvmField
+      var number: String? = null
+
+      @JvmField
+      var type: PhoneType = PhoneType.HOME
+
+      /**
+       * The customer's phone number.
+       */
+      fun number(number: String): Builder {
+        this.number = number
+        return this
+      }
+
+      /**
+       * The type of phone stored here.
+       */
+      fun type(type: PhoneType): Builder {
+        this.type = type
+        return this
+      }
+
+      override fun build(): PhoneNumber = PhoneNumber(
+        number = number ?: throw Internal.missingRequiredFields(number, "number"),
+        type = type,
+        unknownFields = buildUnknownFields()
+      )
     }
 
     companion object {
-        @JvmField
-        val ADAPTER: ProtoAdapter<Person> = object : ProtoAdapter<Person>(
-            FieldEncoding.LENGTH_DELIMITED, 
-            Person::class.java
-        ) {
-            override fun encodedSize(value: Person): Int = 
-                ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-                ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
-                ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-                PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
-                value.unknownFields.size
+      @JvmField
+      val ADAPTER: ProtoAdapter<PhoneNumber> = object : ProtoAdapter<PhoneNumber>(
+        FieldEncoding.LENGTH_DELIMITED, 
+        PhoneNumber::class.java
+      ) {
+        override fun encodedSize(value: PhoneNumber): Int = 
+          ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
+          PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
+          value.unknownFields.size
 
-            override fun encode(writer: ProtoWriter, value: Person) {
-                ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
-                ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
-                ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
-                PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
-                writer.writeBytes(value.unknownFields)
-            }
-
-            override fun decode(reader: ProtoReader): Person {
-                var name: String? = null
-                var id: Int? = null
-                var email: String? = null
-                val phone = mutableListOf<PhoneNumber>()
-                val unknownFields = reader.forEachTag { tag ->
-                    when (tag) {
-                        1 -> name = ProtoAdapter.STRING.decode(reader)
-                        2 -> id = ProtoAdapter.INT32.decode(reader)
-                        3 -> email = ProtoAdapter.STRING.decode(reader)
-                        4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
-                        else -> TagHandler.UNKNOWN_TAG
-                    }
-                }
-                return Person(
-                    name = name ?: throw Internal.missingRequiredFields(name, "name"),
-                    id = id ?: throw Internal.missingRequiredFields(id, "id"),
-                    email = email,
-                    phone = phone,
-                    unknownFields = unknownFields
-                )
-            }
+        override fun encode(writer: ProtoWriter, value: PhoneNumber) {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
+          PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
+          writer.writeBytes(value.unknownFields)
         }
+
+        override fun decode(reader: ProtoReader): PhoneNumber {
+          var number: String? = null
+          var type: PhoneType = PhoneType.HOME
+          val unknownFields = reader.forEachTag { tag ->
+            when (tag) {
+              1 -> number = ProtoAdapter.STRING.decode(reader)
+              2 -> type = PhoneType.ADAPTER.decode(reader)
+              else -> TagHandler.UNKNOWN_TAG
+            }
+          }
+          return PhoneNumber(
+            number = number ?: throw Internal.missingRequiredFields(number, "number"),
+            type = type,
+            unknownFields = unknownFields
+          )
+        }
+      }
     }
-
-    enum class PhoneType(private val value: Int) : WireEnum {
-        MOBILE(0),
-
-        HOME(1),
-
-        /**
-         * Could be phone or fax.
-         */
-        WORK(2);
-
-        override fun getValue(): Int = value
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<PhoneType> = object : EnumAdapter<PhoneType>(
-                PhoneType::class.java
-            ) {
-                override fun fromValue(value: Int): PhoneType = PhoneType.fromValue(value)
-            }
-
-            @JvmStatic
-            fun fromValue(value: Int): PhoneType = when (value) {
-                0 -> MOBILE
-                1 -> HOME
-                2 -> WORK
-                else -> throw IllegalArgumentException("""Unexpected value: $value""")
-            }
-        }
-    }
-
-    data class PhoneNumber(
-        @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val
-                number: String,
-        @field:WireField(tag = 2, adapter =
-                "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER") @JvmField val
-                type: PhoneType? = PhoneType.HOME,
-        val unknownFields: ByteString = ByteString.EMPTY
-    ) : Message<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {
-        override fun newBuilder(): Builder {
-            val builder = Builder()
-            builder.number = number
-            builder.type = type
-            builder.addUnknownFields(unknownFields())
-            return builder
-        }
-
-        class Builder : Message.Builder<PhoneNumber, Builder>() {
-            @JvmField
-            var number: String? = null
-
-            @JvmField
-            var type: PhoneType = PhoneType.HOME
-
-            /**
-             * The customer's phone number.
-             */
-            fun number(number: String): Builder {
-                this.number = number
-                return this
-            }
-
-            /**
-             * The type of phone stored here.
-             */
-            fun type(type: PhoneType): Builder {
-                this.type = type
-                return this
-            }
-
-            override fun build(): PhoneNumber = PhoneNumber(
-                number = number ?: throw Internal.missingRequiredFields(number, "number"),
-                type = type,
-                unknownFields = buildUnknownFields()
-            )
-        }
-
-        companion object {
-            @JvmField
-            val ADAPTER: ProtoAdapter<PhoneNumber> = object : ProtoAdapter<PhoneNumber>(
-                FieldEncoding.LENGTH_DELIMITED, 
-                PhoneNumber::class.java
-            ) {
-                override fun encodedSize(value: PhoneNumber): Int = 
-                    ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
-                    PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-                    value.unknownFields.size
-
-                override fun encode(writer: ProtoWriter, value: PhoneNumber) {
-                    ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
-                    PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
-                    writer.writeBytes(value.unknownFields)
-                }
-
-                override fun decode(reader: ProtoReader): PhoneNumber {
-                    var number: String? = null
-                    var type: PhoneType = PhoneType.HOME
-                    val unknownFields = reader.forEachTag { tag ->
-                        when (tag) {
-                            1 -> number = ProtoAdapter.STRING.decode(reader)
-                            2 -> type = PhoneType.ADAPTER.decode(reader)
-                            else -> TagHandler.UNKNOWN_TAG
-                        }
-                    }
-                    return PhoneNumber(
-                        number = number ?: throw Internal.missingRequiredFields(number, "number"),
-                        type = type,
-                        unknownFields = unknownFields
-                    )
-                }
-            }
-        }
-    }
+  }
 }


### PR DESCRIPTION
One side effect is current generated `Type` in kotlin are now using 2 spaces indent.