### PR TITLE
Includes and Excludes for Wire targets

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -29,13 +29,22 @@ import java.nio.file.FileSystem
 
 sealed class Target {
   /**
-   * Proto types to generate sources for with this target. Types included here will be generated
-   * for this target and not for subsequent targets in the task.
+   * Proto types to include generated sources for. Types listed here will be generated for this
+   * target and not for subsequent targets in the task.
    *
    * This list should contain package names (suffixed with `.*`) and type names only. It should
    * not contain member names.
    */
-  abstract val elements: List<String>
+  abstract val includes: List<String>
+
+  /**
+   * Proto types to excluded generated sources for. Types listed here will not be generated for this
+   * target.
+   *
+   * This list should contain package names (suffixed with `.*`) and type names only. It should
+   * not contain member names.
+   */
+  abstract val excludes: List<String>
 
   /**
    * True if types emitted for this target should not also be emitted for other targets. Use this
@@ -51,7 +60,8 @@ sealed class Target {
 
   /** Generate `.java` sources. */
   data class JavaTarget(
-    override val elements: List<String> = listOf("*"),
+    override val includes: List<String> = listOf("*"),
+    override val excludes: List<String> = listOf(),
 
     override val exclusive: Boolean = true,
 
@@ -114,7 +124,8 @@ sealed class Target {
 
   /** Generate `.kt` sources. */
   data class KotlinTarget(
-    override val elements: List<String> = listOf("*"),
+    override val includes: List<String> = listOf("*"),
+    override val excludes: List<String> = listOf(),
 
     override val exclusive: Boolean = true,
 
@@ -205,7 +216,8 @@ sealed class Target {
 
   /** Omit code generation for these sources. Use this for a dry-run. */
   data class NullTarget(
-    override val elements: List<String> = listOf("*")
+    override val includes: List<String> = listOf("*"),
+    override val excludes: List<String> = listOf()
   ) : Target() {
     override val exclusive: Boolean = true
 

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -152,7 +152,7 @@ class WireRunTest {
         targets = listOf(
             Target.KotlinTarget(
                 outDirectory = "generated/kt",
-                elements = listOf("squareup.colors.Blue")),
+                includes = listOf("squareup.colors.Blue")),
             Target.JavaTarget(
                 outDirectory = "generated/java")
         )
@@ -180,7 +180,7 @@ class WireRunTest {
         targets = listOf(
             Target.JavaTarget(
                 outDirectory = "generated/java",
-                elements = listOf("squareup.colors.Blue")),
+                includes = listOf("squareup.colors.Blue")),
             Target.KotlinTarget(
                 outDirectory = "generated/kt")
         )
@@ -194,6 +194,72 @@ class WireRunTest {
         .contains("public final class Blue extends Message")
     assertThat(fs.get("generated/kt/squareup/colors/Red.kt"))
         .contains("data class Red")
+  }
+
+  @Test
+  fun excludesTypeName() {
+    writeBlueProto()
+    writeRedProto()
+    writeTriangleProto()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(
+            Location.get("colors/src/main/proto"),
+            Location.get("polygons/src/main/proto")
+        ),
+        targets = listOf(
+            Target.KotlinTarget(
+                outDirectory = "generated/kt",
+                excludes = listOf("squareup.colors.Red")),
+            Target.JavaTarget(
+                outDirectory = "generated/java")
+        )
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.find("generated")).containsExactlyInAnyOrder(
+        "generated/kt/squareup/colors/Blue.kt",
+        "generated/java/squareup/colors/Red.java",
+        "generated/kt/squareup/polygons/Triangle.kt")
+    assertThat(fs.get("generated/kt/squareup/colors/Blue.kt"))
+        .contains("data class Blue")
+    assertThat(fs.get("generated/java/squareup/colors/Red.java"))
+        .contains("public final class Red extends Message")
+    assertThat(fs.get("generated/kt/squareup/polygons/Triangle.kt"))
+        .contains("data class Triangle")
+  }
+
+  @Test
+  fun excludesWildcard() {
+    writeBlueProto()
+    writeRedProto()
+    writeTriangleProto()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(
+            Location.get("colors/src/main/proto"),
+            Location.get("polygons/src/main/proto")
+        ),
+        targets = listOf(
+            Target.KotlinTarget(
+                outDirectory = "generated/kt",
+                excludes = listOf("squareup.colors.*")),
+            Target.JavaTarget(
+                outDirectory = "generated/java")
+        )
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.find("generated")).containsExactlyInAnyOrder(
+        "generated/java/squareup/colors/Blue.java",
+        "generated/java/squareup/colors/Red.java",
+        "generated/kt/squareup/polygons/Triangle.kt")
+    assertThat(fs.get("generated/java/squareup/colors/Blue.java"))
+        .contains("public final class Blue extends Message")
+    assertThat(fs.get("generated/java/squareup/colors/Red.java"))
+        .contains("public final class Red extends Message")
+    assertThat(fs.get("generated/kt/squareup/polygons/Triangle.kt"))
+        .contains("data class Triangle")
   }
 
   @Test
@@ -242,7 +308,7 @@ class WireRunTest {
         sourcePath = listOf(Location.get("colors/src/main/proto")),
         protoPath = listOf(Location.get("polygons/src/main/proto")),
         targets = listOf(
-            Target.NullTarget(elements = listOf("squareup.colors.Red")),
+            Target.NullTarget(includes = listOf("squareup.colors.Red")),
             Target.KotlinTarget(outDirectory = "generated/kt")
         )
     )
@@ -262,7 +328,7 @@ class WireRunTest {
         targets = listOf(
             Target.JavaTarget(
                 outDirectory = "generated/java",
-                elements = listOf("squareup.polygons.Square")),
+                includes = listOf("squareup.polygons.Square")),
             Target.KotlinTarget(
                 outDirectory = "generated/kt")
         )
@@ -287,7 +353,7 @@ class WireRunTest {
             Target.KotlinTarget(
                 outDirectory = "generated/kt",
                 exclusive = false,
-                elements = listOf("squareup.polygons.Square"))
+                includes = listOf("squareup.polygons.Square"))
         )
     )
     wireRun.execute(fs, logger)

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -45,7 +45,8 @@ abstract class WireOutput {
 }
 
 open class JavaOutput @Inject constructor() : WireOutput() {
-  var elements: List<String>? = null
+  var includes: List<String>? = null
+  var excludes: List<String>? = null
   var exclusive: Boolean = true
   var android: Boolean = false
   var androidAnnotations: Boolean = false
@@ -53,7 +54,8 @@ open class JavaOutput @Inject constructor() : WireOutput() {
 
   override fun toTarget(): Target {
     return Target.JavaTarget(
-        elements = elements ?: listOf("*"),
+        includes = includes ?: listOf("*"),
+        excludes = excludes ?: listOf(),
         exclusive = exclusive,
         outDirectory = out!!,
         android = android,
@@ -86,7 +88,8 @@ open class JavaOutput @Inject constructor() : WireOutput() {
 }
 
 open class KotlinOutput @Inject constructor() : WireOutput() {
-  var elements: List<String>? = null
+  var includes: List<String>? = null
+  var excludes: List<String>? = null
   var exclusive: Boolean = true
   var android: Boolean = false
   var javaInterop: Boolean = false
@@ -95,7 +98,8 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
 
   override fun toTarget(): Target.KotlinTarget {
     return Target.KotlinTarget(
-        elements = elements ?: listOf("*"),
+        includes = includes ?: listOf("*"),
+        excludes = excludes ?: listOf(),
         exclusive = exclusive,
         outDirectory = out!!,
         android = android,

--- a/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-java-then-emit-kotlin/build.gradle
@@ -7,7 +7,7 @@ plugins {
 wire {
   java {
     // Java gets the named types only.
-    elements = ['squareup.dinosaurs.Dinosaur']
+    includes = ['squareup.dinosaurs.Dinosaur']
   }
   kotlin {
     // Kotlin gets everything else.

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-and-emit-java/build.gradle
@@ -7,7 +7,7 @@ plugins {
 wire {
   kotlin {
     // Kotlin gets the named types only.
-    elements = ['squareup.dinosaurs.Dinosaur']
+    includes = ['squareup.dinosaurs.Dinosaur']
   }
   java {
     // Java gets everything.

--- a/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-kotlin-then-emit-java/build.gradle
@@ -7,7 +7,7 @@ plugins {
 wire {
   kotlin {
     // Kotlin gets the named types only.
-    elements = ['squareup.dinosaurs.Dinosaur']
+    includes = ['squareup.dinosaurs.Dinosaur']
   }
   java {
     // Java gets everything else.


### PR DESCRIPTION
Previously we supported includes only. This is a little more capable.