### PR TITLE
Don't apply gradle-maven-publish-plugin to :japicmp

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -129,7 +129,7 @@ subprojects { project ->
     configurations.archives.artifacts.removeAll { it.file =~ 'tar' || it.file =~ 'zip' }
   }
 
-  if (project.name != 'wire-runtime') {
+  if (project.name != 'wire-runtime' && project.name != 'japicmp') {
     apply plugin: 'com.vanniktech.maven.publish'
   }
   apply plugin: 'checkstyle'


### PR DESCRIPTION
Since `:japicmp` is a submodule of `:wire-runtime` applying the plugin to it somehow applied it to `:wire-runtime` causing conflicts between modules when publishing. 