### PR TITLE
Expose Schema linking as static method

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -151,7 +151,7 @@ data class WireRun(
     val protoFilesPlusDescriptor = protoFiles.plus(schemaLoader.loadDescriptorProto())
 
     // 3. Validate the schema and resolve references
-    val fullSchema = Linker(protoFilesPlusDescriptor).link()
+    val fullSchema = Schema.fromFiles(protoFilesPlusDescriptor)
 
     // 4. Optionally prune the schema.
     val schema = treeShake(fullSchema, logger)

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -109,6 +109,10 @@ public final class Schema {
     return field;
   }
 
+  public static Schema fromFiles(Iterable<ProtoFile> files) {
+    return new Linker(files).link();
+  }
+
   private static ImmutableMap<String, Type> buildTypesIndex(Iterable<ProtoFile> protoFiles) {
     Map<String, Type> result = new LinkedHashMap<>();
     for (ProtoFile protoFile : protoFiles) {


### PR DESCRIPTION
`SchemaLoader.load()` returned a linked Schema by indirectly calling `Linker.link()`, whereas `NewSchemaLoader.load()` returns a `List<ProtoFile>` pulling the linking behavior up into `WireRun.execute()`.  This change allows tooling (graph visualization, keep rule generator) built on top of the old compiler to migrate to the new Wire approach, albeit temporarily.