### PR TITLE
Do not prune nested type

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -526,6 +526,36 @@ class WireRunTest {
           """.trimMargin())
   }
 
+  @Test
+  fun includeSubTypes() {
+    writeOrangeProto()
+    writeTriangleProto()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(Location.get("colors/src/main/proto")),
+        protoPath = listOf(Location.get("polygons/src/main/proto")),
+        targets = listOf(KotlinTarget(outDirectory = "generated/kt"))
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.find("generated")).containsExactly(
+        "generated/kt/squareup/colors/Orange.kt")
+    assertThat(fs.get("generated/kt/squareup/colors/Orange.kt"))
+        .contains("class Orange")
+  }
+
+  private fun writeOrangeProto() {
+    fs.add("colors/src/main/proto/squareup/colors/orange.proto", """
+          |syntax = "proto2";
+          |package squareup.colors;
+          |import "squareup/polygons/triangle.proto";
+          |message Orange {
+          |  optional string circle = 1;
+          |  optional squareup.polygons.Triangle.Type triangle = 2;
+          |}
+          """.trimMargin())
+  }
+
   private fun writeColorsRouteProto() {
     fs.add("routes/src/main/proto/squareup/routes/route.proto", """
           |syntax = "proto2";
@@ -558,6 +588,11 @@ class WireRunTest {
           |package squareup.polygons;
           |message Triangle {
           |  repeated double angles = 1;
+          |    enum Type {
+          |      EQUILATERAL = 1;
+          |      ISOSCELES = 2;
+          |      RIGHTANGLED = 3;
+          |   }
           |}
           """.trimMargin())
   }

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Linker.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Linker.kt
@@ -120,7 +120,7 @@ class Linker {
       }
 
       // Retain this type if it's used by anything in the source path.
-      val anyTypeIsUsed = fileLinker.protoFile.types
+      val anyTypeIsUsed = fileLinker.protoFile.typesAndNestedTypes()
           .any { type ->
             requestedTypes.contains(type.type)
           }

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/ProtoFile.kt
@@ -66,6 +66,18 @@ actual class ProtoFile private constructor(
     return result
   }
 
+  /**
+   * Returns all types and subtypes which are found in the proto file.
+   */
+  fun typesAndNestedTypes(): List<Type> {
+    val typesAndNestedTypes = mutableListOf<Type>()
+    for (type in types) {
+      typesAndNestedTypes.addAll(type.typesAndNestedTypes())
+    }
+
+    return typesAndNestedTypes
+  }
+
   fun javaPackage(): String? {
     return javaPackage?.toString()
   }

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Type.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Type.kt
@@ -42,6 +42,18 @@ abstract class Type {
    */
   abstract fun retainLinked(linkedTypes: Set<ProtoType>): Type?
 
+  /**
+   * Returns all types and subtypes which are linked to the type.
+   */
+  fun typesAndNestedTypes(): List<Type> {
+    val typesAndNestedTypes = mutableListOf<Type>()
+    typesAndNestedTypes.add(this)
+    for (type in nestedTypes) {
+      typesAndNestedTypes.addAll(type.typesAndNestedTypes())
+    }
+    return typesAndNestedTypes
+  }
+
   companion object {
     operator fun get(packageName: String?, protoType: ProtoType, type: TypeElement): Type {
       return when (type) {


### PR DESCRIPTION
Currently we are pruning protos which provided nested types if no other types in the file is used.