### PR TITLE
Proto2 roundtrip tests with protoc

### DIFF
--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/alltypes/all_types.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/alltypes/all_types.proto
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package squareup.proto2.alltypes;
+
+message AllTypes {
+
+  extensions 1001 to 1217;
+
+  enum NestedEnum {
+    UNKNOWN = 0;
+    A = 1;
+  }
+
+  message NestedMessage {
+    optional int32 a = 1;
+  }
+
+  optional int32 opt_int32 = 1;
+  optional uint32 opt_uint32 = 2;
+  optional sint32 opt_sint32 = 3;
+  optional fixed32 opt_fixed32 = 4;
+  optional sfixed32 opt_sfixed32 = 5;
+  optional int64 opt_int64 = 6;
+  optional uint64 opt_uint64 = 7;
+  optional sint64 opt_sint64 = 8;
+  optional fixed64 opt_fixed64 = 9;
+  optional sfixed64 opt_sfixed64 = 10;
+  optional bool opt_bool = 11;
+  optional float opt_float = 12;
+  optional double opt_double = 13;
+  optional string opt_string = 14;
+  optional bytes opt_bytes = 15;
+  optional NestedEnum opt_nested_enum = 16;
+  optional NestedMessage opt_nested_message = 17;
+
+  required int32 req_int32 = 101;
+  required uint32 req_uint32 = 102;
+  required sint32 req_sint32 = 103;
+  required fixed32 req_fixed32 = 104;
+  required sfixed32 req_sfixed32 = 105;
+  required int64 req_int64 = 106;
+  required uint64 req_uint64 = 107;
+  required sint64 req_sint64 = 108;
+  required fixed64 req_fixed64 = 109;
+  required sfixed64 req_sfixed64 = 110;
+  required bool req_bool = 111;
+  required float req_float = 112;
+  required double req_double = 113;
+  required string req_string = 114;
+  required bytes req_bytes = 115;
+  required NestedEnum req_nested_enum = 116;
+  required NestedMessage req_nested_message = 117;
+
+  repeated int32 rep_int32 = 201;
+  repeated uint32 rep_uint32 = 202;
+  repeated sint32 rep_sint32 = 203;
+  repeated fixed32 rep_fixed32 = 204;
+  repeated sfixed32 rep_sfixed32 = 205;
+  repeated int64 rep_int64 = 206;
+  repeated uint64 rep_uint64 = 207;
+  repeated sint64 rep_sint64 = 208;
+  repeated fixed64 rep_fixed64 = 209;
+  repeated sfixed64 rep_sfixed64 = 210;
+  repeated bool rep_bool = 211;
+  repeated float rep_float = 212;
+  repeated double rep_double = 213;
+  repeated string rep_string = 214;
+  repeated bytes rep_bytes = 215;
+  repeated NestedEnum rep_nested_enum = 216;
+  repeated NestedMessage rep_nested_message = 217;
+
+  repeated int32 pack_int32 = 301 [packed = true];
+  repeated uint32 pack_uint32 = 302 [packed = true];
+  repeated sint32 pack_sint32 = 303 [packed = true];
+  repeated fixed32 pack_fixed32 = 304 [packed = true];
+  repeated sfixed32 pack_sfixed32 = 305 [packed = true];
+  repeated int64 pack_int64 = 306 [packed = true];
+  repeated uint64 pack_uint64 = 307 [packed = true];
+  repeated sint64 pack_sint64 = 308 [packed = true];
+  repeated fixed64 pack_fixed64 = 309 [packed = true];
+  repeated sfixed64 pack_sfixed64 = 310 [packed = true];
+  repeated bool pack_bool = 311 [packed = true];
+  repeated float pack_float = 312 [packed = true];
+  repeated double pack_double = 313 [packed = true];
+  repeated NestedEnum pack_nested_enum = 316 [packed = true];
+
+  optional int32 default_int32 = 401 [default = 2147483647 ];
+  optional uint32 default_uint32 = 402 [default = 4294967295 ];
+  optional sint32 default_sint32 = 403 [default = -2147483648 ];
+  optional fixed32 default_fixed32 = 404 [default = 4294967295 ];
+  optional sfixed32 default_sfixed32 = 405 [default = -2147483648 ];
+  optional int64 default_int64 = 406 [default = 9223372036854775807 ];
+  optional uint64 default_uint64 = 407 [default = 18446744073709551615 ];
+  optional sint64 default_sint64 = 408 [default = -9223372036854775808 ];
+  optional fixed64 default_fixed64 = 409 [default = 18446744073709551615 ];
+  optional sfixed64 default_sfixed64 = 410 [default = -9223372036854775808 ];
+  optional bool default_bool = 411 [default = true ];
+  optional float default_float = 412 [default = 123.456e7 ];
+  optional double default_double = 413 [default = 123.456e78 ];
+  optional string default_string = 414 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01" ];
+  optional bytes default_bytes = 415 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01" ];
+  optional NestedEnum default_nested_enum = 416 [default = A ];
+
+  map<int32, int32> map_int32_int32 = 501;
+  map<string, string> map_string_string = 502;
+  map<string, NestedMessage> map_string_message = 503;
+  map<string, NestedEnum> map_string_enum = 504;
+
+  oneof choice {
+    string oneof_string = 601;
+    int32 oneof_int32 = 602;
+    NestedMessage oneof_nested_message = 603;
+  }
+}
+
+extend AllTypes {
+  optional int32 ext_opt_int32 = 1001;
+  optional uint32 ext_opt_uint32 = 1002;
+  optional sint32 ext_opt_sint32 = 1003;
+  optional fixed32 ext_opt_fixed32 = 1004;
+  optional sfixed32 ext_opt_sfixed32 = 1005;
+  optional int64 ext_opt_int64 = 1006;
+  optional uint64 ext_opt_uint64 = 1007;
+  optional sint64 ext_opt_sint64 = 1008;
+  optional fixed64 ext_opt_fixed64 = 1009;
+  optional sfixed64 ext_opt_sfixed64 = 1010;
+  optional bool ext_opt_bool = 1011;
+  optional float ext_opt_float = 1012;
+  optional double ext_opt_double = 1013;
+  optional string ext_opt_string = 1014;
+  optional bytes ext_opt_bytes = 1015;
+  optional AllTypes.NestedEnum ext_opt_nested_enum = 1016;
+  optional AllTypes.NestedMessage ext_opt_nested_message = 1017;
+
+  repeated int32 ext_rep_int32 = 1101;
+  repeated uint32 ext_rep_uint32 = 1102;
+  repeated sint32 ext_rep_sint32 = 1103;
+  repeated fixed32 ext_rep_fixed32 = 1104;
+  repeated sfixed32 ext_rep_sfixed32 = 1105;
+  repeated int64 ext_rep_int64 = 1106;
+  repeated uint64 ext_rep_uint64 = 1107;
+  repeated sint64 ext_rep_sint64 = 1108;
+  repeated fixed64 ext_rep_fixed64 = 1109;
+  repeated sfixed64 ext_rep_sfixed64 = 1110;
+  repeated bool ext_rep_bool = 1111;
+  repeated float ext_rep_float = 1112;
+  repeated double ext_rep_double = 1113;
+  repeated string ext_rep_string = 1114;
+  repeated bytes ext_rep_bytes = 1115;
+  repeated AllTypes.NestedEnum ext_rep_nested_enum = 1116;
+  repeated AllTypes.NestedMessage ext_rep_nested_message = 1117;
+
+  repeated int32 ext_pack_int32 = 1201 [packed = true];
+  repeated uint32 ext_pack_uint32 = 1202 [packed = true];
+  repeated sint32 ext_pack_sint32 = 1203 [packed = true];
+  repeated fixed32 ext_pack_fixed32 = 1204 [packed = true];
+  repeated sfixed32 ext_pack_sfixed32 = 1205 [packed = true];
+  repeated int64 ext_pack_int64 = 1206 [packed = true];
+  repeated uint64 ext_pack_uint64 = 1207 [packed = true];
+  repeated sint64 ext_pack_sint64 = 1208 [packed = true];
+  repeated fixed64 ext_pack_fixed64 = 1209 [packed = true];
+  repeated sfixed64 ext_pack_sfixed64 = 1210 [packed = true];
+  repeated bool ext_pack_bool = 1211 [packed = true];
+  repeated float ext_pack_float = 1212 [packed = true];
+  repeated double ext_pack_double = 1213 [packed = true];
+  repeated AllTypes.NestedEnum ext_pack_nested_enum = 1216 [packed = true];
+}

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
@@ -17,8 +17,14 @@ package com.squareup.wire
 
 import com.squareup.wire.proto2.simple.SimpleMessage
 import com.squareup.wire.proto2.simple.SimpleMessageOuterClass
