### PR TITLE
Proto3: convert Wire Schema Packed options to proto files

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
@@ -25,7 +25,7 @@ interface SyntaxRules {
   fun allowUserDefinedDefaultValue(): Boolean
   fun canExtend(protoType: ProtoType): Boolean
   fun enumRequiresZeroValueAtFirstPosition(): Boolean
-  fun shouldBePacked(type: String, label: Field.Label?, options: List<OptionElement>): Boolean
+  fun isPackedByDefault(type: String, label: Field.Label?): Boolean
 
   companion object {
     fun get(syntax: Syntax?): SyntaxRules {
@@ -40,10 +40,9 @@ interface SyntaxRules {
       override fun allowUserDefinedDefaultValue(): Boolean = true
       override fun canExtend(protoType: ProtoType): Boolean = true
       override fun enumRequiresZeroValueAtFirstPosition(): Boolean = false
-      override fun shouldBePacked(
+      override fun isPackedByDefault(
         type: String,
-        label: Field.Label?,
-        options: List<OptionElement>
+        label: Field.Label?
       ): Boolean = false
     }
 
@@ -53,14 +52,12 @@ interface SyntaxRules {
         return protoType in Options.GOOGLE_PROTOBUF_OPTION_TYPES
       }
       override fun enumRequiresZeroValueAtFirstPosition(): Boolean = true
-      override fun shouldBePacked(
+      override fun isPackedByDefault(
         type: String,
-        label: Field.Label?,
-        options: List<OptionElement>
+        label: Field.Label?
       ): Boolean {
         return label == Field.Label.REPEATED &&
-            ProtoType.get(type) in ProtoType.NUMERIC_SCALAR_TYPES &&
-            options.none { it.name == OptionElement.PACKED_OPTION_ELEMENT.name && !it.isParenthesized }
+            ProtoType.get(type) in ProtoType.NUMERIC_SCALAR_TYPES
       }
     }
   }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
@@ -349,7 +349,8 @@ class ProtoParser internal constructor(
 
     // Mutable copy to extract the default value, and add packed if necessary.
     val options: MutableList<OptionElement> = OptionReader(reader).readOptions().toMutableList()
-    if (syntaxRules?.shouldBePacked(type, label, options) == true) {
+    if (syntaxRules?.isPackedByDefault(type, label) == true &&
+        options.none { it.name == PACKED_OPTION_ELEMENT.name && !it.isParenthesized }) {
       options.add(PACKED_OPTION_ELEMENT)
     }
 


### PR DESCRIPTION
Fixes #1383: don't print packed="true" for those on proto3 schemas (when doing Element.toSchema())

As the doc says, packed option is `false` by default in proto2[1]. On the other hand, the option is `true` for scalar numeric scalar types by default in proto3[2].
```
In proto3, repeated fields of scalar numeric types use packed encoding by default.
```

With this change, packed option values are properly generated in both proto2 and proto3 files.

Note that we *DO NOT* add `[packed = true]` option in numeric repeated fields in proto3 files since Wire Schema doesn't _know_ whether or not the "true" value was set by the user(proto3 file) or by Wire. These generated proto3 files follow the proto3 specs correctly as scalar numeric types are packed by default. (We can possibly fix this behavior later.)

[1] https://developers.google.com/protocol-buffers/docs/proto#options
[2] https://developers.google.com/protocol-buffers/docs/proto3#specifying-field-rules