### PR TITLE
Retained used imports only

### DIFF
--- a/proto-pruner/src/test/expected/foreign.proto
+++ b/proto-pruner/src/test/expected/foreign.proto
@@ -1,8 +1,6 @@
 // ../wire-tests/src/commonTest/proto/java/foreign.proto
 package squareup.protos.foreign;
 
-import "google/protobuf/descriptor.proto";
-
 option java_package = "com.squareup.wire.protos.foreign";
 option java_outer_classname = "Foreign";
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Extend.java
@@ -73,6 +73,10 @@ public final class Extend {
     return fields;
   }
 
+  public String getName() {
+    return name;
+  }
+
   void link(Linker linker) {
     linker = linker.withContext(this);
     protoType = linker.resolveMessageType(name);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -185,7 +185,7 @@ public final class ProtoFile {
           && importedProtoFile.extendList().isEmpty()) {
 
         // If we extend a google protobuf type, we should keep the import.
-        if (path.startsWith("google/protobuf")) {
+        if (path.startsWith("google/protobuf/")) {
           for (Extend extend : extendList) {
             if (extend.getName().startsWith("google.protobuf")) {
               retainedImportsBuilder.add(path);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -185,7 +185,7 @@ public final class ProtoFile {
           && importedProtoFile.extendList().isEmpty()) {
 
         // If we extend a google protobuf type, we should keep the import.
-        if (path.startsWith("google/protobuf/")) {
+        if (path.equals("google/protobuf/descriptor.proto")) {
           for (Extend extend : extendList) {
             if (extend.getName().startsWith("google.protobuf.")) {
               retainedImportsBuilder.add(path);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/ProtoFile.java
@@ -187,7 +187,7 @@ public final class ProtoFile {
         // If we extend a google protobuf type, we should keep the import.
         if (path.startsWith("google/protobuf/")) {
           for (Extend extend : extendList) {
-            if (extend.getName().startsWith("google.protobuf")) {
+            if (extend.getName().startsWith("google.protobuf.")) {
               retainedImportsBuilder.add(path);
               break;
             }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
@@ -46,9 +46,16 @@ final class Pruner {
     markRoots();
     markReachable();
 
-    ImmutableList.Builder<ProtoFile> retained = ImmutableList.builder();
+    // We do a first round to detect later unused imports.
+    ImmutableList.Builder<ProtoFile> retainedFirstRoundBuilder = ImmutableList.builder();
     for (ProtoFile protoFile : schema.protoFiles()) {
-      retained.add(protoFile.retainAll(schema, marks));
+      retainedFirstRoundBuilder.add(protoFile.retainAll(schema, marks));
+    }
+    ImmutableList<ProtoFile> firstRound = retainedFirstRoundBuilder.build();
+
+    ImmutableList.Builder<ProtoFile> retained = ImmutableList.builder();
+    for (ProtoFile protoFile : firstRound) {
+      retained.add(protoFile.retainImports(firstRound));
     }
 
     return new Schema(retained.build());

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
@@ -46,19 +46,25 @@ final class Pruner {
     markRoots();
     markReachable();
 
-    // We do a first round to detect later unused imports.
-    ImmutableList.Builder<ProtoFile> retainedFirstRoundBuilder = ImmutableList.builder();
-    for (ProtoFile protoFile : schema.protoFiles()) {
-      retainedFirstRoundBuilder.add(protoFile.retainAll(schema, marks));
-    }
-    ImmutableList<ProtoFile> firstRound = retainedFirstRoundBuilder.build();
+    ImmutableList<ProtoFile> retained = retainImports(retainAll(schema, marks));
 
+    return new Schema(retained);
+  }
+
+  private ImmutableList<ProtoFile> retainAll(Schema schema, MarkSet marks) {
     ImmutableList.Builder<ProtoFile> retained = ImmutableList.builder();
-    for (ProtoFile protoFile : firstRound) {
-      retained.add(protoFile.retainImports(firstRound));
+    for (ProtoFile protoFile : schema.protoFiles()) {
+      retained.add(protoFile.retainAll(schema, marks));
     }
+    return retained.build();
+  }
 
-    return new Schema(retained.build());
+  private ImmutableList<ProtoFile> retainImports(ImmutableList<ProtoFile> protoFiles) {
+    ImmutableList.Builder<ProtoFile> retained = ImmutableList.builder();
+    for (ProtoFile protoFile : protoFiles) {
+      retained.add(protoFile.retainImports(protoFiles));
+    }
+    return retained.build();
   }
 
   private void markRoots() {


### PR DESCRIPTION
part of #1243 

We don't prune imports and this can create broken proto filed code base. The technique I'm using is that once we retained all types/services/extends (first round), we do another round on each proto files, and check if
　a) the referenced imported proto has any retained types, services, or extends, or
　b) we're extending some google protobuf thing. (_Not super happy with the string comparison but couldn't find better._)
