### PR TITLE
Keep ServiceOptions if used when pruning

### DIFF
--- a/proto-pruner/src/test/expected/letter.proto
+++ b/proto-pruner/src/test/expected/letter.proto
@@ -20,3 +20,11 @@ enum Style {
   SHORT = 1 [(squareup.options.misc.text_alignment) = 3];
   LONG = 2 [(squareup.options.misc.text_alignment) = 4];
 }
+
+service Post {
+  option (squareup.options.misc.httpOneOnly) = false;
+
+  rpc ExchangeLetter (stream Letter) returns (stream Letter) {
+    option (squareup.options.misc.hide) = true;
+  };
+}

--- a/proto-pruner/src/test/expected/options.proto
+++ b/proto-pruner/src/test/expected/options.proto
@@ -13,3 +13,9 @@ extend google.protobuf.MessageOptions {
 extend google.protobuf.EnumValueOptions {
   optional int32 text_alignment = 54000;
 }
+extend google.protobuf.ServiceOptions {
+  optional bool httpOneOnly = 56000;
+}
+extend google.protobuf.MethodOptions {
+  optional bool hide = 56001;
+}

--- a/proto-pruner/src/test/java/com/squareup/wire/prune/ProtoPrunerTest.kt
+++ b/proto-pruner/src/test/java/com/squareup/wire/prune/ProtoPrunerTest.kt
@@ -67,7 +67,7 @@ class ProtoPrunerTest {
 
   @Test
   fun testOptions() {
-    val sources = arrayOf("squareup.options.letter.Letter")
+    val sources = arrayOf("squareup.options.letter.Letter", "squareup.options.letter.Post")
     invokeProtoPruner(sources, "--excludes=google.protobuf.*")
 
     val outputs = arrayOf(

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
@@ -233,6 +233,22 @@ public final class Field {
       for (Type type : protoFile.types()) {
         if (isUsedAsOption(markSet, enclosingType, type)) return true;
       }
+      for (Service service : protoFile.services()) {
+        if (isUsedAsOption(markSet, enclosingType, service)) return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isUsedAsOption(MarkSet markSet, ProtoType enclosingType, Service service) {
+    if (!markSet.contains(service.type())) return false;
+
+    ProtoMember protoMember = ProtoMember.get(enclosingType, this.qualifiedName());
+    if (service.options().assignsMember(protoMember)) {
+      return true;
+    }
+    for (Rpc rpc : service.rpcs()) {
+      if (rpc.options().assignsMember(protoMember)) return true;
     }
     return false;
   }

--- a/wire-tests/src/commonTest/proto/java/letter.proto
+++ b/wire-tests/src/commonTest/proto/java/letter.proto
@@ -32,3 +32,11 @@ enum Style {
   SHORT = 1 [(squareup.options.misc.text_alignment) = 3];
   LONG = 2 [(squareup.options.misc.text_alignment) = 4];
 }
+
+service Post {
+  option (squareup.options.misc.httpOneOnly) = false;
+
+  rpc ExchangeLetter (stream Letter) returns (stream Letter) {
+    option (squareup.options.misc.hide) = true;
+  }
+}

--- a/wire-tests/src/commonTest/proto/java/options.proto
+++ b/wire-tests/src/commonTest/proto/java/options.proto
@@ -30,3 +30,11 @@ extend google.protobuf.MessageOptions {
 extend google.protobuf.EnumValueOptions {
   optional int32 text_alignment = 54000;
 }
+
+extend google.protobuf.ServiceOptions {
+  optional bool httpOneOnly = 56000;
+}
+
+extend google.protobuf.MethodOptions {
+  optional bool hide = 56001;
+}

--- a/wire-tests/src/jvmJavaTest/proto-java/com/google/protobuf/MethodOptions.java
+++ b/wire-tests/src/jvmJavaTest/proto-java/com/google/protobuf/MethodOptions.java
@@ -29,6 +29,8 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
 
   public static final IdempotencyLevel DEFAULT_IDEMPOTENCY_LEVEL = IdempotencyLevel.IDEMPOTENCY_UNKNOWN;
 
+  public static final Boolean DEFAULT_HIDE = false;
+
   /**
    * Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
    *   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -61,17 +63,27 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
   )
   public final List<UninterpretedOption> uninterpreted_option;
 
+  /**
+   * Extension source: options.proto
+   */
+  @WireField(
+      tag = 56001,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
+  public final Boolean hide;
+
   public MethodOptions(Boolean deprecated, IdempotencyLevel idempotency_level,
-      List<UninterpretedOption> uninterpreted_option) {
-    this(deprecated, idempotency_level, uninterpreted_option, ByteString.EMPTY);
+      List<UninterpretedOption> uninterpreted_option, Boolean hide) {
+    this(deprecated, idempotency_level, uninterpreted_option, hide, ByteString.EMPTY);
   }
 
   public MethodOptions(Boolean deprecated, IdempotencyLevel idempotency_level,
-      List<UninterpretedOption> uninterpreted_option, ByteString unknownFields) {
+      List<UninterpretedOption> uninterpreted_option, Boolean hide, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
     this.deprecated = deprecated;
     this.idempotency_level = idempotency_level;
     this.uninterpreted_option = Internal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.hide = hide;
   }
 
   @Override
@@ -80,6 +92,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     builder.deprecated = deprecated;
     builder.idempotency_level = idempotency_level;
     builder.uninterpreted_option = Internal.copyOf(uninterpreted_option);
+    builder.hide = hide;
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -92,7 +105,8 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     return unknownFields().equals(o.unknownFields())
         && Internal.equals(deprecated, o.deprecated)
         && Internal.equals(idempotency_level, o.idempotency_level)
-        && uninterpreted_option.equals(o.uninterpreted_option);
+        && uninterpreted_option.equals(o.uninterpreted_option)
+        && Internal.equals(hide, o.hide);
   }
 
   @Override
@@ -103,6 +117,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
       result = result * 37 + (idempotency_level != null ? idempotency_level.hashCode() : 0);
       result = result * 37 + uninterpreted_option.hashCode();
+      result = result * 37 + (hide != null ? hide.hashCode() : 0);
       super.hashCode = result;
     }
     return result;
@@ -114,6 +129,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
     if (idempotency_level != null) builder.append(", idempotency_level=").append(idempotency_level);
     if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (hide != null) builder.append(", hide=").append(hide);
     return builder.replace(0, 2, "MethodOptions{").append('}').toString();
   }
 
@@ -123,6 +139,8 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
     public IdempotencyLevel idempotency_level;
 
     public List<UninterpretedOption> uninterpreted_option;
+
+    public Boolean hide;
 
     public Builder() {
       uninterpreted_option = Internal.newMutableList();
@@ -157,9 +175,14 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
       return this;
     }
 
+    public Builder hide(Boolean hide) {
+      this.hide = hide;
+      return this;
+    }
+
     @Override
     public MethodOptions build() {
-      return new MethodOptions(deprecated, idempotency_level, uninterpreted_option, super.buildUnknownFields());
+      return new MethodOptions(deprecated, idempotency_level, uninterpreted_option, hide, super.buildUnknownFields());
     }
   }
 
@@ -228,6 +251,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
       return ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated)
           + IdempotencyLevel.ADAPTER.encodedSizeWithTag(34, value.idempotency_level)
           + UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999, value.uninterpreted_option)
+          + ProtoAdapter.BOOL.encodedSizeWithTag(56001, value.hide)
           + value.unknownFields().size();
     }
 
@@ -236,6 +260,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
       ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated);
       IdempotencyLevel.ADAPTER.encodeWithTag(writer, 34, value.idempotency_level);
       UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      ProtoAdapter.BOOL.encodeWithTag(writer, 56001, value.hide);
       writer.writeBytes(value.unknownFields());
     }
 
