### PR TITLE
Fix a bug where protopath maven resources weren't working

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -131,10 +131,13 @@ open class WireTask : SourceTask() {
     }
 
     val includes = dependencyToIncludes[dependency]
-        ?: return listOf(Location.get(path))
 
-    return includes.map {
-      include -> Location.get(base = path, path = include)
+    if (includes == null || includes.isEmpty()) {
+      return listOf(Location.get(path))
+    }
+
+    return includes.map { include ->
+      Location.get(base = path, path = include)
     }
   }
 }

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -242,6 +242,20 @@ class WirePluginTest {
   }
 
   @Test
+  fun protoPathMavenCoordinates() {
+    val fixtureRoot = File("src/test/projects/protopath-maven")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+        .doesNotContain("Writing com.squareup.dinosaurs.Dinosaur")
+        .doesNotContain("Writing com.squareup.geology.Period")
+        .contains("Writing com.squareup.dinosaurs.Dig")
+        .contains("src/test/projects/protopath-maven/build/generated/src/main/java")
+  }
+
+  @Test
   fun differentJavaOutputDir() {
     val fixtureRoot = File("src/test/projects/different-java-out")
 

--- a/wire-gradle-plugin/src/test/projects/protopath-maven/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/protopath-maven/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'application'
+  id 'com.squareup.wire'
+}
+
+// See installProtoJars task in wire-gradle-plugin/build.gradle
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+}
+
+wire {
+  protoPath {
+    srcJar 'com.squareup.wire.dinosaur:all-protos:+'
+  }
+  sourcePath {
+    srcDir 'src/main/proto'
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/protopath-maven/src/main/proto/squareup/dinosaurs/dig.proto
+++ b/wire-gradle-plugin/src/test/projects/protopath-maven/src/main/proto/squareup/dinosaurs/dig.proto
@@ -1,0 +1,14 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+import "squareup/dinosaurs/dinosaur.proto";
+
+message Dig {
+  optional string location = 1;
+  optional squareup.geology.Period artifact_period = 2;
+  repeated squareup.dinosaurs.Dinosaur dinosaurs = 3;
+}


### PR DESCRIPTION
We were resolving the includes to an empty list, which caused it to
return zero locations instead of a location of the entire jar file.