### PR TITLE
Support kotlin projects using java protos

### DIFF
--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -217,9 +217,7 @@ class WirePluginTest {
 
     assertThat(result.task(":generateProtos")).isNull()
     assertThat(result.output)
-        .contains(
-            "Task with name 'compileKotlin' not found in root project 'missing-kotlin-plugin'"
-        )
+        .contains("To generate Kotlin protos, please apply a Kotlin plugin.")
   }
 
   @Test
@@ -300,6 +298,99 @@ class WirePluginTest {
     assertThat(generatedProto).exists()
 
     assertThat(generatedProto.readText()).doesNotContain("val name")
+  }
+
+  @Test
+  fun javaProjectJavaProtos() {
+    val fixtureRoot = File("src/test/projects/java-project-java-protos")
+
+    val result = gradleRunner
+        .withProjectDir(fixtureRoot)
+        .withArguments("run", "--stacktrace")
+        .build()
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+        .contains("src/test/projects/java-project-java-protos/build/generated/src/main/java")
+
+    val generatedProto1 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.java")
+    val generatedProto2 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/geology/Period.java")
+    assertThat(generatedProto1).exists()
+    assertThat(generatedProto2).exists()
+  }
+
+  @Test
+  fun javaProjectKotlinProtos() {
+    val fixtureRoot = File("src/test/projects/java-project-kotlin-protos")
+
+    val result = gradleRunner
+        .withProjectDir(fixtureRoot)
+        .withArguments("run", "--stacktrace")
+        .build()
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+        .contains("src/test/projects/java-project-kotlin-protos/build/generated/src/main/java")
+
+    val generatedProto1 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
+    val generatedProto2 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/geology/Period.kt")
+    assertThat(generatedProto1).exists()
+    assertThat(generatedProto2).exists()
+  }
+
+  @Test
+  fun kotlinProjectJavaProtos() {
+    val fixtureRoot = File("src/test/projects/kotlin-project-java-protos")
+
+    val result = gradleRunner
+        .withProjectDir(fixtureRoot)
+        .withArguments("run", "--stacktrace")
+        .withDebug(true)
+        .build()
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+        .contains("src/test/projects/kotlin-project-java-protos/build/generated/src/main/java")
+
+    val generatedProto1 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.java")
+    val generatedProto2 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/geology/Period.java")
+    assertThat(generatedProto1).exists()
+    assertThat(generatedProto2).exists()
+  }
+
+  @Test
+  fun kotlinProjectKotlinProtos() {
+    val fixtureRoot = File("src/test/projects/kotlin-project-kotlin-protos")
+
+    val result = gradleRunner
+        .withProjectDir(fixtureRoot)
+        .withArguments("run", "--stacktrace")
+        .build()
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+        .contains("src/test/projects/kotlin-project-kotlin-protos/build/generated/src/main/java")
+
+    val generatedProto1 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
+    val generatedProto2 =
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/geology/Period.kt")
+    assertThat(generatedProto1).exists()
+    assertThat(generatedProto2).exists()
   }
 
   private fun fieldsFromProtoSource(generatedProtoSource: String): List<String> {

--- a/wire-gradle-plugin/src/test/projects/java-project-java-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/java-project-java-protos/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'application'
+  id 'com.squareup.wire'
+}
+
+mainClassName = 'com.squareup.dinosaurs.Sample'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'com.squareup.wire:wire-runtime:+'
+  implementation 'com.squareup.okio:okio:+'
+}

