### PR TITLE
New mechanism to retain only linked things in the schema

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/schema/LinkerTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/LinkerTest.kt
@@ -19,16 +19,34 @@ import com.google.common.jimfs.Configuration
 import com.google.common.jimfs.Jimfs
 import com.squareup.wire.testing.add
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 
 class LinkerTest {
   private val fs = Jimfs.newFileSystem(Configuration.unix())
 
-  @Ignore("TODO: implement")
   @Test
-  fun unusedPathFileExcludedFromSchema() {
-    fs.add("proto-source/a.proto", """
+  fun usedProtoPathFileIncludedInSchema() {
+    fs.add("source-path/a.proto", """
+            |import "b.proto";
+            |message A {
+            |  optional B b = 1;
+            |}
+            """.trimMargin())
+    fs.add("proto-path/b.proto", """
+            |message B {
+            |}
+            """.trimMargin())
+    val schema = loadAndLinkSchema()
+
+    assertThat(schema.protoFiles().map { it.location() }).containsExactly(
+        Location.get("source-path", "a.proto"),
+        Location.get("proto-path", "b.proto")
+    )
+  }
+
+  @Test
+  fun unusedProtoPathFileExcludedFromSchema() {
+    fs.add("source-path/a.proto", """
             |import "b.proto";
             |message A {
             |}
@@ -40,13 +58,100 @@ class LinkerTest {
     val schema = loadAndLinkSchema()
 
     assertThat(schema.protoFiles().map { it.location() })
-        .containsExactly(Location.get("src", "a.proto"))
+        .containsExactly(Location.get("source-path", "a.proto"))
+  }
+
+  @Test
+  fun onlyProtoPathTypesAreIncludedInSchema() {
+    fs.add("source-path/a.proto", """
+            |import "b.proto";
+            |message A {
+            |  optional B b = 1;
+            |}
+            """.trimMargin())
+    fs.add("proto-path/b.proto", """
+            |message B {
+            |}
+            |message C {
+            |}
+            """.trimMargin())
+    val schema = loadAndLinkSchema()
+
+    assertThat(schema.getType("B")).isNotNull()
+    assertThat(schema.getType("C")).isNull()
+  }
+
+  @Test
+  fun protoPathMembersAreIncludedInSchemaIfTheyAreUsedInOptions() {
+    fs.add("source-path/a.proto", """
+             |import "formatting_options.proto";
+             |message A {
+             |  optional string s = 1 [formatting_options.language.name = "English"];
+             |}
+            """.trimMargin())
+    fs.add("proto-path/formatting_options.proto", """
+             |import "google/protobuf/descriptor.proto";
+             |
+             |message FormattingOptions {
+             |  optional Language language = 1;
+             |  optional StringCasing string_casing = 2;
+             |}
+             |
+             |extend google.protobuf.FieldOptions {
+             |  optional FormattingOptions formatting_options = 22001;
+             |}
+             |
+             |message Language {
+             |  optional string name = 1;
+             |  optional string locale = 2;
+             |}
+             |
+             |enum StringCasing {
+             |  LOWER_CASE = 1;
+             |  TITLE_CASE = 2;
+             |  SENTENCE_CASE = 3;
+             |}
+            """.trimMargin())
+    val schema = loadAndLinkSchema()
+
+    assertThat(schema.getType("FormattingOptions")).isNotNull()
+    assertThat(schema.getType("Language")).isNotNull()
+    assertThat(schema.getType("StringCasing")).isNotNull()
+
+    assertThat(schema.getField("FormattingOptions", "language")).isNotNull()
+    assertThat(schema.getField("FormattingOptions", "string_casing")).isNotNull()
+    assertThat(schema.getField("Language", "name")).isNotNull()
+
+    val fieldOptionsType = ProtoType.get("google.protobuf", "FieldOptions")
+    assertThat(schema.getField(fieldOptionsType, "formatting_options")).isNotNull()
+  }
+
+  @Test
+  fun protoPathMembersAreNotIncludedInSchemaIfTheyAreNotUsedInOptions() {
+    fs.add("source-path/a.proto", """
+            |import "b.proto";
+            |message A {
+            |  optional B b = 1;
+            |}
+            """.trimMargin())
+    fs.add("proto-path/b.proto", """
+            |message B {
+            |  optional C c = 1;
+            |}
+            |message C {
+            |}
+            """.trimMargin())
+    val schema = loadAndLinkSchema()
+
+    assertThat(schema.getType("B")).isNotNull()
+    assertThat(schema.getType("C")).isNull()
+    assertThat(schema.getField("B", "c")).isNull()
   }
 
   private fun loadAndLinkSchema(): Schema {
     return NewSchemaLoader(fs).use { loader ->
       loader.initRoots(
-          sourcePath = listOf(Location.get("proto-source")),
+          sourcePath = listOf(Location.get("source-path")),
           protoPath = listOf(Location.get("proto-path"))
       )
       val sourceProtoFiles = loader.loadSourcePathFiles()

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/OptionsLinkingTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/OptionsLinkingTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.google.common.jimfs.Configuration
+import com.google.common.jimfs.Jimfs
+import com.squareup.wire.testing.add
+import com.squareup.wire.testing.exists
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class OptionsLinkingTest {
+  private val fs = Jimfs.newFileSystem(Configuration.unix())
+
+  @Test
+  fun extensionOnTheSourcePathIsApplied() {
+    fs.add("source-path/a.proto", """
+             |import "formatting_options.proto";
+             |message A {
+             |  optional string s = 1 [formatting_options.language = "English"];
+             |}
+            """.trimMargin())
+    fs.add("source-path/formatting_options.proto", """
+             |import "google/protobuf/descriptor.proto";
+             |
+             |message FormattingOptions {
+             |  optional string language = 1;
+             |}
+             |
+             |extend google.protobuf.FieldOptions {
+             |  optional FormattingOptions formatting_options = 22001;
+             |}
+            """.trimMargin())
+    val schema = loadAndLinkSchema()
+
+    val typeA = schema.getType("A") as MessageType
+    assertThat(typeA.field("s").options().map()).isEqualTo(
+        mapOf(
+            formattingOptionsField to mapOf(
+                languageField to "English"
+            )
+        )
+    )
+  }
+
+  @Test
+  fun extensionOnTheProtoPathIsApplied() {
+    fs.add("source-path/a.proto", """
+             |import "formatting_options.proto";
+             |message A {
+             |  optional string s = 1 [formatting_options.language = "English"];
+             |}
+            """.trimMargin())
+    fs.add("proto-path/formatting_options.proto", """
+             |import "google/protobuf/descriptor.proto";
+             |
+             |message FormattingOptions {
+             |  optional string language = 1;
+             |}
+             |
+             |extend google.protobuf.FieldOptions {
+             |  optional FormattingOptions formatting_options = 22001;
+             |}
+            """.trimMargin())
+    val schema = loadAndLinkSchema()
+
+    val typeA = schema.getType("A") as MessageType
+    assertThat(typeA.field("s").options().map()).isEqualTo(
+        mapOf(
+            formattingOptionsField to mapOf(
+                languageField to "English"
+            )
+        )
+    )
+  }
+
+  @Test
+  fun fieldsOfExtensions() {
+    fs.add("source-path/a.proto", """
+             |import "formatting_options.proto";
+             |message A {
+             |  optional string s = 1 [formatting_options.language.name = "English"];
+             |}
+            """.trimMargin())
+    fs.add("proto-path/formatting_options.proto", """
+             |import "google/protobuf/descriptor.proto";
+             |
+             |message FormattingOptions {
+             |  optional Language language = 1;
+             |  optional StringCasing string_casing = 2;
+             |}
+             |
+             |extend google.protobuf.FieldOptions {
+             |  optional FormattingOptions formatting_options = 22001;
+             |}
+             |
+             |message Language {
+             |  optional string name = 1;
+             |  optional string locale = 2;
+             |}
+             |
+             |enum StringCasing {
+             |  LOWER_CASE = 1;
+             |  TITLE_CASE = 2;
+             |  SENTENCE_CASE = 3;
+             |}
+            """.trimMargin())
+    val schema = loadAndLinkSchema()
+
+    val typeA = schema.getType("A") as MessageType
+    assertThat(typeA.field("s").options().map()).isEqualTo(
+        mapOf(
+            formattingOptionsField to mapOf(
+                languageField to mapOf(
+                    nameField to "English"
+                )
+            )
+        )
+    )
+  }
+
+  private fun loadAndLinkSchema(): Schema {
+    return NewSchemaLoader(fs).use { loader ->
+      val protoPath = when {
+        fs.exists("proto-path") -> listOf(Location.get("proto-path"))
+        else -> listOf()
+      }
+
+      loader.initRoots(
+          sourcePath = listOf(Location.get("source-path")),
+          protoPath = protoPath
+      )
+      val sourceProtoFiles = loader.loadSourcePathFiles()
+      Schema.fromFiles(sourceProtoFiles, loader)
+    }
+  }
+
+  companion object {
+    private val fieldOptions = ProtoType.get("google.protobuf.FieldOptions")
+    private val formattingOptionsField = ProtoMember.get(fieldOptions, "formatting_options")
+
+    private val formattingOptionsType = ProtoType.get("FormattingOptions")
+    private val languageField = ProtoMember.get(formattingOptionsType, "language")
+
+    private val languageType = ProtoType.get("Language")
+    private val nameField = ProtoMember.get(languageType, "name")
+  }
+}

--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnclosingType.kt
@@ -44,6 +44,12 @@ class EnclosingType internal constructor(
     else EnclosingType(location, type, documentation, retainedNestedTypes)
   }
 
+  override fun retainLinked(linkedTypes: MutableSet<ProtoType>?): Type? {
+    val retainedNestedTypes = nestedTypes.mapNotNull { it.retainLinked(linkedTypes) }
+    return if (retainedNestedTypes.isEmpty()) null
+    else EnclosingType(location, type, documentation, retainedNestedTypes)
+  }
+
   fun toElement() = MessageElement(
       location = location,
       name = type.simpleName(),

--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnumConstant.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnumConstant.kt
@@ -34,6 +34,9 @@ class EnumConstant private constructor(
     markSet: MarkSet
   ) = EnumConstant(location, name, tag, documentation, options.retainAll(schema, markSet))
 
+  internal fun retainLinked() =
+      EnumConstant(location, name, tag, documentation, options.retainLinked())
+
   companion object {
     internal fun fromElements(elements: List<EnumConstantElement>) =
       elements.map {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.kt
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/EnumType.kt
@@ -106,6 +106,20 @@ class EnumType private constructor(
     return result
   }
 
+  override fun retainLinked(linkedTypes: Set<ProtoType>): Type? {
+    if (!linkedTypes.contains(type())) {
+      return null
+    }
+
+    val retainedConstants = constants.map { it.retainLinked() }
+
+    return EnumType(
+        protoType, location, documentation, name,
+        retainedConstants,
+        options.retainLinked()
+    )
+  }
+
   fun toElement(): EnumElement {
     return EnumElement(
         location,

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Field.java
@@ -207,13 +207,29 @@ public final class Field {
       if (!markSet.contains(protoMember)) return null;
     }
 
+    return withOptions(options.retainAll(schema, markSet));
+  }
+
+  /** Returns a copy of this whose options is {@code options}. */
+  private Field withOptions(Options options) {
     Field result = new Field(packageName, location, label, name, documentation, tag, defaultValue,
-        elementType, options.retainAll(schema, markSet), extension);
+        elementType, options, extension);
     result.type = type;
     result.deprecated = deprecated;
     result.packed = packed;
     result.redacted = redacted;
     return result;
+  }
+
+  static ImmutableList<Field> retainLinked(List<Field> fields) {
+    ImmutableList.Builder<Field> result = ImmutableList.builder();
+    for (Field field : fields) {
+      // If the type is non-null, then the field has been linked.
+      if (field.type != null) {
+        result.add(field.withOptions(field.options.retainLinked()));
+      }
+    }
+    return result.build();
   }
 
   static ImmutableList<Field> retainAll(

--- a/wire-schema/src/main/java/com/squareup/wire/schema/FileLinker.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/FileLinker.java
@@ -31,6 +31,9 @@ final class FileLinker {
   /** True once this linker has registered its types with the enclosing linker. */
   private boolean typesRegistered;
 
+  private boolean extensionsLinked;
+  private boolean importedExtensionsRegistered;
+
   /** The set of types defined in this file whose members have been linked. */
   private final Set<ProtoType> typesWithMembersLinked = new LinkedHashSet<>();
 
@@ -83,9 +86,26 @@ final class FileLinker {
     }
   }
 
-  void linkExtensions() {
+  void requireExtensionsLinked() {
+    if (extensionsLinked) return;
+    extensionsLinked = true;
+
+    requireTypesRegistered();
     for (Extend extend : protoFile.extendList()) {
       extend.link(linker);
+    }
+  }
+
+  /**
+   * This file might use extensions defined on one of the files we import. Make sure those
+   * extensions are registered before we try to use our extensions.
+   */
+  void requireImportedExtensionsRegistered() {
+    if (importedExtensionsRegistered) return;
+    importedExtensionsRegistered = true;
+
+    for (FileLinker importedFileLinker : linker.contextImportedTypes()) {
+      importedFileLinker.requireExtensionsLinked();
     }
   }
 

--- a/wire-schema/src/main/java/com/squareup/wire/schema/OneOf.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/OneOf.java
@@ -62,6 +62,12 @@ public final class OneOf {
     return new OneOf(name, documentation, retainedFields);
   }
 
+  OneOf retainLinked() {
+    ImmutableList<Field> retainedFields = Field.retainLinked(fields);
+    if (retainedFields.isEmpty()) return null;
+    return new OneOf(name, documentation, retainedFields);
+  }
+
   static ImmutableList<OneOf> fromElements(String packageName, List<OneOfElement> elements,
       boolean extension) {
     ImmutableList.Builder<OneOf> oneOfs = ImmutableList.builder();

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Options.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Options.java
@@ -55,6 +55,10 @@ public final class Options {
     this.optionElements = ImmutableList.copyOf(elements);
   }
 
+  public Options retainLinked() {
+    return new Options(optionType, ImmutableList.of());
+  }
+
   /**
    * Returns a map with the values for these options. Map values may be either a single entry, like
    * {@code {deprecated: "true"}}, or more sophisticated, with nested maps and lists.
@@ -140,6 +144,7 @@ public final class Options {
       Map<ProtoMember, Object> nested = new LinkedHashMap<>();
       last.put(ProtoMember.get(lastProtoType, field), nested);
       lastProtoType = field.type();
+      if (lastProtoType != null) linker.getForOptions(lastProtoType); // Force members linking.
       last = nested;
       field = linker.dereference(field, path[i]);
       if (field == null) {

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Schema.java
@@ -109,6 +109,14 @@ public final class Schema {
     return field;
   }
 
+  public Field getField(String typeName, String memberName) {
+    return getField(ProtoType.get(typeName), memberName);
+  }
+
+  public Field getField(ProtoType protoType, String memberName) {
+    return getField(ProtoMember.get(protoType, memberName));
+  }
+
   public static Schema fromFiles(Iterable<ProtoFile> sourceFiles) {
     return new Linker(CoreLoader.INSTANCE).link(sourceFiles);
   }

--- a/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
+++ b/wire-schema/src/main/java/com/squareup/wire/schema/Type.java
@@ -20,6 +20,7 @@ import com.squareup.wire.schema.internal.parser.EnumElement;
 import com.squareup.wire.schema.internal.parser.MessageElement;
 import com.squareup.wire.schema.internal.parser.TypeElement;
 import java.util.List;
+import java.util.Set;
 
 public abstract class Type {
   public abstract Location location();
@@ -31,6 +32,16 @@ public abstract class Type {
   abstract void linkOptions(Linker linker);
   abstract void validate(Linker linker);
   abstract Type retainAll(Schema schema, MarkSet markSet);
+
+  /**
+   * Returns a copy of this containing only the types in {@code linkedTypes}, or null if that set
+   * is empty. This will return an {@code EnclosingType} if it is itself not linked, but its
+   * nested types are linked.
+   *
+   * The returned type is a shadow of its former self. It it useful for linking against, but lacks
+   * most of the members of the original type.
+   */
+  abstract Type retainLinked(Set<ProtoType> linkedTypes);
 
   public static Type get(String packageName, ProtoType protoType, TypeElement type) {
     if (type instanceof EnumElement) {

--- a/wire-test-utils/src/main/java/com/squareup/wire/testing/files.kt
+++ b/wire-test-utils/src/main/java/com/squareup/wire/testing/files.kt
@@ -48,6 +48,11 @@ fun FileSystem.get(pathString: String): String {
   return String(Files.readAllBytes(path), Charsets.UTF_8)
 }
 
+fun FileSystem.exists(pathString: String): Boolean {
+  val path = getPath(pathString)
+  return Files.exists(path)
+}
+
 fun FileSystem.find(path: String): Set<String> {
   val result = mutableSetOf<String>()
   Files.walkFileTree(getPath(path), object : SimpleFileVisitor<Path>() {


### PR DESCRIPTION
When we load a schema with a separate source path and proto path, the returned
schema only contains the bits of the proto path that are used.