### PR TITLE
Add SyntaxRules to avoid passing Syntax

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
@@ -15,7 +15,6 @@
  */
 package com.squareup.wire.schema
 
-import com.squareup.wire.schema.ProtoFile.Syntax
 import com.squareup.wire.schema.internal.parser.MessageElement
 
 /** An empty type which only holds nested types.  */
@@ -30,8 +29,8 @@ class EnclosingType internal constructor(
 
   override fun linkMembers(linker: Linker) {}
   override fun linkOptions(linker: Linker) = nestedTypes.forEach { it.linkOptions(linker) }
-  override fun validate(linker: Linker, syntax: Syntax?) {
-    nestedTypes.forEach { it.validate(linker, syntax) }
+  override fun validate(linker: Linker, syntaxRules: SyntaxRules) {
+    nestedTypes.forEach { it.validate(linker, syntaxRules) }
   }
 
   override fun retainAll(schema: Schema, markSet: MarkSet): Type? {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -16,8 +16,6 @@
 package com.squareup.wire.schema
 
 import com.squareup.wire.schema.Options.Companion.ENUM_OPTIONS
-import com.squareup.wire.schema.ProtoFile.Syntax
-import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_3
 import com.squareup.wire.schema.internal.parser.EnumElement
 import kotlin.jvm.JvmStatic
 
@@ -52,18 +50,18 @@ class EnumType private constructor(
     allowAlias = options.get(ALLOW_ALIAS)
   }
 
-  override fun validate(linker: Linker, syntax: Syntax?) {
+  override fun validate(linker: Linker, syntaxRules: SyntaxRules) {
     val linker = linker.withContext(this)
 
     if ("true" != allowAlias) {
       validateTagUniqueness(linker)
     }
-    if (syntax === PROTO_3) {
-      validateFirstElement(linker)
+    if (syntaxRules.enumRequiresZeroValueAtFirstPosition()) {
+      validateZeroValueAtFirstPosition(linker)
     }
   }
 
-  private fun validateFirstElement(linker: Linker) {
+  private fun validateZeroValueAtFirstPosition(linker: Linker) {
     if (constants.isEmpty() || constants.first().tag != 0) {
       linker.addError("missing a zero value at the first element [proto3]")
     }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
@@ -137,11 +137,11 @@ internal class FileLinker(
     protoFile.linkOptions(linker)
   }
 
-  fun validate() {
+  fun validate(syntaxRules: SyntaxRules) {
     protoFile.validate(linker)
 
     for (type in protoFile.types) {
-      type.validate(linker, protoFile.syntax)
+      type.validate(linker, syntaxRules)
     }
     for (service in protoFile.services) {
       service.validate(linker)

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -106,7 +106,8 @@ class Linker {
     }
 
     for (fileLinker in sourceFiles) {
-      fileLinker.validate()
+      val syntaxRules = SyntaxRules.get(fileLinker.protoFile.syntax)
+      fileLinker.validate(syntaxRules)
     }
 
     if (errors.isNotEmpty()) {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -23,7 +23,6 @@ import com.squareup.wire.schema.Field.Companion.retainLinked
 import com.squareup.wire.schema.Field.Companion.toElements
 import com.squareup.wire.schema.OneOf.Companion.fromElements
 import com.squareup.wire.schema.OneOf.Companion.toElements
-import com.squareup.wire.schema.ProtoFile.Syntax
 import com.squareup.wire.schema.Reserved.Companion.fromElements
 import com.squareup.wire.schema.Reserved.Companion.toElements
 import com.squareup.wire.schema.internal.parser.MessageElement
@@ -132,7 +131,7 @@ class MessageType private constructor(
     options.link(linker)
   }
 
-  override fun validate(linker: Linker, syntax: Syntax?) {
+  override fun validate(linker: Linker, syntaxRules: SyntaxRules) {
     val linker = linker.withContext(this)
     linker.validateFields(fieldsAndOneOfFields, reserveds)
     linker.validateEnumConstantNameUniqueness(nestedTypes)
@@ -140,7 +139,7 @@ class MessageType private constructor(
       field.validate(linker)
     }
     for (nestedType in nestedTypes) {
-      nestedType.validate(linker, syntax)
+      nestedType.validate(linker, syntaxRules)
     }
     for (extensions in extensionsList) {
       extensions.validate(linker)

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.squareup.wire.schema.ProtoFile.Syntax
+import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_2
+import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_3
+
+/** A set of rules which defines schema requirements for a specific [Syntax]. */
+interface SyntaxRules {
+  fun enumRequiresZeroValueAtFirstPosition(): Boolean
+
+  companion object {
+    fun get(syntax: Syntax?): SyntaxRules {
+      return when (syntax) {
+        PROTO_3 -> PROTO_3_SYNTAX_RULES
+        PROTO_2,
+        null -> PROTO_2_SYNTAX_RULES
+      }
+    }
+
+    internal val PROTO_2_SYNTAX_RULES = object : SyntaxRules {
+      override fun enumRequiresZeroValueAtFirstPosition(): Boolean = false
+    }
+
+    internal val PROTO_3_SYNTAX_RULES = object : SyntaxRules {
+      override fun enumRequiresZeroValueAtFirstPosition(): Boolean = true
+    }
+  }
+}

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
@@ -17,7 +17,6 @@ package com.squareup.wire.schema
 
 import com.squareup.wire.schema.EnumType.Companion.fromElement
 import com.squareup.wire.schema.MessageType.Companion.fromElement
-import com.squareup.wire.schema.ProtoFile.Syntax
 import com.squareup.wire.schema.internal.parser.EnumElement
 import com.squareup.wire.schema.internal.parser.MessageElement
 import com.squareup.wire.schema.internal.parser.TypeElement
@@ -31,7 +30,7 @@ abstract class Type {
   abstract val nestedTypes: List<Type>
   abstract fun linkMembers(linker: Linker)
   abstract fun linkOptions(linker: Linker)
-  abstract fun validate(linker: Linker, syntax: Syntax?)
+  abstract fun validate(linker: Linker, syntaxRules: SyntaxRules)
   abstract fun retainAll(schema: Schema, markSet: MarkSet): Type?
 
   /**


### PR DESCRIPTION
Follow-up for https://github.com/square/wire/pull/1394

SyntaxRules is used to have logic for a particular proto syntax.