### PR TITLE
Add workaround to unblock running Gradle plugin tests locally

### DIFF
--- a/gradle/gradle-mvn-mpp-push.gradle
+++ b/gradle/gradle-mvn-mpp-push.gradle
@@ -82,7 +82,10 @@ task javadocsJar(type: Jar, dependsOn: dokka) {
 
 signing {
   required { isReleaseBuild() && gradle.taskGraph.hasTask("uploadArchives") }
-  sign(publishing.publications)
+  // TODO(egorand): Remove if statement when https://github.com/gradle/gradle/issues/11387 is fixed
+  if (required) {
+    sign(publishing.publications)
+  }
 }
 
 publishing {


### PR DESCRIPTION
`:wire-runtime:installLocally` has been failing with:
```
Signing Gradle Module Metadata is not supported for snapshot dependencies.
```