### PR TITLE
Solves #1496: Make the gradle plugin compatible with instant execution.

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
@@ -32,33 +32,30 @@ import java.net.URI
  * directory trees, jars, and coordinates). This includes registering dependencies with the project
  * so they can be resolved for us.
  */
-internal class WireInput(
-  var project: Project,
-  var configuration: Configuration
-) {
+internal class WireInput(var configuration: Configuration) {
   val name: String
     get() = configuration.name
 
   private val dependencyToIncludes = mutableMapOf<Dependency, List<String>>()
 
-  fun addPaths(paths: Set<String>) {
+  fun addPaths(project: Project, paths: Set<String>) {
     for (path in paths) {
-      val dependency = resolveDependency(path)
+      val dependency = resolveDependency(project, path)
       configuration.dependencies.add(dependency)
     }
   }
 
-  fun addJars(jars: Set<ProtoRootSet>) {
+  fun addJars(project: Project, jars: Set<ProtoRootSet>) {
     for (jar in jars) {
       jar.srcJar?.let { path ->
-        val dependency = resolveDependency(path)
+        val dependency = resolveDependency(project, path)
         dependencyToIncludes[dependency] = jar.includes
         configuration.dependencies.add(dependency)
       }
     }
   }
 
-  fun addTrees(trees: Set<SourceDirectorySet>) {
+  fun addTrees(project: Project, trees: Set<SourceDirectorySet>) {
     for (tree in trees) {
       // TODO: this eagerly resolves dependencies; fix this!
       tree.srcDirs.forEach {
@@ -71,7 +68,7 @@ internal class WireInput(
     }
   }
 
-  private fun resolveDependency(path: String): Dependency {
+  private fun resolveDependency(project: Project, path: String): Dependency {
     val parser = FileOrUriNotationConverter.parser()
 
     val converted = parser.parseNotation(path)

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -78,24 +78,24 @@ class WirePlugin : Plugin<Project> {
     project: Project,
     extension: WireExtension
   ) {
-    val sourceInput = WireInput(project, project.configurations.getByName("protoSource"))
+    val sourceInput = WireInput(project.configurations.getByName("protoSource"))
     if (extension.sourcePaths.isNotEmpty() ||
         extension.sourceTrees.isNotEmpty() ||
         extension.sourceJars.isNotEmpty()) {
-      sourceInput.addTrees(extension.sourceTrees)
-      sourceInput.addJars(extension.sourceJars)
-      sourceInput.addPaths(extension.sourcePaths)
+      sourceInput.addTrees(project, extension.sourceTrees)
+      sourceInput.addJars(project, extension.sourceJars)
+      sourceInput.addPaths(project, extension.sourcePaths)
     } else {
-      sourceInput.addPaths(setOf("src/main/proto"))
+      sourceInput.addPaths(project, setOf("src/main/proto"))
     }
 
-    val protoInput = WireInput(project, project.configurations.getByName("protoPath"))
+    val protoInput = WireInput(project.configurations.getByName("protoPath"))
     if (extension.protoPaths.isNotEmpty() ||
         extension.protoTrees.isNotEmpty() ||
         extension.protoJars.isNotEmpty()) {
-      protoInput.addTrees(extension.protoTrees)
-      protoInput.addJars(extension.protoJars)
-      protoInput.addPaths(extension.protoPaths)
+      protoInput.addTrees(project, extension.protoTrees)
+      protoInput.addJars(project, extension.protoJars)
+      protoInput.addPaths(project, extension.protoPaths)
     }
 
     // At this point, all source and proto file references should be set up for Gradle to resolve.


### PR DESCRIPTION
The problem was that the `WireInput` class was not serializable as it was using the project as a property. All tasks using an input of the type `WireInput` couldn't be serialialized.

I passed the project object to methods that needed it.