### PR TITLE
Organise usage of Wire plugin on module basis

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ buildscript {
       'animalSniffer': '1.16',
       'animalSnifferGradle': '1.5.0',
       'mavenPublish': '0.8.0',
-      'releasedWire': '3.0.2'
+      'releasedWire': '3.1.0'
   ]
 
   ext.deps = [
@@ -30,6 +30,8 @@ buildscript {
           kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
           shadow: 'com.github.jengelman.gradle.plugins:shadow:4.0.1',
           releasedWire: "com.squareup.wire:wire-gradle-plugin:${versions.releasedWire}",
+          // This would usually take the SNAPSHOT, and we don't fail when releasing.
+          snapshotWire: "com.squareup.wire:wire-gradle-plugin:+",
           japicmp: 'me.champeau.gradle:japicmp-gradle-plugin:0.2.8',
           mavenPublish: "com.vanniktech:gradle-maven-publish-plugin:${versions.mavenPublish}"
       ],
@@ -91,7 +93,6 @@ buildscript {
   dependencies {
     classpath deps.plugins.kotlin
     classpath deps.plugins.shadow
-    classpath deps.plugins.releasedWire
     classpath deps.plugins.japicmp
     classpath deps.plugins.mavenPublish
     classpath deps.animalSniffer.gradle

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -1,3 +1,12 @@
+buildscript {
+  dependencies {
+    classpath deps.plugins.releasedWire
+  }
+  repositories {
+    mavenCentral()
+  }
+}
+
 apply plugin: 'application'
 apply plugin: 'com.squareup.wire'
 
@@ -11,6 +20,11 @@ jar {
 
 dependencies {
   implementation deps.releasedWire.runtime
+}
+
+sourceSets {
+  // TODO(benoit): we do this to make IntelliJ happy but the Wire Gradle plugin should do that.
+  main.java.srcDirs += 'build/generated/source/wire'
 }
 
 /**

--- a/wire-protoc-compatibility-tests/build.gradle
+++ b/wire-protoc-compatibility-tests/build.gradle
@@ -1,11 +1,15 @@
 buildscript {
   dependencies {
     classpath deps.protobuf.gradlePlugin
+    classpath deps.plugins.snapshotWire
   }
 
   repositories {
     mavenCentral()
     gradlePluginPortal()
+    maven {
+      url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    }
   }
 }
 
@@ -16,12 +20,6 @@ apply plugin: 'com.google.protobuf'
 apply plugin: 'com.squareup.wire'
 
 protobuf {
-  plugins {
-    grpc {
-      artifact = deps.grpc.genJava
-    }
-  }
-
   protoc {
     artifact = deps.protobuf.protoc
   }


### PR DESCRIPTION
How about that so we use the latest wire gradle plugin (always one build away but good enough?) save the sample which stays on regular build?

The goal would be for `wire-tests` to use that as well, and generate what it needs via the Gradle plugin (not `WireCompiler` )