### PR TITLE
Revert "Remove obsolete withJava() from JVM compilation"

### DIFF
--- a/wire-library/wire-runtime/build.gradle
+++ b/wire-library/wire-runtime/build.gradle
@@ -1,7 +1,9 @@
 apply plugin: 'org.jetbrains.kotlin.multiplatform'
 
 kotlin {
-  jvm()
+  jvm {
+    withJava()
+  }
   js {
     configure([compilations.main, compilations.test]) {
       tasks.getByName(compileKotlinTaskName).kotlinOptions {


### PR DESCRIPTION
This reverts commit 2ffbeeae65787449b711a78bb91daa8344628854. This
wasn't obsolete it seems.

I wouldn't be able to build the project without it.

```
$ ./gradlew clean generateTests
Starting a Gradle Daemon, 5 stopped Daemons could not be reused, use --status for details

> Configure project :wire-library:wire-grpc-client
Kotlin Multiplatform Projects are an experimental feature.

FAILURE: Build failed with an exception.

* What went wrong:
Could not determine the dependencies of task ':wire-library:wire-schema:compileJava'.
> Could not resolve all task dependencies for configuration ':wire-library:wire-schema:compileClasspath'.
   > Could not resolve project :wire-library:wire-runtime.
     Required by:
         project :wire-library:wire-schema
      > Cannot choose between the following variants of project :wire-library:wire-runtime:
          - apiElements
          - iosArm64Compile
          - iosArm64CompileOnly
          - iosArm64Default
          - iosArm64RuntimeOnly
          - iosArm64TestCompile
          - iosX64Compile
          - iosX64CompileOnly
          - iosX64Default
          - iosX64RuntimeOnly
          - iosX64TestCompile
          - jsCompile
          - jsCompileOnly
          - jsDefault
          - jsRuntime
          - jsTestCompile
          - jsTestRuntime
          - jvmApiElements
          - jvmCompile
          - jvmCompileOnly
          - jvmDefault
          - jvmRuntime
          - jvmRuntimeElements
          - jvmTestCompile
          - jvmTestRuntime
          - linuxX64Compile
          - linuxX64CompileOnly
          - linuxX64Default
          - linuxX64RuntimeOnly
          - linuxX64TestCompile
          - macosX64Compile
          - macosX64CompileOnly
          - macosX64Default
          - macosX64RuntimeOnly
          - macosX64TestCompile
          - metadataCompile
          - metadataCompileOnly
          - metadataDefault
          - runtimeElements
        All of them match the consumer attributes:
          - Variant 'apiElements' capability com.squareup.wire:wire-runtime:3.2.0-SNAPSHOT:
              - Unmatched attribute:
                  - Found org.gradle.category 'library' but wasn't required.
              - Compatible attributes:
                  - Required org.gradle.dependency.bundling 'external' and found compatible value 'external'.
                  - Required org.gradle.jvm.version '12' and found compatible value '12'.
                  - Required org.gradle.libraryelements 'classes' and found compatible value 'jar'.
                  - Required org.gradle.usage 'java-api' and found compatible value 'java-api'.
          - Variant 'iosArm64Compile' capability com.squareup.wire:wire-runtime:3.2.0-SNAPSHOT:
		  ..................
```