### PR TITLE
Fix generated Kotlin code is malformed for long identifiers

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -486,12 +486,12 @@ class KotlinGenerator private constructor(
 
     val body = buildCodeBlock {
       addStatement("if (%N === this) return true", otherName)
-      addStatement("if (%N !is %T) return false", otherName, kotlinType)
+      addStatement("if (%N !is %T) return·false", otherName, kotlinType)
       add("«return unknownFields == %N.unknownFields", otherName)
       val fields = type.fieldsAndOneOfFields
       for (field in fields) {
         val fieldName = localNameAllocator[field]
-        add("\n&& %1L == %2N.%1L", fieldName, otherName)
+        add("\n&& %1L·== %2N.%1L", fieldName, otherName)
       }
       add("\n»")
     }
@@ -904,7 +904,7 @@ class KotlinGenerator private constructor(
       val nameAllocator = nameAllocator(schema.getType(protoType)!!)
       if (!first) add(",")
       first = false
-      add("\n⇥%L = %L⇤", nameAllocator[field], valueInitializer)
+      add("\n⇥%L·= %L⇤", nameAllocator[field], valueInitializer)
     }
     add("\n)")
   }
@@ -1067,7 +1067,7 @@ class KotlinGenerator private constructor(
     }
 
     val returnBody = buildCodeBlock {
-      addStatement("return %T(⇥", className)
+      addStatement("return·%T(⇥", className)
 
       val missingRequiredFields = MemberName("com.squareup.wire.internal", "missingRequiredFields")
       message.fieldsAndOneOfFields.forEach { field ->
@@ -1130,7 +1130,7 @@ class KotlinGenerator private constructor(
     return CodeBlock.of(when {
       field.isRepeated -> "%L.add(%L)"
       field.isMap -> "%L.putAll(%L)"
-      else -> "%L = %L"
+      else -> "%L·= %L"
     }, fieldName, decode)
   }
 

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1055,6 +1055,21 @@ class KotlinGeneratorTest {
     assertEquals(expected, input.sanitizeKdoc())
   }
 
+  @Test fun handleLongIdentifiers() {
+    val longType = "MessageWithNameLongerThan100Chars00000000000000000000000000000000000000000000000000000000000000000000"
+    val longMember = "member_with_name_which_is_longer_then_100_chars_00000000000000000000000000000000000000000000000000000"
+    val repoBuilder = RepoBuilder()
+        .add("$longType.proto", """
+        |message $longType {
+        |  required string $longMember = 1;
+        |}""".trimMargin())
+    val code = repoBuilder.generateKotlin(longType)
+    assertTrue(code.contains("return false"))
+    assertTrue(code.contains("return $longType("))
+    assertTrue(code.contains("$longMember =="))
+    assertTrue(code.contains("$longMember =\n"))
+  }
+
   companion object {
     private val pointMessage = """
           |message Point {


### PR DESCRIPTION
About:
---------
* Replace space in KotlinGenerator in critical places with KotlinPoet non-breaking space symbol `·` to prevent generation of broken code for long message names or member names

This PR fixes #1451 