### PR TITLE
Support includes on coordinate dependencies.

### DIFF
--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -130,6 +130,18 @@ class WirePluginTest {
   }
 
   @Test
+  fun sourcePathMavenCoordinatesSingleFile() {
+    val fixtureRoot = File("src/test/projects/sourcepath-maven-single-file")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+        .doesNotContain("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+  }
+
+  @Test
   fun sourceTreeOneSrcDirOneFile() {
     val fixtureRoot = File("src/test/projects/sourcetree-one-srcdir-one-file")
 

--- a/wire-gradle-plugin/src/test/projects/sourcepath-maven-single-file/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/sourcepath-maven-single-file/build.gradle
@@ -1,0 +1,18 @@
+plugins {
+  id 'application'
+  id 'com.squareup.wire'
+}
+
+// See installProtoJars task in wire-gradle-plugin/build.gradle
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+}
+
+wire {
+  sourcePath {
+    srcJar 'com.squareup.wire.dinosaur:all-protos:+'
+    include 'squareup/geology/period.proto'
+  }
+}


### PR DESCRIPTION
Previously if you included a dependency by its Maven coordinates you
wouldn't benefit from includes filtering.