### PR TITLE
Add validation to check default values in proto3

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -102,13 +102,16 @@ class Field private constructor(
     isRedacted = options.optionMatches(".*\\.redacted", "true")
   }
 
-  fun validate(linker: Linker) {
+  fun validate(linker: Linker, syntaxRules: SyntaxRules) {
     val linker = linker.withContext(this)
     if (isPacked && !isPackable(linker, type!!)) {
       linker.addError("packed=true not permitted on $type")
     }
     if (isExtension && isRequired) {
       linker.addError("extension fields cannot be required")
+    }
+    if (default != null && !syntaxRules.allowUserDefinedDefaultValue()) {
+      linker.addError("user-defined default values are not permitted [proto3]")
     }
     linker.validateImport(location, type!!)
   }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -136,7 +136,7 @@ class MessageType private constructor(
     linker.validateFields(fieldsAndOneOfFields, reserveds)
     linker.validateEnumConstantNameUniqueness(nestedTypes)
     for (field in fieldsAndOneOfFields) {
-      field.validate(linker)
+      field.validate(linker, syntaxRules)
     }
     for (nestedType in nestedTypes) {
       nestedType.validate(linker, syntaxRules)

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
@@ -21,6 +21,7 @@ import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_3
 
 /** A set of rules which defines schema requirements for a specific [Syntax]. */
 interface SyntaxRules {
+  fun allowUserDefinedDefaultValue(): Boolean
   fun canExtend(protoType: ProtoType): Boolean
   fun enumRequiresZeroValueAtFirstPosition(): Boolean
 
@@ -34,11 +35,13 @@ interface SyntaxRules {
     }
 
     internal val PROTO_2_SYNTAX_RULES = object : SyntaxRules {
+      override fun allowUserDefinedDefaultValue(): Boolean = true
       override fun canExtend(protoType: ProtoType): Boolean = true
       override fun enumRequiresZeroValueAtFirstPosition(): Boolean = false
     }
 
     internal val PROTO_3_SYNTAX_RULES = object : SyntaxRules {
+      override fun allowUserDefinedDefaultValue(): Boolean = false
       override fun canExtend(protoType: ProtoType): Boolean {
         return protoType in Options.GOOGLE_PROTOBUF_OPTION_TYPES
       }

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
@@ -1715,4 +1715,28 @@ class SchemaTest {
       )
     }
   }
+
+  @Test
+  fun proto3DoesNotAllowUserDefinedDefaultValue() {
+    try {
+      RepoBuilder()
+          .add("dinosaur.proto", """
+              |syntax = "proto3";
+              |
+              |message Dinosaur {
+              |  string name = 1 [default = "T-Rex"];
+              |}
+              |""".trimMargin()
+          )
+          .schema()
+      fail()
+    } catch (expected: SchemaException) {
+      assertThat(expected).hasMessage("""
+            |user-defined default values are not permitted [proto3]
+            |  for field name (/source/dinosaur.proto at 4:3)
+            |  in message Dinosaur (/source/dinosaur.proto at 3:1)
+            """.trimMargin()
+      )
+    }
+  }
 }


### PR DESCRIPTION
fixes: #1385 

In proto3, users are not allowed to set a default value unlike proto2.

https://developers.google.com/protocol-buffers/docs/proto3#default
`When a message is parsed, if the encoded message does not contain a particular singular element, the corresponding field in the parsed object is set to the default value for that field.`