@@ -255,6 +280,7 @@ public final class MethodOptions extends Message<MethodOptions, MethodOptions.Bu
             break;
           }
           case 999: builder.uninterpreted_option.add(UninterpretedOption.ADAPTER.decode(reader)); break;
+          case 56001: builder.hide(ProtoAdapter.BOOL.decode(reader)); break;
           default: {
             reader.readUnknownField(tag);
           }

--- a/wire-tests/src/jvmJavaTest/proto-java/com/google/protobuf/ServiceOptions.java
+++ b/wire-tests/src/jvmJavaTest/proto-java/com/google/protobuf/ServiceOptions.java
@@ -25,6 +25,8 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
 
   public static final Boolean DEFAULT_DEPRECATED = false;
 
+  public static final Boolean DEFAULT_HTTPONEONLY = false;
+
   /**
    * Note:  Field numbers 1 through 32 are reserved for Google's internal RPC
    *   framework.  We apologize for hoarding these numbers to ourselves, but
@@ -51,15 +53,26 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
   )
   public final List<UninterpretedOption> uninterpreted_option;
 
-  public ServiceOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option) {
-    this(deprecated, uninterpreted_option, ByteString.EMPTY);
+  /**
+   * Extension source: options.proto
+   */
+  @WireField(
+      tag = 56000,
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
+  public final Boolean httpOneOnly;
+
+  public ServiceOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option,
+      Boolean httpOneOnly) {
+    this(deprecated, uninterpreted_option, httpOneOnly, ByteString.EMPTY);
   }
 
   public ServiceOptions(Boolean deprecated, List<UninterpretedOption> uninterpreted_option,
-      ByteString unknownFields) {
+      Boolean httpOneOnly, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
     this.deprecated = deprecated;
     this.uninterpreted_option = Internal.immutableCopyOf("uninterpreted_option", uninterpreted_option);
+    this.httpOneOnly = httpOneOnly;
   }
 
   @Override
