### PR TITLE
Deprecate isOptional/isRequired in Field and introduce encodeMode

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
@@ -16,7 +16,6 @@
 package com.squareup.wire.schema
 
 import com.squareup.wire.schema.Field.Companion.retainAll
-import com.squareup.wire.schema.Options.Companion.GOOGLE_PROTOBUF_OPTION_TYPES
 import com.squareup.wire.schema.internal.parser.ExtendElement
 import kotlin.jvm.JvmStatic
 

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -995,7 +995,8 @@ class PrunerTest {
              |option java_package = "p";
              |
              |message Message {
-             |  optional int32 a = 1 [packed = true, deprecated = true, default = 5];
+             |  optional int32 a = 1 [deprecated = true, default = 5];
+             |  repeated int32 b = 2 [packed = true, deprecated = true];
              |}
              |enum Enum {
              |  option allow_alias = true;
@@ -1012,10 +1013,12 @@ class PrunerTest {
     assertThat(protoFile!!.javaPackage()).isEqualTo("p")
 
     val message = pruned.getType("Message") as MessageType
-    val field = message.field("a")
-    assertThat(field!!.default).isEqualTo("5")
-    assertThat(field.isDeprecated).isTrue()
-    assertThat(field.isPacked).isTrue()
+    val fieldA = message.field("a")!!
+    assertThat(fieldA.default).isEqualTo("5")
+    assertThat(fieldA.isDeprecated).isTrue()
+    val fieldB = message.field("b")!!
+    assertThat(fieldB.isDeprecated).isTrue()
+    assertThat(fieldB.isPacked).isTrue()
 
     val enumType = pruned.getType("Enum") as EnumType
     assertThat(enumType.allowAlias()).isTrue()

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
@@ -373,47 +373,6 @@ class ProtoFileElementTest {
   }
 
   @Test
-  fun defaultIsNotSetInProto3() {
-    val field = FieldElement(
-        location = location.at(9, 3),
-        label = Field.Label.REQUIRED,
-        type = "string",
-        name = "name",
-        tag = 1,
-        defaultValue = "defaultValue"
-    )
-    val message =
-        MessageElement(location = location.at(8, 1), name = "Message", fields = listOf(field))
-    val file = ProtoFileElement(
-        syntax = PROTO_3,
-        location = location,
-        packageName = "example.simple",
-        imports = listOf("example.thing"),
-        publicImports = listOf("example.other"),
-        types = listOf(message)
-    )
-    assertThat(file.toSchema()).doesNotContain("defaultValue")
-
-    // TODO(benoit|masaru): Ignore the test below now. This will be fixed by #1386.
-    // val expected = """
-    //     |// file.proto
-    //     |syntax = "proto3";
-    //     |package example.simple;
-    //     |
-    //     |import "example.thing";
-    //     |import public "example.other";
-    //     |
-    //     |message Message {
-    //     |  string name = 1;
-    //     |}
-    //     |""".trimMargin()
-    // assertThat(file.toSchema()).isEqualTo(expected)
-    // // Re-parse the expected string into a ProtoFile and ensure they're equal.
-    // val parsed = ProtoParser.parse(location, expected)
-    // assertThat(parsed).isEqualTo(file)
-  }
-
-  @Test
   fun convertPackedOptionFromWireSchemaInProto2() {
     val fieldNumeric = FieldElement(
         location = location.at(6, 3),


### PR DESCRIPTION
Remake of #1462, part of #1386

The goal is to rely on encode mode from within the generators to fully support proto3 as well, for optionality/requiredness is a proto2 only concept.

The fact that the golden files didn't change is my test for not breaking old code. We'll test proto3 in follow-ups when we update the generators.