### PR TITLE
Remove test source set in wire-runtime

### DIFF
--- a/wire-runtime/build.gradle
+++ b/wire-runtime/build.gradle
@@ -50,11 +50,6 @@ kotlin {
         implementation deps.kotlin.test.junit
       }
     }
-    test {
-      // Not required, but helps IntelliJ configure inter-project dependencies:
-      // https://youtrack.jetbrains.com/issue/KT-31179
-      dependsOn jvmTest
-    }
     jsMain {
       dependencies {
         api deps.kotlin.stdlib.js


### PR DESCRIPTION
Not needed since we don't use `jvmWithJava`. IDE was also complaining about it.