### PR TITLE
Use gzip encoding for Grpc's communication

### DIFF
--- a/wire-grpc-client/src/main/java/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/main/java/com/squareup/wire/GrpcClient.kt
@@ -61,6 +61,7 @@ class GrpcClient private constructor(
         .addHeader("te", "trailers")
         .addHeader("grpc-trace-bin", "")
         .addHeader("grpc-accept-encoding", "gzip")
+        .addHeader("grpc-encoding", "gzip")
         .method("POST", requestBody)
         .build())
   }

--- a/wire-grpc-client/src/main/java/com/squareup/wire/internal/GrpcMessageSource.kt
+++ b/wire-grpc-client/src/main/java/com/squareup/wire/internal/GrpcMessageSource.kt
@@ -55,10 +55,11 @@ internal class GrpcMessageSource<T : Any>(
 
     val encodedLength = source.readInt().toLong() and 0xffffffffL
 
-    val encodedMessage = Buffer()
-    encodedMessage.write(source, encodedLength)
+    val encodedMessage = Buffer().write(source, encodedLength)
 
-    return messageAdapter.decode(messageDecoding.decode(encodedMessage).buffer())
+    return messageDecoding.decode(encodedMessage).buffer().use {
+      messageAdapter.decode(it)
+    }
   }
 
   fun readExactlyOneAndClose(): T {

--- a/wire-grpc-client/src/main/java/com/squareup/wire/internal/grpc.kt
+++ b/wire-grpc-client/src/main/java/com/squareup/wire/internal/grpc.kt
@@ -47,7 +47,7 @@ internal fun <S : Any> newRequestBody(
           sink = sink,
           messageAdapter = requestAdapter,
           callForCancel = null,
-          grpcEncoding = "identity"
+          grpcEncoding = "gzip"
       )
       grpcMessageSink.use {
         it.write(onlyMessage)
@@ -72,7 +72,7 @@ internal fun <S : Any> PipeDuplexRequestBody.messageSink(
     sink = createSink(),
     messageAdapter = requestAdapter,
     callForCancel = callForCancel,
-    grpcEncoding = "identity"
+    grpcEncoding = "gzip"
 )
 
 /** Sends the response messages to the channel. */


### PR DESCRIPTION
Just replaced all "identity" with "gzip", added the reading header, and tests pass.