### PR TITLE
Improve regex in Gradle plugin tests to ignore formatting when matching fields

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
       'gson': '2.8.1',
       'guava': '20.0',
       'javapoet': '1.10.0',
-      'kotlinpoet': '1.1.0',
+      'kotlinpoet': '1.3.0',
       'jsr305': '3.0.2',
       'kotlin': '1.3.30',
       'okio': '2.3.0-SNAPSHOT',

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -7,6 +7,7 @@ import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Test
 import java.io.File
+import kotlin.text.RegexOption.DOT_MATCHES_ALL
 import kotlin.text.RegexOption.MULTILINE
 
 class WirePluginTest {
@@ -461,8 +462,8 @@ class WirePluginTest {
   }
 
   private fun fieldsFromProtoSource(generatedProtoSource: String): List<String> {
-    val protoFieldPattern = "@field:WireField.*(val .*):"
-    val matchedFields = protoFieldPattern.toRegex(MULTILINE)
+    val protoFieldPattern = "@field:WireField.*?(val .*?):"
+    val matchedFields = protoFieldPattern.toRegex(setOf(MULTILINE, DOT_MATCHES_ALL))
         .findAll(generatedProtoSource)
     return matchedFields
         .map { it.groupValues[1] }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -25,21 +25,30 @@ data class Feature(
   /**
    * The name of the feature.
    */
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val name: String? =
-      null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val name: String? = null,
   /**
    * The point where the feature is detected.
    */
-  @field:WireField(tag = 2, adapter = "routeguide.Point#ADAPTER") val location: Point? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "routeguide.Point#ADAPTER"
+  )
+  val location: Point? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Feature, Feature.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: Feature) : Message.Builder<Feature, Builder>() {
+  class Builder(
+    private val message: Feature
+  ) : Message.Builder<Feature, Builder>() {
     override fun build(): Feature = message
   }
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -20,17 +20,23 @@ import okio.ByteString
 /**
  * Not used in the RPC.  Instead, this is here for the form serialized to disk.
  */
-data class FeatureDatabase(@field:WireField(tag = 1, adapter = "routeguide.Feature#ADAPTER")
-    val feature: List<Feature> = emptyList(), val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<FeatureDatabase, FeatureDatabase.Builder>(ADAPTER, unknownFields) {
+data class FeatureDatabase(
+  @field:WireField(
+    tag = 1,
+    adapter = "routeguide.Feature#ADAPTER"
+  )
+  val feature: List<Feature> = emptyList(),
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<FeatureDatabase, FeatureDatabase.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: FeatureDatabase) : Message.Builder<FeatureDatabase, Builder>()
-      {
+  class Builder(
+    private val message: FeatureDatabase
+  ) : Message.Builder<FeatureDatabase, Builder>() {
     override fun build(): FeatureDatabase = message
   }
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -22,19 +22,27 @@ import okio.ByteString
  * the range +/- 180 degrees (inclusive).
  */
 data class Point(
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") val latitude: Int? =
-      null,
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val longitude: Int? =
-      null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val latitude: Int? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val longitude: Int? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Point, Point.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: Point) : Message.Builder<Point, Builder>() {
+  class Builder(
+    private val message: Point
+  ) : Message.Builder<Point, Builder>() {
     override fun build(): Point = message
   }
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -23,20 +23,30 @@ data class Rectangle(
   /**
    * One corner of the rectangle.
    */
-  @field:WireField(tag = 1, adapter = "routeguide.Point#ADAPTER") val lo: Point? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "routeguide.Point#ADAPTER"
+  )
+  val lo: Point? = null,
   /**
    * The other corner of the rectangle.
    */
-  @field:WireField(tag = 2, adapter = "routeguide.Point#ADAPTER") val hi: Point? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "routeguide.Point#ADAPTER"
+  )
+  val hi: Point? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Rectangle, Rectangle.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: Rectangle) : Message.Builder<Rectangle, Builder>() {
+  class Builder(
+    private val message: Rectangle
+  ) : Message.Builder<Rectangle, Builder>() {
     override fun build(): Rectangle = message
   }
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteGuide.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteGuide.kt
@@ -11,30 +11,30 @@ import kotlinx.coroutines.channels.SendChannel
 
 interface RouteGuide : Service {
   @WireRpc(
-      path = "/routeguide.RouteGuide/GetFeature",
-      requestAdapter = "routeguide.Point#ADAPTER",
-      responseAdapter = "routeguide.Feature#ADAPTER"
+    path = "/routeguide.RouteGuide/GetFeature",
+    requestAdapter = "routeguide.Point#ADAPTER",
+    responseAdapter = "routeguide.Feature#ADAPTER"
   )
   suspend fun GetFeature(request: Point): Feature
 
   @WireRpc(
-      path = "/routeguide.RouteGuide/ListFeatures",
-      requestAdapter = "routeguide.Rectangle#ADAPTER",
-      responseAdapter = "routeguide.Feature#ADAPTER"
+    path = "/routeguide.RouteGuide/ListFeatures",
+    requestAdapter = "routeguide.Rectangle#ADAPTER",
+    responseAdapter = "routeguide.Feature#ADAPTER"
   )
   fun ListFeatures(request: Rectangle): ReceiveChannel<Feature>
 
   @WireRpc(
-      path = "/routeguide.RouteGuide/RecordRoute",
-      requestAdapter = "routeguide.Point#ADAPTER",
-      responseAdapter = "routeguide.RouteSummary#ADAPTER"
+    path = "/routeguide.RouteGuide/RecordRoute",
+    requestAdapter = "routeguide.Point#ADAPTER",
+    responseAdapter = "routeguide.RouteSummary#ADAPTER"
   )
   fun RecordRoute(): Pair<SendChannel<Point>, Deferred<RouteSummary>>
 
   @WireRpc(
-      path = "/routeguide.RouteGuide/RouteChat",
-      requestAdapter = "routeguide.RouteNote#ADAPTER",
-      responseAdapter = "routeguide.RouteNote#ADAPTER"
+    path = "/routeguide.RouteGuide/RouteChat",
+    requestAdapter = "routeguide.RouteNote#ADAPTER",
+    responseAdapter = "routeguide.RouteNote#ADAPTER"
   )
   fun RouteChat(): Pair<SendChannel<RouteNote>, ReceiveChannel<RouteNote>>
 }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -23,21 +23,30 @@ data class RouteNote(
   /**
    * The location from which the message is sent.
    */
-  @field:WireField(tag = 1, adapter = "routeguide.Point#ADAPTER") val location: Point? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "routeguide.Point#ADAPTER"
+  )
+  val location: Point? = null,
   /**
    * The message to be sent.
    */
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#STRING") val message: String?
-      = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val message: String? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RouteNote, RouteNote.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: RouteNote) : Message.Builder<RouteNote, Builder>() {
+  class Builder(
+    private val message: RouteNote
+  ) : Message.Builder<RouteNote, Builder>() {
     override fun build(): RouteNote = message
   }
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -26,32 +26,46 @@ data class RouteSummary(
   /**
    * The number of points received.
    */
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") val point_count: Int?
-      = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val point_count: Int? = null,
   /**
    * The number of known features passed while traversing the route.
    */
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val feature_count:
-      Int? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val feature_count: Int? = null,
   /**
    * The distance covered in metres.
    */
-  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#INT32") val distance: Int? =
-      null,
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val distance: Int? = null,
   /**
    * The duration of the traversal in seconds.
    */
-  @field:WireField(tag = 4, adapter = "com.squareup.wire.ProtoAdapter#INT32") val elapsed_time: Int?
-      = null,
+  @field:WireField(
+    tag = 4,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val elapsed_time: Int? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RouteSummary, RouteSummary.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: RouteSummary) : Message.Builder<RouteSummary, Builder>() {
+  class Builder(
+    private val message: RouteSummary
+  ) : Message.Builder<RouteSummary, Builder>() {
     override fun build(): RouteSummary = message
   }
 

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -21,6 +21,7 @@ import com.squareup.wire.schema.RepoBuilder
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.text.RegexOption.DOT_MATCHES_ALL
 
 class KotlinGeneratorTest {
   @Test fun basic() {
@@ -41,13 +42,13 @@ class KotlinGeneratorTest {
         |	}
         |	repeated PhoneNumber phone = 4;
         |}""".trimMargin())
-    val code = repoBuilder.generateKotlin("Person")
+    val code = repoBuilder.generateKotlin("Person").replace("\n", "")
     assertTrue(code.contains("data class Person"))
-    assertTrue(code.contains("object : ProtoAdapter<PhoneNumber>(\n"))
+    assertTrue(code.contains("object : ProtoAdapter<PhoneNumber>("))
     assertTrue(code.contains("FieldEncoding.LENGTH_DELIMITED"))
     assertTrue(code.contains("PhoneNumber::class"))
     assertTrue(code.contains("override fun encode(writer: ProtoWriter, value: Person)"))
-    assertTrue(code.contains("enum class PhoneType(override val value: Int) : WireEnum"))
+    assertTrue(code.contains("enum class PhoneType(    override val value: Int  ) : WireEnum"))
     assertTrue(code.contains("WORK(1),"))
   }
 
@@ -99,7 +100,7 @@ class KotlinGeneratorTest {
     val typeSpec = kotlinGenerator.generateType(pruned.getType("A"))
     val code = FileSpec.get("", typeSpec).toString()
     assertTrue(code.contains("object A {"))
-    assertTrue(code.contains("data class B(.*) : Message<B, B.Builder>".toRegex()))
+    assertTrue(code.contains("data class B(.*) : Message<B, B.Builder>".toRegex(DOT_MATCHES_ALL)))
   }
 
   @Test fun requestResponse() {
@@ -110,12 +111,12 @@ class KotlinGeneratorTest {
           |import com.squareup.wire.WireRpc
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/GetFeature",
-          |            requestAdapter = "routeguide.Point#ADAPTER",
-          |            responseAdapter = "routeguide.Feature#ADAPTER"
-          |    )
-          |    suspend fun GetFeature(request: Point): Feature
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER"
+          |  )
+          |  suspend fun GetFeature(request: Point): Feature
           |}
           |""".trimMargin()
 
@@ -140,12 +141,12 @@ class KotlinGeneratorTest {
           |import com.squareup.wire.WireRpc
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/GetFeature",
-          |            requestAdapter = "routeguide.Point#ADAPTER",
-          |            responseAdapter = "routeguide.Feature#ADAPTER"
-          |    )
-          |    fun GetFeature(request: Point): Feature
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER"
+          |  )
+          |  fun GetFeature(request: Point): Feature
           |}
           |""".trimMargin()
 
@@ -168,12 +169,12 @@ class KotlinGeneratorTest {
           |import com.squareup.wire.WireRpc
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/RouteGuide/GetFeature",
-          |            requestAdapter = "Point#ADAPTER",
-          |            responseAdapter = "Feature#ADAPTER"
-          |    )
-          |    suspend fun GetFeature(request: Point): Feature
+          |  @WireRpc(
+          |    path = "/RouteGuide/GetFeature",
+          |    requestAdapter = "Point#ADAPTER",
+          |    responseAdapter = "Feature#ADAPTER"
+          |  )
+          |  suspend fun GetFeature(request: Point): Feature
           |}
           |""".trimMargin()
 
@@ -196,12 +197,12 @@ class KotlinGeneratorTest {
           |import com.squareup.wire.WireRpc
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.grpc.RouteGuide/GetFeature",
-          |            requestAdapter = "routeguide.grpc.Point#ADAPTER",
-          |            responseAdapter = "routeguide.grpc.Feature#ADAPTER"
-          |    )
-          |    suspend fun GetFeature(request: Point): Feature
+          |  @WireRpc(
+          |    path = "/routeguide.grpc.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.grpc.Point#ADAPTER",
+          |    responseAdapter = "routeguide.grpc.Feature#ADAPTER"
+          |  )
+          |  suspend fun GetFeature(request: Point): Feature
           |}
           |""".trimMargin()
 
@@ -229,12 +230,12 @@ class KotlinGeneratorTest {
           |import kotlinx.coroutines.channels.SendChannel
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/RecordRoute",
-          |            requestAdapter = "routeguide.Point#ADAPTER",
-          |            responseAdapter = "routeguide.RouteSummary#ADAPTER"
-          |    )
-          |    fun RecordRoute(): Pair<SendChannel<Point>, Deferred<RouteSummary>>
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/RecordRoute",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.RouteSummary#ADAPTER"
+          |  )
+          |  fun RecordRoute(): Pair<SendChannel<Point>, Deferred<RouteSummary>>
           |}
           |""".trimMargin()
 
@@ -260,12 +261,12 @@ class KotlinGeneratorTest {
           |import kotlinx.coroutines.channels.ReceiveChannel
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/ListFeatures",
-          |            requestAdapter = "routeguide.Rectangle#ADAPTER",
-          |            responseAdapter = "routeguide.Feature#ADAPTER"
-          |    )
-          |    fun ListFeatures(request: Rectangle): ReceiveChannel<Feature>
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/ListFeatures",
+          |    requestAdapter = "routeguide.Rectangle#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER"
+          |  )
+          |  fun ListFeatures(request: Rectangle): ReceiveChannel<Feature>
           |}
           |""".trimMargin()
 
@@ -294,12 +295,12 @@ class KotlinGeneratorTest {
           |import kotlinx.coroutines.channels.SendChannel
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/RouteChat",
-          |            requestAdapter = "routeguide.RouteNote#ADAPTER",
-          |            responseAdapter = "routeguide.RouteNote#ADAPTER"
-          |    )
-          |    fun RouteChat(): Pair<SendChannel<RouteNote>, ReceiveChannel<RouteNote>>
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/RouteChat",
+          |    requestAdapter = "routeguide.RouteNote#ADAPTER",
+          |    responseAdapter = "routeguide.RouteNote#ADAPTER"
+          |  )
+          |  fun RouteChat(): Pair<SendChannel<RouteNote>, ReceiveChannel<RouteNote>>
           |}
           |""".trimMargin()
 
@@ -327,19 +328,19 @@ class KotlinGeneratorTest {
           |import kotlinx.coroutines.channels.SendChannel
           |
           |interface RouteGuide : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/GetFeature",
-          |            requestAdapter = "routeguide.Point#ADAPTER",
-          |            responseAdapter = "routeguide.Feature#ADAPTER"
-          |    )
-          |    suspend fun GetFeature(request: Point): Feature
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER"
+          |  )
+          |  suspend fun GetFeature(request: Point): Feature
           |
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/RouteChat",
-          |            requestAdapter = "routeguide.RouteNote#ADAPTER",
-          |            responseAdapter = "routeguide.RouteNote#ADAPTER"
-          |    )
-          |    fun RouteChat(): Pair<SendChannel<RouteNote>, ReceiveChannel<RouteNote>>
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/RouteChat",
+          |    requestAdapter = "routeguide.RouteNote#ADAPTER",
+          |    responseAdapter = "routeguide.RouteNote#ADAPTER"
+          |  )
+          |  fun RouteChat(): Pair<SendChannel<RouteNote>, ReceiveChannel<RouteNote>>
           |}
           |""".trimMargin()
 
@@ -379,12 +380,12 @@ class KotlinGeneratorTest {
           |import com.squareup.wire.WireRpc
           |
           |interface RouteGuideGetFeature : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/GetFeature",
-          |            requestAdapter = "routeguide.Point#ADAPTER",
-          |            responseAdapter = "routeguide.Feature#ADAPTER"
-          |    )
-          |    suspend fun GetFeature(request: Point): Feature
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER"
+          |  )
+          |  suspend fun GetFeature(request: Point): Feature
           |}
           |""".trimMargin()
 
