### PR TITLE
[WIP] Failing gradle config

### DIFF
--- a/wire-grpc-tests/build.gradle
+++ b/wire-grpc-tests/build.gradle
@@ -13,6 +13,7 @@ apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
 apply plugin: 'ru.vyarus.animalsniffer'
 apply plugin: 'com.google.protobuf'
+apply plugin: 'com.squareup.wire'
 
 protobuf {
   plugins {
@@ -45,6 +46,20 @@ sourceSets {
 jar {
   manifest {
     attributes('Automatic-Module-Name': 'wire-grpc-tests')
+  }
+}
+
+wire {
+  sourcePath {
+    srcDir "src/test/proto"
+  }
+  kotlin {
+    out "src/test/proto-grpc"
+    exclusive = false
+    includes = ['routeguide.RouteGuideProto']
+    rpcCallStyle = 'blocking'
+    rpcRole = 'server'
+    singleMethodServices = true
   }
 }
 


### PR DESCRIPTION
Wanna know why this doesn't work. I get the following error

```
~/workspace/wire on bquenaudon.2019-08-21.wire-grpc-tests-gradle
$ ./gradlew wire-grpc-tests:generateProtos

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/bquenaudon/workspace/wire/wire-grpc-tests/build.gradle' line: 58

* What went wrong:
A problem occurred evaluating project ':wire-grpc-tests'.
> Could not set unknown property 'exclusive' for object of type com.squareup.wire.gradle.WireExtension$KotlinTarget.

BUILD FAILED in 484ms
```