### PR TITLE
Use by lazy to create packed and repeated adapters

### DIFF
--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -41,8 +41,8 @@ expect abstract class ProtoAdapter<E>(
   internal val fieldEncoding: FieldEncoding
   val type: KClass<*>?
 
-  internal var packedAdapter: ProtoAdapter<List<E>>?
-  internal var repeatedAdapter: ProtoAdapter<List<E>>?
+  internal val packedAdapter: ProtoAdapter<List<E>>
+  internal val repeatedAdapter: ProtoAdapter<List<E>>
 
   /** Returns the redacted form of `value`. */
   abstract fun redact(value: E): E
@@ -213,13 +213,6 @@ internal inline fun <E> ProtoAdapter<E>.commonWithLabel(label: WireField.Label):
 }
 
 @Suppress("NOTHING_TO_INLINE")
-internal inline fun <E> ProtoAdapter<E>.commonAsPacked(): ProtoAdapter<List<E>> {
-  return packedAdapter ?: commonCreatePacked().also {
-    packedAdapter = it
-  }
-}
-
-@Suppress("NOTHING_TO_INLINE")
 internal inline fun <E> ProtoAdapter<E>.commonCreatePacked(): ProtoAdapter<List<E>> {
   require(fieldEncoding != FieldEncoding.LENGTH_DELIMITED) {
     "Unable to pack a length-delimited type."
@@ -256,13 +249,6 @@ internal inline fun <E> ProtoAdapter<E>.commonCreatePacked(): ProtoAdapter<List<
     override fun decode(reader: ProtoReader): List<E> = listOf(adapter.decode(reader))
 
     override fun redact(value: List<E>): List<E> = emptyList()
-  }
-}
-
-@Suppress("NOTHING_TO_INLINE")
-internal inline fun <E> ProtoAdapter<E>.commonAsRepeated(): ProtoAdapter<List<E>> {
-  return repeatedAdapter ?: commonCreateRepeated().also {
-    repeatedAdapter = it
   }
 }
 

--- a/wire-runtime/src/jsMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-runtime/src/jsMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -24,8 +24,8 @@ actual abstract class ProtoAdapter<E> actual constructor(
   internal actual val fieldEncoding: FieldEncoding,
   actual val type: KClass<*>?
 ) {
-  internal actual var packedAdapter: ProtoAdapter<List<E>>? = null
-  internal actual var repeatedAdapter: ProtoAdapter<List<E>>? = null
+  internal actual val packedAdapter: ProtoAdapter<List<E>> by lazy { commonCreatePacked() }
+  internal actual val repeatedAdapter: ProtoAdapter<List<E>> by lazy { commonCreateRepeated() }
 
   /** Returns the redacted form of `value`. */
   actual abstract fun redact(value: E): E
@@ -91,9 +91,7 @@ actual abstract class ProtoAdapter<E> actual constructor(
   }
 
   /** Returns an adapter for `E` but as a packed, repeated value. */
-  actual fun asPacked(): ProtoAdapter<List<E>> {
-    return commonAsPacked()
-  }
+  actual fun asPacked(): ProtoAdapter<List<E>> = packedAdapter
 
   /**
    * Returns an adapter for `E` but as a repeated value.
@@ -102,9 +100,7 @@ actual abstract class ProtoAdapter<E> actual constructor(
    * the returned adapter, only single-element lists will be returned and it is the caller's
    * responsibility to merge them into the final list.
    */
-  actual fun asRepeated(): ProtoAdapter<List<E>> {
-    return commonAsRepeated()
-  }
+  actual fun asRepeated(): ProtoAdapter<List<E>> = repeatedAdapter
 
   actual class EnumConstantNotFoundException actual constructor(
     actual val value: Int,

--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -31,8 +31,8 @@ actual abstract class ProtoAdapter<E> actual constructor(
   internal actual val fieldEncoding: FieldEncoding,
   actual val type: KClass<*>?
 ) {
-  internal actual var packedAdapter: ProtoAdapter<List<E>>? = null
-  internal actual var repeatedAdapter: ProtoAdapter<List<E>>? = null
+  internal actual val packedAdapter: ProtoAdapter<List<E>> by lazy { commonCreatePacked() }
+  internal actual val repeatedAdapter: ProtoAdapter<List<E>> by lazy { commonCreateRepeated() }
 
   constructor(fieldEncoding: FieldEncoding, type: Class<*>): this(fieldEncoding, type.kotlin)
 
@@ -97,13 +97,9 @@ actual abstract class ProtoAdapter<E> actual constructor(
     return commonWithLabel(label)
   }
 
-  actual fun asPacked(): ProtoAdapter<List<E>> {
-    return commonAsPacked()
-  }
+  actual fun asPacked(): ProtoAdapter<List<E>> = packedAdapter
 
-  actual fun asRepeated(): ProtoAdapter<List<E>> {
-    return commonAsRepeated()
-  }
+  actual fun asRepeated(): ProtoAdapter<List<E>> = repeatedAdapter
 
   actual class EnumConstantNotFoundException actual constructor(
     @JvmField actual val value: Int,


### PR DESCRIPTION
Having the fields as vars and lazily assigning doesn't work in
Kotlin Native, cause it's considered a modification of a frozen
object. Lazy delegates are properly implemented to handle this use
case, so we should rely on them.