### PR TITLE
Add IDENTITY_IF_ABSENT label

### DIFF
--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1151,12 +1151,28 @@ public final class JavaGenerator {
       result.addMember("adapter", "$S", adapterString(field.getType()));
     }
 
-    if (!field.isOptional()) {
-      if (field.isPacked()) {
-        result.addMember("label", "$T.PACKED", WireField.Label.class);
-      } else if (field.getLabel() != null) {
-        result.addMember("label", "$T.$L", WireField.Label.class, field.getLabel());
-      }
+    WireField.Label wireFieldLabel;
+    //noinspection ConstantConditions
+    switch (field.getEncodeMode()) {
+      case THROW_IF_ABSENT:
+        wireFieldLabel = WireField.Label.REQUIRED;
+        break;
+      case IDENTITY_IF_ABSENT:
+        wireFieldLabel = WireField.Label.IDENTITY_IF_ABSENT;
+        break;
+      case REPEATED:
+        wireFieldLabel = WireField.Label.REPEATED;
+        break;
+      case PACKED:
+        wireFieldLabel = WireField.Label.PACKED;
+        break;
+      case MAP:
+      case NULL_IF_ABSENT:
+      default:
+        wireFieldLabel = null;
+    }
+    if (wireFieldLabel != null) {
+      result.addMember("label", "$T.$L", WireField.Label.class, wireFieldLabel);
     }
 
     if (field.isRedacted()) {

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1154,11 +1154,11 @@ public final class JavaGenerator {
     WireField.Label wireFieldLabel;
     //noinspection ConstantConditions
     switch (field.getEncodeMode()) {
-      case THROW_IF_ABSENT:
+      case REQUIRED:
         wireFieldLabel = WireField.Label.REQUIRED;
         break;
-      case IDENTITY_IF_ABSENT:
-        wireFieldLabel = WireField.Label.IDENTITY_IF_ABSENT;
+      case OMIT_IDENTITY:
+        wireFieldLabel = WireField.Label.OMIT_IDENTITY;
         break;
       case REPEATED:
         wireFieldLabel = WireField.Label.REPEATED;

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -781,12 +781,21 @@ class KotlinGenerator private constructor(
           }
         }
         .apply {
-          if (!field.isOptional) {
-            if (field.isPacked) {
-              addMember("label = %T.PACKED", WireField.Label::class)
-            } else if (field.label != null) {
-              addMember("label = %T.%L", WireField.Label::class, field.label!!)
-            }
+          val wireFieldLabel: WireField.Label? =
+              when (field.encodeMode!!) {
+                EncodeMode.THROW_IF_ABSENT ->
+                  WireField.Label.REQUIRED
+                EncodeMode.IDENTITY_IF_ABSENT ->
+                  WireField.Label.IDENTITY_IF_ABSENT
+                EncodeMode.REPEATED ->
+                  WireField.Label.REPEATED
+                EncodeMode.PACKED ->
+                  WireField.Label.PACKED
+                EncodeMode.MAP,
+                EncodeMode.NULL_IF_ABSENT -> null
+              }
+          if (wireFieldLabel != null) {
+            addMember("label = %T.%L", WireField.Label::class, wireFieldLabel)
           }
         }
         .apply { if (field.isRedacted) addMember("redacted = true") }

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
@@ -39,7 +39,7 @@ annotation class WireField(
   val adapter: String,
   /**
    * The field's protocol buffer label, one of [Label.OPTIONAL], [Label.REQUIRED], [Label.REPEATED],
-   * [Label.PACKED], or [Label.IDENTITY_IF_ABSENT]. Defaults to [Label.OPTIONAL].
+   * [Label.PACKED], or [Label.OMIT_IDENTITY]. Defaults to [Label.OPTIONAL].
    */
   val label: Label = Label.OPTIONAL,
   /**
@@ -72,7 +72,7 @@ annotation class WireField(
      * to their type's respective identity value. E.g.: a field of type `int32` will not get emitted
      * if its value is `0`.
      */
-    IDENTITY_IF_ABSENT,
+    OMIT_IDENTITY,
     ;
 
     val isRepeated: Boolean

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
@@ -39,7 +39,7 @@ annotation class WireField(
   val adapter: String,
   /**
    * The field's protocol buffer label, one of [Label.OPTIONAL], [Label.REQUIRED], [Label.REPEATED],
-   * or [Label.PACKED]. Defaults to [Label.OPTIONAL].
+   * [Label.PACKED], or [Label.IDENTITY_IF_ABSENT]. Defaults to [Label.OPTIONAL].
    */
   val label: Label = Label.OPTIONAL,
   /**
@@ -66,7 +66,14 @@ annotation class WireField(
     REPEATED,
     ONE_OF,
     /** Implies [REPEATED]. */
-    PACKED;
+    PACKED,
+    /**
+     * Special label to defines proto3 fields which should not be emitted if their value is equal
+     * to their type's respective identity value. E.g.: a field of type `int32` will not get emitted
+     * if its value is `0`.
+     */
+    IDENTITY_IF_ABSENT,
+    ;
 
     val isRepeated: Boolean
       @JvmName("isRepeated") get() = this == REPEATED || this == PACKED

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -66,7 +66,7 @@ class Field private constructor(
 
   @Deprecated("Proto2 concept inexistent in proto3. Use EncodeMode instead.")
   val isRequired: Boolean
-    get() = encodeMode == EncodeMode.THROW_IF_ABSENT
+    get() = encodeMode == EncodeMode.REQUIRED
 
   // Null until this field is linked.
   var encodeMode: EncodeMode? = null
@@ -235,10 +235,10 @@ class Field private constructor(
     NULL_IF_ABSENT,
 
     /** Required from proto2. */
-    THROW_IF_ABSENT,
+    REQUIRED,
 
     /** Non-repeated fields in proto3. Identify can be `0`, `false`, `""`, or `null`. */
-    IDENTITY_IF_ABSENT,
+    OMIT_IDENTITY,
 
     /** List. */
     REPEATED,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
@@ -64,7 +64,7 @@ interface SyntaxRules {
             if (isPacked) Field.EncodeMode.PACKED
             else Field.EncodeMode.REPEATED
           Field.Label.OPTIONAL -> Field.EncodeMode.NULL_IF_ABSENT
-          Field.Label.REQUIRED -> Field.EncodeMode.THROW_IF_ABSENT
+          Field.Label.REQUIRED -> Field.EncodeMode.REQUIRED
           Field.Label.ONE_OF,
           null -> if (protoType.isMap) Field.EncodeMode.MAP else Field.EncodeMode.NULL_IF_ABSENT
         }
@@ -103,7 +103,7 @@ interface SyntaxRules {
         if (protoType.isMap) return Field.EncodeMode.MAP
         if (isOneOf) return Field.EncodeMode.NULL_IF_ABSENT
 
-        return Field.EncodeMode.IDENTITY_IF_ABSENT
+        return Field.EncodeMode.OMIT_IDENTITY
       }
 
       override fun jsonName(name: String): String = camelCase(name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
@@ -37,7 +37,7 @@ class Person(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.IDENTITY_IF_ABSENT
+    label = WireField.Label.OMIT_IDENTITY
   )
   val name: String = "",
   /**
@@ -46,7 +46,7 @@ class Person(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.IDENTITY_IF_ABSENT
+    label = WireField.Label.OMIT_IDENTITY
   )
   val id: Int = 0,
   /**
@@ -55,7 +55,7 @@ class Person(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.IDENTITY_IF_ABSENT
+    label = WireField.Label.OMIT_IDENTITY
   )
   val email: String = "",
   /**
@@ -259,7 +259,7 @@ class Person(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.IDENTITY_IF_ABSENT
+      label = WireField.Label.OMIT_IDENTITY
     )
     val number: String = "",
     /**
@@ -268,7 +268,7 @@ class Person(
     @field:WireField(
       tag = 2,
       adapter = "com.squareup.wire.protos3.kotlin.person.Person${'$'}PhoneType#ADAPTER",
-      label = WireField.Label.IDENTITY_IF_ABSENT
+      label = WireField.Label.OMIT_IDENTITY
     )
     val type: PhoneType = PhoneType.MOBILE,
     unknownFields: ByteString = ByteString.EMPTY

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
@@ -36,7 +36,8 @@ class Person(
    */
   @field:WireField(
     tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.IDENTITY_IF_ABSENT
   )
   val name: String = "",
   /**
@@ -44,7 +45,8 @@ class Person(
    */
   @field:WireField(
     tag = 2,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.IDENTITY_IF_ABSENT
   )
   val id: Int = 0,
   /**
@@ -52,7 +54,8 @@ class Person(
    */
   @field:WireField(
     tag = 3,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.IDENTITY_IF_ABSENT
   )
   val email: String = "",
   /**
@@ -255,7 +258,8 @@ class Person(
      */
     @field:WireField(
       tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.IDENTITY_IF_ABSENT
     )
     val number: String = "",
     /**
@@ -263,7 +267,8 @@ class Person(
      */
     @field:WireField(
       tag = 2,
-      adapter = "com.squareup.wire.protos3.kotlin.person.Person${'$'}PhoneType#ADAPTER"
+      adapter = "com.squareup.wire.protos3.kotlin.person.Person${'$'}PhoneType#ADAPTER",
+      label = WireField.Label.IDENTITY_IF_ABSENT
     )
     val type: PhoneType = PhoneType.MOBILE,
     unknownFields: ByteString = ByteString.EMPTY


### PR DESCRIPTION
I don't think we need the ONE_OF value for oneOfs. Right now, they have the `OPTIONAL` label (which is a lie) but they are treated as optional fields in both proto2 and 3 so I am leaving them as is. Let me know if you wanna set their label to `ONE_OF`.