### PR TITLE
Honor Java package names in Wire gRPC services

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -163,7 +163,8 @@ data class WireRun(
         servicesToHandle += protoFile.services()
       }
     }
-    for (target in targets) {
+    val targetsExclusiveLast = targets.sortedBy { it.exclusive }
+    for (target in targetsExclusiveLast) {
       val schemaHandler = target.newHandler(schema, fs, logger)
 
       val identifierSet = IdentifierSet.Builder()
@@ -176,7 +177,7 @@ data class WireRun(
         if (identifierSet.includes(type.type())) {
           schemaHandler.handle(type)
           // We don't let other targets handle this one.
-          i.remove()
+          if (target.exclusive) i.remove()
         }
       }
 
@@ -186,7 +187,7 @@ data class WireRun(
         if (identifierSet.includes(service.type())) {
           schemaHandler.handle(service)
           // We don't let other targets handle this one.
-          j.remove()
+          if (target.exclusive) j.remove()
         }
       }
 

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -274,6 +274,30 @@ class WireRunTest {
         "generated/kt/com/squareup/polygons/Rhombus.kt")
   }
 
+  @Test
+  fun nonExclusiveTypeEmittedTwice() {
+    writeSquareProto()
+    writeRhombusProto()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(Location.get("polygons/src/main/proto")),
+        targets = listOf(
+            Target.JavaTarget(
+                outDirectory = "generated/java"),
+            Target.KotlinTarget(
+                outDirectory = "generated/kt",
+                exclusive = false,
+                elements = listOf("squareup.polygons.Square"))
+        )
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.find("generated")).containsExactlyInAnyOrder(
+        "generated/java/com/squareup/polygons/Square.java",
+        "generated/java/com/squareup/polygons/Rhombus.java",
+        "generated/kt/com/squareup/polygons/Square.kt")
+  }
+
   private fun writeRedProto() {
     fs.add("colors/src/main/proto/squareup/colors/red.proto", """
           |syntax = "proto2";

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -46,6 +46,7 @@ abstract class WireOutput {
 
 open class JavaOutput @Inject constructor() : WireOutput() {
   var elements: List<String>? = null
+  var exclusive: Boolean = true
   var android: Boolean = false
   var androidAnnotations: Boolean = false
   var compact: Boolean = false
@@ -53,6 +54,7 @@ open class JavaOutput @Inject constructor() : WireOutput() {
   override fun toTarget(): Target {
     return Target.JavaTarget(
         elements = elements ?: listOf("*"),
+        exclusive = exclusive,
         outDirectory = out!!,
         android = android,
         androidAnnotations = androidAnnotations,
@@ -85,6 +87,7 @@ open class JavaOutput @Inject constructor() : WireOutput() {
 
 open class KotlinOutput @Inject constructor() : WireOutput() {
   var elements: List<String>? = null
+  var exclusive: Boolean = true
   var android: Boolean = false
   var javaInterop: Boolean = false
   var blockingServices: Boolean = false
@@ -93,6 +96,7 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
   override fun toTarget(): Target.KotlinTarget {
     return Target.KotlinTarget(
         elements = elements ?: listOf("*"),
+        exclusive = exclusive,
         outDirectory = out!!,
         android = android,
         javaInterop = javaInterop,

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -540,6 +540,58 @@ class WirePluginTest {
     assertThat(File(outputRoot, "com/squareup/geology/Period.kt")).doesNotExist()
   }
 
+  @Test
+  fun emitKotlinAndEmitJava() {
+    val fixtureRoot = File("src/test/projects/emit-kotlin-and-emit-java")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    val task = result.task(":generateProtos")
+    assertThat(task).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.Dinosaur")
+        .contains("Writing com.squareup.geology.Period")
+
+    val outputRoot = File(fixtureRoot, "build/generated/src/main/java")
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/Dinosaur.kt")).exists()
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/Dinosaur.java")).exists()
+    assertThat(File(outputRoot, "com/squareup/geology/Period.java")).exists()
+    assertThat(File(outputRoot, "com/squareup/geology/Period.kt")).doesNotExist()
+  }
+
+  @Test
+  fun emitService() {
+    val fixtureRoot = File("src/test/projects/emit-service")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    val task = result.task(":generateProtos")
+    assertThat(task).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.BattleService")
+
+    val outputRoot = File(fixtureRoot, "build/generated/src/main/java")
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/BattleService.kt")).exists()
+  }
+
+  @Test
+  fun emitServiceTwoWays() {
+    val fixtureRoot = File("src/test/projects/emit-service-two-ways")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    val task = result.task(":generateProtos")
+    assertThat(task).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.BattleServiceFight")
+        .contains("Writing com.squareup.dinosaurs.BattleServiceBrawl")
+
+    val outputRoot = File(fixtureRoot, "build/generated/src/main/java")
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/BattleService.kt")).exists()
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/BattleServiceFight.kt")).exists()
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/BattleServiceBrawl.kt")).exists()
+  }
+
   private fun fieldsFromProtoSource(generatedProtoSource: String): List<String> {
     val protoFieldPattern = "@field:WireField.*?(val .*?):"
     val matchedFields = protoFieldPattern.toRegex(setOf(MULTILINE, DOT_MATCHES_ALL))

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  kotlin {
+    // Kotlin gets the named types only.
+    elements = ['squareup.dinosaurs.Dinosaur']
+  }
+  java {
+    // Java gets everything.
+    exclusive = false
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service-two-ways/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-service-two-ways/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  // Blocking Server API.
+  kotlin {
+    exclusive = false
+    singleMethodServices = true
+    blockingServices = true
+  }
+  // Coroutines Client API.
+  kotlin {
+    exclusive = false
+    singleMethodServices = false
+    blockingServices = false
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service-two-ways/src/main/proto/squareup/dinosaurs/battle.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-service-two-ways/src/main/proto/squareup/dinosaurs/battle.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/dinosaurs/dinosaur.proto";
+
+service BattleService {
+  rpc Fight(Dinosaur) returns (Dinosaur) {}
+  rpc Brawl(stream Dinosaur) returns (stream Dinosaur) {}
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service-two-ways/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-service-two-ways/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service-two-ways/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-service-two-ways/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-service/build.gradle
@@ -1,0 +1,10 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  kotlin {
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service/src/main/proto/squareup/dinosaurs/battle.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-service/src/main/proto/squareup/dinosaurs/battle.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/dinosaurs/dinosaur.proto";
+
+service BattleService {
+  rpc Fight(Dinosaur) returns (Dinosaur) {}
+  rpc Brawl(stream Dinosaur) returns (stream Dinosaur) {}
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-service/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-service/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-service/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -96,6 +96,11 @@ class KotlinGenerator private constructor(
   fun generatedTypeName(type: Type) = type.typeName
   /** Returns the full name of the class generated for [service].  */
   fun generatedServiceName(service: Service) = service.serviceName
+  /** Returns the full name of the class generated for [service]#[rpc].  */
+  fun generatedServiceRpcName(service: Service, rpc: Rpc): ClassName {
+    val typeName = service.serviceName
+    return typeName.peerClass(typeName.simpleName + rpc.name())
+  }
 
   fun generateType(type: Type): TypeSpec = when (type) {
     is MessageType -> generateMessage(type)
@@ -110,8 +115,8 @@ class KotlinGenerator private constructor(
    */
   fun generateService(service: Service, rpc: Rpc? = null): TypeSpec {
     val (interfaceName, rpcs) =
-        if (rpc == null) service.name() to service.rpcs()
-        else service.name() + rpc.name() to listOf(rpc)
+        if (rpc == null) generatedServiceName(service) to service.rpcs()
+        else generatedServiceRpcName(service, rpc) to listOf(rpc)
 
     val superinterface = com.squareup.wire.Service::class.java
 

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -163,6 +163,39 @@ class KotlinGeneratorTest {
     assertEquals(expected, repoBuilder.generateGrpcKotlin("routeguide.RouteGuide", blockingServices = true))
   }
 
+  @Test fun javaPackageOption() {
+    // Note that the @WireRpc path does not use the Java package option.
+    val expected = """
+          |package com.squareup.routeguide
+          |
+          |import com.squareup.wire.Service
+          |import com.squareup.wire.WireRpc
+          |
+          |interface RouteGuide : Service {
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER"
+          |  )
+          |  fun GetFeature(request: Point): Feature
+          |}
+          |""".trimMargin()
+
+    val repoBuilder = RepoBuilder()
+        .add("routeguide.proto", """
+          |package routeguide;
+          |
+          |option java_package = "com.squareup.routeguide";
+          |
+          |service RouteGuide {
+          |  rpc GetFeature(Point) returns (Feature) {}
+          |}
+          |$pointMessage
+          |$featureMessage
+          |""".trimMargin())
+    assertEquals(expected, repoBuilder.generateGrpcKotlin("routeguide.RouteGuide", blockingServices = true))
+  }
+
   @Test fun noPackage() {
     val expected = """
           |import com.squareup.wire.Service

--- a/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.kt
+++ b/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.kt
@@ -101,16 +101,20 @@ class RepoBuilder {
     }
     val type = schema.getType(typeName)
     val typeSpec = javaGenerator.generateType(type)
-    val typeName1 = javaGenerator.generatedTypeName(type)
-    return JavaFile.builder(typeName1.packageName(), typeSpec).build().toString()
+    val packageName = javaGenerator.generatedTypeName(type).packageName()
+    val javaFile = JavaFile.builder(packageName, typeSpec)
+        .build()
+    return javaFile.toString()
   }
 
   fun generateKotlin(typeName: String): String {
     val schema = schema()
     val kotlinGenerator =
         KotlinGenerator(schema, emitAndroid = false, javaInterop = false, blockingServices = false)
-    val typeSpec = kotlinGenerator.generateType(schema.getType(typeName))
-    val fileSpec = FileSpec.builder("", "_")
+    val type = schema.getType(typeName)
+    val typeSpec = kotlinGenerator.generateType(type)
+    val packageName = kotlinGenerator.generatedTypeName(type).packageName
+    val fileSpec = FileSpec.builder(packageName, "_")
         .addType(typeSpec)
         .addImport("com.squareup.wire.kotlin", "decodeMessage")
         .build()
@@ -128,8 +132,8 @@ class RepoBuilder {
     val service = schema.getService(serviceName)
     val rpc = rpcName?.let { service.rpc(rpcName)!! }
     val typeSpec = grpcGenerator.generateService(service, rpc)
-    val packageName = service.type().enclosingTypeOrPackage()
-    val fileSpec = FileSpec.builder(packageName ?: "", "_")
+    val packageName = grpcGenerator.generatedServiceName(service).packageName
+    val fileSpec = FileSpec.builder(packageName, "_")
         .addType(typeSpec)
         .build()
     return fileSpec.toString()


### PR DESCRIPTION
Also add support for non-exclusive targets. This can be used to
emit a service both as a client and as a server in a single run