### PR TITLE
Do not fail the prune enclosed types

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -544,6 +544,25 @@ class WireRunTest {
         .contains("class Orange")
   }
 
+  @Test
+  fun includeSubTypesWithPruning() {
+    writeOrangeProto()
+    writeTriangleProto()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(Location.get("colors/src/main/proto")),
+        protoPath = listOf(Location.get("polygons/src/main/proto")),
+        treeShakingRoots = listOf("squareup.colors.*"),
+        targets = listOf(KotlinTarget(outDirectory = "generated/kt"))
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.find("generated")).containsExactly(
+        "generated/kt/squareup/colors/Orange.kt")
+    assertThat(fs.get("generated/kt/squareup/colors/Orange.kt"))
+        .contains("class Orange")
+  }
+
   private fun writeOrangeProto() {
     fs.add("colors/src/main/proto/squareup/colors/orange.proto", """
           |syntax = "proto2";

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EnclosingType.kt
@@ -25,7 +25,7 @@ class EnclosingType internal constructor(
   override val nestedTypes: List<Type>
 ) : Type() {
   override val options
-    get() = throw UnsupportedOperationException()
+    get() = Options(Options.MESSAGE_OPTIONS, listOf())
 
   override fun linkMembers(linker: Linker) {}
   override fun linkOptions(linker: Linker) = nestedTypes.forEach { it.linkOptions(linker) }

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Pruner.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Pruner.kt
@@ -232,6 +232,9 @@ internal class Pruner(
             result.add(get(type.type, constant.name))
           }
 
+        } else if (type is EnclosingType) {
+          options = type.options
+
         } else if (service != null) {
           options = service.options()
           for (rpc in service.rpcs()) {


### PR DESCRIPTION
Currently we fail when there are EnclosingType and we attempt to prune.
We don't want to do anything with these types when pruning, simple set the option to empty and don't fail. 