### PR TITLE
[wire-kotlin-generator] Use NameAllocator to avoid param name clash in ADAPTER#decode

### DIFF
--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -69,11 +69,11 @@ data class Feature(
       override fun decode(reader: ProtoReader): Feature {
         var name: String? = null
         var location: Point? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> location = Point.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Feature(

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -55,10 +55,10 @@ data class FeatureDatabase(
 
       override fun decode(reader: ProtoReader): FeatureDatabase {
         val feature = mutableListOf<Feature>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> feature.add(Feature.ADAPTER.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return FeatureDatabase(

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -63,11 +63,11 @@ data class Point(
       override fun decode(reader: ProtoReader): Point {
         var latitude: Int? = null
         var longitude: Int? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> latitude = ProtoAdapter.INT32.decode(reader)
             2 -> longitude = ProtoAdapter.INT32.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Point(

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -67,11 +67,11 @@ data class Rectangle(
       override fun decode(reader: ProtoReader): Rectangle {
         var lo: Point? = null
         var hi: Point? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> lo = Point.ADAPTER.decode(reader)
             2 -> hi = Point.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Rectangle(

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -67,11 +67,11 @@ data class RouteNote(
       override fun decode(reader: ProtoReader): RouteNote {
         var location: Point? = null
         var message: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> location = Point.ADAPTER.decode(reader)
             2 -> message = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RouteNote(

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -92,13 +92,13 @@ data class RouteSummary(
         var feature_count: Int? = null
         var distance: Int? = null
         var elapsed_time: Int? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> point_count = ProtoAdapter.INT32.decode(reader)
             2 -> feature_count = ProtoAdapter.INT32.decode(reader)
             3 -> distance = ProtoAdapter.INT32.decode(reader)
             4 -> elapsed_time = ProtoAdapter.INT32.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RouteSummary(

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -193,7 +193,6 @@ class KotlinGenerator private constructor(
             newName("reader", "reader")
             newName("Builder", "Builder")
             newName("builder", "builder")
-            newName("readerTag", "readerTag")
 
             if (emitAndroid) {
               newName("CREATOR", "CREATOR")
@@ -744,7 +743,8 @@ class KotlinGenerator private constructor(
     }
 
     val decodeBlock = buildCodeBlock {
-      val readerTagParamName = nameAllocator["readerTag"]
+      val decodeNameAllocator = nameAllocator.copy().apply { newName("readerTag", "readerTag") }
+      val readerTagParamName = decodeNameAllocator["readerTag"]
 
       addStatement("val unknownFields = reader.forEachTag { $readerTagParamName ->")
       addStatement("⇥when ($readerTagParamName) {⇥")

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -193,6 +193,7 @@ class KotlinGenerator private constructor(
             newName("reader", "reader")
             newName("Builder", "Builder")
             newName("builder", "builder")
+            newName("readerTag", "readerTag")
 
             if (emitAndroid) {
               newName("CREATOR", "CREATOR")
@@ -743,8 +744,10 @@ class KotlinGenerator private constructor(
     }
 
     val decodeBlock = buildCodeBlock {
-      addStatement("val unknownFields = reader.forEachTag { tag ->")
-      addStatement("⇥when (tag) {⇥")
+      val readerTagParamName = nameAllocator["readerTag"]
+
+      addStatement("val unknownFields = reader.forEachTag { $readerTagParamName ->")
+      addStatement("⇥when ($readerTagParamName) {⇥")
 
       message.fieldsAndOneOfFields().forEach { field ->
         val fieldName = nameAllocator[field]
@@ -758,7 +761,7 @@ class KotlinGenerator private constructor(
 
         addStatement(decodeBodyTemplate, field.tag(), fieldName, adapterName)
       }
-      addStatement("else -> reader.readUnknownField(tag)")
+      addStatement("else -> reader.readUnknownField($readerTagParamName)")
       add("⇤}\n⇤}\n") // close the block
     }
 

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -421,10 +421,10 @@ class KotlinGeneratorTest {
         |  required float readerTag = 1;
         |}""".trimMargin())
     val code = repoBuilder.generateKotlin("Message")
-    assertTrue(code.contains("val unknownFields = reader.forEachTag { readerTag ->"))
-    assertTrue(code.contains("when (readerTag)"))
-    assertTrue(code.contains("1 -> readerTag_ = ProtoAdapter.FLOAT.decode(reader)"))
-    assertTrue(code.contains("else -> reader.readUnknownField(readerTag)"))
+    assertTrue(code.contains("val unknownFields = reader.forEachTag { readerTag_ ->"))
+    assertTrue(code.contains("when (readerTag_)"))
+    assertTrue(code.contains("1 -> readerTag = ProtoAdapter.FLOAT.decode(reader)"))
+    assertTrue(code.contains("else -> reader.readUnknownField(readerTag_)"))
   }
 
   companion object {

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -414,6 +414,19 @@ class KotlinGeneratorTest {
         repoBuilder.generateGrpcKotlin("routeguide.RouteGuide", "RouteChat"))
   }
 
+  @Test fun nameAllocatorIsUsedInDecodeForReaderTag() {
+    val repoBuilder = RepoBuilder()
+        .add("message.proto", """
+        |message Message {
+        |  required float readerTag = 1;
+        |}""".trimMargin())
+    val code = repoBuilder.generateKotlin("Message")
+    assertTrue(code.contains("val unknownFields = reader.forEachTag { readerTag ->"))
+    assertTrue(code.contains("when (readerTag)"))
+    assertTrue(code.contains("1 -> readerTag_ = ProtoAdapter.FLOAT.decode(reader)"))
+    assertTrue(code.contains("else -> reader.readUnknownField(readerTag)"))
+  }
+
   companion object {
     private val pointMessage = """
           |message Point {

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/javainteropkotlin/Person.kt
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/javainteropkotlin/Person.kt
@@ -156,13 +156,13 @@ data class Person(
         var id: Int? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Person(
@@ -297,11 +297,11 @@ data class Person(
         override fun decode(reader: ProtoReader): PhoneNumber {
           var number: String? = null
           var type: PhoneType? = null
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
               1 -> number = ProtoAdapter.STRING.decode(reader)
               2 -> type = PhoneType.ADAPTER.decode(reader)
-              else -> reader.readUnknownField(tag)
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return PhoneNumber(

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/kotlin/Person.kt
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/kotlin/Person.kt
@@ -98,13 +98,13 @@ data class Person(
         var id: Int? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Person(
@@ -207,11 +207,11 @@ data class Person(
         override fun decode(reader: ProtoReader): PhoneNumber {
           var number: String? = null
           var type: PhoneType? = null
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
               1 -> number = ProtoAdapter.STRING.decode(reader)
               2 -> type = PhoneType.ADAPTER.decode(reader)
-              else -> reader.readUnknownField(tag)
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return PhoneNumber(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -51,10 +51,10 @@ data class DeprecatedProto(
 
       override fun decode(reader: ProtoReader): DeprecatedProto {
         var foo: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> foo = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return DeprecatedProto(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt.java.interop
@@ -64,10 +64,10 @@ data class DeprecatedProto(
 
       override fun decode(reader: ProtoReader): DeprecatedProto {
         var foo: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> foo = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return DeprecatedProto(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -148,8 +148,8 @@ data class Form(
         var option_picker_element: OptionPickerElement? = null
         var detail_row_element: DetailRowElement? = null
         var currency_conversion_flags_element: CurrencyConversionFlagsElement? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> button_element = ButtonElement.ADAPTER.decode(reader)
             2 -> local_image_element = LocalImageElement.ADAPTER.decode(reader)
             3 -> remote_image_element = RemoteImageElement.ADAPTER.decode(reader)
@@ -163,7 +163,7 @@ data class Form(
             11 -> detail_row_element = DetailRowElement.ADAPTER.decode(reader)
             12 -> currency_conversion_flags_element =
                 CurrencyConversionFlagsElement.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Form(
@@ -229,9 +229,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): ButtonElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return ButtonElement(
@@ -271,9 +271,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): LocalImageElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return LocalImageElement(
@@ -313,9 +313,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): RemoteImageElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return RemoteImageElement(
@@ -355,9 +355,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): MoneyElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return MoneyElement(
@@ -397,9 +397,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): SpacerElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return SpacerElement(
@@ -439,9 +439,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): TextElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return TextElement(
@@ -482,9 +482,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): CustomizedCardElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return CustomizedCardElement(
@@ -524,9 +524,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): AddressElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return AddressElement(
@@ -566,9 +566,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): TextInputElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return TextInputElement(
@@ -608,9 +608,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): OptionPickerElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return OptionPickerElement(
@@ -650,9 +650,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): DetailRowElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return DetailRowElement(
@@ -693,9 +693,9 @@ data class Form(
         }
 
         override fun decode(reader: ProtoReader): CurrencyConversionFlagsElement {
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
-              else -> reader.readUnknownField(tag)
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return CurrencyConversionFlagsElement(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -61,11 +61,11 @@ data class MessageUsingMultipleEnums(
       override fun decode(reader: ProtoReader): MessageUsingMultipleEnums {
         var a: MessageWithStatus.Status? = null
         var b: OtherMessageWithStatus.Status? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a = MessageWithStatus.Status.ADAPTER.decode(reader)
             2 -> b = OtherMessageWithStatus.Status.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return MessageUsingMultipleEnums(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt.java.interop
@@ -83,11 +83,11 @@ data class MessageUsingMultipleEnums(
       override fun decode(reader: ProtoReader): MessageUsingMultipleEnums {
         var a: MessageWithStatus.Status? = null
         var b: OtherMessageWithStatus.Status? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a = MessageWithStatus.Status.ADAPTER.decode(reader)
             2 -> b = OtherMessageWithStatus.Status.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return MessageUsingMultipleEnums(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -43,9 +43,9 @@ data class MessageWithStatus(
       }
 
       override fun decode(reader: ProtoReader): MessageWithStatus {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return MessageWithStatus(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt.java.interop
@@ -43,9 +43,9 @@ data class MessageWithStatus(
       }
 
       override fun decode(reader: ProtoReader): MessageWithStatus {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return MessageWithStatus(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageRequest.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageRequest.kt
@@ -40,9 +40,9 @@ data class NoPackageRequest(
       }
 
       override fun decode(reader: ProtoReader): NoPackageRequest {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return NoPackageRequest(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageResponse.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoPackageResponse.kt
@@ -40,9 +40,9 @@ data class NoPackageResponse(
       }
 
       override fun decode(reader: ProtoReader): NoPackageResponse {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return NoPackageResponse(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -85,12 +85,12 @@ data class OneOfMessage(
         var foo: Int? = null
         var bar: String? = null
         var baz: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> foo = ProtoAdapter.INT32.decode(reader)
             3 -> bar = ProtoAdapter.STRING.decode(reader)
             4 -> baz = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return OneOfMessage(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt.java.interop
@@ -127,12 +127,12 @@ data class OneOfMessage(
         var foo: Int? = null
         var bar: String? = null
         var baz: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> foo = ProtoAdapter.INT32.decode(reader)
             3 -> bar = ProtoAdapter.STRING.decode(reader)
             4 -> baz = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return OneOfMessage(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -52,10 +52,10 @@ data class OptionalEnumUser(
 
       override fun decode(reader: ProtoReader): OptionalEnumUser {
         var optional_enum: OptionalEnum? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> optional_enum = OptionalEnum.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return OptionalEnumUser(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -44,9 +44,9 @@ data class OtherMessageWithStatus(
       }
 
       override fun decode(reader: ProtoReader): OtherMessageWithStatus {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return OtherMessageWithStatus(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt.java.interop
@@ -44,9 +44,9 @@ data class OtherMessageWithStatus(
       }
 
       override fun decode(reader: ProtoReader): OtherMessageWithStatus {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return OtherMessageWithStatus(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt.java.interop
@@ -67,10 +67,10 @@ data class Percents(
 
       override fun decode(reader: ProtoReader): Percents {
         var text: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> text = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Percents(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/SomeRequest.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/SomeRequest.kt
@@ -40,9 +40,9 @@ data class SomeRequest(
       }
 
       override fun decode(reader: ProtoReader): SomeRequest {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return SomeRequest(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/SomeResponse.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/SomeResponse.kt
@@ -40,9 +40,9 @@ data class SomeResponse(
       }
 
       override fun decode(reader: ProtoReader): SomeResponse {
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
-            else -> reader.readUnknownField(tag)
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return SomeResponse(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -1296,8 +1296,8 @@ data class AllTypes(
         val ext_map_string_string = mutableMapOf<String, String>()
         val ext_map_string_message = mutableMapOf<String, NestedMessage>()
         val ext_map_string_enum = mutableMapOf<String, NestedEnum>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> opt_int32 = ProtoAdapter.INT32.decode(reader)
             2 -> opt_uint32 = ProtoAdapter.UINT32.decode(reader)
             3 -> opt_sint32 = ProtoAdapter.SINT32.decode(reader)
@@ -1435,7 +1435,7 @@ data class AllTypes(
             1402 -> ext_map_string_string.putAll(ext_map_string_stringAdapter.decode(reader))
             1503 -> ext_map_string_message.putAll(ext_map_string_messageAdapter.decode(reader))
             1504 -> ext_map_string_enum.putAll(ext_map_string_enumAdapter.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return AllTypes(
@@ -1649,10 +1649,10 @@ data class AllTypes(
 
         override fun decode(reader: ProtoReader): NestedMessage {
           var a: Int? = null
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
               1 -> a = ProtoAdapter.INT32.decode(reader)
-              else -> reader.readUnknownField(tag)
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return NestedMessage(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt.java.interop
@@ -2868,8 +2868,8 @@ data class AllTypes(
         val ext_map_string_string = mutableMapOf<String, String>()
         val ext_map_string_message = mutableMapOf<String, NestedMessage>()
         val ext_map_string_enum = mutableMapOf<String, NestedEnum>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> opt_int32 = ProtoAdapter.INT32.decode(reader)
             2 -> opt_uint32 = ProtoAdapter.UINT32.decode(reader)
             3 -> opt_sint32 = ProtoAdapter.SINT32.decode(reader)
@@ -3007,7 +3007,7 @@ data class AllTypes(
             1402 -> ext_map_string_string.putAll(ext_map_string_stringAdapter.decode(reader))
             1503 -> ext_map_string_message.putAll(ext_map_string_messageAdapter.decode(reader))
             1504 -> ext_map_string_enum.putAll(ext_map_string_enumAdapter.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return AllTypes(
@@ -3236,10 +3236,10 @@ data class AllTypes(
 
         override fun decode(reader: ProtoReader): NestedMessage {
           var a: Int? = null
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
               1 -> a = ProtoAdapter.INT32.decode(reader)
-              else -> reader.readUnknownField(tag)
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return NestedMessage(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -56,10 +56,10 @@ data class Mappy(
 
       override fun decode(reader: ProtoReader): Mappy {
         val things = mutableMapOf<String, Thing>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> things.putAll(thingsAdapter.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Mappy(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt.java.interop
@@ -67,10 +67,10 @@ data class Mappy(
 
       override fun decode(reader: ProtoReader): Mappy {
         val things = mutableMapOf<String, Thing>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> things.putAll(thingsAdapter.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Mappy(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -50,10 +50,10 @@ data class Thing(
 
       override fun decode(reader: ProtoReader): Thing {
         var name: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Thing(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt.java.interop
@@ -61,10 +61,10 @@ data class Thing(
 
       override fun decode(reader: ProtoReader): Thing {
         var name: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Thing(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -98,13 +98,13 @@ data class Person(
         var id: Int? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Person(
@@ -207,11 +207,11 @@ data class Person(
         override fun decode(reader: ProtoReader): PhoneNumber {
           var number: String? = null
           var type: PhoneType? = null
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
               1 -> number = ProtoAdapter.STRING.decode(reader)
               2 -> type = PhoneType.ADAPTER.decode(reader)
-              else -> reader.readUnknownField(tag)
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return PhoneNumber(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.android
@@ -99,13 +99,13 @@ data class Person(
         var id: Int? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Person(
@@ -211,11 +211,11 @@ data class Person(
         override fun decode(reader: ProtoReader): PhoneNumber {
           var number: String? = null
           var type: PhoneType? = null
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
               1 -> number = ProtoAdapter.STRING.decode(reader)
               2 -> type = PhoneType.ADAPTER.decode(reader)
-              else -> reader.readUnknownField(tag)
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return PhoneNumber(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt.java.interop
@@ -156,13 +156,13 @@ data class Person(
         var id: Int? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Person(
@@ -297,11 +297,11 @@ data class Person(
         override fun decode(reader: ProtoReader): PhoneNumber {
           var number: String? = null
           var type: PhoneType? = null
-          val unknownFields = reader.forEachTag { tag ->
-            when (tag) {
+          val unknownFields = reader.forEachTag { readerTag ->
+            when (readerTag) {
               1 -> number = ProtoAdapter.STRING.decode(reader)
               2 -> type = PhoneType.ADAPTER.decode(reader)
-              else -> reader.readUnknownField(tag)
+              else -> reader.readUnknownField(readerTag)
             }
           }
           return PhoneNumber(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
@@ -58,11 +58,11 @@ data class NotRedacted(
       override fun decode(reader: ProtoReader): NotRedacted {
         var a: String? = null
         var b: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a = ProtoAdapter.STRING.decode(reader)
             2 -> b = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return NotRedacted(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
@@ -84,13 +84,13 @@ data class Redacted(
         var b: String? = null
         var c: String? = null
         var extension: RedactedExtension? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a = ProtoAdapter.STRING.decode(reader)
             2 -> b = ProtoAdapter.STRING.decode(reader)
             3 -> c = ProtoAdapter.STRING.decode(reader)
             10 -> extension = RedactedExtension.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return Redacted(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
@@ -66,12 +66,12 @@ data class RedactedChild(
         var a: String? = null
         var b: Redacted? = null
         var c: NotRedacted? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a = ProtoAdapter.STRING.decode(reader)
             2 -> b = Redacted.ADAPTER.decode(reader)
             3 -> c = NotRedacted.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedChild(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
@@ -49,10 +49,10 @@ data class RedactedCycleA(
 
       override fun decode(reader: ProtoReader): RedactedCycleA {
         var b: RedactedCycleB? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> b = RedactedCycleB.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedCycleA(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
@@ -49,10 +49,10 @@ data class RedactedCycleB(
 
       override fun decode(reader: ProtoReader): RedactedCycleB {
         var a: RedactedCycleA? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a = RedactedCycleA.ADAPTER.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedCycleB(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
@@ -66,11 +66,11 @@ data class RedactedExtension(
       override fun decode(reader: ProtoReader): RedactedExtension {
         var d: String? = null
         var e: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> d = ProtoAdapter.STRING.decode(reader)
             2 -> e = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedExtension(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -73,11 +73,11 @@ data class RedactedOneOf(
       override fun decode(reader: ProtoReader): RedactedOneOf {
         var b: Int? = null
         var c: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> b = ProtoAdapter.INT32.decode(reader)
             2 -> c = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedOneOf(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt.java.interop
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt.java.interop
@@ -95,11 +95,11 @@ data class RedactedOneOf(
       override fun decode(reader: ProtoReader): RedactedOneOf {
         var b: Int? = null
         var c: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> b = ProtoAdapter.INT32.decode(reader)
             2 -> c = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedOneOf(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -73,11 +73,11 @@ data class RedactedRepeated(
       override fun decode(reader: ProtoReader): RedactedRepeated {
         val a = mutableListOf<String>()
         val b = mutableListOf<Redacted>()
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a.add(ProtoAdapter.STRING.decode(reader))
             2 -> b.add(Redacted.ADAPTER.decode(reader))
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedRepeated(

--- a/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
+++ b/wire-tests/src/jvmTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
@@ -60,10 +60,10 @@ data class RedactedRequired(
 
       override fun decode(reader: ProtoReader): RedactedRequired {
         var a: String? = null
-        val unknownFields = reader.forEachTag { tag ->
-          when (tag) {
+        val unknownFields = reader.forEachTag { readerTag ->
+          when (readerTag) {
             1 -> a = ProtoAdapter.STRING.decode(reader)
-            else -> reader.readUnknownField(tag)
+            else -> reader.readUnknownField(readerTag)
           }
         }
         return RedactedRequired(


### PR DESCRIPTION
Resolves #1060