### PR TITLE
Don't emit proto2 sources for proto3 syntax

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -371,6 +371,29 @@ class WireRunTest {
         "generated/kt/com/squareup/polygons/Square.kt")
   }
 
+  @Test
+  fun proto3Skipped() {
+    writeBlueProto()
+    fs.add("colors/src/main/proto/squareup/colors/red.proto", """
+          |syntax = "proto3";
+          |package squareup.colors;
+          |message Red {
+          |  string oval = 1;
+          |}
+          """.trimMargin())
+    writeTriangleProto()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(Location.get("colors/src/main/proto")),
+        protoPath = listOf(Location.get("polygons/src/main/proto")),
+        targets = listOf(KotlinTarget(outDirectory = "generated/kt"))
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.find("generated")).containsExactlyInAnyOrder(
+        "generated/kt/squareup/colors/Blue.kt")
+  }
+
   private fun writeRedProto() {
     fs.add("colors/src/main/proto/squareup/colors/red.proto", """
           |syntax = "proto2";

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -117,6 +117,10 @@ public final class ProtoFile {
     return packageName;
   }
 
+  public Syntax syntax() {
+    return syntax;
+  }
+
   public String javaPackage() {
     return javaPackage != null ? String.valueOf(javaPackage) : null;
   }


### PR DESCRIPTION
We don't currently implement proto3 syntax. Detect it and skip rather than emitting
an invalid message.