### PR TITLE
Move GrpcMessageSink/Source to common

### DIFF
--- a/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/GrpcMessageSink.kt
+++ b/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/GrpcMessageSink.kt
@@ -17,7 +17,6 @@ package com.squareup.wire.internal
 
 import com.squareup.wire.MessageSink
 import com.squareup.wire.ProtoAdapter
-import okhttp3.Call
 import okio.Buffer
 import okio.BufferedSink
 
@@ -40,7 +39,7 @@ internal class GrpcMessageSink<T : Any> constructor(
     check(!closed) { "closed" }
 
     val encodedMessage = Buffer()
-    grpcEncoding.toGrpcEncoder().encode(encodedMessage).use { encodingSink ->
+    grpcEncoding.toGrpcEncoder().encode(encodedMessage).use(BufferedSink::close) { encodingSink ->
       messageAdapter.encode(encodingSink, message)
     }
 

--- a/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/platform.common.kt
+++ b/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/platform.common.kt
@@ -18,5 +18,12 @@ package com.squareup.wire.internal
 import okio.Sink
 import okio.Source
 
+// TODO make internal https://youtrack.jetbrains.com/issue/KT-37316
+expect interface Call {
+  fun cancel()
+}
+
 internal expect fun Sink.asGzip(): Sink
 internal expect fun Source.asGzip(): Source
+
+internal expect fun Throwable.addSuppressed(other: Throwable)

--- a/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/util.kt
+++ b/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/util.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.internal
+
+/**
+ * Executes the given [block] function on this resource and then closes it down correctly using
+ * [close] whether an exception is thrown or not.
+ *
+ * Differs from the JVM `use` in that it can be called on any type provided that you supply a
+ * [close] function.
+ *
+ * @return the result of [block] function invoked on this resource.
+ */
+internal inline fun <C, R> C.use(close: (C) -> Unit, block: (C) -> R): R {
+  var closed = false
+
+  return try {
+    block(this)
+  } catch (first: Throwable) {
+    try {
+      closed = true
+      close(this)
+    } catch (second: Throwable) {
+      first.addSuppressed(second)
+    }
+    throw first
+  } finally {
+    if (!closed) {
+      close(this)
+    }
+  }
+}

--- a/wire-library/wire-grpc-client/src/jsMain/kotlin/com/squareup/wire/internal/platform.kt
+++ b/wire-library/wire-grpc-client/src/jsMain/kotlin/com/squareup/wire/internal/platform.kt
@@ -18,10 +18,17 @@ package com.squareup.wire.internal
 import okio.Sink
 import okio.Source
 
+actual interface Call {
+  actual fun cancel()
+}
+
 internal actual fun Sink.asGzip(): Sink {
   throw UnsupportedOperationException("Gzip not implemented for JS")
 }
 
 internal actual fun Source.asGzip(): Source {
   throw UnsupportedOperationException("Gzip not implemented for JS")
+}
+
+internal actual fun Throwable.addSuppressed(other: Throwable) {
 }

--- a/wire-library/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/platform.kt
+++ b/wire-library/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/platform.kt
@@ -18,6 +18,21 @@ package com.squareup.wire.internal
 import okio.Sink
 import okio.Source
 import okio.gzip
+import java.lang.reflect.Method
+
+actual typealias Call = okhttp3.Call
 
 internal actual inline fun Sink.asGzip(): Sink = gzip()
 internal actual inline fun Source.asGzip(): Source = gzip()
+
+internal actual fun Throwable.addSuppressed(other: Throwable) {
+  AddSuppressedMethod?.invoke(this, other)
+}
+
+private val AddSuppressedMethod: Method? by lazy {
+  try {
+    Throwable::class.java.getMethod("addSuppressed", Throwable::class.java)
+  } catch (t: Throwable) {
+    null
+  }
+}

--- a/wire-library/wire-grpc-client/src/nativeMain/kotlin/com/squareup/wire/internal/platform.kt
+++ b/wire-library/wire-grpc-client/src/nativeMain/kotlin/com/squareup/wire/internal/platform.kt
@@ -18,10 +18,17 @@ package com.squareup.wire.internal
 import okio.Sink
 import okio.Source
 
+actual interface Call {
+  actual fun cancel()
+}
+
 internal actual fun Sink.asGzip(): Sink {
   throw UnsupportedOperationException("Gzip not implemented for native")
 }
 
 internal actual fun Source.asGzip(): Source {
   throw UnsupportedOperationException("Gzip not implemented for native")
+}
+
+internal actual fun Throwable.addSuppressed(other: Throwable) {
 }


### PR DESCRIPTION
This is also the start of moving OkHttp's HTTP model in common code.