### PR TITLE
Print default values for scalar types for proto target within the options 

### DIFF
--- a/proto-pruner/src/test/expected/external_message.proto
+++ b/proto-pruner/src/test/expected/external_message.proto
@@ -4,7 +4,7 @@ package squareup.protos.simple;
 option java_package = "com.squareup.wire.protos.simple";
 
 message ExternalMessage {
-  optional float f = 1;
+  optional float f = 1 [default = 20];
 
   extensions 100 to 200;
 }

--- a/proto-pruner/src/test/expected/letter.proto
+++ b/proto-pruner/src/test/expected/letter.proto
@@ -9,6 +9,11 @@ message Letter {
 
   optional string title = 1 [(squareup.options.misc.relevant) = true];
   optional Style style = 2;
+  optional bool about_love = 3 [default = true];
+  repeated int32 path = 4 [
+    packed = true,
+    deprecated = true
+  ];
 }
 enum Style {
   SHORT = 1 [(squareup.options.misc.text_alignment) = 3];

--- a/proto-pruner/src/test/expected/simple_message.proto
+++ b/proto-pruner/src/test/expected/simple_message.proto
@@ -9,14 +9,14 @@ option java_package = "com.squareup.wire.protos.simple";
 // A message for testing.
 message SimpleMessage {
   // An optional int32
-  optional int32 optional_int32 = 1;
+  optional int32 optional_int32 = 1 [default = 123];
   // An optional NestedMessage, deprecated
   optional NestedMessage optional_nested_msg = 2 [deprecated = true];
   // An optional ExternalMessage
   optional ExternalMessage optional_external_msg = 3;
   optional NestedEnum default_nested_enum = 4;
   // A required int32
-  required int32 required_int32 = 5;
+  required int32 required_int32 = 5 [default = 456];
   // A repeated double, deprecated
   repeated double repeated_double = 6 [deprecated = true];
   // enum from another package with an explicit default

--- a/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
+++ b/wire-schema/src/test/java/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
@@ -549,6 +549,48 @@ class MessageElementTest {
   }
 
   @Test
+  fun fieldWithDefaultStringToSchema() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "string",
+        name = "name",
+        tag = 1,
+        defaultValue = "benoît"
+    )
+    val expected = "required string name = 1 [default = \"benoît\"];\n"
+    assertThat(field.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
+  fun fieldWithDefaultNumberToSchema() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "int32",
+        name = "age",
+        tag = 1,
+        defaultValue = "34"
+    )
+    val expected = "required int32 age = 1 [default = 34];\n"
+    assertThat(field.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
+  fun fieldWithDefaultBoolToSchema() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "bool",
+        name = "human",
+        tag = 1,
+        defaultValue = "true"
+    )
+    val expected = "required bool human = 1 [default = true];\n"
+    assertThat(field.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
   fun oneOfFieldToSchema() {
     val field = FieldElement(
         location = location,

--- a/wire-tests/src/commonTest/proto/java/letter.proto
+++ b/wire-tests/src/commonTest/proto/java/letter.proto
@@ -23,6 +23,8 @@ message Letter {
 
   optional string title = 1 [(squareup.options.misc.relevant) = true];
   optional Style style = 2;
+  optional bool about_love = 3 [default = true];
+  repeated int32 path = 4 [packed = true, deprecated = true];
 }
 enum Style {
   SHORT = 1 [(squareup.options.misc.text_alignment) = 3];

--- a/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/options/letter/Letter.java
+++ b/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/options/letter/Letter.java
@@ -10,10 +10,14 @@ import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import java.io.IOException;
+import java.lang.Boolean;
+import java.lang.Deprecated;
+import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
+import java.util.List;
 import okio.ByteString;
 
 public final class Letter extends Message<Letter, Letter.Builder> {
@@ -24,6 +28,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
   public static final String DEFAULT_TITLE = "";
 
   public static final Style DEFAULT_STYLE = Style.SHORT;
+
+  public static final Boolean DEFAULT_ABOUT_LOVE = true;
 
   @WireField(
       tag = 1,
@@ -37,14 +43,31 @@ public final class Letter extends Message<Letter, Letter.Builder> {
   )
   public final Style style;
 
-  public Letter(String title, Style style) {
-    this(title, style, ByteString.EMPTY);
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
+  public final Boolean about_love;
+
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+  )
+  @Deprecated
+  public final List<Integer> path;
+
+  public Letter(String title, Style style, Boolean about_love, List<Integer> path) {
+    this(title, style, about_love, path, ByteString.EMPTY);
   }
 
-  public Letter(String title, Style style, ByteString unknownFields) {
+  public Letter(String title, Style style, Boolean about_love, List<Integer> path,
+      ByteString unknownFields) {
     super(ADAPTER, unknownFields);
     this.title = title;
     this.style = style;
+    this.about_love = about_love;
+    this.path = Internal.immutableCopyOf("path", path);
   }
 
   @Override
@@ -52,6 +75,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     Builder builder = new Builder();
     builder.title = title;
     builder.style = style;
+    builder.about_love = about_love;
+    builder.path = Internal.copyOf(path);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -63,7 +88,9 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     Letter o = (Letter) other;
     return unknownFields().equals(o.unknownFields())
         && Internal.equals(title, o.title)
-        && Internal.equals(style, o.style);
+        && Internal.equals(style, o.style)
+        && Internal.equals(about_love, o.about_love)
+        && path.equals(o.path);
   }
 
   @Override
@@ -73,6 +100,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
       result = unknownFields().hashCode();
       result = result * 37 + (title != null ? title.hashCode() : 0);
       result = result * 37 + (style != null ? style.hashCode() : 0);
+      result = result * 37 + (about_love != null ? about_love.hashCode() : 0);
+      result = result * 37 + path.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -83,6 +112,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     StringBuilder builder = new StringBuilder();
     if (title != null) builder.append(", title=").append(title);
     if (style != null) builder.append(", style=").append(style);
+    if (about_love != null) builder.append(", about_love=").append(about_love);
+    if (!path.isEmpty()) builder.append(", path=").append(path);
     return builder.replace(0, 2, "Letter{").append('}').toString();
   }
 
@@ -91,7 +122,12 @@ public final class Letter extends Message<Letter, Letter.Builder> {
 
     public Style style;
 
+    public Boolean about_love;
+
+    public List<Integer> path;
+
     public Builder() {
+      path = Internal.newMutableList();
     }
 
     public Builder title(String title) {
@@ -104,9 +140,21 @@ public final class Letter extends Message<Letter, Letter.Builder> {
       return this;
     }
 
+    public Builder about_love(Boolean about_love) {
+      this.about_love = about_love;
+      return this;
+    }
+
+    @Deprecated
+    public Builder path(List<Integer> path) {
+      Internal.checkElementsNotNull(path);
+      this.path = path;
+      return this;
+    }
+
     @Override
     public Letter build() {
-      return new Letter(title, style, super.buildUnknownFields());
+      return new Letter(title, style, about_love, path, super.buildUnknownFields());
     }
   }
 
@@ -119,6 +167,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     public int encodedSize(Letter value) {
       return ProtoAdapter.STRING.encodedSizeWithTag(1, value.title)
           + Style.ADAPTER.encodedSizeWithTag(2, value.style)
+          + ProtoAdapter.BOOL.encodedSizeWithTag(3, value.about_love)
+          + ProtoAdapter.INT32.asPacked().encodedSizeWithTag(4, value.path)
           + value.unknownFields().size();
     }
 
@@ -126,6 +176,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     public void encode(ProtoWriter writer, Letter value) throws IOException {
       ProtoAdapter.STRING.encodeWithTag(writer, 1, value.title);
       Style.ADAPTER.encodeWithTag(writer, 2, value.style);
+      ProtoAdapter.BOOL.encodeWithTag(writer, 3, value.about_love);
+      ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 4, value.path);
       writer.writeBytes(value.unknownFields());
     }
 
@@ -144,6 +196,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
             }
             break;
           }
+          case 3: builder.about_love(ProtoAdapter.BOOL.decode(reader)); break;
+          case 4: builder.path.add(ProtoAdapter.INT32.decode(reader)); break;
           default: {
             reader.readUnknownField(tag);
           }

--- a/wire-tests/src/jvmJavaTest/proto-java/squareup/options/letter/Letter.java
+++ b/wire-tests/src/jvmJavaTest/proto-java/squareup/options/letter/Letter.java
@@ -12,10 +12,14 @@ import com.squareup.wire.ProtoWriter;
 import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import java.io.IOException;
+import java.lang.Boolean;
+import java.lang.Deprecated;
+import java.lang.Integer;
 import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
+import java.util.List;
 import okio.ByteString;
 
 public final class Letter extends Message<Letter, Letter.Builder> {
@@ -35,6 +39,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
 
   public static final Style DEFAULT_STYLE = Style.SHORT;
 
+  public static final Boolean DEFAULT_ABOUT_LOVE = true;
+
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING"
@@ -47,14 +53,31 @@ public final class Letter extends Message<Letter, Letter.Builder> {
   )
   public final Style style;
 
-  public Letter(String title, Style style) {
-    this(title, style, ByteString.EMPTY);
+  @WireField(
+      tag = 3,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
+  public final Boolean about_love;
+
+  @WireField(
+      tag = 4,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+  )
+  @Deprecated
+  public final List<Integer> path;
+
+  public Letter(String title, Style style, Boolean about_love, List<Integer> path) {
+    this(title, style, about_love, path, ByteString.EMPTY);
   }
 
-  public Letter(String title, Style style, ByteString unknownFields) {
+  public Letter(String title, Style style, Boolean about_love, List<Integer> path,
+      ByteString unknownFields) {
     super(ADAPTER, unknownFields);
     this.title = title;
     this.style = style;
+    this.about_love = about_love;
+    this.path = Internal.immutableCopyOf("path", path);
   }
 
   @Override
@@ -62,6 +85,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     Builder builder = new Builder();
     builder.title = title;
     builder.style = style;
+    builder.about_love = about_love;
+    builder.path = Internal.copyOf(path);
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -73,7 +98,9 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     Letter o = (Letter) other;
     return unknownFields().equals(o.unknownFields())
         && Internal.equals(title, o.title)
-        && Internal.equals(style, o.style);
+        && Internal.equals(style, o.style)
+        && Internal.equals(about_love, o.about_love)
+        && path.equals(o.path);
   }
 
   @Override
@@ -83,6 +110,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
       result = unknownFields().hashCode();
       result = result * 37 + (title != null ? title.hashCode() : 0);
       result = result * 37 + (style != null ? style.hashCode() : 0);
+      result = result * 37 + (about_love != null ? about_love.hashCode() : 0);
+      result = result * 37 + path.hashCode();
       super.hashCode = result;
     }
     return result;
@@ -93,6 +122,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     StringBuilder builder = new StringBuilder();
     if (title != null) builder.append(", title=").append(title);
     if (style != null) builder.append(", style=").append(style);
+    if (about_love != null) builder.append(", about_love=").append(about_love);
+    if (!path.isEmpty()) builder.append(", path=").append(path);
     return builder.replace(0, 2, "Letter{").append('}').toString();
   }
 
@@ -101,7 +132,12 @@ public final class Letter extends Message<Letter, Letter.Builder> {
 
     public Style style;
 
+    public Boolean about_love;
+
+    public List<Integer> path;
+
     public Builder() {
+      path = Internal.newMutableList();
     }
 
     public Builder title(String title) {
@@ -114,9 +150,21 @@ public final class Letter extends Message<Letter, Letter.Builder> {
       return this;
     }
 
+    public Builder about_love(Boolean about_love) {
+      this.about_love = about_love;
+      return this;
+    }
+
+    @Deprecated
+    public Builder path(List<Integer> path) {
+      Internal.checkElementsNotNull(path);
+      this.path = path;
+      return this;
+    }
+
     @Override
     public Letter build() {
-      return new Letter(title, style, super.buildUnknownFields());
+      return new Letter(title, style, about_love, path, super.buildUnknownFields());
     }
   }
 
@@ -129,6 +177,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     public int encodedSize(Letter value) {
       return ProtoAdapter.STRING.encodedSizeWithTag(1, value.title)
           + Style.ADAPTER.encodedSizeWithTag(2, value.style)
+          + ProtoAdapter.BOOL.encodedSizeWithTag(3, value.about_love)
+          + ProtoAdapter.INT32.asPacked().encodedSizeWithTag(4, value.path)
           + value.unknownFields().size();
     }
 
@@ -136,6 +186,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
     public void encode(ProtoWriter writer, Letter value) throws IOException {
       ProtoAdapter.STRING.encodeWithTag(writer, 1, value.title);
       Style.ADAPTER.encodeWithTag(writer, 2, value.style);
+      ProtoAdapter.BOOL.encodeWithTag(writer, 3, value.about_love);
+      ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 4, value.path);
       writer.writeBytes(value.unknownFields());
     }
 
@@ -154,6 +206,8 @@ public final class Letter extends Message<Letter, Letter.Builder> {
             }
             break;
           }
+          case 3: builder.about_love(ProtoAdapter.BOOL.decode(reader)); break;
+          case 4: builder.path.add(ProtoAdapter.INT32.decode(reader)); break;
           default: {
             reader.readUnknownField(tag);
           }


### PR DESCRIPTION
Because `default`s aren't options., we strip them on [parsing](https://github.com/square/wire/blob/5d4ea6f20042ce829bc258cebefc506dbe0a1bf9/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoParser.java#L362-L376).
Now, we wanna print them back when emitting protos, that is what this PR is doing.

One trouble is that the current implementation doesn't respect the order, when printing protos, the default value will always be added last. I don't think that's a blocker anyway.

part of #1243 