### PR TITLE
Fix inconsistencies in GrpcClientTest expectations.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
       'jsr305': '3.0.2',
       'kotlin': '1.3.50',
       'okio': '2.4.1',
-      'okhttp': '4.1.0',
+      'okhttp': '4.2.2',
       'moshi': '1.6.0',
       'protobuf': '0.8.10',
       'protoc': '3.0.0',

--- a/wire-grpc-client/src/main/java/com/squareup/wire/internal/RealGrpcStreamingCall.kt
+++ b/wire-grpc-client/src/main/java/com/squareup/wire/internal/RealGrpcStreamingCall.kt
@@ -53,9 +53,11 @@ internal class RealGrpcStreamingCall<S : Any, R : Any>(
     call.enqueue(responseChannel.readFromResponseBodyCallback(grpcMethod.responseAdapter))
 
     responseChannel.invokeOnClose {
-      call.cancel()
-      requestChannel.cancel()
-      responseChannel.cancel()
+      if (responseChannel.isClosedForReceive) {
+        // Short-circuit the request stream if it's still active.
+        call.cancel()
+        requestChannel.cancel()
+      }
     }
 
     return requestChannel to responseChannel

--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
@@ -32,6 +32,7 @@ import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.Response
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.After
 import org.junit.Assert.fail
 import org.junit.Before
 import org.junit.Ignore
@@ -79,6 +80,11 @@ class GrpcClientTest {
         .baseUrl(mockService.url)
         .build()
     routeGuideService = grpcClient.create(RouteGuideClient::class)
+  }
+
+  @After
+  fun tearDown() {
+    okhttpClient.dispatcher.executorService.shutdown()
   }
 
   @Suppress("ReplaceCallWithBinaryOperator") // We are explicitly testing this behavior.
@@ -224,7 +230,6 @@ class GrpcClientTest {
   }
 
   @Test
-  @Ignore("TODO: This test is flaky, please fix.")
   fun streamingResponseSuspend() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/ListFeatures"))
     mockService.enqueueReceiveRectangle(lo = Point(0, 0), hi = Point(4, 5))
@@ -563,10 +568,11 @@ class GrpcClientTest {
     }
   }
 
-  @Test @Ignore("Flaky")
+  @Test
   fun duplexBlockingReceiveOnly() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/RouteChat"))
     mockService.enqueueSendNote(message = "welcome")
+    mockService.enqueueSendNote(message = "polo")
     mockService.enqueue(SendCompleted)
     mockService.enqueue(ReceiveComplete)
 
@@ -582,7 +588,6 @@ class GrpcClientTest {
    * which is incorrect. https://github.com/square/okhttp/issues/5388
    */
   @Test
-  @Ignore
   fun cancelOutboundStream() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/RouteChat"))
     mockService.enqueueSendNote(message = "welcome")
@@ -700,10 +705,10 @@ class GrpcClientTest {
   }
 
   @Test
-  @Ignore("Timing out")
   fun grpcStreamingCallIsExecutedAfterExecuteBlocking() {
     mockService.enqueue(ReceiveCall("/routeguide.RouteGuide/RouteChat"))
     mockService.enqueueSendNote(message = "welcome")
+    mockService.enqueueSendNote(message = "polo")
     mockService.enqueue(SendCompleted)
     mockService.enqueue(ReceiveComplete)
 

--- a/wire-grpc-tests/src/test/java/com/squareup/wire/MockRouteGuideService.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/MockRouteGuideService.kt
@@ -116,8 +116,8 @@ class MockRouteGuideService : RouteGuideGrpc.RouteGuideImplBase(), TestRule {
           base.evaluate()
         } finally {
           server.shutdown()
-          server.awaitTermination()
         }
+        server.awaitTermination()
       }
     }
   }


### PR DESCRIPTION
Also fix MockRouteGuideService to not mask test crashes as timeouts.