### PR TITLE
Add validation to check proto3 Enum has always a 0 value at the first position

### DIFF
--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EnclosingType.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.schema
 
+import com.squareup.wire.schema.ProtoFile.Syntax
 import com.squareup.wire.schema.internal.parser.MessageElement
 
 /** An empty type which only holds nested types.  */
@@ -29,7 +30,9 @@ class EnclosingType internal constructor(
 
   override fun linkMembers(linker: Linker) {}
   override fun linkOptions(linker: Linker) = nestedTypes.forEach { it.linkOptions(linker) }
-  override fun validate(linker: Linker) = nestedTypes.forEach { it.validate(linker) }
+  override fun validate(linker: Linker, syntax: Syntax?) {
+    nestedTypes.forEach { it.validate(linker, syntax) }
+  }
 
   override fun retainAll(schema: Schema, markSet: MarkSet): Type? {
     val retainedNestedTypes = nestedTypes.mapNotNull { it.retainAll(schema, markSet) }

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EnumType.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/EnumType.kt
@@ -16,6 +16,8 @@
 package com.squareup.wire.schema
 
 import com.squareup.wire.schema.Options.Companion.ENUM_OPTIONS
+import com.squareup.wire.schema.ProtoFile.Syntax
+import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_3
 import com.squareup.wire.schema.internal.parser.EnumElement
 
 class EnumType private constructor(
@@ -49,11 +51,20 @@ class EnumType private constructor(
     allowAlias = options.get(ALLOW_ALIAS)
   }
 
-  override fun validate(linker: Linker) {
+  override fun validate(linker: Linker, syntax: Syntax?) {
     val linker = linker.withContext(this)
 
     if ("true" != allowAlias) {
       validateTagUniqueness(linker)
+    }
+    if (syntax === PROTO_3) {
+      validateFirstElement(linker)
+    }
+  }
+
+  private fun validateFirstElement(linker: Linker) {
+    if (constants.isEmpty() || constants.first().tag != 0) {
+      linker.addError("missing a zero value at the first element [proto3]")
     }
   }
 

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/FileLinker.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/FileLinker.kt
@@ -143,7 +143,7 @@ internal class FileLinker(
     protoFile.validate(linker)
 
     for (type in protoFile.types) {
-      type.validate(linker)
+      type.validate(linker, protoFile.syntax)
     }
     for (service in protoFile.services) {
       service.validate(linker)

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/MessageType.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/MessageType.kt
@@ -23,6 +23,7 @@ import com.squareup.wire.schema.Field.Companion.retainLinked
 import com.squareup.wire.schema.Field.Companion.toElements
 import com.squareup.wire.schema.OneOf.Companion.fromElements
 import com.squareup.wire.schema.OneOf.Companion.toElements
+import com.squareup.wire.schema.ProtoFile.Syntax
 import com.squareup.wire.schema.Reserved.Companion.fromElements
 import com.squareup.wire.schema.Reserved.Companion.toElements
 import com.squareup.wire.schema.internal.parser.MessageElement
@@ -130,7 +131,7 @@ class MessageType private constructor(
     options.link(linker)
   }
 
-  override fun validate(linker: Linker) {
+  override fun validate(linker: Linker, syntax: Syntax?) {
     val linker = linker.withContext(this)
     linker.validateFields(fieldsAndOneOfFields, reserveds)
     linker.validateEnumConstantNameUniqueness(nestedTypes)
@@ -138,7 +139,7 @@ class MessageType private constructor(
       field.validate(linker)
     }
     for (nestedType in nestedTypes) {
-      nestedType.validate(linker)
+      nestedType.validate(linker, syntax)
     }
     for (extensions in extensionsList) {
       extensions.validate(linker)

--- a/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Type.kt
+++ b/wire-schema/src/jvmMain/java/com/squareup/wire/schema/Type.kt
@@ -17,6 +17,7 @@ package com.squareup.wire.schema
 
 import com.squareup.wire.schema.EnumType.Companion.fromElement
 import com.squareup.wire.schema.MessageType.Companion.fromElement
+import com.squareup.wire.schema.ProtoFile.Syntax
 import com.squareup.wire.schema.internal.parser.EnumElement
 import com.squareup.wire.schema.internal.parser.MessageElement
 import com.squareup.wire.schema.internal.parser.TypeElement
@@ -29,7 +30,7 @@ abstract class Type {
   abstract val nestedTypes: List<Type>
   abstract fun linkMembers(linker: Linker)
   abstract fun linkOptions(linker: Linker)
-  abstract fun validate(linker: Linker)
+  abstract fun validate(linker: Linker, syntax: Syntax?)
   abstract fun retainAll(schema: Schema, markSet: MarkSet): Type?
 
   /**


### PR DESCRIPTION
fixes #575 
As the official Google document says, proto3 Enum must have a zero value. To support this, we'll add a validation for this in `EnumType#validate(...)`. Since we need to know the proto version of `ProtoFile` we validate, `Syntax?` should be passed to the function.

Ref: https://developers.google.com/protocol-buffers/docs/proto3#enum
```
There must be a zero value, so that we can use 0 as a numeric default value.
```