--- a/wire-gradle-plugin/src/test/projects/java-project-java-protos/src/main/java/com/squareup/dinosaurs/Sample.java
+++ b/wire-gradle-plugin/src/test/projects/java-project-java-protos/src/main/java/com/squareup/dinosaurs/Sample.java
@@ -1,0 +1,27 @@
+package com.squareup.dinosaurs;
+
+import com.squareup.geology.Period;
+import java.io.IOException;
+import java.util.Arrays;
+import okio.ByteString;
+
+public final class Sample {
+  public void run() throws IOException {
+    // Create an immutable value object with the Builder API.
+    Dinosaur stegosaurus = new Dinosaur.Builder()
+        .name("Stegosaurus")
+        .period(Period.JURASSIC)
+        .length_meters(9.0)
+        .mass_kilograms(5_000.0)
+        .picture_urls(Arrays.asList("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67"))
+        .build();
+
+    // Encode that value to bytes, and print that as base64.
+    byte[] stegosaurusEncoded = Dinosaur.ADAPTER.encode(stegosaurus);
+    System.out.println(ByteString.of(stegosaurusEncoded).base64());
+  }
+
+  public static void main(String[] args) throws IOException {
+    new Sample().run();
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/java-project-java-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/java-project-java-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/java-project-java-protos/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/java-project-java-protos/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/build.gradle
@@ -1,0 +1,22 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+mainClassName = 'com.squareup.dinosaurs.Sample'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'com.squareup.wire:wire-runtime:+'
+  implementation 'com.squareup.okio:okio:+'
+}
+
+wire {
+  kotlin {
+    javaInterop true
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/src/main/java/com/squareup/dinosaurs/Sample.java
+++ b/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/src/main/java/com/squareup/dinosaurs/Sample.java
@@ -1,0 +1,27 @@
+package com.squareup.dinosaurs;
+
+import com.squareup.geology.Period;
+import java.io.IOException;
+import java.util.Arrays;
+import okio.ByteString;
+
+public final class Sample {
+  public void run() throws IOException {
+    // Create an immutable value object with the Builder API.
+    Dinosaur stegosaurus = new Dinosaur.Builder()
+        .name("Stegosaurus")
+        .period(Period.JURASSIC)
+        .length_meters(9.0)
+        .mass_kilograms(5_000.0)
+        .picture_urls(Arrays.asList("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67"))
+        .build();
+
+    // Encode that value to bytes, and print that as base64.
+    byte[] stegosaurusEncoded = Dinosaur.ADAPTER.encode(stegosaurus);
+    System.out.println(ByteString.of(stegosaurusEncoded).base64());
+  }
+
+  public static void main(String[] args) throws IOException {
+    new Sample().run();
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'application'
+  id 'com.squareup.wire' // order matters: https://youtrack.jetbrains.com/issue/KT-12715
+  id 'org.jetbrains.kotlin.jvm'
+}
+
+mainClassName = 'com.squareup.dinosaurs.Sample'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'com.squareup.wire:wire-runtime:+'
+  implementation 'com.squareup.okio:okio:+'
+
+  compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/src/main/java/com/squareup/dinosaurs/Sample.kt
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/src/main/java/com/squareup/dinosaurs/Sample.kt
@@ -1,0 +1,31 @@
+package com.squareup.dinosaurs
+
+import com.squareup.geology.Period
+import java.io.IOException
+import okio.ByteString.Companion.toByteString
+
+class Sample {
+  @Throws(IOException::class)
+  fun run() {
+    // Create an immutable value object with the Builder API.
+    val stegosaurus = Dinosaur.Builder()
+        .name("Stegosaurus")
+        .period(Period.JURASSIC)
+        .length_meters(9.0)
+        .mass_kilograms(5_000.0)
+        .picture_urls(listOf("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67"))
+        .build()
+
+    // Encode that value to bytes, and print that as base64.
+    val stegosaurusEncoded = Dinosaur.ADAPTER.encode(stegosaurus)
+    println(stegosaurusEncoded.toByteString().base64())
+  }
+
+  companion object {
+    @Throws(IOException::class)
+    @JvmStatic
+    fun main(args: Array<String>) {
+      Sample().run()
+    }
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+mainClassName = 'com.squareup.dinosaurs.Sample'
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  implementation 'com.squareup.wire:wire-runtime:+'
+  implementation 'com.squareup.okio:okio:+'
+}
+
+wire {
+  kotlin {}
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/java/com/squareup/dinosaurs/Sample.kt
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/java/com/squareup/dinosaurs/Sample.kt
@@ -1,0 +1,30 @@
+package com.squareup.dinosaurs
+
+import com.squareup.geology.Period
+import java.io.IOException
+import okio.ByteString.Companion.toByteString
+
+class Sample {
+  @Throws(IOException::class)
+  fun run() {
+    // Create an immutable value object with the Builder API.
+    val stegosaurus = Dinosaur(
+        name = "Stegosaurus",
+        period = Period.JURASSIC,
+        length_meters = 9.0,
+        mass_kilograms = 5_000.0,
+        picture_urls = listOf("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67")
+    )
+    // Encode that value to bytes, and print that as base64.
+    val stegosaurusEncoded = Dinosaur.ADAPTER.encode(stegosaurus)
+    println(stegosaurusEncoded.toByteString().base64())
+  }
+
+  companion object {
+    @Throws(IOException::class)
+    @JvmStatic
+    fun main(args: Array<String>) {
+      Sample().run()
+    }
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
Currently, kotlin projects using java protos fail because of:
1) the way we currently link task dependencies
2) the way the kotlin plugin consumes sourceSets in an afterEvaluate block, requiring the Wire plugin to be applied before it: https://youtrack.jetbrains.com/issue/KT-12715

Re: 2), there might be a way to use lazy properties to avoid using `project.afterEvaluate` in the Wire plugin, but that's for a later PR.