### PR TITLE
Implement proto3 durations for the JVM

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -129,6 +129,7 @@ class WireCompiler internal constructor(
         if (namedFilesOnly || protoFile.location.path == DESCRIPTOR_PROTO) continue
       }
       if (protoFile.location.path == ANY_PROTO) continue
+      if (protoFile.location.path == DURATION_PROTO) continue
       queue.addAll(protoFile.types.map(::PendingTypeFileSpec))
       queue.addAll(protoFile.services.map(::PendingServiceFileSpec))
     }
@@ -202,6 +203,7 @@ class WireCompiler internal constructor(
     private const val MAX_WRITE_CONCURRENCY = 8
     private const val DESCRIPTOR_PROTO = "google/protobuf/descriptor.proto"
     private const val ANY_PROTO = "google/protobuf/any.proto"
+    private const val DURATION_PROTO = "google/protobuf/duration.proto"
 
     @Throws(IOException::class)
     @JvmStatic fun main(args: Array<String>) {

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/NewSchemaLoader.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/NewSchemaLoader.kt
@@ -118,6 +118,7 @@ class NewSchemaLoader(
 
     if (path == CoreLoader.ANY_PROTO ||
         path == CoreLoader.DESCRIPTOR_PROTO ||
+        path == CoreLoader.DURATION_PROTO ||
         path == CoreLoader.WIRE_EXTENSIONS_PROTO) {
       return CoreLoader.load(path)
     }

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -131,6 +131,7 @@ public final class JavaGenerator {
           .put(ProtoType.UINT32, (ClassName) TypeName.INT.box())
           .put(ProtoType.UINT64, (ClassName) TypeName.LONG.box())
           .put(ProtoType.ANY, ClassName.get("com.squareup.wire", "AnyMessage"))
+          .put(ProtoType.DURATION, ClassName.get("java.time", "Duration"))
           .put(FIELD_OPTIONS, ClassName.get("com.google.protobuf", "FieldOptions"))
           .put(ENUM_OPTIONS, ClassName.get("com.google.protobuf", "EnumOptions"))
           .put(MESSAGE_OPTIONS, ClassName.get("com.google.protobuf", "MessageOptions"))

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -799,11 +799,6 @@ class KotlinGenerator private constructor(
         .build()
   }
 
-  private fun ProtoType.adapterString() = when {
-    isScalar -> ProtoAdapter::class.java.name + '#' + toString().toUpperCase(Locale.US)
-    else -> typeName.reflectionName() + "#ADAPTER"
-  }
-
   private fun generateToStringMethod(type: MessageType, nameAllocator: NameAllocator): FunSpec {
     val sanitizeMember = MemberName("com.squareup.wire.internal", "sanitize")
     val localNameAllocator = nameAllocator.copy()
@@ -1230,13 +1225,20 @@ class KotlinGenerator private constructor(
 
   private fun ProtoType.getAdapterName(adapterFieldDelimiterName: Char = '.'): CodeBlock {
     return when {
-      isScalar -> CodeBlock.of(
+      isScalar || this == ProtoType.DURATION -> CodeBlock.of(
           "%T$adapterFieldDelimiterName%L",
           ProtoAdapter::class, simpleName.toUpperCase(Locale.US)
       )
       isMap -> throw IllegalArgumentException("Can't create single adapter for map type $this")
       else -> CodeBlock.of("%T${adapterFieldDelimiterName}ADAPTER", typeName)
     }
+  }
+
+  private fun ProtoType.adapterString() = when {
+    isScalar || this == ProtoType.DURATION -> {
+      ProtoAdapter::class.java.name + '#' + simpleName.toUpperCase(Locale.US)
+    }
+    else -> typeName.reflectionName() + "#ADAPTER"
   }
 
   /**
@@ -1542,6 +1544,7 @@ class KotlinGenerator private constructor(
         ProtoType.UINT32 to INT,
         ProtoType.UINT64 to LONG,
         ProtoType.ANY to ClassName("com.squareup.wire", "AnyMessage"),
+        ProtoType.DURATION to ClassName("java.time", "Duration"),
         FIELD_OPTIONS to ClassName("com.google.protobuf", "FieldOptions"),
         MESSAGE_OPTIONS to ClassName("com.google.protobuf", "MessageOptions"),
         ENUM_OPTIONS to ClassName("com.google.protobuf", "EnumOptions")

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/DurationJsonAdapter.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/DurationJsonAdapter.kt
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import java.time.Duration
+
+/**
+ * Encode a duration as a JSON string like "1.200s". From the spec:
+ *
+ * > Generated output always contains 0, 3, 6, or 9 fractional digits, depending on required
+ * > precision, followed by the suffix "s". Accepted are any fractional digits (also none) as long
+ * > as they fit into nano-seconds precision and the suffix "s" is required.
+ *
+ * Note that [Duration] always returns a positive nanosPart, so "-1.200s" is represented as -2
+ * seconds and 800_000_000 nanoseconds.
+ */
+internal object DurationJsonAdapter : JsonAdapter<Duration>() {
+  override fun toJson(out: JsonWriter, duration: Duration?) {
+    out.value(durationToString(duration!!))
+  }
+
+  override fun fromJson(input: JsonReader): Duration? {
+    val string = input.nextString()
+    try {
+      return stringToDuration(string)
+    } catch (_: NumberFormatException) {
+      throw JsonDataException("not a duration: $string at path ${input.path}")
+    }
+  }
+
+  internal fun durationToString(duration: Duration): String {
+    var seconds = duration.seconds
+    var nanos = duration.nano
+    var prefix = ""
+    if (seconds < 0L) {
+      if (seconds == Long.MIN_VALUE) {
+        prefix = "-922337203685477580" // Avoid overflow inverting MIN_VALUE.
+        seconds = 8
+      } else {
+        prefix = "-"
+        seconds = -seconds
+      }
+      if (nanos != 0) {
+        seconds -= 1L
+        nanos = 1_000_000_000 - nanos
+      }
+    }
+    return when {
+      nanos == 0 -> "%s%ds".format(prefix, seconds)
+      nanos % 1_000_000 == 0 -> "%s%d.%03ds".format(prefix, seconds, nanos / 1_000_000L)
+      nanos % 1_000 == 0 -> "%s%d.%06ds".format(prefix, seconds, nanos / 1_000L)
+      else -> "%s%d.%09ds".format(prefix, seconds, nanos / 1L)
+    }
+  }
+
+  /** Throws a NumberFormatException if the string isn't a number like "1s" or "1.23456789s". */
+  internal fun stringToDuration(string: String): Duration {
+    val sIndex = string.indexOf('s')
+    if (sIndex != string.length - 1) throw NumberFormatException()
+
+    val dotIndex = string.indexOf('.')
+    if (dotIndex == -1) {
+      val seconds = string.substring(0, sIndex).toLong()
+      return Duration.ofSeconds(seconds)
+    }
+
+    val seconds = string.substring(0, dotIndex).toLong()
+    var nanos = string.substring(dotIndex + 1, sIndex).toLong()
+    if (string.startsWith("-")) nanos = -nanos
+    val nanosDigits = sIndex - (dotIndex + 1)
+    for (i in nanosDigits until 9) nanos *= 10
+    for (i in 9 until nanosDigits) nanos /= 10
+    return Duration.ofSeconds(seconds, nanos)
+  }
+}

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
@@ -26,6 +26,7 @@ import java.io.IOException
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Type
 import java.math.BigInteger
+import java.time.Duration
 import java.util.ArrayList
 
 /**
@@ -93,6 +94,9 @@ class WireJsonAdapterFactory private constructor(
     }
     if (rawType == AnyMessage::class.java) {
       return AnyMessageJsonAdapter(moshi, typeUrlToAdapter)
+    }
+    if (rawType == Duration::class.java) {
+      return DurationJsonAdapter.nullSafe()
     }
     return if (Message::class.java.isAssignableFrom(rawType)) {
       MessageJsonAdapter<Nothing, Nothing>(moshi, type)

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/DurationJsonAdapterTest.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/DurationJsonAdapterTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.wire.DurationJsonAdapter.durationToString
+import com.squareup.wire.DurationJsonAdapter.stringToDuration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.time.Duration.ofSeconds
+
+class DurationJsonAdapterTest {
+  @Test
+  fun `string to duration`() {
+    assertThat(stringToDuration("1s")).isEqualTo(ofSeconds(1L))
+    assertThat(stringToDuration("1.00000000200s")).isEqualTo(ofSeconds(1L, 2L))
+    assertThat(stringToDuration("1.0000000020s")).isEqualTo(ofSeconds(1L, 2L))
+    assertThat(stringToDuration("1.000000002s")).isEqualTo(ofSeconds(1L, 2L))
+    assertThat(stringToDuration("1.000002s")).isEqualTo(ofSeconds(1L, 2000L))
+    assertThat(stringToDuration("1.002s")).isEqualTo(ofSeconds(1L, 2000000L))
+    assertThat(stringToDuration("1.2s")).isEqualTo(ofSeconds(1L, 200000000L))
+    assertThat(stringToDuration("-1.2s")).isEqualTo(ofSeconds(-1L, -200000000L))
+    assertThat(stringToDuration("-0.2s")).isEqualTo(ofSeconds(0L, -200000000L))
+    assertThat(stringToDuration("0.2s")).isEqualTo(ofSeconds(0L, 200000000L))
+    assertThat(stringToDuration("-9223372036854775808s")).isEqualTo(ofSeconds(Long.MIN_VALUE))
+    assertThat(stringToDuration("9223372036854775807.999999999s"))
+        .isEqualTo(ofSeconds(Long.MAX_VALUE, 999_999_999L))
+    assertThat(stringToDuration("-9223372036854775807.999999999s"))
+        .isEqualTo(ofSeconds(-9223372036854775807L, -999_999_999L))
+  }
+
+  @Test
+  fun `duration to string`() {
+    assertThat(durationToString(ofSeconds( 0L                ))).isEqualTo("0s")
+    assertThat(durationToString(ofSeconds( 1L                ))).isEqualTo("1s")
+    assertThat(durationToString(ofSeconds( 1L,             2L))).isEqualTo( "1.000000002s")
+    assertThat(durationToString(ofSeconds( 1L,            20L))).isEqualTo( "1.000000020s")
+    assertThat(durationToString(ofSeconds( 1L,         2_000L))).isEqualTo( "1.000002s")
+    assertThat(durationToString(ofSeconds( 1L,     2_000_000L))).isEqualTo( "1.002s")
+    assertThat(durationToString(ofSeconds( 1L,   200_000_000L))).isEqualTo( "1.200s")
+    assertThat(durationToString(ofSeconds(-1L,  -200_000_000L))).isEqualTo("-1.200s")
+    assertThat(durationToString(ofSeconds( 0L,  -200_000_000L))).isEqualTo("-0.200s")
+    assertThat(durationToString(ofSeconds( 0L,  -999_999_999L))).isEqualTo("-0.999999999s")
+    assertThat(durationToString(ofSeconds( 0L,  -999_999_000L))).isEqualTo("-0.999999s")
+    assertThat(durationToString(ofSeconds( 0L,  -999_900_000L))).isEqualTo("-0.999900s")
+    assertThat(durationToString(ofSeconds( 0L,  -999_000_000L))).isEqualTo("-0.999s")
+    assertThat(durationToString(ofSeconds(Long.MIN_VALUE, 0L))).isEqualTo("-9223372036854775808s")
+    assertThat(durationToString(ofSeconds(Long.MIN_VALUE, 1L)))
+        .isEqualTo("-9223372036854775807.999999999s")
+  }
+}

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/DurationProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/DurationProtoAdapter.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.wire.FieldEncoding.LENGTH_DELIMITED
+import java.time.Duration
+
+internal object DurationProtoAdapter : ProtoAdapter<Duration>(
+    fieldEncoding = LENGTH_DELIMITED,
+    type = Duration::class,
+    typeUrl = "type.googleapis.com/google.protobuf.Duration"
+) {
+  override fun encodedSize(value: Duration): Int {
+    var result = 0
+    val seconds = value.sameSignSeconds
+    if (seconds != 0L) result += INT64.encodedSizeWithTag(1, seconds)
+    val nanos = value.sameSignNanos
+    if (nanos != 0) result += INT32.encodedSizeWithTag(2, nanos)
+    return result
+  }
+
+  override fun encode(writer: ProtoWriter, value: Duration) {
+    val seconds = value.sameSignSeconds
+    if (seconds != 0L) INT64.encodeWithTag(writer, 1, seconds)
+    val nanos = value.sameSignNanos
+    if (nanos != 0) INT32.encodeWithTag(writer, 2, nanos)
+  }
+
+  override fun decode(reader: ProtoReader): Duration {
+    var seconds = 0L
+    var nanos = 0
+    reader.forEachTag { tag ->
+      when (tag) {
+        1 -> seconds = INT64.decode(reader)
+        2 -> nanos = INT32.decode(reader)
+        else -> reader.readUnknownField(tag)
+      }
+    }
+    return Duration.ofSeconds(seconds, nanos.toLong())
+  }
+
+  override fun redact(value: Duration): Duration = value
+
+  /**
+   * Returns a value like 1 for 1.200s and -1 for -1.200s. This is different from the Duration
+   * seconds field which is always the integer floor when seconds is negative.
+   */
+  private val Duration.sameSignSeconds: Long
+    get() {
+      return when {
+        seconds < 0L && nano != 0 -> seconds + 1L
+        else -> seconds
+      }
+    }
+
+  /**
+   * Returns a value like 200_000_000 for 1.200s and -200_000_000 for -1.200s. This is different
+   * from the Duration nanos field which can be positive when seconds is negative.
+   */
+  private val Duration.sameSignNanos: Int
+    get() {
+      return when {
+        seconds < 0L && nano != 0 -> nano - 1_000_000_000
+        else -> nano
+      }
+    }
+}

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -25,6 +25,7 @@ import okio.source
 import java.io.IOException
 import java.io.InputStream
 import java.io.OutputStream
+import java.time.Duration
 import kotlin.reflect.KClass
 
 actual abstract class ProtoAdapter<E> actual constructor(
@@ -215,5 +216,6 @@ actual abstract class ProtoAdapter<E> actual constructor(
     @JvmField actual val DOUBLE: ProtoAdapter<Double> = commonDouble()
     @JvmField actual val BYTES: ProtoAdapter<ByteString> = commonBytes()
     @JvmField actual val STRING: ProtoAdapter<String> = commonString()
+    @JvmField val DURATION: ProtoAdapter<Duration> = DurationProtoAdapter
   }
 }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
@@ -112,6 +112,7 @@ class ProtoType {
     @JvmField val UINT32 = ProtoType(true, "uint32")
     @JvmField val UINT64 = ProtoType(true, "uint64")
     @JvmField val ANY = ProtoType(false, "google.protobuf.Any")
+    @JvmField val DURATION = ProtoType(false, "google.protobuf.Duration")
 
     private val SCALAR_TYPES: Map<String, ProtoType> = listOf(
         BOOL,

--- a/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
+++ b/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
@@ -32,11 +32,13 @@ import okio.source
 actual object CoreLoader : Loader {
   const val ANY_PROTO = "google/protobuf/any.proto"
   const val DESCRIPTOR_PROTO = "google/protobuf/descriptor.proto"
+  const val DURATION_PROTO = "google/protobuf/duration.proto"
   const val WIRE_EXTENSIONS_PROTO = "wire/extensions.proto"
 
   override fun load(path: String): ProtoFile {
     if (path == ANY_PROTO ||
         path == DESCRIPTOR_PROTO ||
+        path == DURATION_PROTO ||
         path == WIRE_EXTENSIONS_PROTO) {
       val resourceAsStream = SchemaLoader::class.java.getResourceAsStream("/$path")
       resourceAsStream.source().buffer().use { source ->

--- a/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -126,6 +126,7 @@ class SchemaLoader {
     val loaded = mutableMapOf<String, ProtoFile>()
     loaded[DESCRIPTOR_PROTO] = loadSpecialProto(DESCRIPTOR_PROTO)
     loaded[ANY_PROTO] = loadSpecialProto(ANY_PROTO)
+    loaded[DURATION_PROTO] = loadSpecialProto(DURATION_PROTO)
 
     while (!protos.isEmpty()) {
       val proto = protos.removeFirst()
@@ -178,6 +179,7 @@ class SchemaLoader {
   companion object {
     private const val ANY_PROTO = "google/protobuf/any.proto"
     private const val DESCRIPTOR_PROTO = "google/protobuf/descriptor.proto"
+    private const val DURATION_PROTO = "google/protobuf/duration.proto"
 
     @Throws(IOException::class)
     private fun source(base: Path, path: String): Source? {

--- a/wire-library/wire-schema/src/jvmMain/resources/google/protobuf/duration.proto
+++ b/wire-library/wire-schema/src/jvmMain/resources/google/protobuf/duration.proto
@@ -1,0 +1,98 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "github.com/golang/protobuf/ptypes/duration";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "DurationProto";
+option java_multiple_files = true;
+option java_generate_equals_and_hash = true;
+option objc_class_prefix = "GPB";
+
+// A Duration represents a signed, fixed-length span of time represented
+// as a count of seconds and fractions of seconds at nanosecond
+// resolution. It is independent of any calendar and concepts like "day"
+// or "month". It is related to Timestamp in that the difference between
+// two Timestamp values is a Duration and it can be added or subtracted
+// from a Timestamp. Range is approximately +-10,000 years.
+//
+// Example 1: Compute Duration from two Timestamps in pseudo code.
+//
+//     Timestamp start = ...;
+//     Timestamp end = ...;
+//     Duration duration = ...;
+//
+//     duration.seconds = end.seconds - start.seconds;
+//     duration.nanos = end.nanos - start.nanos;
+//
+//     if (duration.seconds < 0 && duration.nanos > 0) {
+//       duration.seconds += 1;
+//       duration.nanos -= 1000000000;
+//     } else if (durations.seconds > 0 && duration.nanos < 0) {
+//       duration.seconds -= 1;
+//       duration.nanos += 1000000000;
+//     }
+//
+// Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+//
+//     Timestamp start = ...;
+//     Duration duration = ...;
+//     Timestamp end = ...;
+//
+//     end.seconds = start.seconds + duration.seconds;
+//     end.nanos = start.nanos + duration.nanos;
+//
+//     if (end.nanos < 0) {
+//       end.seconds -= 1;
+//       end.nanos += 1000000000;
+//     } else if (end.nanos >= 1000000000) {
+//       end.seconds += 1;
+//       end.nanos -= 1000000000;
+//     }
+//
+//
+message Duration {
+
+  // Signed seconds of the span of time. Must be from -315,576,000,000
+  // to +315,576,000,000 inclusive.
+  int64 seconds = 1;
+
+  // Signed fractions of a second at nanosecond resolution of the span
+  // of time. Durations less than one second are represented with a 0
+  // `seconds` field and a positive or negative `nanos` field. For durations
+  // of one second or more, a non-zero value for the `nanos` field must be
+  // of the same sign as the `seconds` field. Must be from -999,999,999
+  // to +999,999,999 inclusive.
+  int32 nanos = 2;
+}

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/pizza/pizza.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/pizza/pizza.proto
@@ -18,12 +18,14 @@ syntax = "proto3";
 package squareup.proto3.pizza;
 
 import 'google/protobuf/any.proto';
+import 'google/protobuf/duration.proto';
 
 message PizzaDelivery {
   string phone_number = 1;
   string address = 2;
   repeated Pizza pizzas = 3;
   google.protobuf.Any promotion = 4;
+  google.protobuf.Duration delivered_within_or_free = 5;
 }
 
 message Pizza {

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/DurationTest.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/DurationTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.google.protobuf.Duration
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class DurationTest {
+  @Test fun `positive values`() {
+    val googleMessage = Duration.newBuilder()
+        .setSeconds(1L)
+        .setNanos(200_000_000)
+        .build()
+
+    val wireMessage = java.time.Duration.ofSeconds(1L, 200_000_000L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.DURATION.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.DURATION.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.DURATION.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+
+  @Test fun `zero`() {
+    val googleMessage = Duration.newBuilder()
+        .setSeconds(0L)
+        .setNanos(0)
+        .build()
+
+    val wireMessage = java.time.Duration.ofSeconds(0L, 0L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.DURATION.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.DURATION.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.DURATION.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+
+  @Test fun `negative near zero`() {
+    val googleMessage = Duration.newBuilder()
+        .setSeconds(0L)
+        .setNanos(-200_000_000)
+        .build()
+
+    val wireMessage = java.time.Duration.ofSeconds(0L, -200_000_000L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.DURATION.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.DURATION.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.DURATION.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+
+  @Test fun `negative values`() {
+    val googleMessage = Duration.newBuilder()
+        .setSeconds(-1L)
+        .setNanos(-200_000_000)
+        .build()
+
+    val wireMessage = java.time.Duration.ofSeconds(-1L, -200_000_000L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.DURATION.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.DURATION.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.DURATION.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+}


### PR DESCRIPTION
Rather than using the generated proto type we use javax.time.Duration.