### PR TITLE
Changes on printing options and enum

### DIFF
--- a/proto-pruner/src/test/java/com/squareup/wire/prune/ProtoPrunerTest.kt
+++ b/proto-pruner/src/test/java/com/squareup/wire/prune/ProtoPrunerTest.kt
@@ -52,7 +52,7 @@ class ProtoPrunerTest {
     assertOutputs(outputs)
   }
 
-  @Test @Ignore("Failing because of wrong indention on the output files.")
+  @Test
   fun testSimpleMessage() {
     val sources = arrayOf("squareup.protos.simple.SimpleMessage")
     invokeProtoPruner(sources, "--excludes=google.protobuf.*")

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/Util.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/Util.java
@@ -35,8 +35,14 @@ public final class Util {
   }
 
   public static void appendOptions(StringBuilder builder, List<OptionElement> options) {
+    int count = options.size();
+    if (count == 1) {
+      builder.append("[").append(options.get(0).toSchema()).append(']');
+      return;
+    }
+
     builder.append("[\n");
-    for (int i = 0, count = options.size(); i < count; i++) {
+    for (int i = 0; i < count; i++) {
       String endl = (i < count - 1) ? "," : "";
       appendIndented(builder, options.get(i).toSchema() + endl);
     }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/EnumElement.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/EnumElement.kt
@@ -33,14 +33,16 @@ data class EnumElement(
     appendDocumentation(this, documentation)
     append("enum $name {")
 
-    if (options.isNotEmpty()) {
+    if (options.isNotEmpty() || constants.isNotEmpty()) {
       append('\n')
+    }
+
+    if (options.isNotEmpty()) {
       for (option in options) {
         appendIndented(this, option.toSchemaDeclaration())
       }
     }
     if (constants.isNotEmpty()) {
-      append('\n')
       for (constant in constants) {
         appendIndented(this, constant.toSchema())
       }

--- a/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/EnumElementTest.kt
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/EnumElementTest.kt
@@ -82,7 +82,6 @@ class EnumElementTest {
     val expected = """
         |enum Enum {
         |  option kit = "kat";
-        |
         |  ONE = 1;
         |  TWO = 2;
         |  SIX = 6;

--- a/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
@@ -578,7 +578,7 @@ class MessageElementTest {
   }
 
   @Test
-  fun fieldWithOptionsToSchema() {
+  fun fieldWithOneOptionToSchema() {
     val field = FieldElement(
         location = location,
         label = REQUIRED,
@@ -588,8 +588,26 @@ class MessageElementTest {
         options = listOf(OptionElement.create("kit", Kind.STRING, "kat"))
     )
     val expected =
+        """required string name = 1 [kit = "kat"];
+        |""".trimMargin()
+    assertThat(field.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
+  fun fieldWithMoreThanOneOptionToSchema() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "string",
+        name = "name",
+        tag = 1,
+        options = listOf(OptionElement.create("kit", Kind.STRING, "kat"),
+            OptionElement.create("dup", Kind.STRING, "lo"))
+    )
+    val expected =
         """required string name = 1 [
-        |  kit = "kat"
+        |  kit = "kat",
+        |  dup = "lo"
         |];
         |""".trimMargin()
     assertThat(field.toSchema()).isEqualTo(expected)


### PR DESCRIPTION
- No empty lines between options and fields for enums (same as types)
- Print options on new lines only when more than one.

Here's the expected output of this test https://github.com/square/wire/blob/47d004cd3271295aca859a2aa7d1d4d2482a5657/proto-pruner/src/test/expected/simple_message.proto