### PR TITLE
Don't assume all fields are linked for typeName

### DIFF
--- a/wire-library/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/kotlin-project-kotlin-protos/src/main/proto/squareup/geology/period.proto
@@ -9,7 +9,7 @@ enum Period {
   CRETACEOUS = 1;
 
   /** 201.3 million years ago — 145.0 million years ago. */
-  JURASSIC = 2;
+  JURASSIC = 2 [deprecated = true];
 
   /** 252.17 million years ago — 201.3 million years ago. */
   TRIASSIC = 3;

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1440,26 +1440,30 @@ class KotlinGenerator private constructor(
         if (isOneOf) baseClass.copy(nullable = false)
         else baseClass.copy(nullable = true)
       }
-      else -> baseClass.copy(nullable = false)
+      EncodeMode.THROW_IF_ABSENT,
+      EncodeMode.IDENTITY_IF_ABSENT -> baseClass.copy(nullable = false)
     }
   }
 
   private val Field.typeName: TypeName
     get() {
-      return when (encodeMode!!) {
+      val type = type!!
+
+      return when (encodeMode) {
         EncodeMode.MAP ->
           Map::class.asTypeName().parameterizedBy(keyType.typeName, valueType.typeName)
         EncodeMode.REPEATED,
-        EncodeMode.PACKED -> List::class.asClassName().parameterizedBy(type!!.typeName)
-        EncodeMode.NULL_IF_ABSENT -> type!!.typeName.copy(nullable = true)
-        EncodeMode.THROW_IF_ABSENT -> type!!.typeName
+        EncodeMode.PACKED -> List::class.asClassName().parameterizedBy(type.typeName)
+        EncodeMode.NULL_IF_ABSENT -> type.typeName.copy(nullable = true)
+        EncodeMode.THROW_IF_ABSENT -> type.typeName
         EncodeMode.IDENTITY_IF_ABSENT -> {
           when {
-            isOneOf -> type!!.typeName.copy(nullable = true)
-            type!!.isMessage -> type!!.typeName.copy(nullable = true)
-            else -> type!!.typeName
+            isOneOf -> type.typeName.copy(nullable = true)
+            type.isMessage -> type.typeName.copy(nullable = true)
+            else -> type.typeName
           }
         }
+        null -> type.typeName.copy(nullable = true)
       }
     }
 


### PR DESCRIPTION
We might have not linked fields at time of generation, e.g. `deprecated = true` is access here https://github.com/square/wire/blob/master/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt#L1282-L1290 and we were assuming that `encodeMode` would be set which is not the case for all.

Other variants of this PR:
- Always assume `encodeMode` to be nullable in all cases. :yuck:
- Kill the weird generation we do for `Enum` by padding them their options in their constructor. This will effectively allow us to consider `encodeMode` always set, in all cases.