### PR TITLE
Proto3: scalar/enum are required but message are optional

### DIFF
--- a/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -502,4 +502,37 @@ public final class JavaGeneratorTest {
         + "      return this;\n"
         + "    }");
   }
+
+  @Test public void noLabelForProto3() throws Exception {
+    RepoBuilder repoBuilder = new RepoBuilder()
+        .add("message.proto", ""
+            + "syntax = \"proto3\";\n"
+            + "package common.proto;\n"
+            + "message LabelMessage {\n"
+            + "  string text = 1;\n"
+            + "  Author author = 2;\n"
+            + "  Enum enum = 3;\n"
+            + "\n"
+            + "  oneof choice {\n"
+            + "    int32 foo = 4;\n"
+            + "    string bar = 5;\n"
+            + "  }\n"
+            + "  enum Enum {\n"
+            + "    UNKNOWN = 0;\n"
+            + "    A = 1;\n"
+            + "  }\n"
+            + "  message Author {\n"
+            + "    string name = 1;\n"
+            + "  }\n"
+            + "}");
+    assertThat(repoBuilder.generateCode("common.proto.LabelMessage")).contains(""
+        + "    public LabelMessage build() {\n"
+        + "      if (text == null\n"
+        + "          || enum_ == null) {\n"
+        + "        throw Internal.missingRequiredFields(text, \"text\",\n"
+        + "            enum_, \"enum\");\n"
+        + "      }\n"
+        + "      return new LabelMessage(text, author, enum_, foo, bar, super.buildUnknownFields());\n"
+        + "    }");
+  }
 }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
@@ -27,7 +27,7 @@ class EnclosingType internal constructor(
   override val options
     get() = Options(Options.MESSAGE_OPTIONS, listOf())
 
-  override fun linkMembers(linker: Linker) {}
+  override fun linkMembers(linker: Linker, syntaxRules: SyntaxRules) {}
   override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
     nestedTypes.forEach { it.linkOptions(linker, syntaxRules) }
   }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -40,7 +40,7 @@ class EnumType private constructor(
   /** Returns the constant tagged `tag`, or null if this enum has no such constant.  */
   fun constant(tag: Int) = constants.find { it.tag == tag }
 
-  override fun linkMembers(linker: Linker) {}
+  override fun linkMembers(linker: Linker, syntaxRules: SyntaxRules) {}
 
   override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
     options.link(linker)

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
@@ -64,7 +64,7 @@ class Extend private constructor(
           location = it.location,
           documentation = it.documentation,
           name = it.name,
-          fields = Field.fromElements(packageName, it.fields, true)
+          fields = Field.fromElements(packageName, it.fields, extension = true, oneOf = false)
       )
     }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
