### PR TITLE
Fix import fails on windows due to path separator

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/SchemaLoader.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/SchemaLoader.java
@@ -115,7 +115,7 @@ public final class SchemaLoader {
           @Override public FileVisitResult visitFile(Path file, BasicFileAttributes attrs)
               throws IOException {
             if (file.getFileName().toString().endsWith(".proto")) {
-              protos.add(entry.getValue().relativize(file).toString());
+              protos.add(entry.getValue().relativize(file).toString().replace(File.separator, "/"));
             }
             return FileVisitResult.CONTINUE;
           }


### PR DESCRIPTION
Easy fixing for importing fails on windows.(Fix #695)

Just make all protos path as *nix style.