### PR TITLE
Add EmittingRules to be used on generation.

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -188,7 +188,7 @@ data class WireRun(
     for (target in targetsExclusiveLast) {
       val schemaHandler = target.newHandler(schema, fs, logger, schemaLoader)
 
-      val pruningRules: PruningRules = PruningRules.Builder()
+      val emittingRules = EmittingRules.Builder()
           .include(target.includes)
           .exclude(target.excludes)
           .build()
@@ -196,7 +196,7 @@ data class WireRun(
       val i = typesToHandle.iterator()
       while (i.hasNext()) {
         val type = i.next()
-        if (pruningRules.includes(type.type)) {
+        if (emittingRules.includes(type.type)) {
           schemaHandler.handle(type)
           // We don't let other targets handle this one.
           if (target.exclusive) i.remove()
@@ -206,22 +206,22 @@ data class WireRun(
       val j = servicesToHandle.iterator()
       while (j.hasNext()) {
         val service = j.next()
-        if (pruningRules.includes(service.type())) {
+        if (emittingRules.includes(service.type())) {
           schemaHandler.handle(service)
           // We don't let other targets handle this one.
           if (target.exclusive) j.remove()
         }
       }
 
-      if (pruningRules.unusedIncludes().isNotEmpty()) {
+      if (emittingRules.unusedIncludes().isNotEmpty()) {
         logger.info("""Unused includes in targets:
-            |  ${pruningRules.unusedExcludes().joinToString(separator = "\n  ")}
+            |  ${emittingRules.unusedIncludes().joinToString(separator = "\n  ")}
             """.trimMargin())
       }
 
-      if (pruningRules.unusedExcludes().isNotEmpty()) {
+      if (emittingRules.unusedExcludes().isNotEmpty()) {
         logger.info("""Unused exclude in targets:
-            |  ${pruningRules.unusedExcludes().joinToString(separator = "\n  ")}
+            |  ${emittingRules.unusedExcludes().joinToString(separator = "\n  ")}
             """.trimMargin())
       }
     }

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EmittingRules.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EmittingRules.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+/**
+ * A set of rules that describes which types to generate.
+ *
+ * Despite the builder, instances of this class are not safe for concurrent use.
+ *
+ * ### Identifier Matching
+ *
+ * Identifiers in this set may be in the following forms:
+ *
+ *  * Package names, followed by `.*`, like `squareup.protos.person.*`. This matches types and
+ *    services defined in the package and its descendant packages.
+ *
+ *  * Fully qualified type and service names, like `squareup.protos.person.Person`.
+ *
+ * Identifiers should not contain member names.
+ *
+ * This set has *included identifiers* and *excluded identifiers*, with excludes taking precedence
+ * over includes. That is, if a type `Movie` is in both the includes and the excludes, it is not
+ * contained in the set.
+ *
+ * If the includes set is empty, that implies that all elements should be included. Use this to
+ * exclude unwanted types and members without also including everything else.
+ */
+class EmittingRules private constructor(builder: Builder) {
+  private val includes = builder.includes.toSet()
+  private val excludes = builder.excludes.toSet()
+  private val usedIncludes = mutableSetOf<String>()
+  private val usedExcludes = mutableSetOf<String>()
+
+  val isEmpty: Boolean
+    get() = includes.isEmpty() && excludes.isEmpty()
+
+  /** Returns true if `type` should be generated. */
+  fun includes(type: ProtoType) = includes(type.toString())
+
+  private fun includes(identifier: String): Boolean {
+    if (includes.isEmpty()) return !exclude(identifier)
+
+    var includeMatch: String? = null
+    var excludeMatch: String? = null
+    var rule: String? = identifier
+    while (rule != null) {
+      if (excludes.contains(rule)) {
+        excludeMatch = rule
+      }
+      if (includes.contains(rule)) {
+        includeMatch = rule
+      }
+      rule = enclosing(rule)
+    }
+
+    return when {
+      excludeMatch != null -> {
+        usedExcludes.add(excludeMatch)
+        false
+      }
+      includeMatch != null -> {
+        usedIncludes.add(includeMatch)
+        true
+      }
+      else -> {
+        false
+      }
+    }
+  }
+
+  private fun exclude(identifier: String): Boolean {
+    var excludeMatch: String? = null
+    var rule: String? = identifier
+    while (rule != null) {
+      if (excludes.contains(rule)) {
+        excludeMatch = rule
+      }
+      rule = PruningRules.enclosing(rule)
+    }
+
+    return when {
+      excludeMatch != null -> {
+        usedExcludes.add(excludeMatch)
+        true
+      }
+      else -> {
+        false
+      }
+    }
+  }
+
+  fun unusedIncludes() = includes - usedIncludes
+
+  fun unusedExcludes() = excludes - usedExcludes
+
+  class Builder {
+    internal val includes = mutableSetOf<String>()
+    internal val excludes = mutableSetOf<String>()
+
+    fun include(identifier: String) = apply {
+      includes.add(identifier)
+    }
+
+    fun include(identifiers: Iterable<String>) = apply {
+      includes.addAll(identifiers)
+    }
+
+    fun exclude(identifiers: Iterable<String>) = apply {
+      excludes.addAll(identifiers)
+    }
+
+    fun exclude(identifier: String) = apply {
+      excludes.add(identifier)
+    }
+
+    fun build(): EmittingRules {
+      return EmittingRules(this)
+    }
+  }
+
+  companion object {
+    /**
+     * Returns the identifier or wildcard that encloses `identifier`, or null if it is not enclosed.
+     *
+     *  * If it is a type it returns the enclosing package with a wildcard, like
+     *    `squareup.dinosaurs.*`.
+     *
+     *  * If it is a package with a wildcard, it returns the parent package with a wildcard, like
+     *    `squareup.*`. The root wildcard is a lone asterisk, `*`.
+     *
+     */
+    internal fun enclosing(identifier: String): String? {
+      val from = if (identifier.endsWith(".*")) identifier.length - 3 else identifier.length - 1
+      val dot = identifier.lastIndexOf('.', from)
+      if (dot != -1) return identifier.substring(0, dot) + ".*"
+
+      if (identifier != "*") return "*"
+      return null
+    }
+  }
+}

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/EmittingRulesTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/EmittingRulesTest.kt
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class EmittingRulesTest {
+  @Test
+  fun enclosing() {
+    assertThat(EmittingRules.enclosing("a.b.Outer")).isEqualTo("a.b.*")
+    assertThat(EmittingRules.enclosing("a.b.*")).isEqualTo("a.*")
+    assertThat(EmittingRules.enclosing("a.*")).isEqualTo("*")
+    assertThat(EmittingRules.enclosing("*")).isNull()
+  }
+
+  @Test
+  fun enclosingOnNestedClass() {
+    assertThat(EmittingRules.enclosing("a.b.Outer.Inner")).isEqualTo("a.b.Outer.*")
+    assertThat(EmittingRules.enclosing("a.b.Outer.*")).isEqualTo("a.b.*")
+  }
+
+  @Test
+  fun empty() {
+    val rules = EmittingRules.Builder().build()
+    assertThat(rules.includes(ProtoType.get("a.b.Message"))).isTrue()
+  }
+
+  /** Note that including a type includes nested members, but not nested types. */
+  @Test
+  fun includeType() {
+    val rules = EmittingRules.Builder()
+        .include("a.b.Message")
+        .build()
+    assertThat(rules.includes(ProtoType.get("a.b.Message"))).isTrue()
+    assertThat(rules.includes(ProtoType.get("a.b.Message.Nested"))).isFalse()
+    assertThat(rules.includes(ProtoType.get("a.b.Another"))).isFalse()
+  }
+
+  @Test
+  fun includePackage() {
+    val rules = EmittingRules.Builder()
+        .include("a.b.*")
+        .build()
+    assertThat(rules.includes(ProtoType.get("a.b.Message"))).isTrue()
+    assertThat(rules.includes(ProtoType.get("a.b.c.Message"))).isTrue()
+    assertThat(rules.includes(ProtoType.get("a.c.Another"))).isFalse()
+  }
+
+  @Test
+  fun includeAll() {
+    val rules = EmittingRules.Builder()
+        .include("*")
+        .build()
+    assertThat(rules.includes(ProtoType.get("a.b.Message"))).isTrue()
+  }
+
+  @Test
+  fun excludeType() {
+    val rules = EmittingRules.Builder()
+        .exclude("a.b.Message")
+        .build()
+    assertThat(rules.includes(ProtoType.get("a.b.Message"))).isFalse()
+    assertThat(rules.includes(ProtoType.get("a.b.Another"))).isTrue()
+  }
+
+  @Test
+  fun excludePackage() {
+    val rules = EmittingRules.Builder()
+        .exclude("a.b.*")
+        .build()
+    assertThat(rules.includes(ProtoType.get("a.b.Message"))).isFalse()
+    assertThat(rules.includes(ProtoType.get("a.b.c.Message"))).isFalse()
+    assertThat(rules.includes(ProtoType.get("a.c.Another"))).isTrue()
+  }
+
+  @Test
+  fun excludePackageTakesPrecedenceOverIncludeType() {
+    val rules = EmittingRules.Builder()
+        .exclude("a.b.*")
+        .include("a.b.Message")
+        .build()
+    assertThat(rules.includes(ProtoType.get("a.b.Message"))).isFalse()
+    assertThat(rules.includes(ProtoType.get("a.b.Another"))).isFalse()
+    assertThat(rules.includes(ProtoType.get("a.c.YetAnother"))).isFalse()
+  }
+
+  @Test
+  fun trackingUnusedIncludes() {
+    val rules = EmittingRules.Builder()
+        .include("a.*")
+        .include("b.IncludedType")
+        .build()
+    assertThat(rules.unusedIncludes()).containsExactly("a.*", "b.IncludedType")
+
+    rules.includes(ProtoType.get("a.*"))
+    assertThat(rules.unusedIncludes()).containsExactly("b.IncludedType")
+
+    rules.includes(ProtoType.get("b.IncludedType"))
+    assertThat(rules.unusedIncludes()).isEmpty()
+  }
+
+  @Test
+  fun trackingUnusedExcludes() {
+    val rules = EmittingRules.Builder()
+        .exclude("a.*")
+        .exclude("b.ExcludedType")
+        .build()
+    assertThat(rules.unusedExcludes()).containsExactly("a.*", "b.ExcludedType")
+
+    rules.includes(ProtoType.get("a.*"))
+    assertThat(rules.unusedExcludes()).containsExactly("b.ExcludedType")
+
+    rules.includes(ProtoType.get("b.ExcludedType"))
+    assertThat(rules.unusedExcludes()).isEmpty()
+  }
+
+  @Test
+  fun trackingUnusedIncludesPrecedence() {
+    val rules = EmittingRules.Builder()
+        .include("a.*")
+        .include("a.IncludedType")
+        .build()
+    rules.includes(ProtoType.get("a.IncludedType.NestedType"))
+    assertThat(rules.unusedIncludes()).containsExactly("a.IncludedType")
+  }
+
+  @Test
+  fun trackingUnusedExcludesPrecedence() {
+    val rules = EmittingRules.Builder()
+        .exclude("a.*")
+        .exclude("a.IncludedType")
+        .build()
+    rules.includes(ProtoType.get("a.IncludedType.NestedType"))
+    assertThat(rules.unusedExcludes()).containsExactly("a.IncludedType")
+  }
+
+  @Test
+  fun trackingUnusedPrecedence() {
+    val rules = EmittingRules.Builder()
+        .include("a.*")
+        .exclude("a.*")
+        .build()
+    rules.includes(ProtoType.get("a.Message"))
+    assertThat(rules.unusedExcludes()).isEmpty()
+    assertThat(rules.unusedIncludes()).containsExactly("a.*")
+  }
+}


### PR DESCRIPTION
`PruningRules` was also used for emission decision. Since no pruning is involved, I've splitten the logic into its own class. Moreover, `member`s were not supported, and it's explicit now.
The logic is taken from `PruningRules` minus what concerns pruning only.

From the point of view of the Gradle Plugin, it's an explicit split between `root/prune` at the root, which is modelled by the pruning rules, and `include/exclude` inside the target modelled by the emitting rules.