### PR TITLE
Add validation to check proto3 extentions are only used for custom options

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema
 
 import com.squareup.wire.schema.Field.Companion.retainAll
+import com.squareup.wire.schema.Options.Companion.GOOGLE_PROTOBUF_OPTION_TYPES
 import com.squareup.wire.schema.internal.parser.ExtendElement
 import kotlin.jvm.JvmStatic
 
@@ -38,9 +39,13 @@ class Extend private constructor(
     }
   }
 
-  fun validate(linker: Linker) {
+  fun validate(linker: Linker, syntaxRules: SyntaxRules) {
     val linker = linker.withContext(this)
     linker.validateImport(location, type!!)
+
+    if (!syntaxRules.canExtend(ProtoType.get(name))) {
+      linker.addError("extensions are not allowed [proto3]")
+    }
   }
 
   fun retainAll(schema: Schema, markSet: MarkSet): Extend? {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
@@ -147,7 +147,7 @@ internal class FileLinker(
       service.validate(linker)
     }
     for (extend in protoFile.extendList) {
-      extend.validate(linker)
+      extend.validate(linker, syntaxRules)
     }
   }
 }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
@@ -21,6 +21,7 @@ import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_3
 
 /** A set of rules which defines schema requirements for a specific [Syntax]. */
 interface SyntaxRules {
+  fun canExtend(protoType: ProtoType): Boolean
   fun enumRequiresZeroValueAtFirstPosition(): Boolean
 
   companion object {
@@ -33,10 +34,14 @@ interface SyntaxRules {
     }
 
     internal val PROTO_2_SYNTAX_RULES = object : SyntaxRules {
+      override fun canExtend(protoType: ProtoType): Boolean = true
       override fun enumRequiresZeroValueAtFirstPosition(): Boolean = false
     }
 
     internal val PROTO_3_SYNTAX_RULES = object : SyntaxRules {
+      override fun canExtend(protoType: ProtoType): Boolean {
+        return protoType in Options.GOOGLE_PROTOBUF_OPTION_TYPES
+      }
       override fun enumRequiresZeroValueAtFirstPosition(): Boolean = true
     }
   }


### PR DESCRIPTION
fixes: #1384 

https://developers.google.com/protocol-buffers/docs/proto3#custom_options
`Note that creating custom options uses extensions, which are permitted only for custom options in proto3.`