### PR TITLE
Workaround for generated annotation on java9+

### DIFF
--- a/wire-grpc-tests/build.gradle
+++ b/wire-grpc-tests/build.gradle
@@ -58,6 +58,11 @@ dependencies {
   implementation project(':wire-grpc')
   implementation project(':wire-grpc-client')
   implementation deps.okio.jvm
+  if (JavaVersion.current().isJava9Compatible()) {
+    // Workaround for @javax.annotation.Generated
+    // see: https://github.com/grpc/grpc-java/issues/3633
+    implementation 'javax.annotation:javax.annotation-api:1.3.1'
+  }
   compileOnly deps.android
   testImplementation deps.junit
   testImplementation deps.assertj


### PR DESCRIPTION
kind of fixes #1003

It doesn't look like the proto team fixed it. We are using it only in tests so I think that's enough for now.