### PR TITLE
Change wire-runtime artifact names to preserve 2.x compat

### DIFF
--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -113,6 +113,18 @@ publishing {
     }
   }
 
+  if (project.name == 'wire-runtime') {
+    // Use default artifact name for the JVM target
+    publications {
+      kotlinMultiplatform {
+        artifactId = 'wire-runtime-multiplatform'
+      }
+      jvm {
+        artifactId = 'wire-runtime'
+      }
+    }
+  }
+
   afterEvaluate {
     publications.getByName('kotlinMultiplatform') {
       // Source jars are only created for platforms, not the common artifact.

--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -113,18 +113,6 @@ publishing {
     }
   }
 
-  if (project.name == 'wire-runtime') {
-    // Use default artifact name for the JVM target
-    publications {
-      kotlinMultiplatform {
-        artifactId = 'wire-runtime-multiplatform'
-      }
-      jvm {
-        artifactId = 'wire-runtime'
-      }
-    }
-  }
-
   afterEvaluate {
     publications.getByName('kotlinMultiplatform') {
       // Source jars are only created for platforms, not the common artifact.

--- a/wire-gradle-plugin/src/test/projects/java-project-java-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/java-project-java-protos/build.gradle
@@ -14,5 +14,5 @@ repositories {
 }
 
 dependencies {
-  implementation "com.squareup.wire:wire-runtime-jvm:$VERSION_NAME"
+  implementation "com.squareup.wire:wire-runtime:$VERSION_NAME"
 }

--- a/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/java-project-kotlin-protos/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-  implementation "com.squareup.wire:wire-runtime-jvm:$VERSION_NAME"
+  implementation "com.squareup.wire:wire-runtime-multiplatform:$VERSION_NAME"
 }
 
 wire {

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-  implementation "com.squareup.wire:wire-runtime-jvm:$VERSION_NAME"
+  implementation "com.squareup.wire:wire-runtime-multiplatform:$VERSION_NAME"
 
   compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
 }

--- a/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/build.gradle
@@ -15,7 +15,7 @@ repositories {
 }
 
 dependencies {
-  implementation "com.squareup.wire:wire-runtime-jvm:$VERSION_NAME"
+  implementation "com.squareup.wire:wire-runtime-multiplatform:$VERSION_NAME"
 }
 
 wire {

--- a/wire-runtime/build.gradle
+++ b/wire-runtime/build.gradle
@@ -102,3 +102,15 @@ repositories.whenObjectAdded {
 
 apply from: 'jvm.gradle'
 apply from: "$rootDir/gradle/gradle-mvn-mpp-push.gradle"
+
+publishing {
+  // Use default artifact name for the JVM target
+  publications {
+    kotlinMultiplatform {
+      artifactId = 'wire-runtime-multiplatform'
+    }
+    jvm {
+      artifactId = 'wire-runtime'
+    }
+  }
+}


### PR DESCRIPTION
Fixes #1093 