### PR TITLE
Fix runtime dependency in wire-compiler

### DIFF
--- a/wire-compiler/build.gradle
+++ b/wire-compiler/build.gradle
@@ -15,7 +15,8 @@ jar {
 
 dependencies {
   api deps.kotlin.stdlib.jdk8
-  implementation project(path: ':wire-runtime', configuration: 'runtimeElements')
+  // TODO(egorand): Depend on runtimeElements once runtime is fully multiplatform
+  implementation project(path: ':wire-runtime', configuration: 'jvmRuntimeElements')
   api project(':wire-schema')
   implementation project(':wire-java-generator')
   implementation project(':wire-kotlin-generator')


### PR DESCRIPTION
This was failing compiler tests in the IDE