### PR TITLE
Change the Gradle plugin to track targets as a list

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
@@ -22,7 +22,6 @@ import org.gradle.api.internal.file.SourceDirectorySetFactory
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
-import javax.inject.Inject
 
 open class WireExtension(
   project: Project,
@@ -68,21 +67,9 @@ open class WireExtension(
   @get:Optional
   var rules: String? = null
 
-  /**
-   * Defines java-specific settings for [com.squareup.wire.schema.WireRun.targets]
-   * Maps to [com.squareup.wire.schema.Target.JavaTarget]
-   */
+  /** Specified what types to output where. Maps to [com.squareup.wire.schema.Target] */
   @get:Input
-  @get:Optional
-  var javaTarget: JavaTarget? = null
-
-  /**
-   * Defines kotlin-specific settings for [com.squareup.wire.schema.WireRun.targets]
-   * Maps to [com.squareup.wire.schema.Target.KotlinTarget]
-   */
-  @get:Input
-  @get:Optional
-  var kotlinTarget: KotlinTarget? = null
+  val outputs = mutableListOf<WireOutput>()
 
   @InputFiles
   @Optional
@@ -174,14 +161,16 @@ open class WireExtension(
     }
   }
 
-  fun java(action: Action<JavaTarget>) {
-    javaTarget = objectFactory.newInstance(JavaTarget::class.java)
-    action.execute(javaTarget!!)
+  fun java(action: Action<JavaOutput>) {
+    val javaOutput = objectFactory.newInstance(JavaOutput::class.java)!!
+    action.execute(javaOutput)
+    outputs += javaOutput
   }
 
-  fun kotlin(action: Action<KotlinTarget>) {
-    kotlinTarget = objectFactory.newInstance(KotlinTarget::class.java)
-    action.execute(kotlinTarget!!)
+  fun kotlin(action: Action<KotlinOutput>) {
+    val kotlinOutput = objectFactory.newInstance(KotlinOutput::class.java)!!
+    action.execute(kotlinOutput)
+    outputs += kotlinOutput
   }
 
   open class ProtoRootSet {
@@ -204,22 +193,5 @@ open class WireExtension(
     fun include(vararg includePaths: String) {
       includes += includePaths
     }
-  }
-
-  open class JavaTarget @Inject constructor() {
-    var elements: List<String>? = null
-    var out: String? = null
-    var android: Boolean = false
-    var androidAnnotations: Boolean = false
-    var compact: Boolean = false
-  }
-
-  open class KotlinTarget @Inject constructor() {
-    var out: String? = null
-    var elements: List<String>? = null
-    var android: Boolean = false
-    var javaInterop: Boolean = false
-    var blockingServices: Boolean = false
-    var singleMethodServices: Boolean = false
   }
 }

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.gradle
+
+import com.squareup.wire.schema.Target
+import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetContainer
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.compile.JavaCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import javax.inject.Inject
+
+/**
+ * Specifies Wire's outputs (expressed as a list of [Target] objects) using Gradle's DSL (expressed
+ * as destination directories and configuration options). This includes registering output
+ * directories with the project so they can be compiled after they are generated.
+ */
+abstract class WireOutput {
+  /** This will be set to a non-null value before [toTarget] is invoked. */
+  var out: String? = null
+
+  /** Create a target for the WireCompiler to use when emitting sources. */
+  abstract fun toTarget(): Target
+
+  /** Configure the project's graph to compile the files emitted. */
+  abstract fun applyToProject(
+    project: Project,
+    wireTask: TaskProvider<WireTask>?,
+    kotlin: Boolean
+  )
+}
+
+open class JavaOutput @Inject constructor() : WireOutput() {
+  var elements: List<String>? = null
+  var android: Boolean = false
+  var androidAnnotations: Boolean = false
+  var compact: Boolean = false
+
+  override fun toTarget(): Target {
+    return Target.JavaTarget(
+        elements = elements ?: listOf("*"),
+        outDirectory = out!!,
+        android = android,
+        androidAnnotations = androidAnnotations,
+        compact = compact
+    )
+  }
+
+  override fun applyToProject(
+    project: Project,
+    wireTask: TaskProvider<WireTask>?,
+    kotlin: Boolean
+  ) {
+    val compileJavaTask = project.tasks.named("compileJava") as TaskProvider<JavaCompile>
+    compileJavaTask.configure {
+      it.source(out)
+      it.dependsOn(wireTask)
+    }
+    if (kotlin) {
+      val sourceSetContainer = project.property("sourceSets") as SourceSetContainer
+      val mainSourceSet = sourceSetContainer.getByName("main") as SourceSet
+      mainSourceSet.java.srcDirs(out)
+
+      val compileKotlinTask = project.tasks.named("compileKotlin") as TaskProvider<KotlinCompile>
+      compileKotlinTask.configure {
+        it.dependsOn(wireTask)
+      }
+    }
+  }
+}
+
+open class KotlinOutput @Inject constructor() : WireOutput() {
+  var elements: List<String>? = null
+  var android: Boolean = false
+  var javaInterop: Boolean = false
+  var blockingServices: Boolean = false
+  var singleMethodServices: Boolean = false
+
+  override fun toTarget(): Target.KotlinTarget {
+    return Target.KotlinTarget(
+        elements = elements ?: listOf("*"),
+        outDirectory = out!!,
+        android = android,
+        javaInterop = javaInterop,
+        blockingServices = blockingServices,
+        singleMethodServices = singleMethodServices
+    )
+  }
+
+  override fun applyToProject(
+    project: Project,
+    wireTask: TaskProvider<WireTask>?,
+    kotlin: Boolean
+  ) {
+    val compileKotlinTasks = project.tasks.withType(KotlinCompile::class.java)
+    check(compileKotlinTasks.isNotEmpty()) {
+      "To generate Kotlin protos, please apply a Kotlin plugin."
+    }
+    compileKotlinTasks.configureEach {
+      it.source(out)
+      it.dependsOn(wireTask)
+    }
+  }
+}

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -301,7 +301,7 @@ class WirePluginTest {
         .doesNotContain("Writing com.squareup.geology.Period")
 
     val generatedProto =
-      File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
     assertThat(generatedProto).exists()
 
     val generatedProtoSource = generatedProto.readText()
@@ -339,7 +339,7 @@ class WirePluginTest {
         .contains("Writing com.squareup.geology.Period")
 
     val generatedProto =
-      File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
     assertThat(generatedProto).exists()
 
     assertThat(generatedProto.readText()).doesNotContain("val name")
@@ -374,7 +374,7 @@ class WirePluginTest {
         .doesNotContain("Writing com.squareup.geology.Period")
 
     val generatedProto =
-      File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
     assertThat(generatedProto).exists()
 
     val generatedProtoSource = generatedProto.readText()
@@ -393,7 +393,7 @@ class WirePluginTest {
         .contains("Writing com.squareup.geology.Period")
 
     val generatedProto =
-      File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
+        File(fixtureRoot, "build/generated/src/main/java/com/squareup/dinosaurs/Dinosaur.kt")
     assertThat(generatedProto).exists()
 
     assertThat(generatedProto.readText()).doesNotContain("val name")
@@ -500,6 +500,44 @@ class WirePluginTest {
         .contains(
             "src/test/projects/sourcepath-and-protopath-intersect/build/generated/src/main/java"
         )
+  }
+
+  @Test
+  fun emitJavaThenEmitKotlin() {
+    val fixtureRoot = File("src/test/projects/emit-java-then-emit-kotlin")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    val task = result.task(":generateProtos")
+    assertThat(task).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+
+    val outputRoot = File(fixtureRoot, "build/generated/src/main/java")
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/Dinosaur.java")).exists()
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/Dinosaur.kt")).doesNotExist()
+    assertThat(File(outputRoot, "com/squareup/geology/Period.kt")).exists()
+    assertThat(File(outputRoot, "com/squareup/geology/Period.java")).doesNotExist()
+  }
+
+  @Test
+  fun emitKotlinThenEmitJava() {
+    val fixtureRoot = File("src/test/projects/emit-kotlin-then-emit-java")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    val task = result.task(":generateProtos")
+    assertThat(task).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+
+    val outputRoot = File(fixtureRoot, "build/generated/src/main/java")
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/Dinosaur.kt")).exists()
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/Dinosaur.java")).doesNotExist()
+    assertThat(File(outputRoot, "com/squareup/geology/Period.java")).exists()
+    assertThat(File(outputRoot, "com/squareup/geology/Period.kt")).doesNotExist()
   }
 
   private fun fieldsFromProtoSource(generatedProtoSource: String): List<String> {

--- a/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  java {
+    // Java gets the named types only.
+    elements = ['squareup.dinosaurs.Dinosaur']
+  }
+  kotlin {
+    // Kotlin gets everything else.
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/build.gradle
@@ -1,0 +1,15 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  kotlin {
+    // Kotlin gets the named types only.
+    elements = ['squareup.dinosaurs.Dinosaur']
+  }
+  java {
+    // Java gets everything else.
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
This way we can allowlist the targets for one language and the other language
gets everything else. The order matters.