### PR TITLE
Always link option values

### DIFF
--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/OptionsLinkingTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/OptionsLinkingTest.kt
@@ -93,6 +93,7 @@ class OptionsLinkingTest {
              |import "formatting_options.proto";
              |message A {
              |  optional string s = 1 [formatting_options.language.name = "English"];
+             |  optional string t = 2 [(length).max = 80];
              |}
             """.trimMargin())
     fs.add("proto-path/formatting_options.proto", """
@@ -105,6 +106,7 @@ class OptionsLinkingTest {
              |
              |extend google.protobuf.FieldOptions {
              |  optional FormattingOptions formatting_options = 22001;
+             |  optional Range length = 22002;
              |}
              |
              |message Language {
@@ -116,6 +118,11 @@ class OptionsLinkingTest {
              |  LOWER_CASE = 1;
              |  TITLE_CASE = 2;
              |  SENTENCE_CASE = 3;
+             |}
+             |
+             |message Range {
+             |  optional double min = 1;
+             |  optional double max = 2;
              |}
             """.trimMargin())
     val schema = loadAndLinkSchema()
@@ -130,6 +137,12 @@ class OptionsLinkingTest {
             )
         )
     )
+
+    val typeLanguage = schema.getType("Language") as MessageType
+    assertThat(typeLanguage.field("name")).isNotNull()
+
+    val typeRange = schema.getType("Range") as MessageType
+    assertThat(typeRange.field("max")).isNotNull()
   }
 
   private fun loadAndLinkSchema(): Schema {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -304,7 +304,7 @@ class Linker {
       field = field.substring(1, field.length - 1)
     }
 
-    val type = get(self.type!!)
+    val type = getForOptions(self.type!!)
     if (type is MessageType) {
       val messageField = type.field(field)
       if (messageField != null) return messageField


### PR DESCRIPTION
We had a bug where we were crashing in ProtoPruner because the schema
referenced an extension member but it wasn't in the schema.

This uses getForOptions which causes the resolved value to be included
in the schema.

This should fix this crash:

    kotlin.KotlinNullPointerException
      at com.squareup.wire.schema.Pruner.isRetainedVersion(Pruner.kt:107)
      at com.squareup.wire.schema.Pruner.markReachable(Pruner.kt:142)
      at com.squareup.wire.schema.Pruner.prune(Pruner.kt:38)
      at com.squareup.wire.schema.Schema.prune(Schema.kt:51)
      at com.squareup.wire.schema.WireRun.treeShake(WireRun.kt:243)
      at com.squareup.wire.schema.WireRun.execute(WireRun.kt:171)
      at com.squareup.wire.schema.WireRun.execute(WireRun.kt:159)
      at com.squareup.wire.schema.WireRun.execute(WireRun.kt:157)
      at com.squareup.wire.gradle.WireTask.generateWireFiles(WireTask.kt:105)