### PR TITLE
[wire-runtime] Explode vararg `args` before passing them to String.format

### DIFF
--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/-Platform.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/-Platform.kt
@@ -34,4 +34,4 @@ actual inline fun <K, V> MutableMap<K, V>.toUnmodifiableMap(): Map<K, V> =
     Collections.unmodifiableMap(this)
 
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
-internal actual inline fun String.format(vararg args: Any?): String = String.format(this, args)
+internal actual inline fun String.format(vararg args: Any?): String = String.format(this, *args)


### PR DESCRIPTION
Resolves https://github.com/square/wire/issues/1048