### PR TITLE
Prepare to lazy-load and lazy-evaluate the proto path

### DIFF
--- a/wire-schema/src/main/java/com/squareup/wire/schema/FileLinker.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/FileLinker.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema;
+
+import java.util.Collection;
+
+final class FileLinker {
+  private final ProtoFile protoFile;
+  private final Linker linker;
+
+  FileLinker(ProtoFile protoFile, Linker linker) {
+    this.protoFile = protoFile;
+    this.linker = linker;
+  }
+
+  ProtoFile protoFile() {
+    return protoFile;
+  }
+
+  /** Register public imports so we know that importing a.proto also imports b.proto and c.proto. */
+  void registerDirectPublicImports() {
+    for (String path : protoFile.publicImports()) {
+      linker.addPublicImport(protoFile.location(), path);
+    }
+  }
+
+  /**
+   * Register the effective set of imports for this file, which includes the direct imports plus
+   * the recursive traversal of public imports.
+   */
+  void registerTransitiveImports() {
+    addImports(protoFile.location(), protoFile.imports());
+    addImports(protoFile.location(), protoFile.publicImports());
+  }
+
+  /** Configures {@code location} to import {@code paths}, plus their public imports recursively. */
+  private void addImports(Location location, Collection<String> paths) {
+    for (String path : paths) {
+      if (linker.addImport(location, path)) {
+        addImports(location, linker.getPublicImports(path));
+      }
+    }
+  }
+
+  void registerTypes() {
+    for (Type type : protoFile.types()) {
+      addTypes(type);
+    }
+  }
+
+  private void addTypes(Type type) {
+    linker.addType(type.type(), type);
+    for (Type nestedType : type.nestedTypes()) {
+      addTypes(nestedType);
+    }
+  }
+
+  void linkExtensions() {
+    for (Extend extend : protoFile.extendList()) {
+      extend.link(linker);
+    }
+  }
+
+  void linkMembers() {
+    for (Type type : protoFile.types()) {
+      type.link(linker);
+    }
+    for (Service service : protoFile.services()) {
+      service.link(linker);
+    }
+  }
+
+  /**
+   * This requires traversal of members of imported types! This may potentially include non-direct
+   * dependencies!
+   */
+  void linkOptions() {
+    protoFile.linkOptions(linker);
+    for (Type type : protoFile.types()) {
+      type.linkOptions(linker);
+    }
+    for (Service service : protoFile.services()) {
+      service.linkOptions(linker);
+    }
+  }
+
+  void validate() {
+    protoFile.validate(linker);
+
+    for (Type type : protoFile.types()) {
+      type.validate(linker);
+    }
+    for (Service service : protoFile.services()) {
+      service.validate(linker);
+    }
+    for (Extend extend : protoFile.extendList()) {
+      extend.validate(linker);
+    }
+  }
+}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -109,8 +109,13 @@ public final class Schema {
     return field;
   }
 
-  public static Schema fromFiles(Iterable<ProtoFile> files) {
-    return new Linker(files).link();
+  public static Schema fromFiles(Iterable<ProtoFile> sourceFiles) {
+    return new Linker().link(sourceFiles, ImmutableList.of());
+  }
+
+  // TODO(jwilson): replace with an interface that loads path files on-demand.
+  static Schema fromFiles(Iterable<ProtoFile> sourceFiles, Iterable<ProtoFile> pathFiles) {
+    return new Linker().link(sourceFiles, pathFiles);
   }
 
   private static ImmutableMap<String, Type> buildTypesIndex(Iterable<ProtoFile> protoFiles) {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/SchemaLoader.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/SchemaLoader.java
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.schema;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
@@ -49,7 +50,7 @@ import static com.google.common.collect.Iterables.getOnlyElement;
  * relative to the root of the archive.
  */
 public final class SchemaLoader {
-  static final String DESCRIPTOR_PROTO = "google/protobuf/descriptor.proto";
+  private static final String DESCRIPTOR_PROTO = "google/protobuf/descriptor.proto";
 
   private final List<Path> sources = new ArrayList<>();
   private final List<String> protos = new ArrayList<>();
@@ -164,7 +165,7 @@ public final class SchemaLoader {
       }
     }
 
-    return new Linker(loaded.values()).link();
+    return new Linker().link(loaded.values(), ImmutableList.of());
   }
 
   /**


### PR DESCRIPTION
We currently aggressively load and validate everything on the proto path.
Making it load dependencies as necessary should make builds faster and
simplify configuration for sprawling declarations.