### PR TITLE
Better filter used Extends on pruning

### DIFF
--- a/proto-pruner/src/test/expected/foreign.proto
+++ b/proto-pruner/src/test/expected/foreign.proto
@@ -10,10 +10,3 @@ enum ForeignEnum {
   BAV = 0;
   BAX = 1;
 }
-
-extend google.protobuf.MessageOptions {
-  optional ForeignMessage foreign_message_option = 50007;
-}
-extend google.protobuf.EnumValueOptions {
-  optional bool foreign_enum_value_option = 70002;
-}

--- a/proto-pruner/src/test/expected/simple_message.proto
+++ b/proto-pruner/src/test/expected/simple_message.proto
@@ -52,6 +52,3 @@ extend ExternalMessage {
   optional SimpleMessage.NestedMessage nested_message_ext = 128;
   optional SimpleMessage.NestedEnum nested_enum_ext = 129;
 }
-extend squareup.protos.foreign.ForeignMessage {
-  optional int32 j = 100;
-}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
@@ -19,7 +19,7 @@ import com.google.common.collect.ImmutableList;
 import com.squareup.wire.schema.internal.parser.ExtendElement;
 import java.util.List;
 
-final class Extend {
+public final class Extend {
   private final Location location;
   private final String documentation;
   private final String name;
@@ -85,5 +85,11 @@ final class Extend {
   void validate(Linker linker) {
     linker = linker.withContext(this);
     linker.validateImport(location(), type());
+  }
+
+  public Extend retainAll(Schema schema, MarkSet markSet) {
+    ImmutableList<Field> retainedFields = Field.retainAll(schema, markSet, protoType, fields);
+    if (retainedFields.isEmpty()) return null;
+    else return new Extend(location, documentation, name, retainedFields);
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -133,7 +133,7 @@ public final class ProtoFile {
     return services;
   }
 
-  List<Extend> extendList() {
+  public List<Extend> extendList() {
     return extendList;
   }
 
@@ -159,8 +159,16 @@ public final class ProtoFile {
       }
     }
 
+    ImmutableList.Builder<Extend> retainedExtends = ImmutableList.builder();
+    for (Extend extend : extendList) {
+      Extend retainedExtend = extend.retainAll(schema, markSet);
+      if (retainedExtend != null) {
+        retainedExtends.add(retainedExtend);
+      }
+    }
+
     ProtoFile result = new ProtoFile(location, imports, publicImports, packageName,
-        retainedTypes.build(), retainedServices.build(), extendList,
+        retainedTypes.build(), retainedServices.build(), retainedExtends.build(),
         options.retainAll(schema, markSet), syntax);
     result.javaPackage = javaPackage;
     return result;


### PR DESCRIPTION
We wanna keep `Extend`s when they are either used as a field, or as an option.

part of #1243 