### PR TITLE
GH-1081: Removed attempt to override JVM source/target version

### DIFF
--- a/wire-tests/jvm.gradle
+++ b/wire-tests/jvm.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'java-library'
 
 kotlin.targets.matching { it.platformType.name == 'jvm' }.all { target ->
-  target.project.sourceCompatibility = JavaVersion.VERSION_1_8
-  target.project.targetCompatibility = JavaVersion.VERSION_1_8
-  
   target.project.sourceSets.test.java.srcDirs += 'src/jvmTest/proto-java'
 
   tasks['jar'].configure {


### PR DESCRIPTION
Fixes #1081.

_First PR, so apologies if I've missed something!_

Removed JVM overrides in `wire-tests` since main `./build.gradle` already does this for all submodules in a more standard way and for some reason, these overrides cause the build to fail with JDK > 8.

I tested that changing the versions in the main `build.gradle`:

```
tasks.withType(JavaCompile).configureEach {
    sourceCompatibility = JavaVersion.VERSION_1_8
    targetCompatibility = JavaVersion.VERSION_1_8
  }
```

Does in fact already affect the `.class` output in `wire-tests`, so I'm 99% sure these overrides were unnecessary anyway!