@@ -67,6 +80,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     Builder builder = new Builder();
     builder.deprecated = deprecated;
     builder.uninterpreted_option = Internal.copyOf(uninterpreted_option);
+    builder.httpOneOnly = httpOneOnly;
     builder.addUnknownFields(unknownFields());
     return builder;
   }
@@ -78,7 +92,8 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     ServiceOptions o = (ServiceOptions) other;
     return unknownFields().equals(o.unknownFields())
         && Internal.equals(deprecated, o.deprecated)
-        && uninterpreted_option.equals(o.uninterpreted_option);
+        && uninterpreted_option.equals(o.uninterpreted_option)
+        && Internal.equals(httpOneOnly, o.httpOneOnly);
   }
 
   @Override
@@ -88,6 +103,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
       result = unknownFields().hashCode();
       result = result * 37 + (deprecated != null ? deprecated.hashCode() : 0);
       result = result * 37 + uninterpreted_option.hashCode();
+      result = result * 37 + (httpOneOnly != null ? httpOneOnly.hashCode() : 0);
       super.hashCode = result;
     }
     return result;
@@ -98,6 +114,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     StringBuilder builder = new StringBuilder();
     if (deprecated != null) builder.append(", deprecated=").append(deprecated);
     if (!uninterpreted_option.isEmpty()) builder.append(", uninterpreted_option=").append(uninterpreted_option);
+    if (httpOneOnly != null) builder.append(", httpOneOnly=").append(httpOneOnly);
     return builder.replace(0, 2, "ServiceOptions{").append('}').toString();
   }
 
@@ -105,6 +122,8 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     public Boolean deprecated;
 
     public List<UninterpretedOption> uninterpreted_option;
+
+    public Boolean httpOneOnly;
 
     public Builder() {
       uninterpreted_option = Internal.newMutableList();
@@ -134,9 +153,14 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
       return this;
     }
 
+    public Builder httpOneOnly(Boolean httpOneOnly) {
+      this.httpOneOnly = httpOneOnly;
+      return this;
+    }
+
     @Override
     public ServiceOptions build() {
-      return new ServiceOptions(deprecated, uninterpreted_option, super.buildUnknownFields());
+      return new ServiceOptions(deprecated, uninterpreted_option, httpOneOnly, super.buildUnknownFields());
     }
   }
 
@@ -149,6 +173,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     public int encodedSize(ServiceOptions value) {
       return ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated)
           + UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999, value.uninterpreted_option)
+          + ProtoAdapter.BOOL.encodedSizeWithTag(56000, value.httpOneOnly)
           + value.unknownFields().size();
     }
 
@@ -156,6 +181,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
     public void encode(ProtoWriter writer, ServiceOptions value) throws IOException {
       ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated);
       UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999, value.uninterpreted_option);
+      ProtoAdapter.BOOL.encodeWithTag(writer, 56000, value.httpOneOnly);
       writer.writeBytes(value.unknownFields());
     }
 
@@ -167,6 +193,7 @@ public final class ServiceOptions extends Message<ServiceOptions, ServiceOptions
         switch (tag) {
           case 33: builder.deprecated(ProtoAdapter.BOOL.decode(reader)); break;
           case 999: builder.uninterpreted_option.add(UninterpretedOption.ADAPTER.decode(reader)); break;
+          case 56000: builder.httpOneOnly(ProtoAdapter.BOOL.decode(reader)); break;
           default: {
             reader.readUnknownField(tag);
           }


### PR DESCRIPTION
part of #1243 

wire-schema/src/main/java/com/squareup/wire/schema/Field.java is where the logic is.