### PR TITLE
Add WireGrpcExperimental annotation

### DIFF
--- a/wire-grpc-client/build.gradle
+++ b/wire-grpc-client/build.gradle
@@ -13,6 +13,13 @@ animalsniffer {
   ignore 'com.squareup.wire.internal'
 }
 
+compileKotlin {
+  kotlinOptions {
+    freeCompilerArgs += "-Xuse-experimental=kotlinx.coroutines.ExperimentalCoroutinesApi"
+    freeCompilerArgs += "-Xexperimental=com.squareup.wire.WireGrpcExperimental"
+  }
+}
+
 dependencies {
   api project(':wire-runtime')
   api deps.okhttp

--- a/wire-grpc-client/src/main/java/com/squareup/wire/WireGrpcExperimental.kt
+++ b/wire-grpc-client/src/main/java/com/squareup/wire/WireGrpcExperimental.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.squareup.wire
+
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+
+/**
+ * Marker annotation for experimental Wire gRPC features.
+ */
+@ExperimentalCoroutinesApi
+@Retention(AnnotationRetention.BINARY)
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+annotation class WireGrpcExperimental


### PR DESCRIPTION
Closes #1151.

This is a quick way to mark the entire module as experimental and require consumers to opt-in. 

A better approach would probably be to generate code with `@WireGrpcExperimental` annotations if coroutines are going to be used under the hood.