### PR TITLE
Use the extension's file's imports when resolving extension types

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -247,8 +247,15 @@ class Linker {
     val result = mutableListOf<FileLinker>()
     for (i in contextStack.indices.reversed()) {
       val context = contextStack[i]
-      if (context is ProtoFile) {
-        val path = context.location.path
+
+      val location = when {
+        context is ProtoFile -> context.location
+        context is Field && context.isExtension -> context.location
+        else -> null
+      }
+
+      if (location != null) {
+        val path = location.path
         val fileLinker = getFileLinker(path)
         for (effectiveImport in fileLinker.effectiveImports()) {
           result.add(getFileLinker(effectiveImport))


### PR DESCRIPTION
We had a bug where an extension whose type was in a different file
wouldn't use the imports of that different file. This caused the
imported type to be missed.