### PR TITLE
Lazily load from the proto path.

### DIFF
--- a/proto-pruner/src/main/java/com/squareup/wire/prune/ProtoPruner.kt
+++ b/proto-pruner/src/main/java/com/squareup/wire/prune/ProtoPruner.kt
@@ -24,16 +24,19 @@ import java.nio.file.FileSystem
 import java.nio.file.FileSystems
 
 class ProtoPruner(
-  private val fs : FileSystem,
+  private val fs: FileSystem,
   private val inPaths: List<String>,
   private val outPath: String,
   private val identifierSet: IdentifierSet
 ) : Runnable {
   override fun run() {
+    val sourcePathFiles = NewSchemaLoader(fs).use { loader ->
+      loader.initRoots(inPaths.map { Location.get(it) })
+      loader.loadSourcePathFiles()
+    }
+
     val schema = Schema
-        .fromFiles(
-            NewSchemaLoader(fs, inPaths.map { Location.get(it) }).load()
-        )
+        .fromFiles(sourcePathFiles)
         .prune(identifierSet)
 
     schema.protoFiles()

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -400,7 +400,6 @@ class WireRunTest {
    * [SchemaException]. But we no longer do this to make Wire both faster and to eliminate the need
    * to place all transitive dependencies in the proto path.
    */
-  @Ignore("WireRun currently evaluates path files entirely")
   @Test
   fun onlyDirectDependenciesOfSourcePathRequired() {
     writeBlueProto()

--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnclosingType.kt
@@ -31,7 +31,7 @@ class EnclosingType internal constructor(
   override fun options() = throw UnsupportedOperationException()
   override fun nestedTypes() = nestedTypes
 
-  internal override fun link(linker: Linker) = nestedTypes.forEach { it.link(linker) }
+  internal override fun linkMembers(linker: Linker) {}
   internal override fun linkOptions(linker: Linker) = nestedTypes.forEach { it.linkOptions(linker) }
   internal override fun validate(linker: Linker) = nestedTypes.forEach { it.validate(linker) }
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.kt
@@ -15,8 +15,8 @@
  */
 package com.squareup.wire.schema
 
-import com.squareup.wire.schema.internal.parser.EnumElement
 import com.squareup.wire.schema.Options.ENUM_OPTIONS
+import com.squareup.wire.schema.internal.parser.EnumElement
 
 class EnumType private constructor(
   private val protoType: ProtoType,
@@ -46,7 +46,7 @@ class EnumType private constructor(
 
   fun constants() = constants
 
-  internal override fun link(linker: Linker) {}
+  internal override fun linkMembers(linker: Linker) {}
 
   internal override fun linkOptions(linker: Linker) {
     options.link(linker)

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
@@ -191,6 +191,10 @@ public final class Field {
 
   Field retainAll(Schema schema, MarkSet markSet, ProtoType enclosingType) {
     if (!isUsedAsOption(schema, markSet, enclosingType)) {
+      // If the type is null this field was never linked. Prune it.
+      // TODO(jwilson): perform this transformation in the Linker.
+      if (type == null) return null;
+
       // For map types only the value can participate in pruning as the key will always be scalar.
       if (type.isMap() && !markSet.contains(type.valueType())) return null;
 
@@ -238,20 +242,20 @@ public final class Field {
 
     ProtoMember protoMember = ProtoMember.get(enclosingType, this.qualifiedName());
     if (type instanceof MessageType) {
-      if (type.options().map().containsKey(protoMember)) {
+      if (type.options().assignsMember(protoMember)) {
         return true;
       }
       for (Field messageField : ((MessageType) type).fields()) {
-        if (messageField.options().map().containsKey(protoMember)) {
+        if (messageField.options().assignsMember(protoMember)) {
           return true;
         }
       }
     } else if (type instanceof EnumType) {
-      if (type.options().map().containsKey(protoMember)) {
+      if (type.options().assignsMember(protoMember)) {
         return true;
       }
       for (EnumConstant constant : ((EnumType) type).constants()) {
-        if (constant.getOptions().map().containsKey(protoMember)) {
+        if (constant.getOptions().assignsMember(protoMember)) {
           return true;
         }
       }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Loader.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Loader.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.squareup.wire.schema.internal.parser.ProtoParser
+import okio.buffer
+import okio.source
+
+/** Loads other files as needed by their import path. */
+interface Loader {
+  fun load(path: String): ProtoFile
+}
+
+/**
+ * A loader that can only load Google's protobuf descriptor, which defines standard options like
+ * default, deprecated, and java_package. If the user has provided their own version of the
+ * descriptor proto, that is preferred.
+ */
+object CoreLoader : Loader {
+  const val DESCRIPTOR_PROTO = "google/protobuf/descriptor.proto"
+
+  override fun load(path: String): ProtoFile {
+    if (path == DESCRIPTOR_PROTO) {
+      val resourceAsStream = SchemaLoader::class.java.getResourceAsStream("/$DESCRIPTOR_PROTO")
+      resourceAsStream.source().buffer().use { source ->
+        val data = source.readUtf8()
+        val location = Location.get(DESCRIPTOR_PROTO)
+        val element = ProtoParser.parse(location, data)
+        return ProtoFile.get(element)
+      }
+    }
+
+    throw error("unexpected load: $path")
+  }
+}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/MessageType.java
@@ -178,7 +178,7 @@ public final class MessageType extends Type {
     extensionFields.addAll(fields);
   }
 
-  void link(Linker linker) {
+  void linkMembers(Linker linker) {
     linker = linker.withContext(this);
     for (Field field : declaredFields) {
       field.link(linker);
@@ -188,9 +188,6 @@ public final class MessageType extends Type {
     }
     for (OneOf oneOf : oneOfs) {
       oneOf.link(linker);
-    }
-    for (Type type : nestedTypes) {
-      type.link(linker);
     }
   }
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Options.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Options.java
@@ -105,7 +105,7 @@ public final class Options {
 
   Map<ProtoMember, Object> canonicalizeOption(
       Linker linker, ProtoType extensionType, OptionElement option) {
-    Type type = linker.get(extensionType);
+    Type type = linker.getForOptions(extensionType);
     if (!(type instanceof MessageType)) {
       return null; // No known extensions for the given extension type.
     }
@@ -284,7 +284,7 @@ public final class Options {
   }
 
   Options retainAll(Schema schema, MarkSet markSet) {
-    if (map.isEmpty()) return this; // Nothing to prune.
+    if (map == null || map.isEmpty()) return this; // Nothing to prune.
     Options result = new Options(optionType, optionElements);
     Object mapOrNull = retainAll(schema, markSet, optionType, map);
     result.map = mapOrNull != null
@@ -326,5 +326,10 @@ public final class Options {
     } else {
       return o;
     }
+  }
+
+  /** Returns true if these options assigns a value to {@code protoMember}. */
+  boolean assignsMember(ProtoMember protoMember) {
+    return map != null && map.containsKey(protoMember);
   }
 }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Pruner.java
@@ -128,6 +128,9 @@ final class Pruner {
           if (marks.mark((ProtoMember) reachable)) {
             queue.add(reachable);
           }
+        } else if (reachable == null) {
+          // Skip nulls.
+          // TODO(jwilson): create a dedicated UNLINKED type as a placeholder.
         } else {
           throw new IllegalStateException("unexpected object: " + reachable);
         }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -110,12 +110,11 @@ public final class Schema {
   }
 
   public static Schema fromFiles(Iterable<ProtoFile> sourceFiles) {
-    return new Linker().link(sourceFiles, ImmutableList.of());
+    return new Linker(CoreLoader.INSTANCE).link(sourceFiles);
   }
 
-  // TODO(jwilson): replace with an interface that loads path files on-demand.
-  static Schema fromFiles(Iterable<ProtoFile> sourceFiles, Iterable<ProtoFile> pathFiles) {
-    return new Linker().link(sourceFiles, pathFiles);
+  static Schema fromFiles(Iterable<ProtoFile> sourceProtoFiles, Loader pathFilesLoader) {
+    return new Linker(pathFilesLoader).link(sourceProtoFiles);
   }
 
   private static ImmutableMap<String, Type> buildTypesIndex(Iterable<ProtoFile> protoFiles) {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/SchemaLoader.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/SchemaLoader.java
@@ -15,7 +15,6 @@
  */
 package com.squareup.wire.schema;
 
-import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 import com.squareup.wire.schema.internal.parser.ProtoFileElement;
 import com.squareup.wire.schema.internal.parser.ProtoParser;
@@ -165,7 +164,7 @@ public final class SchemaLoader {
       }
     }
 
-    return new Linker().link(loaded.values(), ImmutableList.of());
+    return new Linker(CoreLoader.INSTANCE).link(loaded.values());
   }
 
   /**

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
@@ -27,7 +27,7 @@ public abstract class Type {
   public abstract String documentation();
   public abstract Options options();
   public abstract List<Type> nestedTypes();
-  abstract void link(Linker linker);
+  abstract void linkMembers(Linker linker);
   abstract void linkOptions(Linker linker);
   abstract void validate(Linker linker);
   abstract Type retainAll(Schema schema, MarkSet markSet);

--- a/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
@@ -75,4 +75,12 @@ data class ProtoFileElement(
       }
     }
   }
+
+  companion object {
+    /** Returns an empty proto file to serve as a null object when a file cannot be found. */
+    @JvmStatic
+    fun empty(path: String): ProtoFileElement {
+      return ProtoFileElement(location = Location.get(path))
+    }
+  }
 }


### PR DESCRIPTION
Previously the proto path and source path were symmetric: all types and members and
options were always loaded, parsed, and linked.

With this change we lazily load, parse, and link from the proto path.

The biggest fallout of this change is that some things are newly null when
pruning including the options map and field types. This should be cleaned up
in a follow-up PR, but this PR is big enough as-is.