### PR TITLE
Do not fail to build when the profile cannot find a dependancy

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/schema/NewSchemaLoader.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/NewSchemaLoader.kt
@@ -198,7 +198,13 @@ class NewSchemaLoader(
 
         val resolvedType = schema.getType(type)
         if (resolvedType == null) {
-          errors.add(String.format("unable to resolve %s (%s)", type, typeConfig.location))
+          // This type is either absent from .proto files, or merely not loaded because our schema
+          // is incomplete. Unfortunately we can't tell the difference! Assume that this type is
+          // just absent from the schema-as-loaded and therefore irrelevant to the current project.
+          // Ignore it!
+          //
+          // (A fancier implementation would load the schema and profile in one step and they would
+          // be mutually complete. We aren't bothering with this correctness at this phase.)
           continue
         }
 

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/NewProfileLoaderTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/NewProfileLoaderTest.kt
@@ -119,13 +119,9 @@ class NewProfileLoaderTest {
         |}
         """.trimMargin()
     )
-    try {
-      loadAndLinkProfile("android")
-      fail()
-    } catch (expected: IllegalArgumentException) {
-      assertThat(expected)
-          .hasMessage("unable to resolve a.b.Message2 (source-path/a/b/android.wire at 2:1)")
-    }
+    val profile = loadAndLinkProfile("android")
+    val message = ProtoType.get("a.b.Message")
+    assertThat(profile.getTarget(message)).isNull()
   }
 
   @Test

--- a/wire-java-generator/src/test/java/com/squareup/wire/java/ProfileLoaderTest.kt
+++ b/wire-java-generator/src/test/java/com/squareup/wire/java/ProfileLoaderTest.kt
@@ -194,13 +194,9 @@ class ProfileLoaderTest {
               |}
               """.trimMargin()
         )
-    try {
-      repoBuilder.profile("android")
-      fail()
-    } catch (expected: IllegalArgumentException) {
-      assertThat(expected)
-          .hasMessage("unable to resolve a.b.Message2 (/source/a/b/android.wire at 2:1)")
-    }
+    val profile = repoBuilder.profile("android")
+    val message = ProtoType.get("a.b.Message")
+    assertThat(profile.getTarget(message)).isNull()
   }
 
   @Test @Throws(Exception::class)


### PR DESCRIPTION
If the type is missing we won't load it as the profile is incomplete. We assume the type is absent. A more fancy version would load the profile and schema in one step to avoid this issue.