@@ -112,7 +112,7 @@ internal class FileLinker(
   /** Link the members of [type] that haven't been linked already. */
   fun requireMembersLinked(type: Type) {
     if (typesWithMembersLinked.add(type.type)) {
-      type.linkMembers(linker)
+      type.linkMembers(linker, SyntaxRules.get(protoFile.syntax))
     }
   }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -263,6 +263,7 @@ class Linker {
     protoTypeNames[protoType.toString()] = type
   }
 
+  // TODO(benoit) Remove the operator. This isn't a getter method.
   /** Returns the type or null if it doesn't exist. */
   operator fun get(protoType: ProtoType): Type? {
     var result = protoTypeNames[protoType.toString()]

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -101,16 +101,16 @@ class MessageType private constructor(
     extensionFields.addAll(fields)
   }
 
-  override fun linkMembers(linker: Linker) {
+  override fun linkMembers(linker: Linker, syntaxRules: SyntaxRules) {
     val linker = linker.withContext(this)
     for (field in declaredFields) {
-      field.link(linker)
+      field.link(linker, syntaxRules)
     }
     for (field in extensionFields) {
-      field.link(linker)
+      field.link(linker, syntaxRules)
     }
     for (oneOf in oneOfs) {
-      oneOf.link(linker)
+      oneOf.link(linker, syntaxRules)
     }
   }
 
@@ -238,9 +238,10 @@ class MessageType private constructor(
           location = messageElement.location,
           documentation = messageElement.documentation,
           name = messageElement.name,
-          declaredFields = fromElements(packageName, messageElement.fields, false),
+          declaredFields =
+              fromElements(packageName, messageElement.fields, extension = false, oneOf = false),
           extensionFields = mutableListOf(), // Extension fields are populated during linking.
-          oneOfs = fromElements(packageName, messageElement.oneOfs, false),
+          oneOfs = fromElements(packageName, messageElement.oneOfs, extension = false),
           nestedTypes = nestedTypes,
           extensionsList = fromElements(messageElement.extensions),
           reserveds = fromElements(messageElement.reserveds),

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/OneOf.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/OneOf.kt
@@ -23,9 +23,9 @@ class OneOf private constructor(
   val documentation: String,
   val fields: List<Field>
 ) {
-  fun link(linker: Linker) {
+  fun link(linker: Linker, syntaxRules: SyntaxRules) {
     for (field in fields) {
-      field.link(linker)
+      field.link(linker, syntaxRules)
     }
   }
 
@@ -66,7 +66,7 @@ class OneOf private constructor(
       return@map OneOf(
           name = it.name,
           documentation = it.documentation,
-          fields = Field.fromElements(packageName, it.fields, extension)
+          fields = Field.fromElements(packageName, it.fields, extension, oneOf = true)
       )
     }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
@@ -25,6 +25,18 @@ interface SyntaxRules {
   fun canExtend(protoType: ProtoType): Boolean
   fun enumRequiresZeroValueAtFirstPosition(): Boolean
   fun isPackedByDefault(type: ProtoType, label: Field.Label?): Boolean
+  fun isTypeOptionalByDefault(
+    protoType: ProtoType,
+    type: Type?,
+    isExtension: Boolean,
+    isOneOf: Boolean
+  ): Boolean
+  fun isTypeRequiredByDefault(
+    protoType: ProtoType,
+    type: Type?,
+    isExtension: Boolean,
+    isOneOf: Boolean
+  ): Boolean
 
   companion object {
     fun get(syntax: Syntax?): SyntaxRules {
@@ -43,6 +55,20 @@ interface SyntaxRules {
         type: ProtoType,
         label: Field.Label?
       ): Boolean = false
+
+      override fun isTypeOptionalByDefault(
+        protoType: ProtoType,
+        type: Type?,
+        isExtension: Boolean,
+        isOneOf: Boolean
+      ): Boolean = false
+
+      override fun isTypeRequiredByDefault(
+        protoType: ProtoType,
+        type: Type?,
+        isExtension: Boolean,
+        isOneOf: Boolean
+      ): Boolean = false
     }
 
     internal val PROTO_3_SYNTAX_RULES = object : SyntaxRules {
@@ -56,6 +82,28 @@ interface SyntaxRules {
         label: Field.Label?
       ): Boolean {
         return label == Field.Label.REPEATED && type in ProtoType.NUMERIC_SCALAR_TYPES
+      }
+
+      override fun isTypeOptionalByDefault(
+        protoType: ProtoType,
+        type: Type?,
+        isExtension: Boolean,
+        isOneOf: Boolean
+      ): Boolean {
+        return !(protoType.isScalar || type is EnumType) ||
+            // Extensions (custom options) are always optional.
+            isExtension ||
+            // OneOfs are always optional.
+            isOneOf
+      }
+
+      override fun isTypeRequiredByDefault(
+        protoType: ProtoType,
+        type: Type?,
+        isExtension: Boolean,
+        isOneOf: Boolean
+      ): Boolean {
+        return !isTypeOptionalByDefault(protoType, type, isExtension, isOneOf)
       }
     }
   }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
@@ -28,7 +28,7 @@ abstract class Type {
   abstract val documentation: String
   abstract val options: Options
   abstract val nestedTypes: List<Type>
-  abstract fun linkMembers(linker: Linker)
+  abstract fun linkMembers(linker: Linker, syntaxRules: SyntaxRules)
   abstract fun linkOptions(linker: Linker, syntaxRules: SyntaxRules)
   abstract fun validate(linker: Linker, syntaxRules: SyntaxRules)
   abstract fun retainAll(schema: Schema, markSet: MarkSet): Type?

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/FieldElementTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/FieldElementTest.kt
@@ -84,13 +84,12 @@ class FieldElementTest {
   fun defaultIsNotSetInProto3File() {
     val field = FieldElement(
         location = location,
-        label = REQUIRED,
         type = "string",
         name = "name",
         tag = 1,
         defaultValue = "default value shouldn't be set"
     )
 
-    assertThat(field.toSchema(PROTO_3_SYNTAX_RULES)).isEqualTo("required string name = 1;\n")
+    assertThat(field.toSchema(PROTO_3_SYNTAX_RULES)).isEqualTo("string name = 1;\n")
   }
 }

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
@@ -373,47 +373,6 @@ class ProtoFileElementTest {
   }
 
   @Test
-  fun defaultIsNotSetInProto3() {
-    val field = FieldElement(
-        location = location.at(9, 3),
-        label = Field.Label.REQUIRED,
-        type = "string",
-        name = "name",
-        tag = 1,
-        defaultValue = "defaultValue"
-    )
-    val message =
-        MessageElement(location = location.at(8, 1), name = "Message", fields = listOf(field))
-    val file = ProtoFileElement(
-        syntax = PROTO_3,
-        location = location,
-        packageName = "example.simple",
-        imports = listOf("example.thing"),
-        publicImports = listOf("example.other"),
-        types = listOf(message)
-    )
-    assertThat(file.toSchema()).doesNotContain("defaultValue")
-
-    // TODO(benoit|masaru): Ignore the test below now. This will be fixed by #1386.
-    // val expected = """
-    //     |// file.proto
-    //     |syntax = "proto3";
-    //     |package example.simple;
-    //     |
-    //     |import "example.thing";
-    //     |import public "example.other";
-    //     |
-    //     |message Message {
-    //     |  string name = 1;
-    //     |}
-    //     |""".trimMargin()
-    // assertThat(file.toSchema()).isEqualTo(expected)
-    // // Re-parse the expected string into a ProtoFile and ensure they're equal.
-    // val parsed = ProtoParser.parse(location, expected)
-    // assertThat(parsed).isEqualTo(file)
-  }
-
-  @Test
   fun convertPackedOptionFromWireSchemaInProto2() {
     val fieldNumeric = FieldElement(
         location = location.at(6, 3),


### PR DESCRIPTION
part of #1386
All implicitly. And we don't wanna mess up with oneofs, they don't have labels but their required logic is bound among their peers.

The same way we store wether a field is redacted, we store if a field _should_ be optional or _should_ be required.
This was a bit tough but couldn't come up with a better way for now.