### PR TITLE
Fix kotlin MessageType allocated name list

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -295,6 +295,7 @@ class KotlinGenerator private constructor(
           is MessageType -> {
             newName("unknownFields", "unknownFields")
             newName("ADAPTER", "ADAPTER")
+            newName("adapter", "adapter")
             newName("reader", "reader")
             newName("Builder", "Builder")
             newName("builder", "builder")

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -76,10 +76,12 @@ class KotlinGeneratorTest {
         |message Message {
         |  required float when = 1;
         |  required int32 ADAPTER = 2;
+        |  optional int64 adapter = 3;
         |}""".trimMargin())
     val code = repoBuilder.generateKotlin("Message")
     assertTrue(code.contains("val when_: Float"))
     assertTrue(code.contains("val ADAPTER_: Int"))
+    assertTrue(code.contains("val adapter_: Long?"))
     assertTrue(code.contains("ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.when_) +"))
     assertTrue(code.contains("ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.when_)"))
     assertTrue(code.contains("ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.when_)"))


### PR DESCRIPTION
Add `adapter` to allocated name list for MessageType in KotlinGenerator, since it is already used in Message interface.

This fixes #1446 