### PR TITLE
object methods still work for our gRPC services

### DIFF
--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
@@ -69,6 +69,14 @@ class GrpcClientTest {
     routeGuideService = grpcClient.create(RouteGuideClient::class)
   }
 
+  @Suppress("ReplaceCallWithBinaryOperator") // We are explicitly testing this behavior.
+  @Test
+  fun objectMethodsStillWork() {
+    assertThat(routeGuideService.hashCode()).isNotZero()
+    assertThat(routeGuideService.equals(this)).isFalse()
+    assertThat(routeGuideService.toString()).isNotEmpty()
+  }
+
   @Test
   fun requestResponseSuspend() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/GetFeature"))


### PR DESCRIPTION
fixes #1180 