@@ -401,12 +402,12 @@ class KotlinGeneratorTest {
           |import kotlinx.coroutines.channels.SendChannel
           |
           |interface RouteGuideRouteChat : Service {
-          |    @WireRpc(
-          |            path = "/routeguide.RouteGuide/RouteChat",
-          |            requestAdapter = "routeguide.RouteNote#ADAPTER",
-          |            responseAdapter = "routeguide.RouteNote#ADAPTER"
-          |    )
-          |    fun RouteChat(): Pair<SendChannel<RouteNote>, ReceiveChannel<RouteNote>>
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/RouteChat",
+          |    requestAdapter = "routeguide.RouteNote#ADAPTER",
+          |    responseAdapter = "routeguide.RouteNote#ADAPTER"
+          |  )
+          |  fun RouteChat(): Pair<SendChannel<RouteNote>, ReceiveChannel<RouteNote>>
           |}
           |""".trimMargin()
     assertEquals(expectedRouteChat,

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedEnum.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedEnum.kt
@@ -10,7 +10,9 @@ import kotlin.Int
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
-enum class DeprecatedEnum(override val value: Int) : WireEnum {
+enum class DeprecatedEnum(
+  override val value: Int
+) : WireEnum {
   @Deprecated(message = "DISABLED is deprecated")
   DISABLED(1),
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -16,18 +16,24 @@ import kotlin.String
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class DeprecatedProto(@Deprecated(message = "foo is deprecated") @field:WireField(tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING") val foo: String? = null, val unknownFields:
-    ByteString = ByteString.EMPTY) : Message<DeprecatedProto, DeprecatedProto.Builder>(ADAPTER,
-    unknownFields) {
+data class DeprecatedProto(
+  @Deprecated(message = "foo is deprecated")
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val foo: String? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<DeprecatedProto, DeprecatedProto.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: DeprecatedProto) : Message.Builder<DeprecatedProto, Builder>()
-      {
+  class Builder(
+    private val message: DeprecatedProto
+  ) : Message.Builder<DeprecatedProto, Builder>() {
     override fun build(): DeprecatedProto = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt.java.interop
@@ -15,10 +15,16 @@ import kotlin.String
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class DeprecatedProto(@Deprecated(message = "foo is deprecated") @field:WireField(tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val foo: String? = null,
-    val unknownFields: ByteString = ByteString.EMPTY) : Message<DeprecatedProto,
-    DeprecatedProto.Builder>(ADAPTER, unknownFields) {
+data class DeprecatedProto(
+  @Deprecated(message = "foo is deprecated")
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val foo: String? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<DeprecatedProto, DeprecatedProto.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.foo = foo

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -19,22 +19,27 @@ import okio.ByteString
  * Enum names must be fully qualified in generated Kotlin
  */
 data class MessageUsingMultipleEnums(
-  @field:WireField(tag = 1, adapter =
-      "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER") val a:
-      MessageWithStatus.Status? = null,
-  @field:WireField(tag = 2, adapter =
-      "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER") val b:
-      OtherMessageWithStatus.Status? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER"
+  )
+  val a: MessageWithStatus.Status? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER"
+  )
+  val b: OtherMessageWithStatus.Status? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<MessageUsingMultipleEnums, MessageUsingMultipleEnums.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: MessageUsingMultipleEnums) :
-      Message.Builder<MessageUsingMultipleEnums, Builder>() {
+  class Builder(
+    private val message: MessageUsingMultipleEnums
+  ) : Message.Builder<MessageUsingMultipleEnums, Builder>() {
     override fun build(): MessageUsingMultipleEnums = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt.java.interop
@@ -17,12 +17,18 @@ import okio.ByteString
  * Enum names must be fully qualified in generated Kotlin
  */
 data class MessageUsingMultipleEnums(
-  @field:WireField(tag = 1, adapter =
-      "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER") @JvmField val a:
-      MessageWithStatus.Status? = null,
-  @field:WireField(tag = 2, adapter =
-      "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER") @JvmField val b:
-      OtherMessageWithStatus.Status? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.protos.kotlin.MessageWithStatus.Status#ADAPTER"
+  )
+  @JvmField
+  val a: MessageWithStatus.Status? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.protos.kotlin.OtherMessageWithStatus.Status#ADAPTER"
+  )
+  @JvmField
+  val b: OtherMessageWithStatus.Status? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<MessageUsingMultipleEnums, MessageUsingMultipleEnums.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -17,16 +17,18 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
 
-data class MessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
+data class MessageWithStatus(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: MessageWithStatus) : Message.Builder<MessageWithStatus,
-      Builder>() {
+  class Builder(
+    private val message: MessageWithStatus
+  ) : Message.Builder<MessageWithStatus, Builder>() {
     override fun build(): MessageWithStatus = message
   }
 
@@ -60,7 +62,9 @@ data class MessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
     }
   }
 
-  enum class Status(override val value: Int) : WireEnum {
+  enum class Status(
+    override val value: Int
+  ) : WireEnum {
     A(1);
 
     companion object {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt.java.interop
@@ -15,8 +15,9 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
 
-data class MessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
+data class MessageWithStatus(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<MessageWithStatus, MessageWithStatus.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.addUnknownFields(unknownFields())
@@ -59,7 +60,9 @@ data class MessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
     }
   }
 
-  enum class Status(override val value: Int) : WireEnum {
+  enum class Status(
+    override val value: Int
+  ) : WireEnum {
     A(1);
 
     companion object {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageRequest.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageRequest.kt
@@ -14,16 +14,18 @@ import kotlin.Int
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class NoPackageRequest(val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<NoPackageRequest, NoPackageRequest.Builder>(ADAPTER, unknownFields) {
+data class NoPackageRequest(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<NoPackageRequest, NoPackageRequest.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: NoPackageRequest) : Message.Builder<NoPackageRequest,
-      Builder>() {
+  class Builder(
+    private val message: NoPackageRequest
+  ) : Message.Builder<NoPackageRequest, Builder>() {
     override fun build(): NoPackageRequest = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageResponse.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageResponse.kt
@@ -14,16 +14,18 @@ import kotlin.Int
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class NoPackageResponse(val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<NoPackageResponse, NoPackageResponse.Builder>(ADAPTER, unknownFields) {
+data class NoPackageResponse(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<NoPackageResponse, NoPackageResponse.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: NoPackageResponse) : Message.Builder<NoPackageResponse,
-      Builder>() {
+  class Builder(
+    private val message: NoPackageResponse
+  ) : Message.Builder<NoPackageResponse, Builder>() {
     override fun build(): NoPackageResponse = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageService.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageService.kt
@@ -7,9 +7,9 @@ import com.squareup.wire.WireRpc
 
 interface NoPackageService : Service {
   @WireRpc(
-      path = "/NoPackageService/NoPackageMethod",
-      requestAdapter = "NoPackageRequest#ADAPTER",
-      responseAdapter = "NoPackageResponse#ADAPTER"
+    path = "/NoPackageService/NoPackageMethod",
+    requestAdapter = "NoPackageRequest#ADAPTER",
+    responseAdapter = "NoPackageResponse#ADAPTER"
   )
   suspend fun NoPackageMethod(request: NoPackageRequest): NoPackageResponse
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -19,15 +19,19 @@ import okio.ByteString
 /**
  * It's a one of message.
  */
-data class OneOfMessage(val choice: Choice? = null, val unknownFields: ByteString =
-    ByteString.EMPTY) : Message<OneOfMessage, OneOfMessage.Builder>(ADAPTER, unknownFields) {
+data class OneOfMessage(
+  val choice: Choice? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<OneOfMessage, OneOfMessage.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: OneOfMessage) : Message.Builder<OneOfMessage, Builder>() {
+  class Builder(
+    private val message: OneOfMessage
+  ) : Message.Builder<OneOfMessage, Builder>() {
     override fun build(): OneOfMessage = message
   }
 
@@ -79,10 +83,16 @@ data class OneOfMessage(val choice: Choice? = null, val unknownFields: ByteStrin
   }
 
   sealed class Choice {
-    data class Foo(val foo: Int) : Choice()
+    data class Foo(
+      val foo: Int
+    ) : Choice()
 
-    data class Bar(val bar: String) : Choice()
+    data class Bar(
+      val bar: String
+    ) : Choice()
 
-    data class Baz(val baz: String) : Choice()
+    data class Baz(
+      val baz: String
+    ) : Choice()
   }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt.java.interop
@@ -22,18 +22,30 @@ data class OneOfMessage(
   /**
    * What foo.
    */
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") @JvmField val foo:
-      Int? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  @JvmField
+  val foo: Int? = null,
   /**
    * Such bar.
    */
-  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val bar:
-      String? = null,
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val bar: String? = null,
   /**
    * Nice baz.
    */
-  @field:WireField(tag = 4, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val baz:
-      String? = null,
+  @field:WireField(
+    tag = 4,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val baz: String? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<OneOfMessage, OneOfMessage.Builder>(ADAPTER, unknownFields) {
   init {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -18,18 +18,23 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
 
-data class OptionalEnumUser(@field:WireField(tag = 1, adapter =
-    "com.squareup.wire.protos.kotlin.OptionalEnumUser.OptionalEnum#ADAPTER") val optional_enum:
-    OptionalEnum? = null, val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<OptionalEnumUser, OptionalEnumUser.Builder>(ADAPTER, unknownFields) {
+data class OptionalEnumUser(
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.protos.kotlin.OptionalEnumUser.OptionalEnum#ADAPTER"
+  )
+  val optional_enum: OptionalEnum? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<OptionalEnumUser, OptionalEnumUser.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: OptionalEnumUser) : Message.Builder<OptionalEnumUser,
-      Builder>() {
+  class Builder(
+    private val message: OptionalEnumUser
+  ) : Message.Builder<OptionalEnumUser, Builder>() {
     override fun build(): OptionalEnumUser = message
   }
 
@@ -68,7 +73,9 @@ data class OptionalEnumUser(@field:WireField(tag = 1, adapter =
     }
   }
 
-  enum class OptionalEnum(override val value: Int) : WireEnum {
+  enum class OptionalEnum(
+    override val value: Int
+  ) : WireEnum {
     FOO(1),
 
     BAR(2);

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -17,16 +17,18 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
 
-data class OtherMessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
+data class OtherMessageWithStatus(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: OtherMessageWithStatus) :
-      Message.Builder<OtherMessageWithStatus, Builder>() {
+  class Builder(
+    private val message: OtherMessageWithStatus
+  ) : Message.Builder<OtherMessageWithStatus, Builder>() {
     override fun build(): OtherMessageWithStatus = message
   }
 
@@ -61,7 +63,9 @@ data class OtherMessageWithStatus(val unknownFields: ByteString = ByteString.EMP
     }
   }
 
-  enum class Status(override val value: Int) : WireEnum {
+  enum class Status(
+    override val value: Int
+  ) : WireEnum {
     A(1);
 
     companion object {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt.java.interop
@@ -15,8 +15,9 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
 
-data class OtherMessageWithStatus(val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
+data class OtherMessageWithStatus(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<OtherMessageWithStatus, OtherMessageWithStatus.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.addUnknownFields(unknownFields())
@@ -60,7 +61,9 @@ data class OtherMessageWithStatus(val unknownFields: ByteString = ByteString.EMP
     }
   }
 
-  enum class Status(override val value: Int) : WireEnum {
+  enum class Status(
+    override val value: Int
+  ) : WireEnum {
     A(1);
 
     companion object {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt.java.interop
@@ -18,8 +18,12 @@ data class Percents(
   /**
    * e.g. "No limits, free to send and just 2.75% to receive".
    */
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val text:
-      String? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val text: String? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Percents, Percents.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeRequest.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeRequest.kt
@@ -14,15 +14,18 @@ import kotlin.Int
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class SomeRequest(val unknownFields: ByteString = ByteString.EMPTY) : Message<SomeRequest,
-    SomeRequest.Builder>(ADAPTER, unknownFields) {
+data class SomeRequest(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<SomeRequest, SomeRequest.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: SomeRequest) : Message.Builder<SomeRequest, Builder>() {
+  class Builder(
+    private val message: SomeRequest
+  ) : Message.Builder<SomeRequest, Builder>() {
     override fun build(): SomeRequest = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeResponse.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeResponse.kt
@@ -14,15 +14,18 @@ import kotlin.Int
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class SomeResponse(val unknownFields: ByteString = ByteString.EMPTY) : Message<SomeResponse,
-    SomeResponse.Builder>(ADAPTER, unknownFields) {
+data class SomeResponse(
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<SomeResponse, SomeResponse.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: SomeResponse) : Message.Builder<SomeResponse, Builder>() {
+  class Builder(
+    private val message: SomeResponse
+  ) : Message.Builder<SomeResponse, Builder>() {
     override fun build(): SomeResponse = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeService.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/SomeService.kt
@@ -7,9 +7,9 @@ import com.squareup.wire.WireRpc
 
 interface SomeService : Service {
   @WireRpc(
-      path = "/squareup.protos.kotlin.SomeService/SomeMethod",
-      requestAdapter = "squareup.protos.kotlin.SomeRequest#ADAPTER",
-      responseAdapter = "squareup.protos.kotlin.SomeResponse#ADAPTER"
+    path = "/squareup.protos.kotlin.SomeService/SomeMethod",
+    requestAdapter = "squareup.protos.kotlin.SomeRequest#ADAPTER",
+    responseAdapter = "squareup.protos.kotlin.SomeResponse#ADAPTER"
   )
   suspend fun SomeMethod(request: SomeRequest): SomeResponse
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -18,16 +18,23 @@ import kotlin.collections.Map
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class Mappy(@field:WireField(tag = 1, adapter = "thingsAdapter") val things: Map<String,
-    Thing>, val unknownFields: ByteString = ByteString.EMPTY) : Message<Mappy,
-    Mappy.Builder>(ADAPTER, unknownFields) {
+data class Mappy(
+  @field:WireField(
+    tag = 1,
+    adapter = "thingsAdapter"
+  )
+  val things: Map<String, Thing>,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<Mappy, Mappy.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: Mappy) : Message.Builder<Mappy, Builder>() {
+  class Builder(
+    private val message: Mappy
+  ) : Message.Builder<Mappy, Builder>() {
     override fun build(): Mappy = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt.java.interop
@@ -16,9 +16,15 @@ import kotlin.collections.Map
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class Mappy(@field:WireField(tag = 1, adapter = "thingsAdapter") @JvmField val things:
-    Map<String, Thing>, val unknownFields: ByteString = ByteString.EMPTY) : Message<Mappy,
-    Mappy.Builder>(ADAPTER, unknownFields) {
+data class Mappy(
+  @field:WireField(
+    tag = 1,
+    adapter = "thingsAdapter"
+  )
+  @JvmField
+  val things: Map<String, Thing>,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<Mappy, Mappy.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.things = things

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -16,16 +16,23 @@ import kotlin.String
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class Thing(@field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING")
-    val name: String? = null, val unknownFields: ByteString = ByteString.EMPTY) : Message<Thing,
-    Thing.Builder>(ADAPTER, unknownFields) {
+data class Thing(
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val name: String? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<Thing, Thing.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: Thing) : Message.Builder<Thing, Builder>() {
+  class Builder(
+    private val message: Thing
+  ) : Message.Builder<Thing, Builder>() {
     override fun build(): Thing = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt.java.interop
@@ -14,9 +14,15 @@ import kotlin.String
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class Thing(@field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING")
-    @JvmField val name: String? = null, val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<Thing, Thing.Builder>(ADAPTER, unknownFields) {
+data class Thing(
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val name: String? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<Thing, Thing.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -29,31 +29,46 @@ data class Person(
   /**
    * The customer's full name.
    */
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val name: String,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val name: String,
   /**
    * The customer's ID number.
    */
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val id: Int,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val id: Int,
   /**
    * Email address for the customer.
    */
-  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") val email: String? =
-      null,
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val email: String? = null,
   /**
    * A list of the customer's phone numbers.
    */
-  @field:WireField(tag = 4, adapter =
-      "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER") val phone:
-      List<PhoneNumber> = emptyList(),
+  @field:WireField(
+    tag = 4,
+    adapter = "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER"
+  )
+  val phone: List<PhoneNumber> = emptyList(),
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Person, Person.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: Person) : Message.Builder<Person, Builder>() {
+  class Builder(
+    private val message: Person
+  ) : Message.Builder<Person, Builder>() {
     override fun build(): Person = message
   }
 
@@ -111,7 +126,9 @@ data class Person(
   /**
    * Represents the type of the phone number: mobile, home or work.
    */
-  enum class PhoneType(override val value: Int) : WireEnum {
+  enum class PhoneType(
+    override val value: Int
+  ) : WireEnum {
     MOBILE(0),
 
     HOME(1),
@@ -143,22 +160,30 @@ data class Person(
     /**
      * The customer's phone number.
      */
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val number: String,
+    @field:WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+    )
+    val number: String,
     /**
      * The type of phone stored here.
      */
-    @field:WireField(tag = 2, adapter =
-        "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER") val type: PhoneType? =
-        PhoneType.HOME,
+    @field:WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER"
+    )
+    val type: PhoneType? = PhoneType.HOME,
     val unknownFields: ByteString = ByteString.EMPTY
   ) : Message<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {
     @Deprecated(
-        message = "Shouldn't be used in Kotlin",
-        level = DeprecationLevel.HIDDEN
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
     )
     override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: PhoneNumber) : Message.Builder<PhoneNumber, Builder>() {
+    class Builder(
+      private val message: PhoneNumber
+    ) : Message.Builder<PhoneNumber, Builder>() {
       override fun build(): PhoneNumber = message
     }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
@@ -31,31 +31,46 @@ data class Person(
   /**
    * The customer's full name.
    */
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val name: String,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val name: String,
   /**
    * The customer's ID number.
    */
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") val id: Int,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val id: Int,
   /**
    * Email address for the customer.
    */
-  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") val email: String? =
-      null,
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val email: String? = null,
   /**
    * A list of the customer's phone numbers.
    */
-  @field:WireField(tag = 4, adapter =
-      "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER") val phone:
-      List<PhoneNumber> = emptyList(),
+  @field:WireField(
+    tag = 4,
+    adapter = "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER"
+  )
+  val phone: List<PhoneNumber> = emptyList(),
   val unknownFields: ByteString = ByteString.EMPTY
 ) : AndroidMessage<Person, Person.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: Person) : Message.Builder<Person, Builder>() {
+  class Builder(
+    private val message: Person
+  ) : Message.Builder<Person, Builder>() {
     override fun build(): Person = message
   }
 
@@ -116,7 +131,9 @@ data class Person(
   /**
    * Represents the type of the phone number: mobile, home or work.
    */
-  enum class PhoneType(override val value: Int) : WireEnum {
+  enum class PhoneType(
+    override val value: Int
+  ) : WireEnum {
     MOBILE(0),
 
     HOME(1),
@@ -148,22 +165,30 @@ data class Person(
     /**
      * The customer's phone number.
      */
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val number: String,
+    @field:WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+    )
+    val number: String,
     /**
      * The type of phone stored here.
      */
-    @field:WireField(tag = 2, adapter =
-        "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER") val type: PhoneType? =
-        PhoneType.HOME,
+    @field:WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER"
+    )
+    val type: PhoneType? = PhoneType.HOME,
     val unknownFields: ByteString = ByteString.EMPTY
   ) : AndroidMessage<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {
     @Deprecated(
-        message = "Shouldn't be used in Kotlin",
-        level = DeprecationLevel.HIDDEN
+      message = "Shouldn't be used in Kotlin",
+      level = DeprecationLevel.HIDDEN
     )
     override fun newBuilder(): Builder = Builder(this.copy())
 
-    class Builder(private val message: PhoneNumber) : Message.Builder<PhoneNumber, Builder>() {
+    class Builder(
+      private val message: PhoneNumber
+    ) : Message.Builder<PhoneNumber, Builder>() {
       override fun build(): PhoneNumber = message
     }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
@@ -28,23 +28,39 @@ data class Person(
   /**
    * The customer's full name.
    */
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val name:
-      String,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val name: String,
   /**
    * The customer's ID number.
    */
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#INT32") @JvmField val id: Int,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  @JvmField
+  val id: Int,
   /**
    * Email address for the customer.
    */
-  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField val email:
-      String? = null,
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val email: String? = null,
   /**
    * A list of the customer's phone numbers.
    */
-  @field:WireField(tag = 4, adapter =
-      "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER") @JvmField val phone:
-      List<PhoneNumber> = emptyList(),
+  @field:WireField(
+    tag = 4,
+    adapter = "com.squareup.wire.protos.kotlin.person.Person.PhoneNumber#ADAPTER"
+  )
+  @JvmField
+  val phone: List<PhoneNumber> = emptyList(),
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Person, Person.Builder>(ADAPTER, unknownFields) {
   override fun newBuilder(): Builder {
@@ -166,7 +182,9 @@ data class Person(
   /**
    * Represents the type of the phone number: mobile, home or work.
    */
-  enum class PhoneType(override val value: Int) : WireEnum {
+  enum class PhoneType(
+    override val value: Int
+  ) : WireEnum {
     MOBILE(0),
 
     HOME(1),
@@ -198,14 +216,21 @@ data class Person(
     /**
      * The customer's phone number.
      */
-    @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") @JvmField
-        val number: String,
+    @field:WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+    )
+    @JvmField
+    val number: String,
     /**
      * The type of phone stored here.
      */
-    @field:WireField(tag = 2, adapter =
-        "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER") @JvmField val type:
-        PhoneType? = PhoneType.HOME,
+    @field:WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.protos.kotlin.person.Person.PhoneType#ADAPTER"
+    )
+    @JvmField
+    val type: PhoneType? = PhoneType.HOME,
     val unknownFields: ByteString = ByteString.EMPTY
   ) : Message<PhoneNumber, PhoneNumber.Builder>(ADAPTER, unknownFields) {
     override fun newBuilder(): Builder {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
@@ -17,19 +17,27 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class NotRedacted(
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val a: String? =
-      null,
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#STRING") val b: String? =
-      null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val a: String? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val b: String? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<NotRedacted, NotRedacted.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: NotRedacted) : Message.Builder<NotRedacted, Builder>() {
+  class Builder(
+    private val message: NotRedacted
+  ) : Message.Builder<NotRedacted, Builder>() {
     override fun build(): NotRedacted = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
@@ -17,20 +17,32 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class Redacted(
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING", redacted = true)
-      val a: String? = null,
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#STRING") val b: String? =
-      null,
-  @field:WireField(tag = 3, adapter = "com.squareup.wire.ProtoAdapter#STRING") val c: String? =
-      null,
-  @field:WireField(tag = 10, adapter =
-      "com.squareup.wire.protos.kotlin.redacted.RedactedExtension#ADAPTER") val extension:
-      RedactedExtension? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    redacted = true
+  )
+  val a: String? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val b: String? = null,
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val c: String? = null,
+  @field:WireField(
+    tag = 10,
+    adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedExtension#ADAPTER"
+  )
+  val extension: RedactedExtension? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Redacted, Redacted.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
@@ -43,7 +55,9 @@ data class Redacted(
     append(")")
   }
 
-  class Builder(private val message: Redacted) : Message.Builder<Redacted, Builder>() {
+  class Builder(
+    private val message: Redacted
+  ) : Message.Builder<Redacted, Builder>() {
     override fun build(): Redacted = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
@@ -17,21 +17,32 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class RedactedChild(
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING") val a: String? =
-      null,
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.protos.kotlin.redacted.Redacted#ADAPTER")
-      val b: Redacted? = null,
-  @field:WireField(tag = 3, adapter =
-      "com.squareup.wire.protos.kotlin.redacted.NotRedacted#ADAPTER") val c: NotRedacted? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val a: String? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.protos.kotlin.redacted.Redacted#ADAPTER"
+  )
+  val b: Redacted? = null,
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.protos.kotlin.redacted.NotRedacted#ADAPTER"
+  )
+  val c: NotRedacted? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RedactedChild, RedactedChild.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: RedactedChild) : Message.Builder<RedactedChild, Builder>() {
+  class Builder(
+    private val message: RedactedChild
+  ) : Message.Builder<RedactedChild, Builder>() {
     override fun build(): RedactedChild = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
@@ -15,17 +15,23 @@ import kotlin.Int
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class RedactedCycleA(@field:WireField(tag = 1, adapter =
-    "com.squareup.wire.protos.kotlin.redacted.RedactedCycleB#ADAPTER") val b: RedactedCycleB? =
-    null, val unknownFields: ByteString = ByteString.EMPTY) : Message<RedactedCycleA,
-    RedactedCycleA.Builder>(ADAPTER, unknownFields) {
+data class RedactedCycleA(
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedCycleB#ADAPTER"
+  )
+  val b: RedactedCycleB? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<RedactedCycleA, RedactedCycleA.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: RedactedCycleA) : Message.Builder<RedactedCycleA, Builder>() {
+  class Builder(
+    private val message: RedactedCycleA
+  ) : Message.Builder<RedactedCycleA, Builder>() {
     override fun build(): RedactedCycleA = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
@@ -15,17 +15,23 @@ import kotlin.Int
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class RedactedCycleB(@field:WireField(tag = 1, adapter =
-    "com.squareup.wire.protos.kotlin.redacted.RedactedCycleA#ADAPTER") val a: RedactedCycleA? =
-    null, val unknownFields: ByteString = ByteString.EMPTY) : Message<RedactedCycleB,
-    RedactedCycleB.Builder>(ADAPTER, unknownFields) {
+data class RedactedCycleB(
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedCycleA#ADAPTER"
+  )
+  val a: RedactedCycleA? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<RedactedCycleB, RedactedCycleB.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
-  class Builder(private val message: RedactedCycleB) : Message.Builder<RedactedCycleB, Builder>() {
+  class Builder(
+    private val message: RedactedCycleB
+  ) : Message.Builder<RedactedCycleB, Builder>() {
     override fun build(): RedactedCycleB = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
@@ -17,15 +17,22 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class RedactedExtension(
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING", redacted = true)
-      val d: String? = null,
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#STRING") val e: String? =
-      null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    redacted = true
+  )
+  val d: String? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val e: String? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RedactedExtension, RedactedExtension.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
@@ -36,8 +43,9 @@ data class RedactedExtension(
     append(")")
   }
 
-  class Builder(private val message: RedactedExtension) : Message.Builder<RedactedExtension,
-      Builder>() {
+  class Builder(
+    private val message: RedactedExtension
+  ) : Message.Builder<RedactedExtension, Builder>() {
     override fun build(): RedactedExtension = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -16,11 +16,13 @@ import kotlin.String
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class RedactedOneOf(val a: A? = null, val unknownFields: ByteString = ByteString.EMPTY) :
-    Message<RedactedOneOf, RedactedOneOf.Builder>(ADAPTER, unknownFields) {
+data class RedactedOneOf(
+  val a: A? = null,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<RedactedOneOf, RedactedOneOf.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
@@ -30,7 +32,9 @@ data class RedactedOneOf(val a: A? = null, val unknownFields: ByteString = ByteS
     append(")")
   }
 
-  class Builder(private val message: RedactedOneOf) : Message.Builder<RedactedOneOf, Builder>() {
+  class Builder(
+    private val message: RedactedOneOf
+  ) : Message.Builder<RedactedOneOf, Builder>() {
     override fun build(): RedactedOneOf = message
   }
 
@@ -79,8 +83,12 @@ data class RedactedOneOf(val a: A? = null, val unknownFields: ByteString = ByteS
   }
 
   sealed class A {
-    data class B(val b: Int) : A()
+    data class B(
+      val b: Int
+    ) : A()
 
-    data class C(val c: String) : A()
+    data class C(
+      val c: String
+    ) : A()
   }
 }

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt.java.interop
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt.java.interop
@@ -16,10 +16,19 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class RedactedOneOf(
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#INT32") @JvmField val b: Int?
-      = null,
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.ProtoAdapter#STRING", redacted = true)
-      @JvmField val c: String? = null,
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  @JvmField
+  val b: Int? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    redacted = true
+  )
+  @JvmField
+  val c: String? = null,
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RedactedOneOf, RedactedOneOf.Builder>(ADAPTER, unknownFields) {
   init {

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -19,18 +19,25 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 data class RedactedRepeated(
-  @field:WireField(tag = 1, adapter = "com.squareup.wire.ProtoAdapter#STRING", redacted = true)
-      val a: List<String> = emptyList(),
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    redacted = true
+  )
+  val a: List<String> = emptyList(),
   /**
    * Values in the repeated type need redacting.
    */
-  @field:WireField(tag = 2, adapter = "com.squareup.wire.protos.kotlin.redacted.Redacted#ADAPTER")
-      val b: List<Redacted> = emptyList(),
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.protos.kotlin.redacted.Redacted#ADAPTER"
+  )
+  val b: List<Redacted> = emptyList(),
   val unknownFields: ByteString = ByteString.EMPTY
 ) : Message<RedactedRepeated, RedactedRepeated.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
@@ -41,8 +48,9 @@ data class RedactedRepeated(
     append(")")
   }
 
-  class Builder(private val message: RedactedRepeated) : Message.Builder<RedactedRepeated,
-      Builder>() {
+  class Builder(
+    private val message: RedactedRepeated
+  ) : Message.Builder<RedactedRepeated, Builder>() {
     override fun build(): RedactedRepeated = message
   }
 

--- a/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
+++ b/wire-tests/src/test/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
@@ -18,13 +18,18 @@ import kotlin.String
 import kotlin.jvm.JvmField
 import okio.ByteString
 
-data class RedactedRequired(@field:WireField(tag = 1, adapter =
-    "com.squareup.wire.ProtoAdapter#STRING", redacted = true) val a: String, val unknownFields:
-    ByteString = ByteString.EMPTY) : Message<RedactedRequired, RedactedRequired.Builder>(ADAPTER,
-    unknownFields) {
+data class RedactedRequired(
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    redacted = true
+  )
+  val a: String,
+  val unknownFields: ByteString = ByteString.EMPTY
+) : Message<RedactedRequired, RedactedRequired.Builder>(ADAPTER, unknownFields) {
   @Deprecated(
-      message = "Shouldn't be used in Kotlin",
-      level = DeprecationLevel.HIDDEN
+    message = "Shouldn't be used in Kotlin",
+    level = DeprecationLevel.HIDDEN
   )
   override fun newBuilder(): Builder = Builder(this.copy())
 
@@ -34,8 +39,9 @@ data class RedactedRequired(@field:WireField(tag = 1, adapter =
     append(")")
   }
 
-  class Builder(private val message: RedactedRequired) : Message.Builder<RedactedRequired,
-      Builder>() {
+  class Builder(
+    private val message: RedactedRequired
+  ) : Message.Builder<RedactedRequired, Builder>() {
     override fun build(): RedactedRequired = message
   }
 


### PR DESCRIPTION
`.` doesn't match line separators by default, `DOT_MATCHES_ALL` changes this behavior. But since this makes the regex less restrictive, and `*` quantifier is greedy by default, it will now match the last `val` it can find. Switched to using reluctant quantifiers to make sure the closest `val` to `@field:WireField` is matched.