### PR TITLE
Use 'declared' vs 'original' in WireField.declaredName doc, use bette…

### DIFF
--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
@@ -47,9 +47,9 @@ annotation class WireField(
    */
   val redacted: Boolean = false,
   /**
-   * Original name of this field as defined in the proto schema. This value is set to a non-empty
-   * string only when the original name differs from the generated one; for instance, a proto field
-   * named `object` generated in Java will be renamed `object_`.
+   * Name of this field as declared in the proto schema. This value is set to a non-empty string
+   * only when the declared name differs from the generated one; for instance, a proto field named
+   * `final` generated in Java will be renamed to `final_`.
    */
   val declaredName: String = ""
 ) {


### PR DESCRIPTION
…r Java example