### PR TITLE
Remove use of String.format in common

### DIFF
--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -23,7 +23,6 @@ import com.squareup.wire.ProtoWriter.Companion.int32Size
 import com.squareup.wire.ProtoWriter.Companion.varint32Size
 import com.squareup.wire.ProtoWriter.Companion.varint64Size
 import com.squareup.wire.internal.Throws
-import com.squareup.wire.internal.format
 import okio.Buffer
 import okio.BufferedSink
 import okio.BufferedSource
@@ -422,7 +421,7 @@ internal fun commonBool(): ProtoAdapter<Boolean> = object : ProtoAdapter<Boolean
   override fun decode(reader: ProtoReader): Boolean = when (val value = reader.readVarint32()) {
     0 -> false
     1 -> true
-    else -> throw IOException("Invalid boolean value 0x%02x".format(value))
+    else -> throw IOException("Invalid boolean value 0x" + value.toString(16).padStart(2, '0'))
   }
 
   override fun redact(value: Boolean): Boolean = throw UnsupportedOperationException()

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/-Platform.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/-Platform.kt
@@ -32,5 +32,3 @@ expect class ProtocolException(host: String) : IOException
 expect fun <T> MutableList<T>.toUnmodifiableList(): List<T>
 
 expect fun <K, V> MutableMap<K, V>.toUnmodifiableMap(): Map<K, V>
-
-internal expect fun String.format(vararg args: Any?): String

--- a/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/internal/-Platform.kt
+++ b/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/internal/-Platform.kt
@@ -29,5 +29,3 @@ actual inline fun <T> MutableList<T>.toUnmodifiableList(): List<T> = this
 
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
 actual inline fun <K, V> MutableMap<K, V>.toUnmodifiableMap(): Map<K, V> = this
-
-internal actual fun String.format(vararg args: Any?): String = TODO("Not implemented")

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/-Platform.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/-Platform.kt
@@ -32,6 +32,3 @@ actual inline fun <T> MutableList<T>.toUnmodifiableList(): List<T>
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
 actual inline fun <K, V> MutableMap<K, V>.toUnmodifiableMap(): Map<K, V> =
     Collections.unmodifiableMap(this)
-
-@Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
-internal actual inline fun String.format(vararg args: Any?): String = String.format(this, *args)

--- a/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/internal/-Platform.kt
+++ b/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/internal/-Platform.kt
@@ -29,5 +29,3 @@ actual inline fun <T> MutableList<T>.toUnmodifiableList(): List<T> = this
 
 @Suppress("NOTHING_TO_INLINE") // Syntactic sugar.
 actual inline fun <K, V> MutableMap<K, V>.toUnmodifiableMap(): Map<K, V> = this
-
-internal actual fun String.format(vararg args: Any?): String = TODO("Not implemented")


### PR DESCRIPTION
This was unimplemented in JS and native anyway. Replace with equivalent stdlib functions.

```
$ kotlinc
Welcome to Kotlin version 1.3.61 (JRE 13.0.2+8)
Type :help for help, :quit for quit
>>> "0x%02x".format(1)
res0: kotlin.String = 0x01
>>> "0x%02x".format(15)
res1: kotlin.String = 0x0f
>>> "0x%02x".format(16)
res2: kotlin.String = 0x10
>>> "0x%02x".format(255)
res3: kotlin.String = 0xff
>>> "0x" + 1.toString(16).padStart(2, '0')
res4: kotlin.String = 0x01
>>> "0x" + 15.toString(16).padStart(2, '0')
res5: kotlin.String = 0x0f
>>> "0x" + 16.toString(16).padStart(2, '0')
res6: kotlin.String = 0x10
>>> "0x" + 255.toString(16).padStart(2, '0')
res7: kotlin.String = 0xff
```