### PR TITLE
Generate non-instantiable class for EnclosingType in Kotlin

### DIFF
--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1351,7 +1351,8 @@ class KotlinGenerator private constructor(
   }
 
   private fun generateEnclosing(type: EnclosingType): TypeSpec {
-    val classBuilder = TypeSpec.objectBuilder(type.typeName)
+    val classBuilder = TypeSpec.classBuilder(type.typeName)
+        .primaryConstructor(FunSpec.constructorBuilder().addModifiers(KModifier.PRIVATE).build())
 
     type.nestedTypes.forEach { classBuilder.addType(generateType(it)) }
 

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -100,7 +100,7 @@ class KotlinGeneratorTest {
     val kotlinGenerator = KotlinGenerator.invoke(pruned)
     val typeSpec = kotlinGenerator.generateType(pruned.getType("A")!!)
     val code = FileSpec.get("", typeSpec).toString()
-    assertTrue(code.contains("object A {"))
+    assertTrue(code.contains("class A private constructor() {"))
     assertTrue(code.contains("class B(.*) : Message<B, Nothing>".toRegex(DOT_MATCHES_ALL)))
   }
 


### PR DESCRIPTION
Fixes #1359 