### PR TITLE
Rename Util classes in wire-runtime and wire-grpc-client

### DIFF
--- a/wire-grpc-client/src/main/java/com/squareup/wire/internal/util.kt
+++ b/wire-grpc-client/src/main/java/com/squareup/wire/internal/util.kt
@@ -13,6 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("GrpcUtils")
+
 package com.squareup.wire.internal
 
 import kotlinx.coroutines.CoroutineScope

--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Util.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Util.kt
@@ -13,7 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+@file:JvmName("RuntimeUtils")
+
 package com.squareup.wire.internal
+
+import kotlin.jvm.JvmName
 
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
 internal inline infix fun Byte.and(other: Int): Int = toInt() and other


### PR DESCRIPTION
Fixes #1133 