### PR TITLE
Fix Chrome installation failure in Travis CI by executing brew update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ os:
 osx_image: xcode11.2
 
 before_install:
+  - brew update # To avoid SHA-256 checksum errors for example.
   - brew cask install homebrew/cask-versions/adoptopenjdk8
   - export JAVA_HOME=$(/usr/libexec/java_home -v 1.8)
   - brew cask install google-chrome # Required to run JS tests. Remove when https://youtrack.jetbrains.com/issue/KT-32075 ships.


### PR DESCRIPTION
Installing Chrome fails via brew command `brew cask install google-chrome`. As the error message indicates, `brew update` is run before installing Chrome.

ref: https://travis-ci.org/square/wire/builds/653493344?utm_source=github_status&utm_medium=notification
e.g.
```
$ brew cask install google-chrome
==> Downloading https://dl.google.com/chrome/mac/stable/GGRO/googlechrome.dmg
Error: Checksum for Cask 'google-chrome' does not match.
Expected: 9abc6ab31aedf6e05836ff1855a7b94e2571ecf9074ac970b0920ee83559156a
  Actual: f31df78f8e07d520f610f3cc86fea7b869675b15c8caee5724fe2cd54445a54e
    File: /Users/travis/Library/Caches/Homebrew/downloads/9830ac8a5256756d2643fbdb6a47ba0eb019c3816fc4366049f2483999b2ee4f--googlechrome.dmg
To retry an incomplete download, remove the file above.
If the issue persists, visit:
  https://github.com/Homebrew/homebrew-cask/blob/master/doc/reporting_bugs/checksum_does_not_match_error.md
==> Verifying SHA-256 checksum for Cask 'google-chrome'.
==> Note: Running `brew update` may fix SHA-256 checksum errors.
The command "brew cask install google-chrome" failed and exited with 1 during .
```