### PR TITLE
Always attempt to read all messages even if only one is expected.

### DIFF
--- a/wire-grpc-client/src/main/java/com/squareup/wire/internal/GrpcMessageSource.kt
+++ b/wire-grpc-client/src/main/java/com/squareup/wire/internal/GrpcMessageSource.kt
@@ -60,4 +60,13 @@ internal class GrpcMessageSource<T : Any>(
 
     return messageAdapter.decode(messageDecoding.decode(encodedMessage).buffer())
   }
+
+  fun readExactlyOneAndClose(): T {
+    use { reader ->
+      val result = reader.read() ?: throw ProtocolException("expected 1 message but got none")
+      val end = reader.read()
+      if (end != null) throw ProtocolException("expected 1 message but got multiple")
+      return result
+    }
+  }
 }

--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
@@ -94,7 +94,6 @@ class GrpcClientTest {
   }
 
   @Test
-  @Ignore("TODO: This test is flaky, please fix.")
   fun requestResponseBlocking() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/GetFeature"))
     mockService.enqueueReceivePoint(latitude = 5, longitude = 6)
@@ -621,7 +620,7 @@ class GrpcClientTest {
     }
   }
 
-  @Test @Ignore("flaky")
+  @Test
   fun grpcCallIsExecutedAfterExecuteBlocking() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/GetFeature"))
     mockService.enqueueReceivePoint(latitude = 5, longitude = 6)
@@ -688,7 +687,8 @@ class GrpcClientTest {
     }
   }
 
-  @Test @Ignore("Timing out")
+  @Test
+  @Ignore("Timing out")
   fun grpcStreamingCallIsExecutedAfterExecuteBlocking() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/RouteChat"))
     mockService.enqueueSendNote(message = "welcome")


### PR DESCRIPTION
We need to exhaust the inbound stream until it EOFs otherwise when we
close the stream we inadvertently cancel it.