### PR TITLE
Nullify other oneof fields in Builder setters in Kotlin interop

### DIFF
--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -116,6 +116,8 @@ class OneOfMessage(
      */
     fun foo(foo: Int): Builder {
       this.foo = foo
+      this.bar = null
+      this.baz = null
       return this
     }
 
@@ -124,6 +126,8 @@ class OneOfMessage(
      */
     fun bar(bar: String): Builder {
       this.bar = bar
+      this.foo = null
+      this.baz = null
       return this
     }
 
@@ -132,6 +136,8 @@ class OneOfMessage(
      */
     fun baz(baz: String): Builder {
       this.baz = baz
+      this.foo = null
+      this.bar = null
       return this
     }
 

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -88,11 +88,13 @@ class RedactedOneOf(
 
     fun b(b: Int): Builder {
       this.b = b
+      this.c = null
       return this
     }
 
     fun c(c: String): Builder {
       this.c = c
+      this.b = null
       return this
     }
 


### PR DESCRIPTION
Partial fix for #1210 