### PR TITLE
Only print the path of location when priting proto schema.

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
@@ -36,7 +36,7 @@ data class ProtoFileElement(
     val syntaxRules = SyntaxRules.get(syntax)
 
     append("// ")
-    append(location)
+    append(location.withPathOnly())
     append('\n')
 
     if (syntax != null) {

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
@@ -25,7 +25,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class ProtoFileElementTest {
-  internal var location = Location.get("file.proto")
+  internal var location = Location.get("some/folder", "file.proto")
 
   @Test
   fun emptyToSchema() {
@@ -334,7 +334,7 @@ class ProtoFileElementTest {
   }
 
   @Test
-  fun defaultIsSetInProto2(){
+  fun defaultIsSetInProto2() {
     val field = FieldElement(
         location = location.at(9, 3),
         label = Field.Label.REQUIRED,
@@ -373,7 +373,7 @@ class ProtoFileElementTest {
   }
 
   @Test
-  fun defaultIsNotSetInProto3(){
+  fun defaultIsNotSetInProto3() {
     val field = FieldElement(
         location = location.at(9, 3),
         label = Field.Label.REQUIRED,


### PR DESCRIPTION
Otherwise we get deep shit like 
```
// /Users/bquenaudon/.gradle/caches/modules-2/files-2.1/blahblahblah/squareup/franklin/investing/resources.proto
```

which is really sad, and change per machine 🙀 