### PR TITLE
Adding internal access control for Kotlin types (class and enum).

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -96,7 +96,8 @@ class WireCompiler internal constructor(
   val emitAndroid: Boolean,
   val emitAndroidAnnotations: Boolean,
   val emitCompact: Boolean,
-  val javaInterop: Boolean
+  val javaInterop: Boolean,
+  val kotlinInternal: Boolean
 ) {
 
   @Throws(IOException::class)
@@ -157,7 +158,7 @@ class WireCompiler internal constructor(
       }
 
       kotlinOut != null -> {
-        val kotlinGenerator = KotlinGenerator(schema, emitAndroid, javaInterop)
+        val kotlinGenerator = KotlinGenerator(schema, emitAndroid, javaInterop, kotlinInternal)
 
         for (i in 0 until MAX_WRITE_CONCURRENCY) {
           val task = KotlinFileWriter(kotlinOut, kotlinGenerator, queue, fs, log, dryRun)
@@ -198,6 +199,7 @@ class WireCompiler internal constructor(
     private const val ANDROID_ANNOTATIONS = "--android-annotations"
     private const val COMPACT = "--compact"
     private const val JAVA_INTEROP = "--java_interop"
+    private const val KOTLIN_INTERNAL = "--kotlin_internal"
     private const val MAX_WRITE_CONCURRENCY = 8
     private const val DESCRIPTOR_PROTO = "google/protobuf/descriptor.proto"
 
@@ -233,6 +235,7 @@ class WireCompiler internal constructor(
       var emitAndroidAnnotations = false
       var emitCompact = false
       var javaInterop = false
+      var kotlinInternal = false
 
       for (arg in args) {
         when {
@@ -281,6 +284,7 @@ class WireCompiler internal constructor(
           arg == ANDROID_ANNOTATIONS -> emitAndroidAnnotations = true
           arg == COMPACT -> emitCompact = true
           arg == JAVA_INTEROP -> javaInterop = true
+          arg == KOTLIN_INTERNAL -> kotlinInternal = true
           arg.startsWith("--") -> throw IllegalArgumentException("Unknown argument '$arg'.")
           else -> sourceFileNames.add(arg)
         }
@@ -294,7 +298,7 @@ class WireCompiler internal constructor(
 
       return WireCompiler(fileSystem, logger, protoPaths, javaOut, kotlinOut, sourceFileNames,
           identifierSetBuilder.build(), dryRun, namedFilesOnly, emitAndroid, emitAndroidAnnotations,
-          emitCompact, javaInterop)
+          emitCompact, javaInterop, kotlinInternal)
     }
   }
 }

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -26,6 +26,7 @@ import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.INT
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.KModifier.DATA
+import com.squareup.kotlinpoet.KModifier.INTERNAL
 import com.squareup.kotlinpoet.KModifier.OVERRIDE
 import com.squareup.kotlinpoet.KModifier.PRIVATE
 import com.squareup.kotlinpoet.KModifier.SEALED
@@ -209,16 +210,16 @@ class KotlinGenerator private constructor(
 
     val classBuilder = TypeSpec.classBuilder(className)
         .addKdoc(type.documentation())
-        .addModifiers(DATA)
+        .addModifiers(DATA).apply {
+          if (kotlinInternal) {
+            addModifiers(INTERNAL)
+          }
+        }
         .superclass(superclass.parameterizedBy(className, builderClassName))
         .addSuperclassConstructorParameter(adapterName)
         .addSuperclassConstructorParameter(unknownFields)
         .addFunction(generateNewBuilderMethod(type, builderClassName))
         .addType(generateBuilderClass(type, className, builderClassName))
-
-    if (kotlinInternal) {
-      classBuilder.addModifiers(INTERNAL)
-    }
 
     if (emitAndroid) {
       addAndroidCreator(type, companionObjBuilder)
@@ -261,11 +262,7 @@ class KotlinGenerator private constructor(
       val fieldClass = oneOfField.type().typeName
 
       builder.addType(TypeSpec.classBuilder(className)
-          .addModifiers(DATA).apply {
-            if (kotlinInternal) {
-              addModifiers(INTERNAL)
-            }
-          }
+          .addModifiers(DATA)
           .primaryConstructor(FunSpec.constructorBuilder()
               .addParameter(ParameterSpec.builder(name, fieldClass)
                   .build())
@@ -906,7 +903,11 @@ class KotlinGenerator private constructor(
 
     val builder = TypeSpec.enumBuilder(type.simpleName())
         .addKdoc(message.documentation())
-        .addSuperinterface(WireEnum::class)
+        .addSuperinterface(WireEnum::class).apply {
+          if (kotlinInternal) {
+            addModifiers(INTERNAL)
+          }
+        }
         .primaryConstructor(FunSpec.constructorBuilder()
             .addParameter(valueName, Int::class, PRIVATE)
             .build())

--- a/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.java
+++ b/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.java
@@ -112,7 +112,7 @@ public final class RepoBuilder {
 
   public String generateKotlin(String typeName) {
     Schema schema = schema();
-    KotlinGenerator kotlinGenerator = KotlinGenerator.get(schema, false, false);
+    KotlinGenerator kotlinGenerator = KotlinGenerator.get(schema, false, false, false);
     com.squareup.kotlinpoet.TypeSpec typeSpec =
         kotlinGenerator.generateType(schema.getType(typeName));
     FileSpec fileSpec = FileSpec.builder("", "_")

--- a/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.java
+++ b/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.java
@@ -124,7 +124,7 @@ public final class RepoBuilder {
 
   public String generateGrpcKotlin(String serviceName) {
     Schema schema = schema();
-    KotlinGenerator grpcGenerator = KotlinGenerator.get(schema, false, false);
+    KotlinGenerator grpcGenerator = KotlinGenerator.get(schema, false, false, false);
     Service service = schema.getService(serviceName);
     com.squareup.kotlinpoet.TypeSpec typeSpec = grpcGenerator.generateService(service);
     String packageName = service.type().enclosingTypeOrPackage();


### PR DESCRIPTION
Add `--kotlin_interal` command line argument to make all generated class `internal`, so that an SDK using wire to generate protocol class can hide those classes.