### PR TITLE
Correct some of our test protos

### DIFF
--- a/wire-library/wire-tests/src/commonTest/proto/java/all_types.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/java/all_types.proto
@@ -23,6 +23,7 @@ message AllTypes {
   extensions 1001 to 1217;
 
   enum NestedEnum {
+    UNKNOWN = 0;
     A = 1;
   }
 
@@ -112,6 +113,7 @@ message AllTypes {
   optional bool default_bool = 411 [default = true ];
   optional float default_float = 412 [default = 123.456e7 ];
   optional double default_double = 413 [default = 123.456e78 ];
+  // Note: protoc doesn't allow some characters of the default value.
   optional string default_string = 414 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\X1\X01\X11güzel" ];
   optional bytes default_bytes = 415 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\X1\X01\X11güzel" ];
   optional NestedEnum default_nested_enum = 416 [default = A ];
@@ -174,6 +176,7 @@ extend AllTypes {
   repeated double ext_pack_double = 1213 [packed = true];
   repeated AllTypes.NestedEnum ext_pack_nested_enum = 1216 [packed = true];
 
+  // Note: protoc doesn't allow maps in extensions.
   map<int32, int32> ext_map_int32_int32 = 1301;
   map<string, string> ext_map_string_string = 1402;
   map<string, AllTypes.NestedMessage> ext_map_string_message = 1503;

--- a/wire-library/wire-tests/src/commonTest/proto/java/custom_options.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/java/custom_options.proto
@@ -24,15 +24,17 @@ import "option_redacted.proto";
 message FooBar {
   extensions 100 to 200;
 
-  optional int32 foo = 1 [my_field_option_one = 17];
-  optional string bar = 2 [my_field_option_two = 33.5];
-  optional Nested baz = 3 [my_field_option_three = BAR];
-  optional uint64 qux = 4 [my_field_option_one = 18, my_field_option_two = 34.5];
-  repeated float fred = 5 [my_field_option_four = {
+  optional int32 foo = 1 [(squareup.protos.custom_options.my_field_option_one) = 17];
+  optional string bar = 2 [(squareup.protos.custom_options.my_field_option_two) = 33.5];
+  optional Nested baz = 3 [(squareup.protos.custom_options.my_field_option_three) = BAR];
+  optional uint64 qux = 4 [(squareup.protos.custom_options.my_field_option_one) = 18,
+                           (squareup.protos.custom_options.my_field_option_two) = 34.5];
+  repeated float fred = 5 [(squareup.protos.custom_options.my_field_option_four) = {
       foo: 11, bar: "22", baz: { value: BAR }, fred : [444.0, 555.0],
       nested: { foo: 33, fred: [100.0, 200.0] }
-  }, my_field_option_two = 99.9];
-  optional double daisy = 6 [my_field_option_four.baz.value = FOO];
+  }, (squareup.protos.custom_options.my_field_option_two) = 99.9];
+  // We should use parentheses but https://github.com/square/wire/issues/1541
+  optional double daisy = 6 [squareup.protos.custom_options.my_field_option_four.baz.value = FOO];
 
   repeated FooBar nested = 7 [(squareup.protos.redacted_option.redacted) = true];
 
@@ -45,10 +47,12 @@ message FooBar {
   }
 
   enum FooBarBazEnum {
-    option enum_option = true;
-    FOO = 1 [enum_value_option=17, complex_enum_value_option={ serial: [ 99, 199 ] }];
-    BAR = 2 [squareup.protos.foreign.foreign_enum_value_option=true];
-    BAZ = 3 [enum_value_option=18, squareup.protos.foreign.foreign_enum_value_option=false];
+    option (squareup.protos.custom_options.enum_option) = true;
+    FOO = 1 [(squareup.protos.custom_options.enum_value_option)=17,
+             (squareup.protos.custom_options.complex_enum_value_option)={ serial: [ 99, 199 ] }];
+    BAR = 2 [(squareup.protos.foreign.foreign_enum_value_option)=true];
+    BAZ = 3 [(squareup.protos.custom_options.enum_value_option)=18,
+            (squareup.protos.foreign.foreign_enum_value_option)=false];
   }
 }
 
@@ -84,8 +88,9 @@ extend FooBar {
 
 message MessageWithOptions {
   option (my_message_option_one).foo = 1234;
-  option (my_message_option_one.bar) = "5678";
-  option (my_message_option_one.baz.value) = BAZ;
+  option (my_message_option_one).bar = "5678";
+  // The parenthese should end befpre `baz` but https://github.com/square/wire/issues/1541
+  option (my_message_option_one.baz).value = BAZ;
   option (my_message_option_one).qux = 18446744073709551615;
   option (my_message_option_one).fred = 123.0;
   option (my_message_option_one).fred = 321.0;

--- a/wire-library/wire-tests/src/commonTest/proto/java/redacted_test.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/java/redacted_test.proto
@@ -17,7 +17,6 @@ package squareup.protos.redacted_test;
 
 option java_package = "com.squareup.wire.protos.redacted";
 
-import "google/protobuf/descriptor.proto";
 import "option_redacted.proto";
 
 message NotRedacted {

--- a/wire-library/wire-tests/src/commonTest/proto/java/samebasename/single_level.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/java/samebasename/single_level.proto
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package single_level;
+package samebasename.single_level;
 
 option java_package = "com.squareup.wire.protos.single_level";
 

--- a/wire-library/wire-tests/src/jvmJavaCompactTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaCompactTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -54,7 +54,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_OPT_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_OPT_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_OPT_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   public static final Integer DEFAULT_REQ_INT32 = 0;
 
@@ -86,7 +86,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_REQ_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_REQ_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_REQ_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   public static final Integer DEFAULT_DEFAULT_INT32 = 2147483647;
 
@@ -151,7 +151,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_EXT_OPT_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_EXT_OPT_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_EXT_OPT_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   @WireField(
       tag = 1,
@@ -669,6 +669,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   )
   public final Double default_double;
 
+  /**
+   * Note: protoc doesn't allow some characters of the default value.
+   */
   @WireField(
       tag = 414,
       adapter = "com.squareup.wire.ProtoAdapter#STRING"
@@ -1179,6 +1182,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   public final List<NestedEnum> ext_pack_nested_enum;
 
   /**
+   * Note: protoc doesn't allow maps in extensions.
    * Extension source: all_types.proto
    */
   @WireField(
@@ -2564,6 +2568,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       return this;
     }
 
+    /**
+     * Note: protoc doesn't allow some characters of the default value.
+     */
     public Builder default_string(String default_string) {
       this.default_string = default_string;
       return this;
@@ -2874,6 +2881,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       return this;
     }
 
+    /**
+     * Note: protoc doesn't allow maps in extensions.
+     */
     public Builder ext_map_int32_int32(Map<Integer, Integer> ext_map_int32_int32) {
       Internal.checkElementsNotNull(ext_map_int32_int32);
       this.ext_map_int32_int32 = ext_map_int32_int32;
@@ -2940,6 +2950,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   }
 
   public enum NestedEnum implements WireEnum {
+    UNKNOWN(0),
+
     A(1);
 
     public static final ProtoAdapter<NestedEnum> ADAPTER = ProtoAdapter.newEnumAdapter(NestedEnum.class);
@@ -2955,6 +2967,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
      */
     public static NestedEnum fromValue(int value) {
       switch (value) {
+        case 0: return UNKNOWN;
         case 1: return A;
         default: return null;
       }

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -60,7 +60,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_OPT_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_OPT_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_OPT_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   public static final Integer DEFAULT_REQ_INT32 = 0;
 
@@ -92,7 +92,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_REQ_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_REQ_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_REQ_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   public static final Integer DEFAULT_DEFAULT_INT32 = 2147483647;
 
@@ -157,7 +157,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_EXT_OPT_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_EXT_OPT_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_EXT_OPT_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   @WireField(
       tag = 1,
@@ -675,6 +675,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   )
   public final Double default_double;
 
+  /**
+   * Note: protoc doesn't allow some characters of the default value.
+   */
   @WireField(
       tag = 414,
       adapter = "com.squareup.wire.ProtoAdapter#STRING"
@@ -1185,6 +1188,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   public final List<NestedEnum> ext_pack_nested_enum;
 
   /**
+   * Note: protoc doesn't allow maps in extensions.
    * Extension source: all_types.proto
    */
   @WireField(
@@ -2713,6 +2717,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       return this;
     }
 
+    /**
+     * Note: protoc doesn't allow some characters of the default value.
+     */
     public Builder default_string(String default_string) {
       this.default_string = default_string;
       return this;
@@ -3023,6 +3030,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       return this;
     }
 
+    /**
+     * Note: protoc doesn't allow maps in extensions.
+     */
     public Builder ext_map_int32_int32(Map<Integer, Integer> ext_map_int32_int32) {
       Internal.checkElementsNotNull(ext_map_int32_int32);
       this.ext_map_int32_int32 = ext_map_int32_int32;
@@ -3089,6 +3099,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   }
 
   public enum NestedEnum implements WireEnum {
+    UNKNOWN(0),
+
     A(1);
 
     public static final ProtoAdapter<NestedEnum> ADAPTER = new ProtoAdapter_NestedEnum();
@@ -3104,6 +3116,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
      */
     public static NestedEnum fromValue(int value) {
       switch (value) {
+        case 0: return UNKNOWN;
         case 1: return A;
         default: return null;
       }

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -70,6 +70,9 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
   )
   public final List<Float> fred;
 
+  /**
+   * We should use parentheses but https://github.com/square/wire/issues/1541
+   */
   @WireField(
       tag = 6,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
@@ -240,6 +243,9 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       return this;
     }
 
+    /**
+     * We should use parentheses but https://github.com/square/wire/issues/1541
+     */
     public Builder daisy(Double daisy) {
       this.daisy = daisy;
       return this;

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -93,7 +93,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/single_level.Bar");
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/samebasename.single_level.Bar");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -94,7 +94,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
 
   private static final class ProtoAdapter_Bars extends ProtoAdapter<Bars> {
     public ProtoAdapter_Bars() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/single_level.Bars");
+      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/samebasename.single_level.Bars");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -60,7 +60,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_OPT_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_OPT_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_OPT_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   public static final Integer DEFAULT_REQ_INT32 = 0;
 
@@ -92,7 +92,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_REQ_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_REQ_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_REQ_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   public static final Integer DEFAULT_DEFAULT_INT32 = 2147483647;
 
@@ -157,7 +157,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   public static final ByteString DEFAULT_EXT_OPT_BYTES = ByteString.EMPTY;
 
-  public static final NestedEnum DEFAULT_EXT_OPT_NESTED_ENUM = NestedEnum.A;
+  public static final NestedEnum DEFAULT_EXT_OPT_NESTED_ENUM = NestedEnum.UNKNOWN;
 
   @WireField(
       tag = 1,
@@ -675,6 +675,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   )
   public final Double default_double;
 
+  /**
+   * Note: protoc doesn't allow some characters of the default value.
+   */
   @WireField(
       tag = 414,
       adapter = "com.squareup.wire.ProtoAdapter#STRING"
@@ -1185,6 +1188,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   public final List<NestedEnum> ext_pack_nested_enum;
 
   /**
+   * Note: protoc doesn't allow maps in extensions.
    * Extension source: all_types.proto
    */
   @WireField(
@@ -2713,6 +2717,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       return this;
     }
 
+    /**
+     * Note: protoc doesn't allow some characters of the default value.
+     */
     public Builder default_string(String default_string) {
       this.default_string = default_string;
       return this;
@@ -3023,6 +3030,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       return this;
     }
 
+    /**
+     * Note: protoc doesn't allow maps in extensions.
+     */
     public Builder ext_map_int32_int32(Map<Integer, Integer> ext_map_int32_int32) {
       Internal.checkElementsNotNull(ext_map_int32_int32);
       this.ext_map_int32_int32 = ext_map_int32_int32;
@@ -3089,6 +3099,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   }
 
   public enum NestedEnum implements WireEnum {
+    UNKNOWN(0),
+
     A(1);
 
     public static final ProtoAdapter<NestedEnum> ADAPTER = new ProtoAdapter_NestedEnum();
@@ -3104,6 +3116,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
      */
     public static NestedEnum fromValue(int value) {
       switch (value) {
+        case 0: return UNKNOWN;
         case 1: return A;
         default: return null;
       }

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -72,6 +72,9 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
   )
   public final List<Float> fred;
 
+  /**
+   * We should use parentheses but https://github.com/square/wire/issues/1541
+   */
   @WireField(
       tag = 6,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
@@ -242,6 +245,9 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
       return this;
     }
 
+    /**
+     * We should use parentheses but https://github.com/square/wire/issues/1541
+     */
     public Builder daisy(Double daisy) {
       this.daisy = daisy;
       return this;

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -93,7 +93,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/single_level.Bar");
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/samebasename.single_level.Bar");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -94,7 +94,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
 
   private static final class ProtoAdapter_Bars extends ProtoAdapter<Bars> {
     public ProtoAdapter_Bars() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/single_level.Bars");
+      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/samebasename.single_level.Bars");
     }
 
     @Override


### PR DESCRIPTION
I tested them all via `protoc` and that's the result of what had to be fixed.

- Enum used in Maps needs a 0 tag value.
- custom options need parentheses.