+import okio.ByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
+import squareup.proto2.alltypes.AllTypes
+import squareup.proto2.alltypes.AllTypesOuterClass
+import squareup.proto2.alltypes.AllTypesOuterClass.extOptBool
+import squareup.proto2.alltypes.AllTypesOuterClass.extPackBool
+import squareup.proto2.alltypes.AllTypesOuterClass.extRepBool
 
 class Proto2WireProtocCompatibilityTests {
   @Test fun simpleMessage() {
@@ -52,5 +58,290 @@ class Proto2WireProtocCompatibilityTests {
 
     assertThat(wireMessageDecodedFromGoogleMessage).isEqualTo(wireMessage)
     assertThat(googleMessageDecodedFromWireMessage).isEqualTo(googleMessage)
+  }
+
+  @Test fun allTypesSerialization() {
+    val byteArrayWire = AllTypes.ADAPTER.encode(defaultAllTypesWire)
+    val byteArrayProtoc = defaultAllTypesProtoc.toByteArray()
+
+    assertThat(byteArrayWire).isEqualTo(byteArrayProtoc)
+    assertThat(AllTypes.ADAPTER.decode(byteArrayProtoc)).isEqualTo(defaultAllTypesWire)
+    assertThat(AllTypesOuterClass.AllTypes.parseFrom(byteArrayWire))
+        .isEqualTo(defaultAllTypesProtoc)
+  }
+
+  @Test fun allTypesSerializationWithEmptyOrIdentityValues() {
+    val byteArrayWire = AllTypes.ADAPTER.encode(identityAllTypesWire)
+    val byteArrayProtoc = identityAllTypesProtoc.toByteArray()
+
+    assertThat(byteArrayWire).isEqualTo(byteArrayProtoc)
+    assertThat(AllTypes.ADAPTER.decode(byteArrayProtoc)).isEqualTo(identityAllTypesWire)
+    assertThat(AllTypesOuterClass.AllTypes.parseFrom(byteArrayWire))
+        .isEqualTo(identityAllTypesProtoc)
+  }
+
+  companion object {
+    private val defaultAllTypesWire = AllTypes(
+        opt_int32 = 111,
+        opt_uint32 = 112,
+        opt_sint32 = 113,
+        opt_fixed32 = 114,
+        opt_sfixed32 = 115,
+        opt_int64 = 116L,
+        opt_uint64 = 117L,
+        opt_sint64 = 118L,
+        opt_fixed64 = 119L,
+        opt_sfixed64 = 120L,
+        opt_bool = true,
+        opt_float = 122.0F,
+        opt_double = 123.0,
+        opt_string = "124",
+        opt_bytes = ByteString.of(123, 125),
+        opt_nested_enum = AllTypes.NestedEnum.A,
+        opt_nested_message = AllTypes.NestedMessage(a = 999),
+        req_int32 = 111,
+        req_uint32 = 112,
+        req_sint32 = 113,
+        req_fixed32 = 114,
+        req_sfixed32 = 115,
+        req_int64 = 116L,
+        req_uint64 = 117L,
+        req_sint64 = 118L,
+        req_fixed64 = 119L,
+        req_sfixed64 = 120L,
+        req_bool = true,
+        req_float = 122.0F,
+        req_double = 123.0,
+        req_string = "124",
+        req_bytes = ByteString.of(123, 125),
+        req_nested_enum = AllTypes.NestedEnum.A,
+        req_nested_message = AllTypes.NestedMessage(a = 999),
+        rep_int32 = list(111),
+        rep_uint32 = list(112),
+        rep_sint32 = list(113),
+        rep_fixed32 = list(114),
+        rep_sfixed32 = list(115),
+        rep_int64 = list(116L),
+        rep_uint64 = list(117L),
+        rep_sint64 = list(118L),
+        rep_fixed64 = list(119L),
+        rep_sfixed64 = list(120L),
+        rep_bool = list(true),
+        rep_float = list(122.0F),
+        rep_double = list(123.0),
+        rep_string = list("124"),
+        rep_bytes = list(ByteString.of(123, 125)),
+        rep_nested_enum = list(AllTypes.NestedEnum.A),
+        rep_nested_message = list(AllTypes.NestedMessage(a = 999)),
+        pack_int32 = list(111),
+        pack_uint32 = list(112),
+        pack_sint32 = list(113),
+        pack_fixed32 = list(114),
+        pack_sfixed32 = list(115),
+        pack_int64 = list(116L),
+        pack_uint64 = list(117L),
+        pack_sint64 = list(118L),
+        pack_fixed64 = list(119L),
+        pack_sfixed64 = list(120L),
+        pack_bool = list(true),
+        pack_float = list(122.0F),
+        pack_double = list(123.0),
+        pack_nested_enum = list(AllTypes.NestedEnum.A),
+        map_int32_int32 = mapOf(1 to 2),
+        map_string_string = mapOf("key" to "value"),
+        map_string_message = mapOf("message" to AllTypes.NestedMessage(a = 1)),
+        map_string_enum = mapOf("enum" to AllTypes.NestedEnum.A),
+        oneof_int32 = 0
+    )
+
+    private val defaultAllTypesProtoc = AllTypesOuterClass.AllTypes.newBuilder()
+        .setOptInt32(111)
+        .setOptUint32(112)
+        .setOptSint32(113)
+        .setOptFixed32(114)
+        .setOptSfixed32(115)
+        .setOptInt64(116L)
+        .setOptUint64(117L)
+        .setOptSint64(118L)
+        .setOptFixed64(119L)
+        .setOptSfixed64(120L)
+        .setOptBool(true)
+        .setOptFloat(122.0F)
+        .setOptDouble(123.0)
+        .setOptString("124")
+        .setOptBytes(com.google.protobuf.ByteString.copyFrom(ByteString.of(123, 125).toByteArray()))
+        .setOptNestedEnum(AllTypesOuterClass.AllTypes.NestedEnum.A)
+        .setOptNestedMessage(
+            AllTypesOuterClass.AllTypes.NestedMessage.newBuilder().setA(999).build())
+        .setReqInt32(111)
+        .setReqUint32(112)
+        .setReqSint32(113)
+        .setReqFixed32(114)
+        .setReqSfixed32(115)
+        .setReqInt64(116L)
+        .setReqUint64(117L)
+        .setReqSint64(118L)
+        .setReqFixed64(119L)
+        .setReqSfixed64(120L)
+        .setReqBool(true)
+        .setReqFloat(122.0F)
+        .setReqDouble(123.0)
+        .setReqString("124")
+        .setReqBytes(com.google.protobuf.ByteString.copyFrom(ByteString.of(123, 125).toByteArray()))
+        .setReqNestedEnum(AllTypesOuterClass.AllTypes.NestedEnum.A)
+        .setReqNestedMessage(
+            AllTypesOuterClass.AllTypes.NestedMessage.newBuilder().setA(999).build())
+        .addAllRepInt32(list(111))
+        .addAllRepUint32(list(112))
+        .addAllRepSint32(list(113))
+        .addAllRepFixed32(list(114))
+        .addAllRepSfixed32(list(115))
+        .addAllRepInt64(list(116L))
+        .addAllRepUint64(list(117L))
+        .addAllRepSint64(list(118L))
+        .addAllRepFixed64(list(119L))
+        .addAllRepSfixed64(list(120L))
+        .addAllRepBool(list(true))
+        .addAllRepFloat(list(122.0F))
+        .addAllRepDouble(list(123.0))
+        .addAllRepString(list("124"))
+        .addAllRepBytes(
+            list(com.google.protobuf.ByteString.copyFrom(ByteString.of(123, 125).toByteArray())))
+        .addAllRepNestedEnum(list(AllTypesOuterClass.AllTypes.NestedEnum.A))
+        .addAllRepNestedMessage(list(
+            AllTypesOuterClass.AllTypes.NestedMessage.newBuilder().setA(999).build()))
+        .addAllPackInt32(list(111))
+        .addAllPackUint32(list(112))
+        .addAllPackSint32(list(113))
+        .addAllPackFixed32(list(114))
+        .addAllPackSfixed32(list(115))
+        .addAllPackInt64(list(116L))
+        .addAllPackUint64(list(117L))
+        .addAllPackSint64(list(118L))
+        .addAllPackFixed64(list(119L))
+        .addAllPackSfixed64(list(120L))
+        .addAllPackBool(list(true))
+        .addAllPackFloat(list(122.0F))
+        .addAllPackDouble(list(123.0))
+        .addAllPackNestedEnum(list(AllTypesOuterClass.AllTypes.NestedEnum.A))
+        .putMapInt32Int32(1, 2)
+        .putMapStringString("key", "value")
+        .putMapStringMessage("message",
+            AllTypesOuterClass.AllTypes.NestedMessage.newBuilder().setA(1).build())
+        .putMapStringEnum("enum", AllTypesOuterClass.AllTypes.NestedEnum.A)
+        .setOneofInt32(0)
+        .build()
+
+    private val identityAllTypesWire = AllTypes(
+        req_int32 = 0,
+        req_uint32 = 0,
+        req_sint32 = 0,
+        req_fixed32 = 0,
+        req_sfixed32 = 0,
+        req_int64 = 0L,
+        req_uint64 = 0L,
+        req_sint64 = 0L,
+        req_fixed64 = 0L,
+        req_sfixed64 = 0L,
+        req_bool = false,
+        req_float = 0F,
+        req_double = 0.0,
+        req_string = "",
+        req_bytes = ByteString.EMPTY,
+        req_nested_enum = AllTypes.NestedEnum.UNKNOWN,
+        req_nested_message = AllTypes.NestedMessage(a = 0),
+        rep_int32 = emptyList(),
+        rep_uint32 = emptyList(),
+        rep_sint32 = emptyList(),
+        rep_fixed32 = emptyList(),
+        rep_sfixed32 = emptyList(),
+        rep_int64 = emptyList(),
+        rep_uint64 = emptyList(),
+        rep_sint64 = emptyList(),
+        rep_fixed64 = emptyList(),
+        rep_sfixed64 = emptyList(),
+        rep_bool = emptyList(),
+        rep_float = emptyList(),
+        rep_double = emptyList(),
+        rep_string = emptyList(),
+        rep_bytes = emptyList(),
+        rep_nested_enum = emptyList(),
+        rep_nested_message = emptyList(),
+        pack_int32 = list(0),
+        pack_uint32 = list(0),
+        pack_sint32 = list(0),
+        pack_fixed32 = list(0),
+        pack_sfixed32 = list(0),
+        pack_int64 = list(0L),
+        pack_uint64 = list(0L),
+        pack_sint64 = list(0L),
+        pack_fixed64 = list(0L),
+        pack_sfixed64 = list(0L),
+        pack_bool = list(false),
+        pack_float = list(0F),
+        pack_double = list(0.0),
+        pack_nested_enum = list(AllTypes.NestedEnum.UNKNOWN),
+        map_int32_int32 = mapOf(0 to 0),
+        map_string_message = mapOf("" to AllTypes.NestedMessage()),
+        map_string_enum = mapOf("" to AllTypes.NestedEnum.UNKNOWN)
+    )
+
+    private val identityAllTypesProtoc = AllTypesOuterClass.AllTypes.newBuilder()
+        .setReqInt32(0)
+        .setReqUint32(0)
+        .setReqSint32(0)
+        .setReqFixed32(0)
+        .setReqSfixed32(0)
+        .setReqInt64(0L)
+        .setReqUint64(0L)
+        .setReqSint64(0L)
+        .setReqFixed64(0L)
+        .setReqSfixed64(0L)
+        .setReqBool(false)
+        .setReqFloat(0F)
+        .setReqDouble(0.0)
+        .setReqString("")
+        .setReqBytes(com.google.protobuf.ByteString.copyFrom(ByteString.EMPTY.toByteArray()))
+        .setReqNestedEnum(AllTypesOuterClass.AllTypes.NestedEnum.UNKNOWN)
+        .setReqNestedMessage(AllTypesOuterClass.AllTypes.NestedMessage.newBuilder().setA(0).build())
+        .addAllRepInt32(emptyList())
+        .addAllRepUint32(emptyList())
+        .addAllRepSint32(emptyList())
+        .addAllRepFixed32(emptyList())
+        .addAllRepSfixed32(emptyList())
+        .addAllRepInt64(emptyList())
+        .addAllRepUint64(emptyList())
+        .addAllRepSint64(emptyList())
+        .addAllRepFixed64(emptyList())
+        .addAllRepSfixed64(emptyList())
+        .addAllRepBool(emptyList())
+        .addAllRepFloat(emptyList())
+        .addAllRepDouble(emptyList())
+        .addAllRepString(emptyList())
+        .addAllRepBytes(emptyList())
+        .addAllRepNestedEnum(emptyList())
+        .addAllRepNestedMessage(emptyList())
+        .addAllPackInt32(list(0))
+        .addAllPackUint32(list(0))
+        .addAllPackSint32(list(0))
+        .addAllPackFixed32(list(0))
+        .addAllPackSfixed32(list(0))
+        .addAllPackInt64(list(0L))
+        .addAllPackUint64(list(0L))
+        .addAllPackSint64(list(0L))
+        .addAllPackFixed64(list(0L))
+        .addAllPackSfixed64(list(0L))
+        .addAllPackBool(list(false))
+        .addAllPackFloat(list(0F))
+        .addAllPackDouble(list(0.0))
+        .addAllPackNestedEnum(list(AllTypesOuterClass.AllTypes.NestedEnum.UNKNOWN))
+        .putMapInt32Int32(0, 0)
+        .putMapStringMessage("", AllTypesOuterClass.AllTypes.NestedMessage.newBuilder().build())
+        .putMapStringEnum("", AllTypesOuterClass.AllTypes.NestedEnum.UNKNOWN)
+        .build()
+
+    private fun <T : kotlin.Any> list(t: T): List<T> {
+      return listOf(t, t)
+    }
   }
 }


### PR DESCRIPTION
Safeguard against possible side-effect we might unintentionally cause when adding support to proto3.

~Wasn't able to check extensions because of https://github.com/protocolbuffers/protobuf/issues/7534~ used Registry.