### PR TITLE
Add failing test for all64s

### DIFF
--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/alltypes/all64.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/alltypes/all64.proto
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+package squareup.proto3.alltypes;
+
+message All64 {
+  // Prefixing so the generated code doesn't rename it weirdly.
+  int64 my_int64 = 1;
+  uint64 my_uint64 = 2;
+  sint64 my_sint64 = 3;
+  fixed64 my_fixed64 = 4;
+  sfixed64 my_sfixed64 = 5;
+
+  repeated int64 rep_int64 = 201 [packed = false];
+  repeated uint64 rep_uint64 = 202 [packed = false];
+  repeated sint64 rep_sint64 = 203 [packed = false];
+  repeated fixed64 rep_fixed64 = 204 [packed = false];
+  repeated sfixed64 rep_sfixed64 = 205 [packed = false];
+
+  repeated int64 pack_int64 = 301 [packed = true];
+  repeated uint64 pack_uint64 = 302 [packed = true];
+  repeated sint64 pack_sint64 = 303 [packed = true];
+  repeated fixed64 pack_fixed64 = 304 [packed = true];
+  repeated sfixed64 pack_sfixed64 = 305 [packed = true];
+
+  oneof choice {
+    int64 oneof_int64 = 401;
+    sfixed64 oneof_sfixed64 = 402;
+  }
+
+  map<int64, sfixed64> map_int64_sfixed64 = 501;
+}

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -32,6 +32,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Ignore
 import org.junit.Test
+import squareup.proto3.alltypes.All64
+import squareup.proto3.alltypes.All64OuterClass
 import squareup.proto3.alltypes.AllTypes
 import squareup.proto3.alltypes.AllTypesOuterClass
 import squareup.proto3.alltypes.CamelCase
@@ -390,6 +392,67 @@ class Proto3WireProtocCompatibilityTests {
     assertJsonEquals(camelAdapter.toJson(camel), JsonFormat.printer().print(protocCamel))
   }
 
+  @Test fun all64JsonProtoc(){
+    val all64 = All64OuterClass.All64.newBuilder()
+        .setMyInt64(Long.MIN_VALUE)
+        .setMyUint64(Long.MIN_VALUE)
+        .setMySint64(Long.MIN_VALUE)
+        .setMyFixed64(Long.MIN_VALUE)
+        .setMySfixed64(Long.MIN_VALUE)
+        .addAllRepInt64(list(Long.MIN_VALUE))
+        .addAllRepUint64(list(Long.MIN_VALUE))
+        .addAllRepSint64(list(Long.MIN_VALUE))
+        .addAllRepFixed64(list(Long.MIN_VALUE))
+        .addAllRepSfixed64(list(Long.MIN_VALUE))
+        .addAllPackInt64(list(Long.MIN_VALUE))
+        .addAllPackUint64(list(Long.MIN_VALUE))
+        .addAllPackSint64(list(Long.MIN_VALUE))
+        .addAllPackFixed64(list(Long.MIN_VALUE))
+        .addAllPackSfixed64(list(Long.MIN_VALUE))
+        .setOneofInt64(Long.MIN_VALUE)
+        .putMapInt64Sfixed64(Long.MIN_VALUE, Long.MIN_VALUE)
+        .build()
+
+    val jsonPrinter = JsonFormat.printer()
+    assertJsonEquals(jsonPrinter.print(all64), ALL_64_JSON)
+
+    val jsonParser = JsonFormat.parser()
+    val parsed = All64OuterClass.All64.newBuilder()
+        .apply { jsonParser.merge(ALL_64_JSON, this) }
+        .build()
+    assertThat(parsed).isEqualTo(all64)
+  }
+
+  @Ignore("TODO")
+  @Test fun all64JsonMoshi() {
+    val all64 = All64(
+        my_int64 = Long.MIN_VALUE,
+        my_uint64 = Long.MIN_VALUE,
+        my_sint64 = Long.MIN_VALUE,
+        my_fixed64 = Long.MIN_VALUE,
+        my_sfixed64 = Long.MIN_VALUE,
+        rep_int64 = list(Long.MIN_VALUE),
+        rep_uint64 = list(Long.MIN_VALUE),
+        rep_sint64 = list(Long.MIN_VALUE),
+        rep_fixed64 = list(Long.MIN_VALUE),
+        rep_sfixed64 = list(Long.MIN_VALUE),
+        pack_int64 = list(Long.MIN_VALUE),
+        pack_uint64 = list(Long.MIN_VALUE),
+        pack_sint64 = list(Long.MIN_VALUE),
+        pack_fixed64 = list(Long.MIN_VALUE),
+        pack_sfixed64 = list(Long.MIN_VALUE),
+        oneof_int64 = Long.MIN_VALUE,
+        map_int64_sfixed64 = mapOf(Long.MIN_VALUE to Long.MIN_VALUE)
+    )
+
+    val moshi = Moshi.Builder()
+        .add(WireJsonAdapterFactory())
+        .build()
+    val jsonAdapter = moshi.adapter(All64::class.java).indent("  ")
+    assertJsonEquals(jsonAdapter.toJson(all64), ALL_64_JSON)
+    assertThat(jsonAdapter.fromJson(ALL_64_JSON)).isEqualTo(all64)
+  }
+
   companion object {
     private val moshi = Moshi.Builder()
         .add(WireJsonAdapterFactory())
@@ -564,6 +627,29 @@ class Proto3WireProtocCompatibilityTests {
         |"mapStringMessage":{"message":{"a":1}},
         |"mapStringEnum":{"enum":"A"},
         |"oneofInt32" : 0.0
+        |}""".trimMargin()
+
+    private val ALL_64_JSON = """
+        |{
+        |  "myInt64": "-9223372036854775808",
+        |  "myUint64": "9223372036854775808",
+        |  "mySint64": "-9223372036854775808",
+        |  "myFixed64": "9223372036854775808",
+        |  "mySfixed64": "-9223372036854775808",
+        |  "repInt64": ["-9223372036854775808", "-9223372036854775808"],
+        |  "repUint64": ["9223372036854775808", "9223372036854775808"],
+        |  "repSint64": ["-9223372036854775808", "-9223372036854775808"],
+        |  "repFixed64": ["9223372036854775808", "9223372036854775808"],
+        |  "repSfixed64": ["-9223372036854775808", "-9223372036854775808"],
+        |  "packInt64": ["-9223372036854775808", "-9223372036854775808"],
+        |  "packUint64": ["9223372036854775808", "9223372036854775808"],
+        |  "packSint64": ["-9223372036854775808", "-9223372036854775808"],
+        |  "packFixed64": ["9223372036854775808", "9223372036854775808"],
+        |  "packSfixed64": ["-9223372036854775808", "-9223372036854775808"],
+        |  "oneofInt64": "-9223372036854775808",
+        |  "mapInt64Sfixed64": {
+        |    "-9223372036854775808": "-9223372036854775808"
+        |  }
         |}""".trimMargin()
 
     private const val IDENTITY_ALL_TYPES_JSON = "{}"


### PR DESCRIPTION
We need a way to say that's proto3, that's proto2; otherwise we'll end up breaking our JSON behavior for proto2. The problem doesn't show for OMIT_IDENTITY but for list/map/oneof where we cannot tell which syntax it is.