### PR TITLE
Allow using kotlin.Experimental in wire-runtime

### DIFF
--- a/wire-runtime/build.gradle
+++ b/wire-runtime/build.gradle
@@ -28,6 +28,11 @@ kotlin {
   macosX64()
   mingwX64('winX64')
   sourceSets {
+    all {
+      languageSettings {
+        useExperimentalAnnotation("kotlin.Experimental")
+      }
+    }
     commonMain {
       dependencies {
         api deps.kotlin.stdlib.common


### PR DESCRIPTION
Using `@OptionalExpectation` (required for `@Throws` that we
declare in `-Platform.kt`) requires opt in. Hopefully this will
also indicate to wire-runtime consumers that it's in experimental
state, since it's a multiplatform library.