### PR TITLE
add OmitValueJsonAdapter to omit identities

### DIFF
--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
@@ -28,7 +28,8 @@ internal class MessageJsonAdapter<M : Message<M, B>, B : Message.Builder<M, B>>(
   moshi: Moshi,
   type: Type
 ) : JsonAdapter<M>() {
-  private val messageAdapter = RuntimeMessageAdapter.create(type as Class<M>, "square.github.io/wire/unknown")
+  private val messageAdapter =
+      RuntimeMessageAdapter.create(type as Class<M>, "square.github.io/wire/unknown")
   private val fieldBindings = messageAdapter.fieldBindings.values.toTypedArray()
   private val encodeNames: List<String>
   private val options: JsonReader.Options
@@ -61,12 +62,9 @@ internal class MessageJsonAdapter<M : Message<M, B>, B : Message.Builder<M, B>>(
       fieldType = Types.newParameterizedType(List::class.java, fieldType)
     }
 
-    // TODO: use encode mode instead of fieldBinding.label.
     val syntheticQualifier: Class<out Annotation>? = when {
       fieldBinding.singleAdapter() === ProtoAdapter.UINT64 -> Uint64::class.java
-      fieldBinding.label.isOneOf -> null
-      // TODO(benoit) We cannot use it until we read the `encodeMode` instead of the `label`.
-      // else -> IdentityIfAbsent::class.java
+      fieldBinding.label == WireField.Label.OMIT_IDENTITY -> OmitIdentity::class.java
       else -> null
     }
 

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/OmitIdentity.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/OmitIdentity.kt
@@ -23,4 +23,4 @@ import com.squareup.moshi.JsonQualifier
  */
 @Retention(AnnotationRetention.RUNTIME)
 @JsonQualifier
-internal annotation class IdentityIfAbsent
+internal annotation class OmitIdentity

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/OmitValueJsonAdapter.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/OmitValueJsonAdapter.kt
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import java.io.IOException
+
+private class OmitValueJsonAdapter<T : Any>(
+  private val delegate: JsonAdapter<T>,
+  private val omittedValue: T
+) : JsonAdapter<T>() {
+  override fun fromJson(reader: JsonReader): T? {
+    return delegate.fromJson(reader)
+  }
+
+  @Throws(IOException::class)
+  override fun toJson(writer: JsonWriter, value: T?) {
+    if (value == omittedValue) {
+      writer.nullValue()
+    } else {
+      delegate.toJson(writer, value)
+    }
+  }
+
+  override fun toString(): String {
+    return "$delegate.omitValue($omittedValue)"
+  }
+}
+
+/**
+ * Returns a JSON adapter equal to this JSON adapter, except this will not emit if the value is
+ * equal to [omittedValue].
+ */
+internal fun <T : Any> JsonAdapter<T>.omitValue(omittedValue: T): JsonAdapter<T> {
+  return if (this is OmitValueJsonAdapter<*>) {
+    throw IllegalArgumentException("JsonAdapter $this is already of type OmitValueJsonAdapter")
+  } else {
+    OmitValueJsonAdapter(this, omittedValue)
+  }
+}

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
@@ -77,7 +77,7 @@ class WireJsonAdapterFactory private constructor(
   ): JsonAdapter<*>? {
     val rawType = Types.getRawType(type)
 
-    val nextAnnotations = Types.nextAnnotations(annotations, IdentityIfAbsent::class.java)
+    val nextAnnotations = Types.nextAnnotations(annotations, OmitIdentity::class.java)
     if (nextAnnotations != null) {
       return when (type) {
         Int::class.javaObjectType -> INT_JSON_ADAPTER

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -101,7 +101,6 @@ class Proto3WireProtocCompatibilityTests {
     assertThat(parsed).isEqualTo(pizzaDelivery)
   }
 
-  @Ignore("Need to finish @IdentityIfAbsent")
   @Test fun wireJson() {
     val pizzaDelivery = PizzaDelivery(
         address = "507 Cross Street",
@@ -136,7 +135,6 @@ class Proto3WireProtocCompatibilityTests {
     assertThat(jsonAdapter.fromJson(json)).isEqualTo(pizzaDelivery)
   }
 
-  @Ignore("Need to finish @IdentityIfAbsent")
   @Test fun wireProtocJsonRoundTrip() {
     val protocMessage = PizzaOuterClass.PizzaDelivery.newBuilder()
         .setAddress("507 Cross Street")


### PR DESCRIPTION
- What do we want to do about list? Leave it to the serializer, or explicitly omit empty list/maps?
- `uint64` needs an identity version as well.