### PR TITLE
Proto3: Use packed encoding by default for repeated fields of scalar numeric types

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
@@ -113,7 +113,7 @@ class ProtoType {
     @JvmField val UINT64 = ProtoType(true, "uint64")
     @JvmField val ANY = ProtoType(false, "google.protobuf.Any")
 
-    private val SCALAR_TYPES = listOf(
+    private val SCALAR_TYPES: Map<String, ProtoType> = listOf(
         BOOL,
         BYTES,
         DOUBLE,
@@ -130,6 +130,21 @@ class ProtoType {
         UINT32,
         UINT64
     ).associateBy { it.string }
+
+    internal val NUMERIC_SCALAR_TYPES = listOf(
+        DOUBLE,
+        FLOAT,
+        FIXED32,
+        FIXED64,
+        INT32,
+        INT64,
+        SFIXED32,
+        SFIXED64,
+        SINT32,
+        SINT64,
+        UINT32,
+        UINT64
+    )
 
     @JvmStatic
     fun get(enclosingTypeOrPackage: String?, typeName: String): ProtoType {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
@@ -30,7 +30,8 @@ data class OptionElement(
   val name: String,
   val kind: Kind,
   val value: Any,
-  private val isParenthesized: Boolean
+  /** If true, this [OptionElement] is a custom option. */
+  val isParenthesized: Boolean
 ) {
   enum class Kind {
     STRING,
@@ -105,6 +106,9 @@ data class OptionElement(
   }
 
   companion object {
+    internal val PACKED_OPTION_ELEMENT =
+        OptionElement("packed", BOOLEAN, value = "true", isParenthesized = false)
+
     @JvmOverloads
     fun create(
       name: String,

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -19,8 +19,9 @@ import com.squareup.wire.schema.Field.Label.OPTIONAL
 import com.squareup.wire.schema.Field.Label.REPEATED
 import com.squareup.wire.schema.Field.Label.REQUIRED
 import com.squareup.wire.schema.Location
-import com.squareup.wire.schema.ProtoFile
+import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_3
 import com.squareup.wire.schema.internal.MAX_TAG_VALUE
+import com.squareup.wire.schema.internal.parser.OptionElement.Companion.PACKED_OPTION_ELEMENT
 import com.squareup.wire.schema.internal.parser.OptionElement.Kind
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
@@ -558,7 +559,7 @@ class ProtoParserTest {
         """.trimMargin()
     val expected = ProtoFileElement(
         location = location,
-        syntax = ProtoFile.Syntax.PROTO_3,
+        syntax = PROTO_3,
         types = listOf(
             MessageElement(
                 location = location.at(2, 1),
@@ -623,7 +624,7 @@ class ProtoParserTest {
         """.trimMargin()
     val expected = ProtoFileElement(
         location = location,
-        syntax = ProtoFile.Syntax.PROTO_3,
+        syntax = PROTO_3,
         types = listOf(
             MessageElement(
                 location = location.at(5, 1),
@@ -645,7 +646,7 @@ class ProtoParserTest {
         """.trimMargin()
     val expected = ProtoFileElement(
         location = location,
-        syntax = ProtoFile.Syntax.PROTO_3,
+        syntax = PROTO_3,
         types = listOf(
             MessageElement(
                 location = location.at(2, 1),
@@ -683,7 +684,7 @@ class ProtoParserTest {
         """.trimMargin()
     val expected = ProtoFileElement(
         location = location,
-        syntax = ProtoFile.Syntax.PROTO_3,
+        syntax = PROTO_3,
         types = listOf(
             MessageElement(
                 location = location.at(2, 1),
@@ -801,7 +802,7 @@ class ProtoParserTest {
 
     val expected = ProtoFileElement(
         location = location,
-        syntax = ProtoFile.Syntax.PROTO_3,
+        syntax = PROTO_3,
         types = listOf(
             MessageElement(
                 location = location.at(2, 1),
@@ -833,7 +834,7 @@ class ProtoParserTest {
         """.trimMargin()
     val expected = ProtoFileElement(
         location = location,
-        syntax = ProtoFile.Syntax.PROTO_3,
+        syntax = PROTO_3,
         types = listOf(
             MessageElement(
                 location = location.at(2, 1),
@@ -2296,6 +2297,197 @@ class ProtoParserTest {
             )
         )
     )
+    assertThat(ProtoParser.parse(location, proto)).isEqualTo(expected)
+  }
+
+  @Test
+  fun proto3DefaultPackedForNumbericScalars() {
+    val proto = """
+            |syntax = "proto3";
+            |
+            |message Message {
+            |  repeated OtherMessage a = 1;
+            |  repeated bool b = 2;
+            |  repeated bytes c = 3;
+            |  repeated string d = 4;
+            |
+            |  repeated double e = 5;
+            |  repeated float f = 6;
+            |  repeated fixed32 g = 7;
+            |  repeated fixed64 h = 8;
+            |  repeated int32 i = 9;
+            |  repeated int64 j = 10;
+            |  repeated sfixed32 k = 11;
+            |  repeated sfixed64 l = 12;
+            |  repeated sint32 m = 13;
+            |  repeated sint64 n = 14;
+            |  repeated uint32 o = 15;
+            |  repeated uint64 p = 16;
+            |
+            |  repeated int32 set_to_false = 17 [packed = false];
+            |  repeated int32 set_to_true = 18 [packed = true];
+            |}
+            |
+            |message OtherMessage {}
+            |""".trimMargin()
+
+    val expected = ProtoFileElement(
+        syntax = PROTO_3,
+        location = location,
+        types = listOf(
+            MessageElement(
+                location = location.at(3, 1),
+                name = "Message",
+                fields = listOf(
+                    FieldElement(
+                        location = location.at(4, 3),
+                        label = REPEATED,
+                        type = "OtherMessage",
+                        name = "a",
+                        tag = 1
+                    ),
+                    FieldElement(
+                        location = location.at(5, 3),
+                        label = REPEATED,
+                        type = "bool",
+                        name = "b",
+                        tag = 2
+                    ),
+                    FieldElement(
+                        location = location.at(6, 3),
+                        label = REPEATED,
+                        type = "bytes",
+                        name = "c",
+                        tag = 3
+                    ),
+                    FieldElement(
+                        location = location.at(7, 3),
+                        label = REPEATED,
+                        type = "string",
+                        name = "d",
+                        tag = 4
+                    ),
+                    FieldElement(
+                        location = location.at(9, 3),
+                        label = REPEATED,
+                        type = "double",
+                        name = "e",
+                        tag = 5,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(10, 3),
+                        label = REPEATED,
+                        type = "float",
+                        name = "f",
+                        tag = 6,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(11, 3),
+                        label = REPEATED,
+                        type = "fixed32",
+                        name = "g",
+                        tag = 7,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(12, 3),
+                        label = REPEATED,
+                        type = "fixed64",
+                        name = "h",
+                        tag = 8,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(13, 3),
+                        label = REPEATED,
+                        type = "int32",
+                        name = "i",
+                        tag = 9,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(14, 3),
+                        label = REPEATED,
+                        type = "int64",
+                        name = "j",
+                        tag = 10,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(15, 3),
+                        label = REPEATED,
+                        type = "sfixed32",
+                        name = "k",
+                        tag = 11,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(16, 3),
+                        label = REPEATED,
+                        type = "sfixed64",
+                        name = "l",
+                        tag = 12,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(17, 3),
+                        label = REPEATED,
+                        type = "sint32",
+                        name = "m",
+                        tag = 13,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(18, 3),
+                        label = REPEATED,
+                        type = "sint64",
+                        name = "n",
+                        tag = 14,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(19, 3),
+                        label = REPEATED,
+                        type = "uint32",
+                        name = "o",
+                        tag = 15,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(20, 3),
+                        label = REPEATED,
+                        type = "uint64",
+                        name = "p",
+                        tag = 16,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    ),
+                    FieldElement(
+                        location = location.at(22, 3),
+                        label = REPEATED,
+                        type = "int32",
+                        name = "set_to_false",
+                        tag = 17,
+                        options = listOf(PACKED_OPTION_ELEMENT.copy(value = "false"))
+                    ),
+                    FieldElement(
+                        location = location.at(23, 3),
+                        label = REPEATED,
+                        type = "int32",
+                        name = "set_to_true",
+                        tag = 18,
+                        options = listOf(PACKED_OPTION_ELEMENT)
+                    )
+                )
+            ),
+            MessageElement(
+                location = location.at(26, 1),
+                name = "OtherMessage"
+            )
+        )
+    )
+
     assertThat(ProtoParser.parse(location, proto)).isEqualTo(expected)
   }
 }


### PR DESCRIPTION
Fixes #1383 

As the Google official doc says, scalar numeric types should be packed by default.

```
In proto3, repeated fields of scalar numeric types use packed encoding by default.
```

https://developers.google.com/protocol-buffers/docs/proto3#specifying-field-rules