### PR TITLE
Proto3: Proto file shouldn't have a default value when converted from Wire Schema

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/EnumElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/EnumElement.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema.internal.parser
 
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules
 import com.squareup.wire.schema.internal.appendDocumentation
 import com.squareup.wire.schema.internal.appendIndented
 
@@ -29,7 +30,7 @@ data class EnumElement(
   // Enums do not allow nested type declarations.
   override val nestedTypes: List<TypeElement> = emptyList()
 
-  override fun toSchema() = buildString {
+  override fun toSchema(syntaxRules: SyntaxRules) = buildString {
     appendDocumentation(documentation)
     append("enum $name {")
 

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ExtendElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ExtendElement.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema.internal.parser
 
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules
 import com.squareup.wire.schema.internal.appendDocumentation
 import com.squareup.wire.schema.internal.appendIndented
 
@@ -25,14 +26,14 @@ data class ExtendElement(
   val documentation: String = "",
   val fields: List<FieldElement> = emptyList()
 ) {
-  fun toSchema() = buildString {
+  fun toSchema(syntaxRules: SyntaxRules = SyntaxRules.get(syntax = null)) = buildString {
     appendDocumentation(documentation)
     append("extend $name {")
 
     if (fields.isNotEmpty()) {
       append('\n')
       for (field in fields) {
-        appendIndented(field.toSchema())
+        appendIndented(field.toSchema(syntaxRules))
       }
     }
 

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/GroupElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/GroupElement.kt
@@ -17,6 +17,7 @@ package com.squareup.wire.schema.internal.parser
 
 import com.squareup.wire.schema.Field
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules
 import com.squareup.wire.schema.internal.appendDocumentation
 import com.squareup.wire.schema.internal.appendIndented
 import com.squareup.wire.schema.internal.toEnglishLowerCase
@@ -29,7 +30,7 @@ data class GroupElement(
   val documentation: String = "",
   val fields: List<FieldElement> = emptyList()
 ) {
-  fun toSchema() = buildString {
+  fun toSchema(syntaxRules: SyntaxRules = SyntaxRules.get(syntax = null)) = buildString {
     appendDocumentation(documentation)
     if (label != null) {
       append("${label.name.toEnglishLowerCase()} ")
@@ -38,7 +39,7 @@ data class GroupElement(
     if (fields.isNotEmpty()) {
       append('\n')
       for (field in fields) {
-        appendIndented(field.toSchema())
+        appendIndented(field.toSchema(syntaxRules))
       }
     }
     append("}\n")

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/MessageElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/MessageElement.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema.internal.parser
 
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules
 import com.squareup.wire.schema.internal.appendDocumentation
 import com.squareup.wire.schema.internal.appendIndented
 
@@ -31,7 +32,7 @@ data class MessageElement(
   val extensions: List<ExtensionsElement> = emptyList(),
   val groups: List<GroupElement> = emptyList()
 ) : TypeElement {
-  override fun toSchema() = buildString {
+  override fun toSchema(syntaxRules: SyntaxRules) = buildString {
     appendDocumentation(documentation)
     append("message $name {")
 
@@ -50,19 +51,19 @@ data class MessageElement(
     if (fields.isNotEmpty()) {
       append('\n')
       for (field in fields) {
-        appendIndented(field.toSchema())
+        appendIndented(field.toSchema(syntaxRules))
       }
     }
     if (oneOfs.isNotEmpty()) {
       append('\n')
       for (oneOf in oneOfs) {
-        appendIndented(oneOf.toSchema())
+        appendIndented(oneOf.toSchema(syntaxRules))
       }
     }
     if (groups.isNotEmpty()) {
       append('\n')
       for (group in groups) {
-        appendIndented(group.toSchema())
+        appendIndented(group.toSchema(syntaxRules))
       }
     }
     if (extensions.isNotEmpty()) {
@@ -74,7 +75,7 @@ data class MessageElement(
     if (nestedTypes.isNotEmpty()) {
       append('\n')
       for (type in nestedTypes) {
-        appendIndented(type.toSchema())
+        appendIndented(type.toSchema(syntaxRules))
       }
     }
     append("}\n")

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OneOfElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OneOfElement.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.schema.internal.parser
 
+import com.squareup.wire.schema.SyntaxRules
 import com.squareup.wire.schema.internal.appendDocumentation
 import com.squareup.wire.schema.internal.appendIndented
 
@@ -24,20 +25,20 @@ data class OneOfElement(
   val fields: List<FieldElement> = emptyList(),
   val groups: List<GroupElement> = emptyList()
 ) {
-  fun toSchema() = buildString {
+  fun toSchema(syntaxRules: SyntaxRules = SyntaxRules.get(syntax = null)) = buildString {
     appendDocumentation(documentation)
     append("oneof $name {")
 
     if (fields.isNotEmpty()) {
       append('\n')
       for (field in fields) {
-        appendIndented(field.toSchema())
+        appendIndented(field.toSchema(syntaxRules))
       }
     }
     if (groups.isNotEmpty()) {
       append('\n')
       for (group in groups) {
-        appendIndented(group.toSchema())
+        appendIndented(group.toSchema(syntaxRules))
       }
     }
     append("}\n")

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
@@ -17,6 +17,7 @@ package com.squareup.wire.schema.internal.parser
 
 import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.ProtoFile
+import com.squareup.wire.schema.SyntaxRules
 import kotlin.jvm.JvmStatic
 
 /** A single `.proto` file.  */
@@ -32,6 +33,8 @@ data class ProtoFileElement(
   val options: List<OptionElement> = emptyList()
 ) {
   fun toSchema() = buildString {
+    val syntaxRules = SyntaxRules.get(syntax)
+
     append("// ")
     append(location)
     append('\n')
@@ -60,13 +63,13 @@ data class ProtoFileElement(
     if (types.isNotEmpty()) {
       append('\n')
       for (typeElement in types) {
-        append(typeElement.toSchema())
+        append(typeElement.toSchema(syntaxRules))
       }
     }
     if (extendDeclarations.isNotEmpty()) {
       append('\n')
       for (extendDeclaration in extendDeclarations) {
-        append(extendDeclaration.toSchema())
+        append(extendDeclaration.toSchema(syntaxRules))
       }
     }
     if (services.isNotEmpty()) {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/TypeElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/TypeElement.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema.internal.parser
 
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules
 
 /** A message type or enum type declaration.  */
 interface TypeElement {
@@ -24,5 +25,5 @@ interface TypeElement {
   val documentation: String
   val options: List<OptionElement>
   val nestedTypes: List<TypeElement>
-  fun toSchema(): String
+  fun toSchema(syntaxRules: SyntaxRules = SyntaxRules.get(syntax = null)): String
 }

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ExtendElementTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ExtendElementTest.kt
@@ -17,6 +17,8 @@ package com.squareup.wire.schema.internal.parser
 
 import com.squareup.wire.schema.Field.Label.REQUIRED
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules.Companion.PROTO_2_SYNTAX_RULES
+import com.squareup.wire.schema.SyntaxRules.Companion.PROTO_3_SYNTAX_RULES
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -103,5 +105,57 @@ class ExtendElementTest {
         |}
         |""".trimMargin()
     assertThat(extend.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
+  fun defaultIsSetInProto2File() {
+    val extend = ExtendElement(
+        location = location,
+        name = "Name",
+        documentation = "Hello",
+        fields = listOf(
+            FieldElement(
+                location = location,
+                label = REQUIRED,
+                type = "string",
+                name = "name",
+                tag = 1,
+                defaultValue = "defaultValue"
+            )
+        )
+    )
+    val expected = """
+        |// Hello
+        |extend Name {
+        |  required string name = 1 [default = "defaultValue"];
+        |}
+        |""".trimMargin()
+    assertThat(extend.toSchema(PROTO_2_SYNTAX_RULES)).isEqualTo(expected)
+  }
+
+  @Test
+  fun defaultIsNotSetInProto3File() {
+    val extend = ExtendElement(
+        location = location,
+        name = "Name",
+        documentation = "Hello",
+        fields = listOf(
+            FieldElement(
+                location = location,
+                label = REQUIRED,
+                type = "string",
+                name = "name",
+                tag = 1,
+                defaultValue = "default value shouldn't be set"
+            )
+        )
+    )
+    val expected = """
+        |// Hello
+        |extend Name {
+        |  required string name = 1;
+        |}
+        |""".trimMargin()
+    assertThat(extend.toSchema(PROTO_3_SYNTAX_RULES)).isEqualTo(expected)
   }
 }

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/FieldElementTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/FieldElementTest.kt
@@ -18,6 +18,9 @@ package com.squareup.wire.schema.internal.parser
 import com.squareup.wire.schema.Field.Label.OPTIONAL
 import com.squareup.wire.schema.Field.Label.REQUIRED
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules
+import com.squareup.wire.schema.SyntaxRules.Companion.PROTO_2_SYNTAX_RULES
+import com.squareup.wire.schema.SyntaxRules.Companion.PROTO_3_SYNTAX_RULES
 import com.squareup.wire.schema.internal.parser.OptionElement.Kind
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -60,5 +63,34 @@ class FieldElementTest {
     )
 
     assertThat(field.options).hasSize(2)
+  }
+
+  @Test
+  fun defaultIsSetInProto2File() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "string",
+        name = "name",
+        tag = 1,
+        defaultValue = "defaultValue"
+    )
+
+    assertThat(field.toSchema(PROTO_2_SYNTAX_RULES))
+        .isEqualTo("required string name = 1 [default = \"defaultValue\"];\n")
+  }
+
+  @Test
+  fun defaultIsNotSetInProto3File() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "string",
+        name = "name",
+        tag = 1,
+        defaultValue = "default value shouldn't be set"
+    )
+
+    assertThat(field.toSchema(PROTO_3_SYNTAX_RULES)).isEqualTo("required string name = 1;\n")
   }
 }

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
@@ -19,6 +19,7 @@ import com.squareup.wire.schema.Field.Label.OPTIONAL
 import com.squareup.wire.schema.Field.Label.REPEATED
 import com.squareup.wire.schema.Field.Label.REQUIRED
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.SyntaxRules.Companion.PROTO_3_SYNTAX_RULES
 import com.squareup.wire.schema.internal.parser.OptionElement.Kind
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -548,7 +549,7 @@ class MessageElementTest {
   }
 
   @Test
-  fun fieldWithDefaultStringToSchema() {
+  fun fieldWithDefaultStringToSchemaInProto2() {
     val field = FieldElement(
         location = location,
         label = REQUIRED,
@@ -559,6 +560,20 @@ class MessageElementTest {
     )
     val expected = "required string name = 1 [default = \"benoît\"];\n"
     assertThat(field.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
+  fun defaultIsNotSetInProto3() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "string",
+        name = "name",
+        tag = 1,
+        defaultValue = "benoît"
+    )
+    val expected = "required string name = 1;\n"
+    assertThat(field.toSchema(PROTO_3_SYNTAX_RULES)).isEqualTo(expected)
   }
 
   @Test

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
@@ -15,8 +15,10 @@
  */
 package com.squareup.wire.schema.internal.parser
 
+import com.squareup.wire.schema.Field
 import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_2
+import com.squareup.wire.schema.ProtoFile.Syntax.PROTO_3
 import com.squareup.wire.schema.internal.parser.OptionElement.Kind
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -328,5 +330,85 @@ class ProtoFileElementTest {
         |message Message {}
         |""".trimMargin()
     assertThat(file.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
+  fun defaultIsSetInProto2(){
+    val field = FieldElement(
+        location = location.at(9, 3),
+        label = Field.Label.REQUIRED,
+        type = "string",
+        name = "name",
+        tag = 1,
+        defaultValue = "defaultValue"
+    )
+    val message =
+        MessageElement(location = location.at(8, 1), name = "Message", fields = listOf(field))
+    val file = ProtoFileElement(
+        syntax = PROTO_2,
+        location = location,
+        packageName = "example.simple",
+        imports = listOf("example.thing"),
+        publicImports = listOf("example.other"),
+        types = listOf(message)
+    )
+    val expected = """
+        |// file.proto
+        |syntax = "proto2";
+        |package example.simple;
+        |
+        |import "example.thing";
+        |import public "example.other";
+        |
+        |message Message {
+        |  required string name = 1 [default = "defaultValue"];
+        |}
+        |""".trimMargin()
+    assertThat(file.toSchema()).isEqualTo(expected)
+
+    // Re-parse the expected string into a ProtoFile and ensure they're equal.
+    val parsed = ProtoParser.parse(location, expected)
+    assertThat(parsed).isEqualTo(file)
+  }
+
+  @Test
+  fun defaultIsNotSetInProto3(){
+    val field = FieldElement(
+        location = location.at(9, 3),
+        label = Field.Label.REQUIRED,
+        type = "string",
+        name = "name",
+        tag = 1,
+        defaultValue = "defaultValue"
+    )
+    val message =
+        MessageElement(location = location.at(8, 1), name = "Message", fields = listOf(field))
+    val file = ProtoFileElement(
+        syntax = PROTO_3,
+        location = location,
+        packageName = "example.simple",
+        imports = listOf("example.thing"),
+        publicImports = listOf("example.other"),
+        types = listOf(message)
+    )
+    assertThat(file.toSchema()).doesNotContain("defaultValue")
+
+    // TODO(benoit|masaru): Ignore the test below now. This will be fixed by #1386.
+    // val expected = """
+    //     |// file.proto
+    //     |syntax = "proto3";
+    //     |package example.simple;
+    //     |
+    //     |import "example.thing";
+    //     |import public "example.other";
+    //     |
+    //     |message Message {
+    //     |  string name = 1;
+    //     |}
+    //     |""".trimMargin()
+    // assertThat(file.toSchema()).isEqualTo(expected)
+    // // Re-parse the expected string into a ProtoFile and ensure they're equal.
+    // val parsed = ProtoParser.parse(location, expected)
+    // assertThat(parsed).isEqualTo(file)
   }
 }


### PR DESCRIPTION
Fixes #1385 (don't print default for proto3 schemas (when doing `Element.toSchema()`))

Wire Schema data has a default value that follows the proto3 spec.
ref. [Default Values](https://developers.google.com/protocol-buffers/docs/proto3#default)

To avoid setting the devault value when Schema data is parsed into proto3 files, SyntaxRules is used and passed to related classes.