### PR TITLE
Use KDoc square brackets to link arguments in function instead of ``

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -139,7 +139,7 @@ class Field private constructor(
     return withOptions(options.retainAll(schema, markSet))
   }
 
-  /** Returns a copy of this whose options is `options`.  */
+  /** Returns a copy of this whose options is [options].  */
   private fun withOptions(options: Options): Field {
     val result = Field(
         packageName = packageName,

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
@@ -101,7 +101,7 @@ internal class FileLinker(
     }
   }
 
-  /** Link the members of `types` and their nested types. */
+  /** Link the members of [types] and their nested types. */
   private fun linkMembersRecursive(types: List<Type>) {
     for (type in types) {
       requireMembersLinked(type)
@@ -109,7 +109,7 @@ internal class FileLinker(
     }
   }
 
-  /** Link the members of `type` that haven't been linked already. */
+  /** Link the members of [type] that haven't been linked already. */
   fun requireMembersLinked(type: Type) {
     if (typesWithMembersLinked.add(type.type)) {
       type.linkMembers(linker)

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -50,7 +50,7 @@ class Linker {
     requestedTypes = enclosing.requestedTypes
   }
 
-  /** Returns a linker for `path`, loading the file if necessary. */
+  /** Returns a linker for [path], loading the file if necessary. */
   internal fun getFileLinker(path: String): FileLinker {
     val existing = fileLinkers[path]
     if (existing != null) return existing
@@ -63,7 +63,7 @@ class Linker {
   }
 
   /**
-   * Link all features of all files in `sourceProtoFiles` to create a schema. This will also
+   * Link all features of all files in [sourceProtoFiles] to create a schema. This will also
    * partially link any imported files necessary.
    */
   fun link(sourceProtoFiles: Iterable<ProtoFile>): Schema {
@@ -136,12 +136,12 @@ class Linker {
     return Schema(result)
   }
 
-  /** Returns the type name for the scalar, relative or fully-qualified name `name`. */
+  /** Returns the type name for the scalar, relative or fully-qualified name [name]. */
   fun resolveType(name: String): ProtoType {
     return resolveType(name, false)
   }
 
-  /** Returns the type name for the relative or fully-qualified name `name`. */
+  /** Returns the type name for the relative or fully-qualified name [name]. */
   fun resolveMessageType(name: String): ProtoType {
     return resolveType(name, true)
   }
@@ -258,7 +258,7 @@ class Linker {
     return result
   }
 
-  /** Adds `type`. */
+  /** Adds [type]. */
   fun addType(protoType: ProtoType, type: Type) {
     protoTypeNames[protoType.toString()] = type
   }
@@ -294,7 +294,7 @@ class Linker {
     return result
   }
 
-  /** Returns the field named `field` on the message type of `self`. */
+  /** Returns the field named [field] on the message type of [self]. */
   fun dereference(
     self: Field,
     field: String
@@ -317,7 +317,7 @@ class Linker {
     return null // Unable to traverse this field path.
   }
 
-  /** Validate that the tags of `fields` are unique and in range. */
+  /** Validate that the tags of [fields] are unique and in range. */
   fun validateFields(
     fields: Iterable<Field>,
     reserveds: List<Reserved>
@@ -411,7 +411,7 @@ class Linker {
     }
   }
 
-  /** Returns a new linker that uses `context` to resolve type names and report errors. */
+  /** Returns a new linker that uses [context] to resolve type names and report errors. */
   fun withContext(context: Any): Linker {
     return Linker(this, context)
   }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -49,7 +49,7 @@ class MessageType private constructor(
   val fieldsAndOneOfFields: List<Field>
     get() = declaredFields + extensionFields + oneOfs.flatMap { it.fields }
 
-  /** Returns the field named `name`, or null if this type has no such field. */
+  /** Returns the field named [name], or null if this type has no such field. */
   fun field(name: String): Field? {
     for (field in declaredFields) {
       if (field.name == name) {
@@ -67,13 +67,13 @@ class MessageType private constructor(
   }
 
   /**
-   * Returns the field with the qualified name `qualifiedName`, or null if this type has no
+   * Returns the field with the qualified name [qualifiedName], or null if this type has no
    * such field.
    */
   fun extensionField(qualifiedName: String): Field? =
       extensionFields.firstOrNull { it.qualifiedName == qualifiedName }
 
-  /** Returns the field tagged `tag`, or null if this type has no such field.  */
+  /** Returns the field tagged [tag], or null if this type has no such field.  */
   fun field(tag: Int): Field? {
     for (field in declaredFields) {
       if (field.tag == tag) {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -47,7 +47,7 @@ class Options(
   }
 
   /**
-   * Returns true if any of the options in `options` matches both of the regular expressions
+   * Returns true if any of the options in [entries] matches both of the regular expressions
    * provided: its name matches the option's name and its value matches the option's value.
    */
   fun optionMatches(namePattern: String, valuePattern: String): Boolean {
@@ -294,7 +294,7 @@ class Options(
     return result
   }
 
-  /** Returns an object of the same type as `o`, or null if it is not retained.  */
+  /** Returns an object of the same type as [o], or null if it is not retained.  */
   private fun retainAll(
     schema: Schema,
     markSet: MarkSet,
@@ -341,7 +341,7 @@ class Options(
     }
   }
 
-  /** Returns true if these options assigns a value to `protoMember`.  */
+  /** Returns true if these options assigns a value to [protoMember].  */
   fun assignsMember(protoMember: ProtoMember?): Boolean {
     // TODO(jwilson): remove the null check; this shouldn't be called until linking completes.
     return entries?.any { it.protoMember == protoMember } ?: false

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/PruningRules.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/PruningRules.kt
@@ -108,14 +108,14 @@ class PruningRules private constructor(builder: Builder) {
     return true
   }
 
-  /** Returns true if `type` is a root. */
+  /** Returns true if [type] is a root. */
   fun isRoot(type: ProtoType) = isRoot(type.toString())
 
-  /** Returns true if `protoMember` is a root. */
+  /** Returns true if [protoMember] is a root. */
   fun isRoot(protoMember: ProtoMember) = isRoot(protoMember.toString())
 
   /**
-   * Returns true if `identifier` or any of its enclosing identifiers is a root. If any enclosing
+   * Returns true if [identifier] or any of its enclosing identifiers is a root. If any enclosing
    * identifier is pruned, that takes precedence and this returns false unless the root identifier
    * is more precise.
    */
@@ -150,15 +150,15 @@ class PruningRules private constructor(builder: Builder) {
   }
 
   /**
-   * Returns true if `type` should be pruned, even if it is a transitive dependency of a root. In
+   * Returns true if [type] should be pruned, even if it is a transitive dependency of a root. In
    * that case, the referring member is also pruned.
    */
   fun prunes(type: ProtoType) = prunes(type.toString())
 
-  /** Returns true if `protoMember` should be pruned. */
+  /** Returns true if [protoMember] should be pruned. */
   fun prunes(protoMember: ProtoMember) = prunes(protoMember.toString())
 
-  /** Returns true if `identifier` or any of its enclosing identifiers is pruned.  */
+  /** Returns true if [identifier] or any of its enclosing identifiers is pruned.  */
   private fun prunes(identifier: String): Boolean {
     var rootMatch: String? = null
     var pruneMatch: String? = null
@@ -245,9 +245,9 @@ class PruningRules private constructor(builder: Builder) {
     internal val ENUM_CONSTANT_UNTIL = ProtoMember.get(Options.ENUM_VALUE_OPTIONS, "wire.until")
 
     /**
-     * Returns the identifier or wildcard that encloses `identifier`, or null if it is not enclosed.
+     * Returns the identifier or wildcard that encloses [identifier], or null if it is not enclosed.
      *
-     *  * If `identifier` is a member this returns the enclosing type.
+     *  * If [identifier] is a member this returns the enclosing type.
      *
      *  * If it is a type it returns the enclosing package with a wildcard, like
      *    `squareup.dinosaurs.*`.


### PR DESCRIPTION
- Use [] instead of ``
- Fix wrong argument reference (options -> entries).