### PR TITLE
Pruning rules: Most precise rule takes precedence, and we crash for conflicting rules.

### DIFF
--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Pruner.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Pruner.kt
@@ -128,8 +128,14 @@ internal class Pruner(
       for (reachable in reachableMembers) {
         when (reachable) {
           is ProtoType -> {
-            if (marks.mark(reachable)) {
-              queue.add(reachable)
+            if (root is ProtoMember) {
+              if (marks.mark(reachable, root)) {
+                queue.add(reachable)
+              }
+            } else {
+              if (marks.mark(reachable)) {
+                queue.add(reachable)
+              }
             }
           }
 

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/PruningRules.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/PruningRules.kt
@@ -46,9 +46,10 @@ import com.squareup.wire.schema.SemVer.Companion.toLowerCaseSemVer
  * as `Movie#name` and `Movie#release_date`). It contains the type `Actor` and one member
  * `Actor#name`, but not `Actor#birth_date` or `Actor#oscar_count`.
  *
- * This set has *included identifiers* and *excluded identifiers*, with excludes taking precedence
- * over includes. That is, if a type `Movie` is in both the includes and the excludes, it is not
- * contained in the set.
+ * This set has *included identifiers* and *excluded identifiers*, with the most precise identifier
+ * taking precedence over the other ones. For instance, if there is one included identifier
+ * `a.Movie` along an excluded identifier `a.*`, the type `a.Movie` is considered included in the
+ * set.
  *
  * If the includes set is empty, that implies that all elements should be included. Use this to
  * exclude unwanted types and members without also including everything else.
@@ -125,28 +126,27 @@ class PruningRules private constructor(builder: Builder) {
     var excludeMatch: String? = null
     var rule: String? = identifier
     while (rule != null) {
-      if (excludes.contains(rule)) {
+      if (excludeMatch == null && excludes.contains(rule)) {
         excludeMatch = rule
       }
-      if (includes.contains(rule)) {
+      if (includeMatch == null && includes.contains(rule)) {
         includeMatch = rule
       }
       rule = enclosing(rule)
     }
 
-    return when {
-      excludeMatch != null -> {
-        usedExcludes.add(excludeMatch)
-        false
-      }
-      includeMatch != null -> {
-        usedIncludes.add(includeMatch)
-        true
-      }
-      else -> {
-        false
-      }
+    val isRoot = when {
+      excludeMatch != null && includeMatch != null -> excludeMatch.length < includeMatch.length
+      excludeMatch != null -> false
+      includeMatch != null -> true
+      else -> false
     }
+    if (isRoot) {
+      usedIncludes.add(includeMatch!!)
+    } else if (excludeMatch != null) {
+      usedExcludes.add(excludeMatch)
+    }
+    return isRoot
   }
 
   /**
@@ -160,24 +160,28 @@ class PruningRules private constructor(builder: Builder) {
 
   /** Returns true if `identifier` or any of its enclosing identifiers is excluded.  */
   private fun exclude(identifier: String): Boolean {
+    var includeMatch: String? = null
     var excludeMatch: String? = null
     var rule: String? = identifier
     while (rule != null) {
-      if (excludes.contains(rule)) {
+      if (excludeMatch == null && excludes.contains(rule)) {
         excludeMatch = rule
+      }
+      if (includeMatch == null && includes.contains(rule)) {
+        includeMatch = rule
       }
       rule = enclosing(rule)
     }
 
-    return when {
-      excludeMatch != null -> {
-        usedExcludes.add(excludeMatch)
-        true
-      }
-      else -> {
-        false
-      }
+    val excluded = when {
+      excludeMatch != null && includeMatch != null -> excludeMatch.length >= includeMatch.length
+      excludeMatch != null -> true
+      else -> false
     }
+    if (excluded) {
+      usedExcludes.add(excludeMatch!!)
+    }
+    return excluded
   }
 
   fun unusedIncludes() = includes - usedIncludes
@@ -225,6 +229,10 @@ class PruningRules private constructor(builder: Builder) {
     fun build(): PruningRules {
       check(oldest == null || newest == null || oldest!! <= newest!!) {
         "expected oldest $oldest <= newest $newest"
+      }
+      val conflictingRules = includes.intersect(excludes)
+      check(conflictingRules.isEmpty()) {
+        "same rule(s) defined in both includes and excludes: ${conflictingRules.joinToString()}"
       }
       return PruningRules(this)
     }

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1537,7 +1537,7 @@ class PrunerTest {
     assertThat(message.field("field_5")).isNull()
   }
 
-  @Test @Ignore("Implement #1349")
+  @Test
   fun typeIsRetainedIfMorePreciseRuleExists() {
     val schema = RepoBuilder()
         .add("service.proto", """
@@ -1557,7 +1557,7 @@ class PrunerTest {
     assertThat(pruned.getType("wire.MessageB")).isNull()
   }
 
-  @Test @Ignore("Implement #1349")
+  @Test
   fun fieldIsRetainedIfMorePreciseRuleExists() {
     val schema = RepoBuilder()
         .add("service.proto", """
@@ -1577,7 +1577,7 @@ class PrunerTest {
     assertThat(myMessageType.field("b")).isNull()
   }
 
-  @Test @Ignore("Implement #1349")
+  @Test
   fun enumConstantIsRetainedIfMorePreciseRuleExists() {
     val schema = RepoBuilder()
         .add("service.proto", """
@@ -1598,23 +1598,6 @@ class PrunerTest {
   }
 
   @Test
-  fun excludeTakesPrecedenceIfRulesAreEquals() {
-    val schema = RepoBuilder()
-        .add("service.proto", """
-            |message MyMessage {
-            |  optional string a = 1;
-            |  optional string b = 2;
-            |}
-            """.trimMargin())
-        .schema()
-    val pruned = schema.prune(PruningRules.Builder()
-        .include("MyMessage")
-        .exclude("MyMessage")
-        .build())
-    assertThat(pruned.getType("MyMessage")).isNull()
-  }
-
-  @Test @Ignore("Implement #1349")
   fun optionFieldIsRetainedIfMorePreciseRuleExists() {
     val schema = RepoBuilder()
         .add("lecture.proto", """
@@ -1651,7 +1634,7 @@ class PrunerTest {
     assertThat(messageType.field("content")!!.options.elements).isEmpty()
   }
 
-  @Test @Ignore("Implement #1349")
+  @Test
   fun nestedInclusion() {
     val schema = RepoBuilder()
         .add("service.proto", """


### PR DESCRIPTION
related to #1243 
fixes #1349 