### PR TITLE
Use wire-runtime as api dependency in wire-grpc

### DIFF
--- a/wire-grpc/build.gradle
+++ b/wire-grpc/build.gradle
@@ -14,7 +14,7 @@ animalsniffer {
 }
 
 dependencies {
-  implementation project(':wire-runtime')
+  api project(':wire-runtime')
   api deps.okio.jvm
   api deps.kotlin.stdlib.jdk8
 }


### PR DESCRIPTION
Both `GrpcReader` and `GrpcWriter` have `ProtoAdapter` params in their public constructors.