### PR TITLE
Fix long expressions in equals and encodedSize functions (#1575)

### DIFF
--- a/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/Point.kt
+++ b/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/Point.kt
@@ -50,10 +50,11 @@ class Point(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Point) return false
-    return unknownFields == other.unknownFields
-        && x == other.x
-        && y == other.y
-        && color == other.color
+    var result = unknownFields == other.unknownFields
+    result = result && (x == other.x)
+    result = result && (y == other.y)
+    result = result && (color == other.color)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -90,11 +91,13 @@ class Point(
       Point::class, 
       "type.googleapis.com/com.squareup.wire.whiteboard.Point"
     ) {
-      override fun encodedSize(value: Point): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.x) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.y) +
-        ProtoAdapter.INT32.encodedSizeWithTag(3, value.color) +
-        value.unknownFields.size
+      override fun encodedSize(value: Point): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.x)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.y)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(3, value.color)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Point) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.x)

--- a/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/Point.kt
+++ b/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/Point.kt
@@ -50,11 +50,11 @@ class Point(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Point) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (x == other.x)
-    result = result && (y == other.y)
-    result = result && (color == other.color)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (x != other.x) return false
+    if (y != other.y) return false
+    if (color != other.color) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardCommand.kt
+++ b/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardCommand.kt
@@ -50,9 +50,10 @@ class WhiteboardCommand(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is WhiteboardCommand) return false
-    return unknownFields == other.unknownFields
-        && add_point == other.add_point
-        && clear_board == other.clear_board
+    var result = unknownFields == other.unknownFields
+    result = result && (add_point == other.add_point)
+    result = result && (clear_board == other.clear_board)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -86,10 +87,12 @@ class WhiteboardCommand(
       WhiteboardCommand::class, 
       "type.googleapis.com/com.squareup.wire.whiteboard.WhiteboardCommand"
     ) {
-      override fun encodedSize(value: WhiteboardCommand): Int = 
-        AddPoint.ADAPTER.encodedSizeWithTag(1, value.add_point) +
-        ClearBoard.ADAPTER.encodedSizeWithTag(2, value.clear_board) +
-        value.unknownFields.size
+      override fun encodedSize(value: WhiteboardCommand): Int {
+        var size = value.unknownFields.size
+        size += AddPoint.ADAPTER.encodedSizeWithTag(1, value.add_point)
+        size += ClearBoard.ADAPTER.encodedSizeWithTag(2, value.clear_board)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: WhiteboardCommand) {
         AddPoint.ADAPTER.encodeWithTag(writer, 1, value.add_point)
@@ -140,8 +143,9 @@ class WhiteboardCommand(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is AddPoint) return false
-      return unknownFields == other.unknownFields
-          && point == other.point
+      var result = unknownFields == other.unknownFields
+      result = result && (point == other.point)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -170,9 +174,11 @@ class WhiteboardCommand(
         AddPoint::class, 
         "type.googleapis.com/com.squareup.wire.whiteboard.WhiteboardCommand.AddPoint"
       ) {
-        override fun encodedSize(value: AddPoint): Int = 
-          Point.ADAPTER.encodedSizeWithTag(1, value.point) +
-          value.unknownFields.size
+        override fun encodedSize(value: AddPoint): Int {
+          var size = value.unknownFields.size
+          size += Point.ADAPTER.encodedSizeWithTag(1, value.point)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: AddPoint) {
           Point.ADAPTER.encodeWithTag(writer, 1, value.point)
@@ -213,7 +219,8 @@ class WhiteboardCommand(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ClearBoard) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -229,8 +236,10 @@ class WhiteboardCommand(
         ClearBoard::class, 
         "type.googleapis.com/com.squareup.wire.whiteboard.WhiteboardCommand.ClearBoard"
       ) {
-        override fun encodedSize(value: ClearBoard): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: ClearBoard): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: ClearBoard) {
           writer.writeBytes(value.unknownFields)

--- a/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardCommand.kt
+++ b/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardCommand.kt
@@ -50,10 +50,10 @@ class WhiteboardCommand(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is WhiteboardCommand) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (add_point == other.add_point)
-    result = result && (clear_board == other.clear_board)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (add_point != other.add_point) return false
+    if (clear_board != other.clear_board) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -143,9 +143,9 @@ class WhiteboardCommand(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is AddPoint) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (point == other.point)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (point != other.point) return false
+      return true
     }
 
     override fun hashCode(): Int {
@@ -219,8 +219,8 @@ class WhiteboardCommand(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ClearBoard) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardUpdate.kt
+++ b/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardUpdate.kt
@@ -52,10 +52,10 @@ class WhiteboardUpdate(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is WhiteboardUpdate) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (initialise_board == other.initialise_board)
-    result = result && (update_points == other.update_points)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (initialise_board != other.initialise_board) return false
+    if (update_points != other.update_points) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -157,11 +157,11 @@ class WhiteboardUpdate(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is InitialiseBoard) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (width == other.width)
-      result = result && (height == other.height)
-      result = result && (color == other.color)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (width != other.width) return false
+      if (height != other.height) return false
+      if (color != other.color) return false
+      return true
     }
 
     override fun hashCode(): Int {
@@ -258,9 +258,9 @@ class WhiteboardUpdate(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is UpdatePoints) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (points == other.points)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (points != other.points) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardUpdate.kt
+++ b/wire-grpc-sample/protos/src/main/java/com/squareup/wire/whiteboard/WhiteboardUpdate.kt
@@ -52,9 +52,10 @@ class WhiteboardUpdate(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is WhiteboardUpdate) return false
-    return unknownFields == other.unknownFields
-        && initialise_board == other.initialise_board
-        && update_points == other.update_points
+    var result = unknownFields == other.unknownFields
+    result = result && (initialise_board == other.initialise_board)
+    result = result && (update_points == other.update_points)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -88,10 +89,12 @@ class WhiteboardUpdate(
       WhiteboardUpdate::class, 
       "type.googleapis.com/com.squareup.wire.whiteboard.WhiteboardUpdate"
     ) {
-      override fun encodedSize(value: WhiteboardUpdate): Int = 
-        InitialiseBoard.ADAPTER.encodedSizeWithTag(1, value.initialise_board) +
-        UpdatePoints.ADAPTER.encodedSizeWithTag(2, value.update_points) +
-        value.unknownFields.size
+      override fun encodedSize(value: WhiteboardUpdate): Int {
+        var size = value.unknownFields.size
+        size += InitialiseBoard.ADAPTER.encodedSizeWithTag(1, value.initialise_board)
+        size += UpdatePoints.ADAPTER.encodedSizeWithTag(2, value.update_points)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: WhiteboardUpdate) {
         InitialiseBoard.ADAPTER.encodeWithTag(writer, 1, value.initialise_board)
@@ -154,10 +157,11 @@ class WhiteboardUpdate(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is InitialiseBoard) return false
-      return unknownFields == other.unknownFields
-          && width == other.width
-          && height == other.height
-          && color == other.color
+      var result = unknownFields == other.unknownFields
+      result = result && (width == other.width)
+      result = result && (height == other.height)
+      result = result && (color == other.color)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -194,11 +198,13 @@ class WhiteboardUpdate(
         InitialiseBoard::class, 
         "type.googleapis.com/com.squareup.wire.whiteboard.WhiteboardUpdate.InitialiseBoard"
       ) {
-        override fun encodedSize(value: InitialiseBoard): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.width) +
-          ProtoAdapter.INT32.encodedSizeWithTag(2, value.height) +
-          ProtoAdapter.INT32.encodedSizeWithTag(3, value.color) +
-          value.unknownFields.size
+        override fun encodedSize(value: InitialiseBoard): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.width)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.height)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(3, value.color)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: InitialiseBoard) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.width)
@@ -252,8 +258,9 @@ class WhiteboardUpdate(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is UpdatePoints) return false
-      return unknownFields == other.unknownFields
-          && points == other.points
+      var result = unknownFields == other.unknownFields
+      result = result && (points == other.points)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -282,9 +289,11 @@ class WhiteboardUpdate(
         UpdatePoints::class, 
         "type.googleapis.com/com.squareup.wire.whiteboard.WhiteboardUpdate.UpdatePoints"
       ) {
-        override fun encodedSize(value: UpdatePoints): Int = 
-          Point.ADAPTER.asRepeated().encodedSizeWithTag(1, value.points) +
-          value.unknownFields.size
+        override fun encodedSize(value: UpdatePoints): Int {
+          var size = value.unknownFields.size
+          size += Point.ADAPTER.asRepeated().encodedSizeWithTag(1, value.points)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: UpdatePoints) {
           Point.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.points)

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -54,9 +54,10 @@ class Feature(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Feature) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && location == other.location
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (location == other.location)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -90,10 +91,12 @@ class Feature(
       Feature::class, 
       "type.googleapis.com/routeguide.Feature"
     ) {
-      override fun encodedSize(value: Feature): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        Point.ADAPTER.encodedSizeWithTag(2, value.location) +
-        value.unknownFields.size
+      override fun encodedSize(value: Feature): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += Point.ADAPTER.encodedSizeWithTag(2, value.location)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Feature) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -54,10 +54,10 @@ class Feature(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Feature) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (location == other.location)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (location != other.location) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -42,9 +42,9 @@ class FeatureDatabase(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FeatureDatabase) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (feature == other.feature)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (feature != other.feature) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -42,8 +42,9 @@ class FeatureDatabase(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FeatureDatabase) return false
-    return unknownFields == other.unknownFields
-        && feature == other.feature
+    var result = unknownFields == other.unknownFields
+    result = result && (feature == other.feature)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -72,9 +73,11 @@ class FeatureDatabase(
       FeatureDatabase::class, 
       "type.googleapis.com/routeguide.FeatureDatabase"
     ) {
-      override fun encodedSize(value: FeatureDatabase): Int = 
-        Feature.ADAPTER.asRepeated().encodedSizeWithTag(1, value.feature) +
-        value.unknownFields.size
+      override fun encodedSize(value: FeatureDatabase): Int {
+        var size = value.unknownFields.size
+        size += Feature.ADAPTER.asRepeated().encodedSizeWithTag(1, value.feature)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FeatureDatabase) {
         Feature.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.feature)

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -48,10 +48,10 @@ class Point(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Point) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (latitude == other.latitude)
-    result = result && (longitude == other.longitude)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (latitude != other.latitude) return false
+    if (longitude != other.longitude) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -48,9 +48,10 @@ class Point(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Point) return false
-    return unknownFields == other.unknownFields
-        && latitude == other.latitude
-        && longitude == other.longitude
+    var result = unknownFields == other.unknownFields
+    result = result && (latitude == other.latitude)
+    result = result && (longitude == other.longitude)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -84,10 +85,12 @@ class Point(
       Point::class, 
       "type.googleapis.com/routeguide.Point"
     ) {
-      override fun encodedSize(value: Point): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.latitude) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.longitude) +
-        value.unknownFields.size
+      override fun encodedSize(value: Point): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.latitude)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.longitude)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Point) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.latitude)

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -52,10 +52,10 @@ class Rectangle(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Rectangle) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (lo == other.lo)
-    result = result && (hi == other.hi)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (lo != other.lo) return false
+    if (hi != other.hi) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -52,9 +52,10 @@ class Rectangle(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Rectangle) return false
-    return unknownFields == other.unknownFields
-        && lo == other.lo
-        && hi == other.hi
+    var result = unknownFields == other.unknownFields
+    result = result && (lo == other.lo)
+    result = result && (hi == other.hi)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -88,10 +89,12 @@ class Rectangle(
       Rectangle::class, 
       "type.googleapis.com/routeguide.Rectangle"
     ) {
-      override fun encodedSize(value: Rectangle): Int = 
-        Point.ADAPTER.encodedSizeWithTag(1, value.lo) +
-        Point.ADAPTER.encodedSizeWithTag(2, value.hi) +
-        value.unknownFields.size
+      override fun encodedSize(value: Rectangle): Int {
+        var size = value.unknownFields.size
+        size += Point.ADAPTER.encodedSizeWithTag(1, value.lo)
+        size += Point.ADAPTER.encodedSizeWithTag(2, value.hi)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Rectangle) {
         Point.ADAPTER.encodeWithTag(writer, 1, value.lo)

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -52,9 +52,10 @@ class RouteNote(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RouteNote) return false
-    return unknownFields == other.unknownFields
-        && location == other.location
-        && message == other.message
+    var result = unknownFields == other.unknownFields
+    result = result && (location == other.location)
+    result = result && (message == other.message)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -88,10 +89,12 @@ class RouteNote(
       RouteNote::class, 
       "type.googleapis.com/routeguide.RouteNote"
     ) {
-      override fun encodedSize(value: RouteNote): Int = 
-        Point.ADAPTER.encodedSizeWithTag(1, value.location) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.message) +
-        value.unknownFields.size
+      override fun encodedSize(value: RouteNote): Int {
+        var size = value.unknownFields.size
+        size += Point.ADAPTER.encodedSizeWithTag(1, value.location)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.message)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RouteNote) {
         Point.ADAPTER.encodeWithTag(writer, 1, value.location)

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -52,10 +52,10 @@ class RouteNote(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RouteNote) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (location == other.location)
-    result = result && (message == other.message)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (location != other.location) return false
+    if (message != other.message) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -71,12 +71,12 @@ class RouteSummary(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RouteSummary) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (point_count == other.point_count)
-    result = result && (feature_count == other.feature_count)
-    result = result && (distance == other.distance)
-    result = result && (elapsed_time == other.elapsed_time)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (point_count != other.point_count) return false
+    if (feature_count != other.feature_count) return false
+    if (distance != other.distance) return false
+    if (elapsed_time != other.elapsed_time) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -71,11 +71,12 @@ class RouteSummary(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RouteSummary) return false
-    return unknownFields == other.unknownFields
-        && point_count == other.point_count
-        && feature_count == other.feature_count
-        && distance == other.distance
-        && elapsed_time == other.elapsed_time
+    var result = unknownFields == other.unknownFields
+    result = result && (point_count == other.point_count)
+    result = result && (feature_count == other.feature_count)
+    result = result && (distance == other.distance)
+    result = result && (elapsed_time == other.elapsed_time)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -115,12 +116,14 @@ class RouteSummary(
       RouteSummary::class, 
       "type.googleapis.com/routeguide.RouteSummary"
     ) {
-      override fun encodedSize(value: RouteSummary): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.point_count) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.feature_count) +
-        ProtoAdapter.INT32.encodedSizeWithTag(3, value.distance) +
-        ProtoAdapter.INT32.encodedSizeWithTag(4, value.elapsed_time) +
-        value.unknownFields.size
+      override fun encodedSize(value: RouteSummary): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.point_count)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.feature_count)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(3, value.distance)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(4, value.elapsed_time)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RouteSummary) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.point_count)

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/protos/kotlin/KeywordKotlin.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/protos/kotlin/KeywordKotlin.kt
@@ -45,9 +45,10 @@ class KeywordKotlin(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is KeywordKotlin) return false
-    return unknownFields == other.unknownFields
-        && object_ == other.object_
-        && when_ == other.when_
+    var result = unknownFields == other.unknownFields
+    result = result && (object_ == other.object_)
+    result = result && (when_ == other.when_)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -105,10 +106,12 @@ class KeywordKotlin(
       KeywordKotlin::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.KeywordKotlin"
     ) {
-      override fun encodedSize(value: KeywordKotlin): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.object_) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.when_) +
-        value.unknownFields.size
+      override fun encodedSize(value: KeywordKotlin): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.object_)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.when_)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: KeywordKotlin) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.object_)

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/protos/kotlin/KeywordKotlin.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/protos/kotlin/KeywordKotlin.kt
@@ -45,10 +45,10 @@ class KeywordKotlin(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is KeywordKotlin) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (object_ == other.object_)
-    result = result && (when_ == other.when_)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (object_ != other.object_) return false
+    if (when_ != other.when_) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -493,8 +493,8 @@ class KotlinGenerator private constructor(
 
       val fields = type.fieldsAndOneOfFields
       for (field in fields) {
-          val fieldName = localNameAllocator[field]
-          addStatement("if (%1L != %2N.%1L) return false", fieldName, otherName)
+        val fieldName = localNameAllocator[field]
+        addStatement("if (%1L != %2N.%1L) return false", fieldName, otherName)
       }
       addStatement("return true")
     }
@@ -1041,7 +1041,7 @@ class KotlinGenerator private constructor(
       message.fieldsAndOneOfFields.forEach{ field ->
         val fieldName = localNameAllocator[field]
         if (field.encodeMode == EncodeMode.OMIT_IDENTITY) {
-          add("if (value.%L == %L) 0\nelse ", fieldName, field.identityValue)
+          add("if (value.%1L != %2L) ", fieldName, field.identityValue)
         }
         addStatement("%N += %L.encodedSizeWithTag(%L, value.%L)", sizeName, adapterFor(field), field.tag, fieldName)
       }

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -473,14 +473,13 @@ class KotlinGenerator private constructor(
   // override fun equals(other: Any?): Boolean {
   //   if (other === this) return true
   //   if (other !is SimpleMessage) return false
-  //   var result = unknownFields == other.unknownFields
-  //   result = result && (optional_int32 == other.optional_int32)
-  //   return result
+  //   if (unknownFields != other.unknownFields) return false
+  //   if (optional_int32 != other.optional_int32) return false
+  //   return true
   // }
   private fun generateEqualsMethod(type: MessageType, nameAllocator: NameAllocator): FunSpec {
     val localNameAllocator = nameAllocator.copy()
     val otherName = localNameAllocator.newName("other")
-    val resultName = localNameAllocator.newName("result")
     val kotlinType = type.typeName
     val result = FunSpec.builder("equals")
         .addModifiers(OVERRIDE)
@@ -490,14 +489,14 @@ class KotlinGenerator private constructor(
     val body = buildCodeBlock {
       addStatement("if (%N === this) return true", otherName)
       addStatement("if (%N !is %T) return·false", otherName, kotlinType)
-      addStatement("var %N = unknownFields == %N.unknownFields", resultName, otherName)
+      addStatement("if (unknownFields != %N.unknownFields) return false", otherName)
 
       val fields = type.fieldsAndOneOfFields
       for (field in fields) {
           val fieldName = localNameAllocator[field]
-          addStatement("%1N = %1N && (%2L·== %3N.%2L)", resultName, fieldName, otherName)
+          addStatement("if (%1L != %2N.%1L) return false", fieldName, otherName)
       }
-      addStatement("return %N", resultName)
+      addStatement("return true")
     }
     result.addCode(body)
 

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -473,7 +473,7 @@ class KotlinGenerator private constructor(
   // override fun equals(other: Any?): Boolean {
   //   if (other === this) return true
   //   if (other !is SimpleMessage) return false
-  //   var result unknownFields == other.unknownFields
+  //   var result = unknownFields == other.unknownFields
   //   result = result && (optional_int32 == other.optional_int32)
   //   return result
   // }

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -82,7 +82,8 @@ class KotlinGeneratorTest {
     assertTrue(code.contains("val when_: Float"))
     assertTrue(code.contains("val ADAPTER_: Int"))
     assertTrue(code.contains("val adapter_: Long?"))
-    assertTrue(code.contains("ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.when_) +"))
+    assertTrue(code.contains("var size = value.unknownFields.size"))
+    assertTrue(code.contains("size += ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.when_)"))
     assertTrue(code.contains("ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.when_)"))
     assertTrue(code.contains("ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.when_)"))
     assertTrue(code.contains("1 -> when_ = ProtoAdapter.FLOAT.decode(reader)"))
@@ -1095,7 +1096,7 @@ class KotlinGeneratorTest {
     val code = repoBuilder.generateKotlin(longType)
     assertTrue(code.contains("return false"))
     assertTrue(code.contains("return $longType("))
-    assertTrue(code.contains("$longMember =="))
+    assertTrue(code.contains("\\($longMember\\s+!=\\s+other.$longMember\\)".toRegex()))
     assertTrue(code.contains("$longMember =\n"))
   }
 

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1094,9 +1094,15 @@ class KotlinGeneratorTest {
         |  required string $longMember = 1;
         |}""".trimMargin())
     val code = repoBuilder.generateKotlin(longType)
+    val expectedEqualsConditionImplementation = """
+          |        ($longMember
+          |        !=
+          |        other.$longMember)
+          """.trimMargin()
+
     assertTrue(code.contains("return false"))
     assertTrue(code.contains("return $longType("))
-    assertTrue(code.contains("\\($longMember\\s+!=\\s+other.$longMember\\)".toRegex()))
+    assertTrue(code.contains(expectedEqualsConditionImplementation))
     assertTrue(code.contains("$longMember =\n"))
   }
 

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -75,13 +75,13 @@ class Dinosaur(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Dinosaur) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (picture_urls == other.picture_urls)
-    result = result && (length_meters == other.length_meters)
-    result = result && (mass_kilograms == other.mass_kilograms)
-    result = result && (period == other.period)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (picture_urls != other.picture_urls) return false
+    if (length_meters != other.length_meters) return false
+    if (mass_kilograms != other.mass_kilograms) return false
+    if (period != other.period) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -75,12 +75,13 @@ class Dinosaur(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Dinosaur) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && picture_urls == other.picture_urls
-        && length_meters == other.length_meters
-        && mass_kilograms == other.mass_kilograms
-        && period == other.period
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (picture_urls == other.picture_urls)
+    result = result && (length_meters == other.length_meters)
+    result = result && (mass_kilograms == other.mass_kilograms)
+    result = result && (period == other.period)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -181,13 +182,15 @@ class Dinosaur(
       Dinosaur::class, 
       "type.googleapis.com/squareup.dinosaurs.Dinosaur"
     ) {
-      override fun encodedSize(value: Dinosaur): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(3, value.length_meters) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(4, value.mass_kilograms) +
-        Period.ADAPTER.encodedSizeWithTag(5, value.period) +
-        value.unknownFields.size
+      override fun encodedSize(value: Dinosaur): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(3, value.length_meters)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(4, value.mass_kilograms)
+        size += Period.ADAPTER.encodedSizeWithTag(5, value.period)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Dinosaur) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/kotlin/Dinosaur.kt
@@ -68,13 +68,13 @@ class Dinosaur(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Dinosaur) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (picture_urls == other.picture_urls)
-    result = result && (length_meters == other.length_meters)
-    result = result && (mass_kilograms == other.mass_kilograms)
-    result = result && (period == other.period)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (picture_urls != other.picture_urls) return false
+    if (length_meters != other.length_meters) return false
+    if (mass_kilograms != other.mass_kilograms) return false
+    if (period != other.period) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/dinosaurs/kotlin/Dinosaur.kt
@@ -68,12 +68,13 @@ class Dinosaur(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Dinosaur) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && picture_urls == other.picture_urls
-        && length_meters == other.length_meters
-        && mass_kilograms == other.mass_kilograms
-        && period == other.period
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (picture_urls == other.picture_urls)
+    result = result && (length_meters == other.length_meters)
+    result = result && (mass_kilograms == other.mass_kilograms)
+    result = result && (period == other.period)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -116,13 +117,15 @@ class Dinosaur(
       Dinosaur::class, 
       "type.googleapis.com/squareup.dinosaurs.Dinosaur"
     ) {
-      override fun encodedSize(value: Dinosaur): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(3, value.length_meters) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(4, value.mass_kilograms) +
-        Period.ADAPTER.encodedSizeWithTag(5, value.period) +
-        value.unknownFields.size
+      override fun encodedSize(value: Dinosaur): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(3, value.length_meters)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(4, value.mass_kilograms)
+        size += Period.ADAPTER.encodedSizeWithTag(5, value.period)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Dinosaur) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/javainteropkotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/javainteropkotlin/Person.kt
@@ -82,12 +82,12 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (id == other.id)
-    result = result && (email == other.email)
-    result = result && (phone == other.phone)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (id != other.id) return false
+    if (email != other.email) return false
+    if (phone != other.phone) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -295,10 +295,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (number == other.number)
-      result = result && (type == other.type)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (number != other.number) return false
+      if (type != other.type) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/javainteropkotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/javainteropkotlin/Person.kt
@@ -82,11 +82,12 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && id == other.id
-        && email == other.email
-        && phone == other.phone
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (id == other.id)
+    result = result && (email == other.email)
+    result = result && (phone == other.phone)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -181,12 +182,14 @@ class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person"
     ) {
-      override fun encodedSize(value: Person): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
-        value.unknownFields.size
+      override fun encodedSize(value: Person): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Person) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -292,9 +295,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      return unknownFields == other.unknownFields
-          && number == other.number
-          && type == other.type
+      var result = unknownFields == other.unknownFields
+      result = result && (number == other.number)
+      result = result && (type == other.type)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -361,10 +365,12 @@ class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
       ) {
-        override fun encodedSize(value: PhoneNumber): Int = 
-          ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
-          PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-          value.unknownFields.size
+        override fun encodedSize(value: PhoneNumber): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
+          size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: PhoneNumber) {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/kotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/kotlin/Person.kt
@@ -77,11 +77,12 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && id == other.id
-        && email == other.email
-        && phone == other.phone
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (id == other.id)
+    result = result && (email == other.email)
+    result = result && (phone == other.phone)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -121,12 +122,14 @@ class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person"
     ) {
-      override fun encodedSize(value: Person): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
-        value.unknownFields.size
+      override fun encodedSize(value: Person): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Person) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -228,9 +231,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      return unknownFields == other.unknownFields
-          && number == other.number
-          && type == other.type
+      var result = unknownFields == other.unknownFields
+      result = result && (number == other.number)
+      result = result && (type == other.type)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -267,10 +271,12 @@ class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
       ) {
-        override fun encodedSize(value: PhoneNumber): Int = 
-          ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
-          PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-          value.unknownFields.size
+        override fun encodedSize(value: PhoneNumber): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
+          size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: PhoneNumber) {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/kotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/protos/person/kotlin/Person.kt
@@ -77,12 +77,12 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (id == other.id)
-    result = result && (email == other.email)
-    result = result && (phone == other.phone)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (id != other.id) return false
+    if (email != other.email) return false
+    if (phone != other.phone) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -231,10 +231,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (number == other.number)
-      result = result && (type == other.type)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (number != other.number) return false
+      if (type != other.type) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-moshi-adapter/src/test/java/squareup/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/squareup/keywords/KeywordKotlin.kt
@@ -68,11 +68,12 @@ class KeywordKotlin(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is KeywordKotlin) return false
-    return unknownFields == other.unknownFields
-        && object_ == other.object_
-        && when_ == other.when_
-        && fun_ == other.fun_
-        && return_ == other.return_
+    var result = unknownFields == other.unknownFields
+    result = result && (object_ == other.object_)
+    result = result && (when_ == other.when_)
+    result = result && (fun_ == other.fun_)
+    result = result && (return_ == other.return_)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -158,12 +159,14 @@ class KeywordKotlin(
       private val funAdapter: ProtoAdapter<Map<String, String>> =
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING)
 
-      override fun encodedSize(value: KeywordKotlin): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.object_) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.when_) +
-        funAdapter.encodedSizeWithTag(3, value.fun_) +
-        ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(4, value.return_) +
-        value.unknownFields.size
+      override fun encodedSize(value: KeywordKotlin): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.object_)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.when_)
+        size += funAdapter.encodedSizeWithTag(3, value.fun_)
+        size += ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(4, value.return_)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: KeywordKotlin) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.object_)

--- a/wire-library/wire-moshi-adapter/src/test/java/squareup/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/squareup/keywords/KeywordKotlin.kt
@@ -68,12 +68,12 @@ class KeywordKotlin(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is KeywordKotlin) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (object_ == other.object_)
-    result = result && (when_ == other.when_)
-    result = result && (fun_ == other.fun_)
-    result = result && (return_ == other.return_)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (object_ != other.object_) return false
+    if (when_ != other.when_) return false
+    if (fun_ != other.fun_) return false
+    if (return_ != other.return_) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
@@ -100,18 +100,18 @@ class DescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (field == other.field)
-    result = result && (extension == other.extension)
-    result = result && (nested_type == other.nested_type)
-    result = result && (enum_type == other.enum_type)
-    result = result && (extension_range == other.extension_range)
-    result = result && (oneof_decl == other.oneof_decl)
-    result = result && (options == other.options)
-    result = result && (reserved_range == other.reserved_range)
-    result = result && (reserved_name == other.reserved_name)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (field != other.field) return false
+    if (extension != other.extension) return false
+    if (nested_type != other.nested_type) return false
+    if (enum_type != other.enum_type) return false
+    if (extension_range != other.extension_range) return false
+    if (oneof_decl != other.oneof_decl) return false
+    if (options != other.options) return false
+    if (reserved_range != other.reserved_range) return false
+    if (reserved_name != other.reserved_name) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -287,11 +287,11 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ExtensionRange) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (start == other.start)
-      result = result && (end == other.end)
-      result = result && (options == other.options)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (start != other.start) return false
+      if (end != other.end) return false
+      if (options != other.options) return false
+      return true
     }
 
     override fun hashCode(): Int {
@@ -404,10 +404,10 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ReservedRange) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (start == other.start)
-      result = result && (end == other.end)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (start != other.start) return false
+      if (end != other.end) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
@@ -100,17 +100,18 @@ class DescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && field == other.field
-        && extension == other.extension
-        && nested_type == other.nested_type
-        && enum_type == other.enum_type
-        && extension_range == other.extension_range
-        && oneof_decl == other.oneof_decl
-        && options == other.options
-        && reserved_range == other.reserved_range
-        && reserved_name == other.reserved_name
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (field == other.field)
+    result = result && (extension == other.extension)
+    result = result && (nested_type == other.nested_type)
+    result = result && (enum_type == other.enum_type)
+    result = result && (extension_range == other.extension_range)
+    result = result && (oneof_decl == other.oneof_decl)
+    result = result && (options == other.options)
+    result = result && (reserved_range == other.reserved_range)
+    result = result && (reserved_name == other.reserved_name)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -169,18 +170,20 @@ class DescriptorProto(
       DescriptorProto::class, 
       "type.googleapis.com/google.protobuf.DescriptorProto"
     ) {
-      override fun encodedSize(value: DescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.field) +
-        FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.extension) +
-        DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(3, value.nested_type) +
-        EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.enum_type) +
-        ExtensionRange.ADAPTER.asRepeated().encodedSizeWithTag(5, value.extension_range) +
-        OneofDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(8, value.oneof_decl) +
-        MessageOptions.ADAPTER.encodedSizeWithTag(7, value.options) +
-        ReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(9, value.reserved_range) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(10, value.reserved_name) +
-        value.unknownFields.size
+      override fun encodedSize(value: DescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.field)
+        size += FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.extension)
+        size += DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(3, value.nested_type)
+        size += EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.enum_type)
+        size += ExtensionRange.ADAPTER.asRepeated().encodedSizeWithTag(5, value.extension_range)
+        size += OneofDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(8, value.oneof_decl)
+        size += MessageOptions.ADAPTER.encodedSizeWithTag(7, value.options)
+        size += ReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(9, value.reserved_range)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(10, value.reserved_name)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: DescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -284,10 +287,11 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ExtensionRange) return false
-      return unknownFields == other.unknownFields
-          && start == other.start
-          && end == other.end
-          && options == other.options
+      var result = unknownFields == other.unknownFields
+      result = result && (start == other.start)
+      result = result && (end == other.end)
+      result = result && (options == other.options)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -324,11 +328,13 @@ class DescriptorProto(
         ExtensionRange::class, 
         "type.googleapis.com/google.protobuf.DescriptorProto.ExtensionRange"
       ) {
-        override fun encodedSize(value: ExtensionRange): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.start) +
-          ProtoAdapter.INT32.encodedSizeWithTag(2, value.end) +
-          ExtensionRangeOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-          value.unknownFields.size
+        override fun encodedSize(value: ExtensionRange): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.start)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.end)
+          size += ExtensionRangeOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: ExtensionRange) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.start)
@@ -398,9 +404,10 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ReservedRange) return false
-      return unknownFields == other.unknownFields
-          && start == other.start
-          && end == other.end
+      var result = unknownFields == other.unknownFields
+      result = result && (start == other.start)
+      result = result && (end == other.end)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -434,10 +441,12 @@ class DescriptorProto(
         ReservedRange::class, 
         "type.googleapis.com/google.protobuf.DescriptorProto.ReservedRange"
       ) {
-        override fun encodedSize(value: ReservedRange): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.start) +
-          ProtoAdapter.INT32.encodedSizeWithTag(2, value.end) +
-          value.unknownFields.size
+        override fun encodedSize(value: ReservedRange): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.start)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.end)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: ReservedRange) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.start)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
@@ -75,12 +75,13 @@ class EnumDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && value == other.value
-        && options == other.options
-        && reserved_range == other.reserved_range
-        && reserved_name == other.reserved_name
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (value == other.value)
+    result = result && (options == other.options)
+    result = result && (reserved_range == other.reserved_range)
+    result = result && (reserved_name == other.reserved_name)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -124,13 +125,15 @@ class EnumDescriptorProto(
       EnumDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.EnumDescriptorProto"
     ) {
-      override fun encodedSize(value: EnumDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        EnumValueDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.value) +
-        EnumOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-        EnumReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(4, value.reserved_range) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.reserved_name) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += EnumValueDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.value)
+        size += EnumOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+        size += EnumReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(4, value.reserved_range)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.reserved_name)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -212,9 +215,10 @@ class EnumDescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is EnumReservedRange) return false
-      return unknownFields == other.unknownFields
-          && start == other.start
-          && end == other.end
+      var result = unknownFields == other.unknownFields
+      result = result && (start == other.start)
+      result = result && (end == other.end)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -248,10 +252,12 @@ class EnumDescriptorProto(
         EnumReservedRange::class, 
         "type.googleapis.com/google.protobuf.EnumDescriptorProto.EnumReservedRange"
       ) {
-        override fun encodedSize(value: EnumReservedRange): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.start) +
-          ProtoAdapter.INT32.encodedSizeWithTag(2, value.end) +
-          value.unknownFields.size
+        override fun encodedSize(value: EnumReservedRange): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.start)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.end)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: EnumReservedRange) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.start)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
@@ -75,13 +75,13 @@ class EnumDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (value == other.value)
-    result = result && (options == other.options)
-    result = result && (reserved_range == other.reserved_range)
-    result = result && (reserved_name == other.reserved_name)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (value != other.value) return false
+    if (options != other.options) return false
+    if (reserved_range != other.reserved_range) return false
+    if (reserved_name != other.reserved_name) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -215,10 +215,10 @@ class EnumDescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is EnumReservedRange) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (start == other.start)
-      result = result && (end == other.end)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (start != other.start) return false
+      if (end != other.end) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
@@ -71,12 +71,12 @@ class EnumOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (allow_alias == other.allow_alias)
-    result = result && (deprecated == other.deprecated)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    result = result && (enum_option == other.enum_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (allow_alias != other.allow_alias) return false
+    if (deprecated != other.deprecated) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    if (enum_option != other.enum_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
@@ -71,11 +71,12 @@ class EnumOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumOptions) return false
-    return unknownFields == other.unknownFields
-        && allow_alias == other.allow_alias
-        && deprecated == other.deprecated
-        && uninterpreted_option == other.uninterpreted_option
-        && enum_option == other.enum_option
+    var result = unknownFields == other.unknownFields
+    result = result && (allow_alias == other.allow_alias)
+    result = result && (deprecated == other.deprecated)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    result = result && (enum_option == other.enum_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -119,13 +120,15 @@ class EnumOptions(
       EnumOptions::class, 
       "type.googleapis.com/google.protobuf.EnumOptions"
     ) {
-      override fun encodedSize(value: EnumOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(2, value.allow_alias) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(71000, value.enum_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.allow_alias)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(71000, value.enum_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 2, value.allow_alias)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
@@ -51,11 +51,11 @@ class EnumValueDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (number == other.number)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (number != other.number) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
@@ -51,10 +51,11 @@ class EnumValueDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && number == other.number
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (number == other.number)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -93,11 +94,13 @@ class EnumValueDescriptorProto(
       EnumValueDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.EnumValueDescriptorProto"
     ) {
-      override fun encodedSize(value: EnumValueDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.number) +
-        EnumValueOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumValueDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.number)
+        size += EnumValueOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumValueDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
@@ -79,13 +79,13 @@ class EnumValueOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (deprecated == other.deprecated)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    result = result && (enum_value_option == other.enum_value_option)
-    result = result && (complex_enum_value_option == other.complex_enum_value_option)
-    result = result && (foreign_enum_value_option == other.foreign_enum_value_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (deprecated != other.deprecated) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    if (enum_value_option != other.enum_value_option) return false
+    if (complex_enum_value_option != other.complex_enum_value_option) return false
+    if (foreign_enum_value_option != other.foreign_enum_value_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
@@ -79,12 +79,13 @@ class EnumValueOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueOptions) return false
-    return unknownFields == other.unknownFields
-        && deprecated == other.deprecated
-        && uninterpreted_option == other.uninterpreted_option
-        && enum_value_option == other.enum_value_option
-        && complex_enum_value_option == other.complex_enum_value_option
-        && foreign_enum_value_option == other.foreign_enum_value_option
+    var result = unknownFields == other.unknownFields
+    result = result && (deprecated == other.deprecated)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    result = result && (enum_value_option == other.enum_value_option)
+    result = result && (complex_enum_value_option == other.complex_enum_value_option)
+    result = result && (foreign_enum_value_option == other.foreign_enum_value_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -133,14 +134,16 @@ class EnumValueOptions(
       EnumValueOptions::class, 
       "type.googleapis.com/google.protobuf.EnumValueOptions"
     ) {
-      override fun encodedSize(value: EnumValueOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(1, value.deprecated) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        ProtoAdapter.INT32.encodedSizeWithTag(70000, value.enum_value_option) +
-        FooBar.More.ADAPTER.encodedSizeWithTag(70001, value.complex_enum_value_option) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(70002, value.foreign_enum_value_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumValueOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.deprecated)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(70000, value.enum_value_option)
+        size += FooBar.More.ADAPTER.encodedSizeWithTag(70001, value.complex_enum_value_option)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(70002, value.foreign_enum_value_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumValueOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.deprecated)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
@@ -42,9 +42,9 @@ class ExtensionRangeOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExtensionRangeOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
@@ -42,8 +42,9 @@ class ExtensionRangeOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExtensionRangeOptions) return false
-    return unknownFields == other.unknownFields
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -74,10 +75,12 @@ class ExtensionRangeOptions(
       ExtensionRangeOptions::class, 
       "type.googleapis.com/google.protobuf.ExtensionRangeOptions"
     ) {
-      override fun encodedSize(value: ExtensionRangeOptions): Int = 
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: ExtensionRangeOptions): Int {
+        var size = value.unknownFields.size
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ExtensionRangeOptions) {
         UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999,

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
@@ -121,17 +121,18 @@ class FieldDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && number == other.number
-        && label == other.label
-        && type == other.type
-        && type_name == other.type_name
-        && extendee == other.extendee
-        && default_value == other.default_value
-        && oneof_index == other.oneof_index
-        && json_name == other.json_name
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (number == other.number)
+    result = result && (label == other.label)
+    result = result && (type == other.type)
+    result = result && (type_name == other.type_name)
+    result = result && (extendee == other.extendee)
+    result = result && (default_value == other.default_value)
+    result = result && (oneof_index == other.oneof_index)
+    result = result && (json_name == other.json_name)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -190,18 +191,20 @@ class FieldDescriptorProto(
       FieldDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.FieldDescriptorProto"
     ) {
-      override fun encodedSize(value: FieldDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(3, value.number) +
-        Label.ADAPTER.encodedSizeWithTag(4, value.label) +
-        Type.ADAPTER.encodedSizeWithTag(5, value.type) +
-        ProtoAdapter.STRING.encodedSizeWithTag(6, value.type_name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.extendee) +
-        ProtoAdapter.STRING.encodedSizeWithTag(7, value.default_value) +
-        ProtoAdapter.INT32.encodedSizeWithTag(9, value.oneof_index) +
-        ProtoAdapter.STRING.encodedSizeWithTag(10, value.json_name) +
-        FieldOptions.ADAPTER.encodedSizeWithTag(8, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: FieldDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(3, value.number)
+        size += Label.ADAPTER.encodedSizeWithTag(4, value.label)
+        size += Type.ADAPTER.encodedSizeWithTag(5, value.type)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(6, value.type_name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.extendee)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(7, value.default_value)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(9, value.oneof_index)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(10, value.json_name)
+        size += FieldOptions.ADAPTER.encodedSizeWithTag(8, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FieldDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
@@ -121,18 +121,18 @@ class FieldDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (number == other.number)
-    result = result && (label == other.label)
-    result = result && (type == other.type)
-    result = result && (type_name == other.type_name)
-    result = result && (extendee == other.extendee)
-    result = result && (default_value == other.default_value)
-    result = result && (oneof_index == other.oneof_index)
-    result = result && (json_name == other.json_name)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (number != other.number) return false
+    if (label != other.label) return false
+    if (type != other.type) return false
+    if (type_name != other.type_name) return false
+    if (extendee != other.extendee) return false
+    if (default_value != other.default_value) return false
+    if (oneof_index != other.oneof_index) return false
+    if (json_name != other.json_name) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
@@ -184,20 +184,20 @@ class FieldOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (ctype == other.ctype)
-    result = result && (packed == other.packed)
-    result = result && (jstype == other.jstype)
-    result = result && (lazy == other.lazy)
-    result = result && (deprecated == other.deprecated)
-    result = result && (weak == other.weak)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    result = result && (my_field_option_one == other.my_field_option_one)
-    result = result && (my_field_option_two == other.my_field_option_two)
-    result = result && (my_field_option_three == other.my_field_option_three)
-    result = result && (my_field_option_four == other.my_field_option_four)
-    result = result && (redacted == other.redacted)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (ctype != other.ctype) return false
+    if (packed != other.packed) return false
+    if (jstype != other.jstype) return false
+    if (lazy != other.lazy) return false
+    if (deprecated != other.deprecated) return false
+    if (weak != other.weak) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    if (my_field_option_one != other.my_field_option_one) return false
+    if (my_field_option_two != other.my_field_option_two) return false
+    if (my_field_option_three != other.my_field_option_three) return false
+    if (my_field_option_four != other.my_field_option_four) return false
+    if (redacted != other.redacted) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
@@ -184,19 +184,20 @@ class FieldOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldOptions) return false
-    return unknownFields == other.unknownFields
-        && ctype == other.ctype
-        && packed == other.packed
-        && jstype == other.jstype
-        && lazy == other.lazy
-        && deprecated == other.deprecated
-        && weak == other.weak
-        && uninterpreted_option == other.uninterpreted_option
-        && my_field_option_one == other.my_field_option_one
-        && my_field_option_two == other.my_field_option_two
-        && my_field_option_three == other.my_field_option_three
-        && my_field_option_four == other.my_field_option_four
-        && redacted == other.redacted
+    var result = unknownFields == other.unknownFields
+    result = result && (ctype == other.ctype)
+    result = result && (packed == other.packed)
+    result = result && (jstype == other.jstype)
+    result = result && (lazy == other.lazy)
+    result = result && (deprecated == other.deprecated)
+    result = result && (weak == other.weak)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    result = result && (my_field_option_one == other.my_field_option_one)
+    result = result && (my_field_option_two == other.my_field_option_two)
+    result = result && (my_field_option_three == other.my_field_option_three)
+    result = result && (my_field_option_four == other.my_field_option_four)
+    result = result && (redacted == other.redacted)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -275,21 +276,23 @@ class FieldOptions(
       FieldOptions::class, 
       "type.googleapis.com/google.protobuf.FieldOptions"
     ) {
-      override fun encodedSize(value: FieldOptions): Int = 
-        CType.ADAPTER.encodedSizeWithTag(1, value.ctype) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(2, value.packed) +
-        JSType.ADAPTER.encodedSizeWithTag(6, value.jstype) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(5, value.lazy) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(10, value.weak) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        ProtoAdapter.INT32.encodedSizeWithTag(60001, value.my_field_option_one) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(60002, value.my_field_option_two) +
-        FooBar.FooBarBazEnum.ADAPTER.encodedSizeWithTag(60003, value.my_field_option_three) +
-        FooBar.ADAPTER.encodedSizeWithTag(60004, value.my_field_option_four) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(22300, value.redacted) +
-        value.unknownFields.size
+      override fun encodedSize(value: FieldOptions): Int {
+        var size = value.unknownFields.size
+        size += CType.ADAPTER.encodedSizeWithTag(1, value.ctype)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.packed)
+        size += JSType.ADAPTER.encodedSizeWithTag(6, value.jstype)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(5, value.lazy)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(10, value.weak)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(60001, value.my_field_option_one)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(60002, value.my_field_option_two)
+        size += FooBar.FooBarBazEnum.ADAPTER.encodedSizeWithTag(60003, value.my_field_option_three)
+        size += FooBar.ADAPTER.encodedSizeWithTag(60004, value.my_field_option_four)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(22300, value.redacted)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FieldOptions) {
         CType.ADAPTER.encodeWithTag(writer, 1, value.ctype)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
@@ -135,20 +135,20 @@ class FileDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (package_ == other.package_)
-    result = result && (dependency == other.dependency)
-    result = result && (public_dependency == other.public_dependency)
-    result = result && (weak_dependency == other.weak_dependency)
-    result = result && (message_type == other.message_type)
-    result = result && (enum_type == other.enum_type)
-    result = result && (service == other.service)
-    result = result && (extension == other.extension)
-    result = result && (options == other.options)
-    result = result && (source_code_info == other.source_code_info)
-    result = result && (syntax == other.syntax)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (package_ != other.package_) return false
+    if (dependency != other.dependency) return false
+    if (public_dependency != other.public_dependency) return false
+    if (weak_dependency != other.weak_dependency) return false
+    if (message_type != other.message_type) return false
+    if (enum_type != other.enum_type) return false
+    if (service != other.service) return false
+    if (extension != other.extension) return false
+    if (options != other.options) return false
+    if (source_code_info != other.source_code_info) return false
+    if (syntax != other.syntax) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
@@ -135,19 +135,20 @@ class FileDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && package_ == other.package_
-        && dependency == other.dependency
-        && public_dependency == other.public_dependency
-        && weak_dependency == other.weak_dependency
-        && message_type == other.message_type
-        && enum_type == other.enum_type
-        && service == other.service
-        && extension == other.extension
-        && options == other.options
-        && source_code_info == other.source_code_info
-        && syntax == other.syntax
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (package_ == other.package_)
+    result = result && (dependency == other.dependency)
+    result = result && (public_dependency == other.public_dependency)
+    result = result && (weak_dependency == other.weak_dependency)
+    result = result && (message_type == other.message_type)
+    result = result && (enum_type == other.enum_type)
+    result = result && (service == other.service)
+    result = result && (extension == other.extension)
+    result = result && (options == other.options)
+    result = result && (source_code_info == other.source_code_info)
+    result = result && (syntax == other.syntax)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -213,20 +214,22 @@ class FileDescriptorProto(
       FileDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.FileDescriptorProto"
     ) {
-      override fun encodedSize(value: FileDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.package_) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(3, value.dependency) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(10, value.public_dependency) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(11, value.weak_dependency) +
-        DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.message_type) +
-        EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(5, value.enum_type) +
-        ServiceDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.service) +
-        FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(7, value.extension) +
-        FileOptions.ADAPTER.encodedSizeWithTag(8, value.options) +
-        SourceCodeInfo.ADAPTER.encodedSizeWithTag(9, value.source_code_info) +
-        ProtoAdapter.STRING.encodedSizeWithTag(12, value.syntax) +
-        value.unknownFields.size
+      override fun encodedSize(value: FileDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.package_)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(3, value.dependency)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(10, value.public_dependency)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(11, value.weak_dependency)
+        size += DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.message_type)
+        size += EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(5, value.enum_type)
+        size += ServiceDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.service)
+        size += FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(7, value.extension)
+        size += FileOptions.ADAPTER.encodedSizeWithTag(8, value.options)
+        size += SourceCodeInfo.ADAPTER.encodedSizeWithTag(9, value.source_code_info)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(12, value.syntax)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FileDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
@@ -43,8 +43,9 @@ class FileDescriptorSet(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorSet) return false
-    return unknownFields == other.unknownFields
-        && file == other.file
+    var result = unknownFields == other.unknownFields
+    result = result && (file == other.file)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -73,9 +74,11 @@ class FileDescriptorSet(
       FileDescriptorSet::class, 
       "type.googleapis.com/google.protobuf.FileDescriptorSet"
     ) {
-      override fun encodedSize(value: FileDescriptorSet): Int = 
-        FileDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(1, value.file) +
-        value.unknownFields.size
+      override fun encodedSize(value: FileDescriptorSet): Int {
+        var size = value.unknownFields.size
+        size += FileDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(1, value.file)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FileDescriptorSet) {
         FileDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.file)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
@@ -43,9 +43,9 @@ class FileDescriptorSet(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorSet) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (file == other.file)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (file != other.file) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileOptions.kt
@@ -274,28 +274,29 @@ class FileOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileOptions) return false
-    return unknownFields == other.unknownFields
-        && java_package == other.java_package
-        && java_outer_classname == other.java_outer_classname
-        && java_multiple_files == other.java_multiple_files
-        && java_generate_equals_and_hash == other.java_generate_equals_and_hash
-        && java_string_check_utf8 == other.java_string_check_utf8
-        && optimize_for == other.optimize_for
-        && go_package == other.go_package
-        && cc_generic_services == other.cc_generic_services
-        && java_generic_services == other.java_generic_services
-        && py_generic_services == other.py_generic_services
-        && php_generic_services == other.php_generic_services
-        && deprecated == other.deprecated
-        && cc_enable_arenas == other.cc_enable_arenas
-        && objc_class_prefix == other.objc_class_prefix
-        && csharp_namespace == other.csharp_namespace
-        && swift_prefix == other.swift_prefix
-        && php_class_prefix == other.php_class_prefix
-        && php_namespace == other.php_namespace
-        && php_metadata_namespace == other.php_metadata_namespace
-        && ruby_package == other.ruby_package
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (java_package == other.java_package)
+    result = result && (java_outer_classname == other.java_outer_classname)
+    result = result && (java_multiple_files == other.java_multiple_files)
+    result = result && (java_generate_equals_and_hash == other.java_generate_equals_and_hash)
+    result = result && (java_string_check_utf8 == other.java_string_check_utf8)
+    result = result && (optimize_for == other.optimize_for)
+    result = result && (go_package == other.go_package)
+    result = result && (cc_generic_services == other.cc_generic_services)
+    result = result && (java_generic_services == other.java_generic_services)
+    result = result && (py_generic_services == other.py_generic_services)
+    result = result && (php_generic_services == other.php_generic_services)
+    result = result && (deprecated == other.deprecated)
+    result = result && (cc_enable_arenas == other.cc_enable_arenas)
+    result = result && (objc_class_prefix == other.objc_class_prefix)
+    result = result && (csharp_namespace == other.csharp_namespace)
+    result = result && (swift_prefix == other.swift_prefix)
+    result = result && (php_class_prefix == other.php_class_prefix)
+    result = result && (php_namespace == other.php_namespace)
+    result = result && (php_metadata_namespace == other.php_metadata_namespace)
+    result = result && (ruby_package == other.ruby_package)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -415,30 +416,32 @@ class FileOptions(
       FileOptions::class, 
       "type.googleapis.com/google.protobuf.FileOptions"
     ) {
-      override fun encodedSize(value: FileOptions): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.java_package) +
-        ProtoAdapter.STRING.encodedSizeWithTag(8, value.java_outer_classname) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(10, value.java_multiple_files) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(20, value.java_generate_equals_and_hash) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(27, value.java_string_check_utf8) +
-        OptimizeMode.ADAPTER.encodedSizeWithTag(9, value.optimize_for) +
-        ProtoAdapter.STRING.encodedSizeWithTag(11, value.go_package) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(16, value.cc_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(17, value.java_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(18, value.py_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(42, value.php_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(23, value.deprecated) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(31, value.cc_enable_arenas) +
-        ProtoAdapter.STRING.encodedSizeWithTag(36, value.objc_class_prefix) +
-        ProtoAdapter.STRING.encodedSizeWithTag(37, value.csharp_namespace) +
-        ProtoAdapter.STRING.encodedSizeWithTag(39, value.swift_prefix) +
-        ProtoAdapter.STRING.encodedSizeWithTag(40, value.php_class_prefix) +
-        ProtoAdapter.STRING.encodedSizeWithTag(41, value.php_namespace) +
-        ProtoAdapter.STRING.encodedSizeWithTag(44, value.php_metadata_namespace) +
-        ProtoAdapter.STRING.encodedSizeWithTag(45, value.ruby_package) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: FileOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.java_package)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(8, value.java_outer_classname)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(10, value.java_multiple_files)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(20, value.java_generate_equals_and_hash)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(27, value.java_string_check_utf8)
+        size += OptimizeMode.ADAPTER.encodedSizeWithTag(9, value.optimize_for)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(11, value.go_package)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(16, value.cc_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(17, value.java_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(18, value.py_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(42, value.php_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(23, value.deprecated)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(31, value.cc_enable_arenas)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(36, value.objc_class_prefix)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(37, value.csharp_namespace)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(39, value.swift_prefix)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(40, value.php_class_prefix)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(41, value.php_namespace)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(44, value.php_metadata_namespace)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(45, value.ruby_package)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FileOptions) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.java_package)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileOptions.kt
@@ -274,29 +274,29 @@ class FileOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (java_package == other.java_package)
-    result = result && (java_outer_classname == other.java_outer_classname)
-    result = result && (java_multiple_files == other.java_multiple_files)
-    result = result && (java_generate_equals_and_hash == other.java_generate_equals_and_hash)
-    result = result && (java_string_check_utf8 == other.java_string_check_utf8)
-    result = result && (optimize_for == other.optimize_for)
-    result = result && (go_package == other.go_package)
-    result = result && (cc_generic_services == other.cc_generic_services)
-    result = result && (java_generic_services == other.java_generic_services)
-    result = result && (py_generic_services == other.py_generic_services)
-    result = result && (php_generic_services == other.php_generic_services)
-    result = result && (deprecated == other.deprecated)
-    result = result && (cc_enable_arenas == other.cc_enable_arenas)
-    result = result && (objc_class_prefix == other.objc_class_prefix)
-    result = result && (csharp_namespace == other.csharp_namespace)
-    result = result && (swift_prefix == other.swift_prefix)
-    result = result && (php_class_prefix == other.php_class_prefix)
-    result = result && (php_namespace == other.php_namespace)
-    result = result && (php_metadata_namespace == other.php_metadata_namespace)
-    result = result && (ruby_package == other.ruby_package)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (java_package != other.java_package) return false
+    if (java_outer_classname != other.java_outer_classname) return false
+    if (java_multiple_files != other.java_multiple_files) return false
+    if (java_generate_equals_and_hash != other.java_generate_equals_and_hash) return false
+    if (java_string_check_utf8 != other.java_string_check_utf8) return false
+    if (optimize_for != other.optimize_for) return false
+    if (go_package != other.go_package) return false
+    if (cc_generic_services != other.cc_generic_services) return false
+    if (java_generic_services != other.java_generic_services) return false
+    if (py_generic_services != other.py_generic_services) return false
+    if (php_generic_services != other.php_generic_services) return false
+    if (deprecated != other.deprecated) return false
+    if (cc_enable_arenas != other.cc_enable_arenas) return false
+    if (objc_class_prefix != other.objc_class_prefix) return false
+    if (csharp_namespace != other.csharp_namespace) return false
+    if (swift_prefix != other.swift_prefix) return false
+    if (php_class_prefix != other.php_class_prefix) return false
+    if (php_namespace != other.php_namespace) return false
+    if (php_metadata_namespace != other.php_metadata_namespace) return false
+    if (ruby_package != other.ruby_package) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
@@ -50,9 +50,9 @@ class GeneratedCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is GeneratedCodeInfo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (annotation == other.annotation)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (annotation != other.annotation) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -162,12 +162,12 @@ class GeneratedCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Annotation) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (path == other.path)
-      result = result && (source_file == other.source_file)
-      result = result && (begin == other.begin)
-      result = result && (end == other.end)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (path != other.path) return false
+      if (source_file != other.source_file) return false
+      if (begin != other.begin) return false
+      if (end != other.end) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
@@ -50,8 +50,9 @@ class GeneratedCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is GeneratedCodeInfo) return false
-    return unknownFields == other.unknownFields
-        && annotation == other.annotation
+    var result = unknownFields == other.unknownFields
+    result = result && (annotation == other.annotation)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -80,9 +81,11 @@ class GeneratedCodeInfo(
       GeneratedCodeInfo::class, 
       "type.googleapis.com/google.protobuf.GeneratedCodeInfo"
     ) {
-      override fun encodedSize(value: GeneratedCodeInfo): Int = 
-        Annotation.ADAPTER.asRepeated().encodedSizeWithTag(1, value.annotation) +
-        value.unknownFields.size
+      override fun encodedSize(value: GeneratedCodeInfo): Int {
+        var size = value.unknownFields.size
+        size += Annotation.ADAPTER.asRepeated().encodedSizeWithTag(1, value.annotation)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: GeneratedCodeInfo) {
         Annotation.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.annotation)
@@ -159,11 +162,12 @@ class GeneratedCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Annotation) return false
-      return unknownFields == other.unknownFields
-          && path == other.path
-          && source_file == other.source_file
-          && begin == other.begin
-          && end == other.end
+      var result = unknownFields == other.unknownFields
+      result = result && (path == other.path)
+      result = result && (source_file == other.source_file)
+      result = result && (begin == other.begin)
+      result = result && (end == other.end)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -203,12 +207,14 @@ class GeneratedCodeInfo(
         Annotation::class, 
         "type.googleapis.com/google.protobuf.GeneratedCodeInfo.Annotation"
       ) {
-        override fun encodedSize(value: Annotation): Int = 
-          ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path) +
-          ProtoAdapter.STRING.encodedSizeWithTag(2, value.source_file) +
-          ProtoAdapter.INT32.encodedSizeWithTag(3, value.begin) +
-          ProtoAdapter.INT32.encodedSizeWithTag(4, value.end) +
-          value.unknownFields.size
+        override fun encodedSize(value: Annotation): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path)
+          size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.source_file)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(3, value.begin)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(4, value.end)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: Annotation) {
           ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.path)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
@@ -176,20 +176,20 @@ class MessageOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (message_set_wire_format == other.message_set_wire_format)
-    result = result && (no_standard_descriptor_accessor == other.no_standard_descriptor_accessor)
-    result = result && (deprecated == other.deprecated)
-    result = result && (map_entry == other.map_entry)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    result = result && (my_message_option_one == other.my_message_option_one)
-    result = result && (my_message_option_two == other.my_message_option_two)
-    result = result && (my_message_option_three == other.my_message_option_three)
-    result = result && (my_message_option_four == other.my_message_option_four)
-    result = result && (my_message_option_five == other.my_message_option_five)
-    result = result && (my_message_option_six == other.my_message_option_six)
-    result = result && (foreign_message_option == other.foreign_message_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (message_set_wire_format != other.message_set_wire_format) return false
+    if (no_standard_descriptor_accessor != other.no_standard_descriptor_accessor) return false
+    if (deprecated != other.deprecated) return false
+    if (map_entry != other.map_entry) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    if (my_message_option_one != other.my_message_option_one) return false
+    if (my_message_option_two != other.my_message_option_two) return false
+    if (my_message_option_three != other.my_message_option_three) return false
+    if (my_message_option_four != other.my_message_option_four) return false
+    if (my_message_option_five != other.my_message_option_five) return false
+    if (my_message_option_six != other.my_message_option_six) return false
+    if (foreign_message_option != other.foreign_message_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
@@ -176,19 +176,20 @@ class MessageOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageOptions) return false
-    return unknownFields == other.unknownFields
-        && message_set_wire_format == other.message_set_wire_format
-        && no_standard_descriptor_accessor == other.no_standard_descriptor_accessor
-        && deprecated == other.deprecated
-        && map_entry == other.map_entry
-        && uninterpreted_option == other.uninterpreted_option
-        && my_message_option_one == other.my_message_option_one
-        && my_message_option_two == other.my_message_option_two
-        && my_message_option_three == other.my_message_option_three
-        && my_message_option_four == other.my_message_option_four
-        && my_message_option_five == other.my_message_option_five
-        && my_message_option_six == other.my_message_option_six
-        && foreign_message_option == other.foreign_message_option
+    var result = unknownFields == other.unknownFields
+    result = result && (message_set_wire_format == other.message_set_wire_format)
+    result = result && (no_standard_descriptor_accessor == other.no_standard_descriptor_accessor)
+    result = result && (deprecated == other.deprecated)
+    result = result && (map_entry == other.map_entry)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    result = result && (my_message_option_one == other.my_message_option_one)
+    result = result && (my_message_option_two == other.my_message_option_two)
+    result = result && (my_message_option_three == other.my_message_option_three)
+    result = result && (my_message_option_four == other.my_message_option_four)
+    result = result && (my_message_option_five == other.my_message_option_five)
+    result = result && (my_message_option_six == other.my_message_option_six)
+    result = result && (foreign_message_option == other.foreign_message_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -268,21 +269,23 @@ class MessageOptions(
       MessageOptions::class, 
       "type.googleapis.com/google.protobuf.MessageOptions"
     ) {
-      override fun encodedSize(value: MessageOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(1, value.message_set_wire_format) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(2, value.no_standard_descriptor_accessor) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(7, value.map_entry) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        FooBar.ADAPTER.encodedSizeWithTag(50001, value.my_message_option_one) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(50002, value.my_message_option_two) +
-        FooBar.ADAPTER.encodedSizeWithTag(50003, value.my_message_option_three) +
-        FooBar.FooBarBazEnum.ADAPTER.encodedSizeWithTag(50004, value.my_message_option_four) +
-        FooBar.ADAPTER.encodedSizeWithTag(50005, value.my_message_option_five) +
-        FooBar.ADAPTER.encodedSizeWithTag(50006, value.my_message_option_six) +
-        ForeignMessage.ADAPTER.encodedSizeWithTag(50007, value.foreign_message_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: MessageOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.message_set_wire_format)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.no_standard_descriptor_accessor)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(7, value.map_entry)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        size += FooBar.ADAPTER.encodedSizeWithTag(50001, value.my_message_option_one)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(50002, value.my_message_option_two)
+        size += FooBar.ADAPTER.encodedSizeWithTag(50003, value.my_message_option_three)
+        size += FooBar.FooBarBazEnum.ADAPTER.encodedSizeWithTag(50004, value.my_message_option_four)
+        size += FooBar.ADAPTER.encodedSizeWithTag(50005, value.my_message_option_five)
+        size += FooBar.ADAPTER.encodedSizeWithTag(50006, value.my_message_option_six)
+        size += ForeignMessage.ADAPTER.encodedSizeWithTag(50007, value.foreign_message_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MessageOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.message_set_wire_format)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
@@ -76,14 +76,14 @@ class MethodDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (input_type == other.input_type)
-    result = result && (output_type == other.output_type)
-    result = result && (options == other.options)
-    result = result && (client_streaming == other.client_streaming)
-    result = result && (server_streaming == other.server_streaming)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (input_type != other.input_type) return false
+    if (output_type != other.output_type) return false
+    if (options != other.options) return false
+    if (client_streaming != other.client_streaming) return false
+    if (server_streaming != other.server_streaming) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
@@ -76,13 +76,14 @@ class MethodDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && input_type == other.input_type
-        && output_type == other.output_type
-        && options == other.options
-        && client_streaming == other.client_streaming
-        && server_streaming == other.server_streaming
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (input_type == other.input_type)
+    result = result && (output_type == other.output_type)
+    result = result && (options == other.options)
+    result = result && (client_streaming == other.client_streaming)
+    result = result && (server_streaming == other.server_streaming)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -133,14 +134,16 @@ class MethodDescriptorProto(
       MethodDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.MethodDescriptorProto"
     ) {
-      override fun encodedSize(value: MethodDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.input_type) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.output_type) +
-        MethodOptions.ADAPTER.encodedSizeWithTag(4, value.options) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(5, value.client_streaming) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(6, value.server_streaming) +
-        value.unknownFields.size
+      override fun encodedSize(value: MethodDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.input_type)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.output_type)
+        size += MethodOptions.ADAPTER.encodedSizeWithTag(4, value.options)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(5, value.client_streaming)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(6, value.server_streaming)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MethodDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
@@ -66,11 +66,11 @@ class MethodOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (deprecated == other.deprecated)
-    result = result && (idempotency_level == other.idempotency_level)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (deprecated != other.deprecated) return false
+    if (idempotency_level != other.idempotency_level) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
@@ -66,10 +66,11 @@ class MethodOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodOptions) return false
-    return unknownFields == other.unknownFields
-        && deprecated == other.deprecated
-        && idempotency_level == other.idempotency_level
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (deprecated == other.deprecated)
+    result = result && (idempotency_level == other.idempotency_level)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -113,12 +114,14 @@ class MethodOptions(
       MethodOptions::class, 
       "type.googleapis.com/google.protobuf.MethodOptions"
     ) {
-      override fun encodedSize(value: MethodOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated) +
-        IdempotencyLevel.ADAPTER.encodedSizeWithTag(34, value.idempotency_level) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: MethodOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated)
+        size += IdempotencyLevel.ADAPTER.encodedSizeWithTag(34, value.idempotency_level)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MethodOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
@@ -46,9 +46,10 @@ class OneofDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -82,10 +83,12 @@ class OneofDescriptorProto(
       OneofDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.OneofDescriptorProto"
     ) {
-      override fun encodedSize(value: OneofDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        OneofOptions.ADAPTER.encodedSizeWithTag(2, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneofDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += OneofOptions.ADAPTER.encodedSizeWithTag(2, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneofDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
@@ -46,10 +46,10 @@ class OneofDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
@@ -42,9 +42,9 @@ class OneofOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
@@ -42,8 +42,9 @@ class OneofOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofOptions) return false
-    return unknownFields == other.unknownFields
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -74,10 +75,12 @@ class OneofOptions(
       OneofOptions::class, 
       "type.googleapis.com/google.protobuf.OneofOptions"
     ) {
-      override fun encodedSize(value: OneofOptions): Int = 
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneofOptions): Int {
+        var size = value.unknownFields.size
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneofOptions) {
         UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999,

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
@@ -54,10 +54,11 @@ class ServiceDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && method == other.method
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (method == other.method)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -95,11 +96,13 @@ class ServiceDescriptorProto(
       ServiceDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.ServiceDescriptorProto"
     ) {
-      override fun encodedSize(value: ServiceDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        MethodDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.method) +
-        ServiceOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: ServiceDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += MethodDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.method)
+        size += ServiceOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ServiceDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
@@ -54,11 +54,11 @@ class ServiceDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (method == other.method)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (method != other.method) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
@@ -58,10 +58,10 @@ class ServiceOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (deprecated == other.deprecated)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (deprecated != other.deprecated) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
@@ -58,9 +58,10 @@ class ServiceOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceOptions) return false
-    return unknownFields == other.unknownFields
-        && deprecated == other.deprecated
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (deprecated == other.deprecated)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -97,11 +98,13 @@ class ServiceOptions(
       ServiceOptions::class, 
       "type.googleapis.com/google.protobuf.ServiceOptions"
     ) {
-      override fun encodedSize(value: ServiceOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: ServiceOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ServiceOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
@@ -92,9 +92,9 @@ class SourceCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SourceCodeInfo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (location == other.location)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (location != other.location) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -276,13 +276,13 @@ class SourceCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Location) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (path == other.path)
-      result = result && (span == other.span)
-      result = result && (leading_comments == other.leading_comments)
-      result = result && (trailing_comments == other.trailing_comments)
-      result = result && (leading_detached_comments == other.leading_detached_comments)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (path != other.path) return false
+      if (span != other.span) return false
+      if (leading_comments != other.leading_comments) return false
+      if (trailing_comments != other.trailing_comments) return false
+      if (leading_detached_comments != other.leading_detached_comments) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
@@ -92,8 +92,9 @@ class SourceCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SourceCodeInfo) return false
-    return unknownFields == other.unknownFields
-        && location == other.location
+    var result = unknownFields == other.unknownFields
+    result = result && (location == other.location)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -122,9 +123,11 @@ class SourceCodeInfo(
       SourceCodeInfo::class, 
       "type.googleapis.com/google.protobuf.SourceCodeInfo"
     ) {
-      override fun encodedSize(value: SourceCodeInfo): Int = 
-        Location.ADAPTER.asRepeated().encodedSizeWithTag(1, value.location) +
-        value.unknownFields.size
+      override fun encodedSize(value: SourceCodeInfo): Int {
+        var size = value.unknownFields.size
+        size += Location.ADAPTER.asRepeated().encodedSizeWithTag(1, value.location)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: SourceCodeInfo) {
         Location.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.location)
@@ -273,12 +276,13 @@ class SourceCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Location) return false
-      return unknownFields == other.unknownFields
-          && path == other.path
-          && span == other.span
-          && leading_comments == other.leading_comments
-          && trailing_comments == other.trailing_comments
-          && leading_detached_comments == other.leading_detached_comments
+      var result = unknownFields == other.unknownFields
+      result = result && (path == other.path)
+      result = result && (span == other.span)
+      result = result && (leading_comments == other.leading_comments)
+      result = result && (trailing_comments == other.trailing_comments)
+      result = result && (leading_detached_comments == other.leading_detached_comments)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -324,13 +328,16 @@ class SourceCodeInfo(
         Location::class, 
         "type.googleapis.com/google.protobuf.SourceCodeInfo.Location"
       ) {
-        override fun encodedSize(value: Location): Int = 
-          ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path) +
-          ProtoAdapter.INT32.asPacked().encodedSizeWithTag(2, value.span) +
-          ProtoAdapter.STRING.encodedSizeWithTag(3, value.leading_comments) +
-          ProtoAdapter.STRING.encodedSizeWithTag(4, value.trailing_comments) +
-          ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.leading_detached_comments) +
-          value.unknownFields.size
+        override fun encodedSize(value: Location): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path)
+          size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(2, value.span)
+          size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.leading_comments)
+          size += ProtoAdapter.STRING.encodedSizeWithTag(4, value.trailing_comments)
+          size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6,
+              value.leading_detached_comments)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: Location) {
           ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.path)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
@@ -86,15 +86,15 @@ class UninterpretedOption(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UninterpretedOption) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (identifier_value == other.identifier_value)
-    result = result && (positive_int_value == other.positive_int_value)
-    result = result && (negative_int_value == other.negative_int_value)
-    result = result && (double_value == other.double_value)
-    result = result && (string_value == other.string_value)
-    result = result && (aggregate_value == other.aggregate_value)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (identifier_value != other.identifier_value) return false
+    if (positive_int_value != other.positive_int_value) return false
+    if (negative_int_value != other.negative_int_value) return false
+    if (double_value != other.double_value) return false
+    if (string_value != other.string_value) return false
+    if (aggregate_value != other.aggregate_value) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -237,10 +237,10 @@ class UninterpretedOption(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NamePart) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (name_part == other.name_part)
-      result = result && (is_extension == other.is_extension)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (name_part != other.name_part) return false
+      if (is_extension != other.is_extension) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
@@ -86,14 +86,15 @@ class UninterpretedOption(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UninterpretedOption) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && identifier_value == other.identifier_value
-        && positive_int_value == other.positive_int_value
-        && negative_int_value == other.negative_int_value
-        && double_value == other.double_value
-        && string_value == other.string_value
-        && aggregate_value == other.aggregate_value
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (identifier_value == other.identifier_value)
+    result = result && (positive_int_value == other.positive_int_value)
+    result = result && (negative_int_value == other.negative_int_value)
+    result = result && (double_value == other.double_value)
+    result = result && (string_value == other.string_value)
+    result = result && (aggregate_value == other.aggregate_value)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -143,15 +144,17 @@ class UninterpretedOption(
       UninterpretedOption::class, 
       "type.googleapis.com/google.protobuf.UninterpretedOption"
     ) {
-      override fun encodedSize(value: UninterpretedOption): Int = 
-        NamePart.ADAPTER.asRepeated().encodedSizeWithTag(2, value.name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.identifier_value) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(4, value.positive_int_value) +
-        ProtoAdapter.INT64.encodedSizeWithTag(5, value.negative_int_value) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(6, value.double_value) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(7, value.string_value) +
-        ProtoAdapter.STRING.encodedSizeWithTag(8, value.aggregate_value) +
-        value.unknownFields.size
+      override fun encodedSize(value: UninterpretedOption): Int {
+        var size = value.unknownFields.size
+        size += NamePart.ADAPTER.asRepeated().encodedSizeWithTag(2, value.name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.identifier_value)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(4, value.positive_int_value)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(5, value.negative_int_value)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(6, value.double_value)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(7, value.string_value)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(8, value.aggregate_value)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: UninterpretedOption) {
         NamePart.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.name)
@@ -234,9 +237,10 @@ class UninterpretedOption(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NamePart) return false
-      return unknownFields == other.unknownFields
-          && name_part == other.name_part
-          && is_extension == other.is_extension
+      var result = unknownFields == other.unknownFields
+      result = result && (name_part == other.name_part)
+      result = result && (is_extension == other.is_extension)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -270,10 +274,12 @@ class UninterpretedOption(
         NamePart::class, 
         "type.googleapis.com/google.protobuf.UninterpretedOption.NamePart"
       ) {
-        override fun encodedSize(value: NamePart): Int = 
-          ProtoAdapter.STRING.encodedSizeWithTag(1, value.name_part) +
-          ProtoAdapter.BOOL.encodedSizeWithTag(2, value.is_extension) +
-          value.unknownFields.size
+        override fun encodedSize(value: NamePart): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name_part)
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.is_extension)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: NamePart) {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name_part)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -95,16 +95,17 @@ class FooBar(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FooBar) return false
-    return unknownFields == other.unknownFields
-        && foo == other.foo
-        && bar == other.bar
-        && baz == other.baz
-        && qux == other.qux
-        && fred == other.fred
-        && daisy == other.daisy
-        && nested == other.nested
-        && ext == other.ext
-        && rep == other.rep
+    var result = unknownFields == other.unknownFields
+    result = result && (foo == other.foo)
+    result = result && (bar == other.bar)
+    result = result && (baz == other.baz)
+    result = result && (qux == other.qux)
+    result = result && (fred == other.fred)
+    result = result && (daisy == other.daisy)
+    result = result && (nested == other.nested)
+    result = result && (ext == other.ext)
+    result = result && (rep == other.rep)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -159,17 +160,19 @@ class FooBar(
       FooBar::class, 
       "type.googleapis.com/squareup.protos.custom_options.FooBar"
     ) {
-      override fun encodedSize(value: FooBar): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.bar) +
-        Nested.ADAPTER.encodedSizeWithTag(3, value.baz) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(4, value.qux) +
-        ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(5, value.fred) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(6, value.daisy) +
-        FooBar.ADAPTER.asRepeated().encodedSizeWithTag(7, value.nested) +
-        FooBarBazEnum.ADAPTER.encodedSizeWithTag(101, value.ext) +
-        FooBarBazEnum.ADAPTER.asRepeated().encodedSizeWithTag(102, value.rep) +
-        value.unknownFields.size
+      override fun encodedSize(value: FooBar): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.bar)
+        size += Nested.ADAPTER.encodedSizeWithTag(3, value.baz)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(4, value.qux)
+        size += ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(5, value.fred)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(6, value.daisy)
+        size += FooBar.ADAPTER.asRepeated().encodedSizeWithTag(7, value.nested)
+        size += FooBarBazEnum.ADAPTER.encodedSizeWithTag(101, value.ext)
+        size += FooBarBazEnum.ADAPTER.asRepeated().encodedSizeWithTag(102, value.rep)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FooBar) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)
@@ -255,8 +258,9 @@ class FooBar(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Nested) return false
-      return unknownFields == other.unknownFields
-          && value == other.value
+      var result = unknownFields == other.unknownFields
+      result = result && (value == other.value)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -285,9 +289,11 @@ class FooBar(
         Nested::class, 
         "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested"
       ) {
-        override fun encodedSize(value: Nested): Int = 
-          FooBarBazEnum.ADAPTER.encodedSizeWithTag(1, value.value) +
-          value.unknownFields.size
+        override fun encodedSize(value: Nested): Int {
+          var size = value.unknownFields.size
+          size += FooBarBazEnum.ADAPTER.encodedSizeWithTag(1, value.value)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: Nested) {
           FooBarBazEnum.ADAPTER.encodeWithTag(writer, 1, value.value)
@@ -337,8 +343,9 @@ class FooBar(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is More) return false
-      return unknownFields == other.unknownFields
-          && serial == other.serial
+      var result = unknownFields == other.unknownFields
+      result = result && (serial == other.serial)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -367,9 +374,11 @@ class FooBar(
         More::class, 
         "type.googleapis.com/squareup.protos.custom_options.FooBar.More"
       ) {
-        override fun encodedSize(value: More): Int = 
-          ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(1, value.serial) +
-          value.unknownFields.size
+        override fun encodedSize(value: More): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(1, value.serial)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: More) {
           ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1, value.serial)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -95,17 +95,17 @@ class FooBar(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FooBar) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (foo == other.foo)
-    result = result && (bar == other.bar)
-    result = result && (baz == other.baz)
-    result = result && (qux == other.qux)
-    result = result && (fred == other.fred)
-    result = result && (daisy == other.daisy)
-    result = result && (nested == other.nested)
-    result = result && (ext == other.ext)
-    result = result && (rep == other.rep)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (foo != other.foo) return false
+    if (bar != other.bar) return false
+    if (baz != other.baz) return false
+    if (qux != other.qux) return false
+    if (fred != other.fred) return false
+    if (daisy != other.daisy) return false
+    if (nested != other.nested) return false
+    if (ext != other.ext) return false
+    if (rep != other.rep) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -258,9 +258,9 @@ class FooBar(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Nested) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (value == other.value)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (value != other.value) return false
+      return true
     }
 
     override fun hashCode(): Int {
@@ -343,9 +343,9 @@ class FooBar(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is More) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (serial == other.serial)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (serial != other.serial) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
@@ -30,8 +30,8 @@ class MessageWithOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageWithOptions) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
@@ -30,7 +30,8 @@ class MessageWithOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageWithOptions) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -47,8 +48,10 @@ class MessageWithOptions(
       MessageWithOptions::class, 
       "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions"
     ) {
-      override fun encodedSize(value: MessageWithOptions): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: MessageWithOptions): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MessageWithOptions) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -39,9 +39,9 @@ class DeprecatedProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DeprecatedProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (foo == other.foo)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (foo != other.foo) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -39,8 +39,9 @@ class DeprecatedProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DeprecatedProto) return false
-    return unknownFields == other.unknownFields
-        && foo == other.foo
+    var result = unknownFields == other.unknownFields
+    result = result && (foo == other.foo)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -69,9 +70,11 @@ class DeprecatedProto(
       DeprecatedProto::class, 
       "type.googleapis.com/squareup.protos.kotlin.DeprecatedProto"
     ) {
-      override fun encodedSize(value: DeprecatedProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo) +
-        value.unknownFields.size
+      override fun encodedSize(value: DeprecatedProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: DeprecatedProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -101,21 +101,20 @@ class Form(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Form) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (button_element == other.button_element)
-    result = result && (local_image_element == other.local_image_element)
-    result = result && (remote_image_element == other.remote_image_element)
-    result = result && (money_element == other.money_element)
-    result = result && (spacer_element == other.spacer_element)
-    result = result && (text_element == other.text_element)
-    result = result && (customized_card_element == other.customized_card_element)
-    result = result && (address_element == other.address_element)
-    result = result && (text_input_element == other.text_input_element)
-    result = result && (option_picker_element == other.option_picker_element)
-    result = result && (detail_row_element == other.detail_row_element)
-    result = result && (currency_conversion_flags_element ==
-        other.currency_conversion_flags_element)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (button_element != other.button_element) return false
+    if (local_image_element != other.local_image_element) return false
+    if (remote_image_element != other.remote_image_element) return false
+    if (money_element != other.money_element) return false
+    if (spacer_element != other.spacer_element) return false
+    if (text_element != other.text_element) return false
+    if (customized_card_element != other.customized_card_element) return false
+    if (address_element != other.address_element) return false
+    if (text_input_element != other.text_input_element) return false
+    if (option_picker_element != other.option_picker_element) return false
+    if (detail_row_element != other.detail_row_element) return false
+    if (currency_conversion_flags_element != other.currency_conversion_flags_element) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -300,8 +299,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ButtonElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -353,8 +352,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is LocalImageElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -406,8 +405,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is RemoteImageElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -459,8 +458,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is MoneyElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -512,8 +511,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is SpacerElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -565,8 +564,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is TextElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -618,8 +617,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is CustomizedCardElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -672,8 +671,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is AddressElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -725,8 +724,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is TextInputElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -778,8 +777,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is OptionPickerElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -831,8 +830,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is DetailRowElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -884,8 +883,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is CurrencyConversionFlagsElement) return false
-      var result = unknownFields == other.unknownFields
-      return result
+      if (unknownFields != other.unknownFields) return false
+      return true
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -101,19 +101,21 @@ class Form(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Form) return false
-    return unknownFields == other.unknownFields
-        && button_element == other.button_element
-        && local_image_element == other.local_image_element
-        && remote_image_element == other.remote_image_element
-        && money_element == other.money_element
-        && spacer_element == other.spacer_element
-        && text_element == other.text_element
-        && customized_card_element == other.customized_card_element
-        && address_element == other.address_element
-        && text_input_element == other.text_input_element
-        && option_picker_element == other.option_picker_element
-        && detail_row_element == other.detail_row_element
-        && currency_conversion_flags_element == other.currency_conversion_flags_element
+    var result = unknownFields == other.unknownFields
+    result = result && (button_element == other.button_element)
+    result = result && (local_image_element == other.local_image_element)
+    result = result && (remote_image_element == other.remote_image_element)
+    result = result && (money_element == other.money_element)
+    result = result && (spacer_element == other.spacer_element)
+    result = result && (text_element == other.text_element)
+    result = result && (customized_card_element == other.customized_card_element)
+    result = result && (address_element == other.address_element)
+    result = result && (text_input_element == other.text_input_element)
+    result = result && (option_picker_element == other.option_picker_element)
+    result = result && (detail_row_element == other.detail_row_element)
+    result = result && (currency_conversion_flags_element ==
+        other.currency_conversion_flags_element)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -182,21 +184,23 @@ class Form(
       Form::class, 
       "type.googleapis.com/squareup.protos.kotlin.oneof.Form"
     ) {
-      override fun encodedSize(value: Form): Int = 
-        ButtonElement.ADAPTER.encodedSizeWithTag(1, value.button_element) +
-        LocalImageElement.ADAPTER.encodedSizeWithTag(2, value.local_image_element) +
-        RemoteImageElement.ADAPTER.encodedSizeWithTag(3, value.remote_image_element) +
-        MoneyElement.ADAPTER.encodedSizeWithTag(4, value.money_element) +
-        SpacerElement.ADAPTER.encodedSizeWithTag(5, value.spacer_element) +
-        TextElement.ADAPTER.encodedSizeWithTag(6, value.text_element) +
-        CustomizedCardElement.ADAPTER.encodedSizeWithTag(7, value.customized_card_element) +
-        AddressElement.ADAPTER.encodedSizeWithTag(8, value.address_element) +
-        TextInputElement.ADAPTER.encodedSizeWithTag(9, value.text_input_element) +
-        OptionPickerElement.ADAPTER.encodedSizeWithTag(10, value.option_picker_element) +
-        DetailRowElement.ADAPTER.encodedSizeWithTag(11, value.detail_row_element) +
-        CurrencyConversionFlagsElement.ADAPTER.encodedSizeWithTag(12,
-            value.currency_conversion_flags_element) +
-        value.unknownFields.size
+      override fun encodedSize(value: Form): Int {
+        var size = value.unknownFields.size
+        size += ButtonElement.ADAPTER.encodedSizeWithTag(1, value.button_element)
+        size += LocalImageElement.ADAPTER.encodedSizeWithTag(2, value.local_image_element)
+        size += RemoteImageElement.ADAPTER.encodedSizeWithTag(3, value.remote_image_element)
+        size += MoneyElement.ADAPTER.encodedSizeWithTag(4, value.money_element)
+        size += SpacerElement.ADAPTER.encodedSizeWithTag(5, value.spacer_element)
+        size += TextElement.ADAPTER.encodedSizeWithTag(6, value.text_element)
+        size += CustomizedCardElement.ADAPTER.encodedSizeWithTag(7, value.customized_card_element)
+        size += AddressElement.ADAPTER.encodedSizeWithTag(8, value.address_element)
+        size += TextInputElement.ADAPTER.encodedSizeWithTag(9, value.text_input_element)
+        size += OptionPickerElement.ADAPTER.encodedSizeWithTag(10, value.option_picker_element)
+        size += DetailRowElement.ADAPTER.encodedSizeWithTag(11, value.detail_row_element)
+        size += CurrencyConversionFlagsElement.ADAPTER.encodedSizeWithTag(12,
+            value.currency_conversion_flags_element)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Form) {
         ButtonElement.ADAPTER.encodeWithTag(writer, 1, value.button_element)
@@ -296,7 +300,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ButtonElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -313,8 +318,10 @@ class Form(
         ButtonElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.ButtonElement"
       ) {
-        override fun encodedSize(value: ButtonElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: ButtonElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: ButtonElement) {
           writer.writeBytes(value.unknownFields)
@@ -346,7 +353,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is LocalImageElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -363,8 +371,10 @@ class Form(
         LocalImageElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.LocalImageElement"
       ) {
-        override fun encodedSize(value: LocalImageElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: LocalImageElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: LocalImageElement) {
           writer.writeBytes(value.unknownFields)
@@ -396,7 +406,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is RemoteImageElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -413,8 +424,10 @@ class Form(
         RemoteImageElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.RemoteImageElement"
       ) {
-        override fun encodedSize(value: RemoteImageElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: RemoteImageElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: RemoteImageElement) {
           writer.writeBytes(value.unknownFields)
@@ -446,7 +459,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is MoneyElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -463,8 +477,10 @@ class Form(
         MoneyElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.MoneyElement"
       ) {
-        override fun encodedSize(value: MoneyElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: MoneyElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: MoneyElement) {
           writer.writeBytes(value.unknownFields)
@@ -496,7 +512,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is SpacerElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -513,8 +530,10 @@ class Form(
         SpacerElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.SpacerElement"
       ) {
-        override fun encodedSize(value: SpacerElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: SpacerElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: SpacerElement) {
           writer.writeBytes(value.unknownFields)
@@ -546,7 +565,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is TextElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -563,8 +583,10 @@ class Form(
         TextElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextElement"
       ) {
-        override fun encodedSize(value: TextElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: TextElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: TextElement) {
           writer.writeBytes(value.unknownFields)
@@ -596,7 +618,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is CustomizedCardElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -614,8 +637,10 @@ class Form(
         CustomizedCardElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CustomizedCardElement"
       ) {
-        override fun encodedSize(value: CustomizedCardElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: CustomizedCardElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: CustomizedCardElement) {
           writer.writeBytes(value.unknownFields)
@@ -647,7 +672,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is AddressElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -664,8 +690,10 @@ class Form(
         AddressElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.AddressElement"
       ) {
-        override fun encodedSize(value: AddressElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: AddressElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: AddressElement) {
           writer.writeBytes(value.unknownFields)
@@ -697,7 +725,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is TextInputElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -714,8 +743,10 @@ class Form(
         TextInputElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextInputElement"
       ) {
-        override fun encodedSize(value: TextInputElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: TextInputElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: TextInputElement) {
           writer.writeBytes(value.unknownFields)
@@ -747,7 +778,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is OptionPickerElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -764,8 +796,10 @@ class Form(
         OptionPickerElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.OptionPickerElement"
       ) {
-        override fun encodedSize(value: OptionPickerElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: OptionPickerElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: OptionPickerElement) {
           writer.writeBytes(value.unknownFields)
@@ -797,7 +831,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is DetailRowElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -814,8 +849,10 @@ class Form(
         DetailRowElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.DetailRowElement"
       ) {
-        override fun encodedSize(value: DetailRowElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: DetailRowElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: DetailRowElement) {
           writer.writeBytes(value.unknownFields)
@@ -847,7 +884,8 @@ class Form(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is CurrencyConversionFlagsElement) return false
-      return unknownFields == other.unknownFields
+      var result = unknownFields == other.unknownFields
+      return result
     }
 
     override fun hashCode(): Int = unknownFields.hashCode()
@@ -865,8 +903,10 @@ class Form(
         CurrencyConversionFlagsElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CurrencyConversionFlagsElement"
       ) {
-        override fun encodedSize(value: CurrencyConversionFlagsElement): Int = 
-          value.unknownFields.size
+        override fun encodedSize(value: CurrencyConversionFlagsElement): Int {
+          var size = value.unknownFields.size
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: CurrencyConversionFlagsElement) {
           writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -45,9 +45,10 @@ class MessageUsingMultipleEnums(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageUsingMultipleEnums) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
-        && b == other.b
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    result = result && (b == other.b)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -83,10 +84,12 @@ class MessageUsingMultipleEnums(
       MessageUsingMultipleEnums::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageUsingMultipleEnums"
     ) {
-      override fun encodedSize(value: MessageUsingMultipleEnums): Int = 
-        MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a) +
-        OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b) +
-        value.unknownFields.size
+      override fun encodedSize(value: MessageUsingMultipleEnums): Int {
+        var size = value.unknownFields.size
+        size += MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a)
+        size += OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums) {
         MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -45,10 +45,10 @@ class MessageUsingMultipleEnums(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageUsingMultipleEnums) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    result = result && (b == other.b)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    if (b != other.b) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -33,8 +33,8 @@ class MessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageWithStatus) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -33,7 +33,8 @@ class MessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageWithStatus) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -50,8 +51,10 @@ class MessageWithStatus(
       MessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageWithStatus"
     ) {
-      override fun encodedSize(value: MessageWithStatus): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: MessageWithStatus): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MessageWithStatus) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -30,8 +30,8 @@ class NoFields(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoFields) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -30,7 +30,8 @@ class NoFields(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoFields) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -46,8 +47,10 @@ class NoFields(
       NoFields::class, 
       "type.googleapis.com/squareup.protos.kotlin.NoFields"
     ) {
-      override fun encodedSize(value: NoFields): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: NoFields): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NoFields) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -67,10 +67,11 @@ class OneOfMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneOfMessage) return false
-    return unknownFields == other.unknownFields
-        && foo == other.foo
-        && bar == other.bar
-        && baz == other.baz
+    var result = unknownFields == other.unknownFields
+    result = result && (foo == other.foo)
+    result = result && (bar == other.bar)
+    result = result && (baz == other.baz)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -107,11 +108,13 @@ class OneOfMessage(
       OneOfMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.oneof.OneOfMessage"
     ) {
-      override fun encodedSize(value: OneOfMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar) +
-        ProtoAdapter.STRING.encodedSizeWithTag(4, value.baz) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneOfMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(4, value.baz)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneOfMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -67,11 +67,11 @@ class OneOfMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneOfMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (foo == other.foo)
-    result = result && (bar == other.bar)
-    result = result && (baz == other.baz)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (foo != other.foo) return false
+    if (bar != other.bar) return false
+    if (baz != other.baz) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -40,8 +40,9 @@ class OptionalEnumUser(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OptionalEnumUser) return false
-    return unknownFields == other.unknownFields
-        && optional_enum == other.optional_enum
+    var result = unknownFields == other.unknownFields
+    result = result && (optional_enum == other.optional_enum)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -70,9 +71,11 @@ class OptionalEnumUser(
       OptionalEnumUser::class, 
       "type.googleapis.com/squareup.protos.kotlin.OptionalEnumUser"
     ) {
-      override fun encodedSize(value: OptionalEnumUser): Int = 
-        OptionalEnum.ADAPTER.encodedSizeWithTag(1, value.optional_enum) +
-        value.unknownFields.size
+      override fun encodedSize(value: OptionalEnumUser): Int {
+        var size = value.unknownFields.size
+        size += OptionalEnum.ADAPTER.encodedSizeWithTag(1, value.optional_enum)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OptionalEnumUser) {
         OptionalEnum.ADAPTER.encodeWithTag(writer, 1, value.optional_enum)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -40,9 +40,9 @@ class OptionalEnumUser(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OptionalEnumUser) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (optional_enum == other.optional_enum)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (optional_enum != other.optional_enum) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -33,7 +33,8 @@ class OtherMessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OtherMessageWithStatus) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -51,8 +52,10 @@ class OtherMessageWithStatus(
       OtherMessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.OtherMessageWithStatus"
     ) {
-      override fun encodedSize(value: OtherMessageWithStatus): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: OtherMessageWithStatus): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -33,8 +33,8 @@ class OtherMessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OtherMessageWithStatus) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
@@ -41,8 +41,9 @@ class VeryLongProtoNameCausingBrokenLineBreaks(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VeryLongProtoNameCausingBrokenLineBreaks) return false
-    return unknownFields == other.unknownFields
-        && foo == other.foo
+    var result = unknownFields == other.unknownFields
+    result = result && (foo == other.foo)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -74,9 +75,11 @@ class VeryLongProtoNameCausingBrokenLineBreaks(
       VeryLongProtoNameCausingBrokenLineBreaks::class, 
       "type.googleapis.com/squareup.protos.tostring.VeryLongProtoNameCausingBrokenLineBreaks"
     ) {
-      override fun encodedSize(value: VeryLongProtoNameCausingBrokenLineBreaks): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo) +
-        value.unknownFields.size
+      override fun encodedSize(value: VeryLongProtoNameCausingBrokenLineBreaks): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: VeryLongProtoNameCausingBrokenLineBreaks) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
@@ -41,9 +41,9 @@ class VeryLongProtoNameCausingBrokenLineBreaks(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VeryLongProtoNameCausingBrokenLineBreaks) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (foo == other.foo)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (foo != other.foo) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -972,144 +972,145 @@ class AllTypes(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is AllTypes) return false
-    return unknownFields == other.unknownFields
-        && opt_int32 == other.opt_int32
-        && opt_uint32 == other.opt_uint32
-        && opt_sint32 == other.opt_sint32
-        && opt_fixed32 == other.opt_fixed32
-        && opt_sfixed32 == other.opt_sfixed32
-        && opt_int64 == other.opt_int64
-        && opt_uint64 == other.opt_uint64
-        && opt_sint64 == other.opt_sint64
-        && opt_fixed64 == other.opt_fixed64
-        && opt_sfixed64 == other.opt_sfixed64
-        && opt_bool == other.opt_bool
-        && opt_float == other.opt_float
-        && opt_double == other.opt_double
-        && opt_string == other.opt_string
-        && opt_bytes == other.opt_bytes
-        && opt_nested_enum == other.opt_nested_enum
-        && opt_nested_message == other.opt_nested_message
-        && req_int32 == other.req_int32
-        && req_uint32 == other.req_uint32
-        && req_sint32 == other.req_sint32
-        && req_fixed32 == other.req_fixed32
-        && req_sfixed32 == other.req_sfixed32
-        && req_int64 == other.req_int64
-        && req_uint64 == other.req_uint64
-        && req_sint64 == other.req_sint64
-        && req_fixed64 == other.req_fixed64
-        && req_sfixed64 == other.req_sfixed64
-        && req_bool == other.req_bool
-        && req_float == other.req_float
-        && req_double == other.req_double
-        && req_string == other.req_string
-        && req_bytes == other.req_bytes
-        && req_nested_enum == other.req_nested_enum
-        && req_nested_message == other.req_nested_message
-        && rep_int32 == other.rep_int32
-        && rep_uint32 == other.rep_uint32
-        && rep_sint32 == other.rep_sint32
-        && rep_fixed32 == other.rep_fixed32
-        && rep_sfixed32 == other.rep_sfixed32
-        && rep_int64 == other.rep_int64
-        && rep_uint64 == other.rep_uint64
-        && rep_sint64 == other.rep_sint64
-        && rep_fixed64 == other.rep_fixed64
-        && rep_sfixed64 == other.rep_sfixed64
-        && rep_bool == other.rep_bool
-        && rep_float == other.rep_float
-        && rep_double == other.rep_double
-        && rep_string == other.rep_string
-        && rep_bytes == other.rep_bytes
-        && rep_nested_enum == other.rep_nested_enum
-        && rep_nested_message == other.rep_nested_message
-        && pack_int32 == other.pack_int32
-        && pack_uint32 == other.pack_uint32
-        && pack_sint32 == other.pack_sint32
-        && pack_fixed32 == other.pack_fixed32
-        && pack_sfixed32 == other.pack_sfixed32
-        && pack_int64 == other.pack_int64
-        && pack_uint64 == other.pack_uint64
-        && pack_sint64 == other.pack_sint64
-        && pack_fixed64 == other.pack_fixed64
-        && pack_sfixed64 == other.pack_sfixed64
-        && pack_bool == other.pack_bool
-        && pack_float == other.pack_float
-        && pack_double == other.pack_double
-        && pack_nested_enum == other.pack_nested_enum
-        && default_int32 == other.default_int32
-        && default_uint32 == other.default_uint32
-        && default_sint32 == other.default_sint32
-        && default_fixed32 == other.default_fixed32
-        && default_sfixed32 == other.default_sfixed32
-        && default_int64 == other.default_int64
-        && default_uint64 == other.default_uint64
-        && default_sint64 == other.default_sint64
-        && default_fixed64 == other.default_fixed64
-        && default_sfixed64 == other.default_sfixed64
-        && default_bool == other.default_bool
-        && default_float == other.default_float
-        && default_double == other.default_double
-        && default_string == other.default_string
-        && default_bytes == other.default_bytes
-        && default_nested_enum == other.default_nested_enum
-        && map_int32_int32 == other.map_int32_int32
-        && map_string_string == other.map_string_string
-        && map_string_message == other.map_string_message
-        && map_string_enum == other.map_string_enum
-        && ext_opt_int32 == other.ext_opt_int32
-        && ext_opt_uint32 == other.ext_opt_uint32
-        && ext_opt_sint32 == other.ext_opt_sint32
-        && ext_opt_fixed32 == other.ext_opt_fixed32
-        && ext_opt_sfixed32 == other.ext_opt_sfixed32
-        && ext_opt_int64 == other.ext_opt_int64
-        && ext_opt_uint64 == other.ext_opt_uint64
-        && ext_opt_sint64 == other.ext_opt_sint64
-        && ext_opt_fixed64 == other.ext_opt_fixed64
-        && ext_opt_sfixed64 == other.ext_opt_sfixed64
-        && ext_opt_bool == other.ext_opt_bool
-        && ext_opt_float == other.ext_opt_float
-        && ext_opt_double == other.ext_opt_double
-        && ext_opt_string == other.ext_opt_string
-        && ext_opt_bytes == other.ext_opt_bytes
-        && ext_opt_nested_enum == other.ext_opt_nested_enum
-        && ext_opt_nested_message == other.ext_opt_nested_message
-        && ext_rep_int32 == other.ext_rep_int32
-        && ext_rep_uint32 == other.ext_rep_uint32
-        && ext_rep_sint32 == other.ext_rep_sint32
-        && ext_rep_fixed32 == other.ext_rep_fixed32
-        && ext_rep_sfixed32 == other.ext_rep_sfixed32
-        && ext_rep_int64 == other.ext_rep_int64
-        && ext_rep_uint64 == other.ext_rep_uint64
-        && ext_rep_sint64 == other.ext_rep_sint64
-        && ext_rep_fixed64 == other.ext_rep_fixed64
-        && ext_rep_sfixed64 == other.ext_rep_sfixed64
-        && ext_rep_bool == other.ext_rep_bool
-        && ext_rep_float == other.ext_rep_float
-        && ext_rep_double == other.ext_rep_double
-        && ext_rep_string == other.ext_rep_string
-        && ext_rep_bytes == other.ext_rep_bytes
-        && ext_rep_nested_enum == other.ext_rep_nested_enum
-        && ext_rep_nested_message == other.ext_rep_nested_message
-        && ext_pack_int32 == other.ext_pack_int32
-        && ext_pack_uint32 == other.ext_pack_uint32
-        && ext_pack_sint32 == other.ext_pack_sint32
-        && ext_pack_fixed32 == other.ext_pack_fixed32
-        && ext_pack_sfixed32 == other.ext_pack_sfixed32
-        && ext_pack_int64 == other.ext_pack_int64
-        && ext_pack_uint64 == other.ext_pack_uint64
-        && ext_pack_sint64 == other.ext_pack_sint64
-        && ext_pack_fixed64 == other.ext_pack_fixed64
-        && ext_pack_sfixed64 == other.ext_pack_sfixed64
-        && ext_pack_bool == other.ext_pack_bool
-        && ext_pack_float == other.ext_pack_float
-        && ext_pack_double == other.ext_pack_double
-        && ext_pack_nested_enum == other.ext_pack_nested_enum
-        && ext_map_int32_int32 == other.ext_map_int32_int32
-        && ext_map_string_string == other.ext_map_string_string
-        && ext_map_string_message == other.ext_map_string_message
-        && ext_map_string_enum == other.ext_map_string_enum
+    var result = unknownFields == other.unknownFields
+    result = result && (opt_int32 == other.opt_int32)
+    result = result && (opt_uint32 == other.opt_uint32)
+    result = result && (opt_sint32 == other.opt_sint32)
+    result = result && (opt_fixed32 == other.opt_fixed32)
+    result = result && (opt_sfixed32 == other.opt_sfixed32)
+    result = result && (opt_int64 == other.opt_int64)
+    result = result && (opt_uint64 == other.opt_uint64)
+    result = result && (opt_sint64 == other.opt_sint64)
+    result = result && (opt_fixed64 == other.opt_fixed64)
+    result = result && (opt_sfixed64 == other.opt_sfixed64)
+    result = result && (opt_bool == other.opt_bool)
+    result = result && (opt_float == other.opt_float)
+    result = result && (opt_double == other.opt_double)
+    result = result && (opt_string == other.opt_string)
+    result = result && (opt_bytes == other.opt_bytes)
+    result = result && (opt_nested_enum == other.opt_nested_enum)
+    result = result && (opt_nested_message == other.opt_nested_message)
+    result = result && (req_int32 == other.req_int32)
+    result = result && (req_uint32 == other.req_uint32)
+    result = result && (req_sint32 == other.req_sint32)
+    result = result && (req_fixed32 == other.req_fixed32)
+    result = result && (req_sfixed32 == other.req_sfixed32)
+    result = result && (req_int64 == other.req_int64)
+    result = result && (req_uint64 == other.req_uint64)
+    result = result && (req_sint64 == other.req_sint64)
+    result = result && (req_fixed64 == other.req_fixed64)
+    result = result && (req_sfixed64 == other.req_sfixed64)
+    result = result && (req_bool == other.req_bool)
+    result = result && (req_float == other.req_float)
+    result = result && (req_double == other.req_double)
+    result = result && (req_string == other.req_string)
+    result = result && (req_bytes == other.req_bytes)
+    result = result && (req_nested_enum == other.req_nested_enum)
+    result = result && (req_nested_message == other.req_nested_message)
+    result = result && (rep_int32 == other.rep_int32)
+    result = result && (rep_uint32 == other.rep_uint32)
+    result = result && (rep_sint32 == other.rep_sint32)
+    result = result && (rep_fixed32 == other.rep_fixed32)
+    result = result && (rep_sfixed32 == other.rep_sfixed32)
+    result = result && (rep_int64 == other.rep_int64)
+    result = result && (rep_uint64 == other.rep_uint64)
+    result = result && (rep_sint64 == other.rep_sint64)
+    result = result && (rep_fixed64 == other.rep_fixed64)
+    result = result && (rep_sfixed64 == other.rep_sfixed64)
+    result = result && (rep_bool == other.rep_bool)
+    result = result && (rep_float == other.rep_float)
+    result = result && (rep_double == other.rep_double)
+    result = result && (rep_string == other.rep_string)
+    result = result && (rep_bytes == other.rep_bytes)
+    result = result && (rep_nested_enum == other.rep_nested_enum)
+    result = result && (rep_nested_message == other.rep_nested_message)
+    result = result && (pack_int32 == other.pack_int32)
+    result = result && (pack_uint32 == other.pack_uint32)
+    result = result && (pack_sint32 == other.pack_sint32)
+    result = result && (pack_fixed32 == other.pack_fixed32)
+    result = result && (pack_sfixed32 == other.pack_sfixed32)
+    result = result && (pack_int64 == other.pack_int64)
+    result = result && (pack_uint64 == other.pack_uint64)
+    result = result && (pack_sint64 == other.pack_sint64)
+    result = result && (pack_fixed64 == other.pack_fixed64)
+    result = result && (pack_sfixed64 == other.pack_sfixed64)
+    result = result && (pack_bool == other.pack_bool)
+    result = result && (pack_float == other.pack_float)
+    result = result && (pack_double == other.pack_double)
+    result = result && (pack_nested_enum == other.pack_nested_enum)
+    result = result && (default_int32 == other.default_int32)
+    result = result && (default_uint32 == other.default_uint32)
+    result = result && (default_sint32 == other.default_sint32)
+    result = result && (default_fixed32 == other.default_fixed32)
+    result = result && (default_sfixed32 == other.default_sfixed32)
+    result = result && (default_int64 == other.default_int64)
+    result = result && (default_uint64 == other.default_uint64)
+    result = result && (default_sint64 == other.default_sint64)
+    result = result && (default_fixed64 == other.default_fixed64)
+    result = result && (default_sfixed64 == other.default_sfixed64)
+    result = result && (default_bool == other.default_bool)
+    result = result && (default_float == other.default_float)
+    result = result && (default_double == other.default_double)
+    result = result && (default_string == other.default_string)
+    result = result && (default_bytes == other.default_bytes)
+    result = result && (default_nested_enum == other.default_nested_enum)
+    result = result && (map_int32_int32 == other.map_int32_int32)
+    result = result && (map_string_string == other.map_string_string)
+    result = result && (map_string_message == other.map_string_message)
+    result = result && (map_string_enum == other.map_string_enum)
+    result = result && (ext_opt_int32 == other.ext_opt_int32)
+    result = result && (ext_opt_uint32 == other.ext_opt_uint32)
+    result = result && (ext_opt_sint32 == other.ext_opt_sint32)
+    result = result && (ext_opt_fixed32 == other.ext_opt_fixed32)
+    result = result && (ext_opt_sfixed32 == other.ext_opt_sfixed32)
+    result = result && (ext_opt_int64 == other.ext_opt_int64)
+    result = result && (ext_opt_uint64 == other.ext_opt_uint64)
+    result = result && (ext_opt_sint64 == other.ext_opt_sint64)
+    result = result && (ext_opt_fixed64 == other.ext_opt_fixed64)
+    result = result && (ext_opt_sfixed64 == other.ext_opt_sfixed64)
+    result = result && (ext_opt_bool == other.ext_opt_bool)
+    result = result && (ext_opt_float == other.ext_opt_float)
+    result = result && (ext_opt_double == other.ext_opt_double)
+    result = result && (ext_opt_string == other.ext_opt_string)
+    result = result && (ext_opt_bytes == other.ext_opt_bytes)
+    result = result && (ext_opt_nested_enum == other.ext_opt_nested_enum)
+    result = result && (ext_opt_nested_message == other.ext_opt_nested_message)
+    result = result && (ext_rep_int32 == other.ext_rep_int32)
+    result = result && (ext_rep_uint32 == other.ext_rep_uint32)
+    result = result && (ext_rep_sint32 == other.ext_rep_sint32)
+    result = result && (ext_rep_fixed32 == other.ext_rep_fixed32)
+    result = result && (ext_rep_sfixed32 == other.ext_rep_sfixed32)
+    result = result && (ext_rep_int64 == other.ext_rep_int64)
+    result = result && (ext_rep_uint64 == other.ext_rep_uint64)
+    result = result && (ext_rep_sint64 == other.ext_rep_sint64)
+    result = result && (ext_rep_fixed64 == other.ext_rep_fixed64)
+    result = result && (ext_rep_sfixed64 == other.ext_rep_sfixed64)
+    result = result && (ext_rep_bool == other.ext_rep_bool)
+    result = result && (ext_rep_float == other.ext_rep_float)
+    result = result && (ext_rep_double == other.ext_rep_double)
+    result = result && (ext_rep_string == other.ext_rep_string)
+    result = result && (ext_rep_bytes == other.ext_rep_bytes)
+    result = result && (ext_rep_nested_enum == other.ext_rep_nested_enum)
+    result = result && (ext_rep_nested_message == other.ext_rep_nested_message)
+    result = result && (ext_pack_int32 == other.ext_pack_int32)
+    result = result && (ext_pack_uint32 == other.ext_pack_uint32)
+    result = result && (ext_pack_sint32 == other.ext_pack_sint32)
+    result = result && (ext_pack_fixed32 == other.ext_pack_fixed32)
+    result = result && (ext_pack_sfixed32 == other.ext_pack_sfixed32)
+    result = result && (ext_pack_int64 == other.ext_pack_int64)
+    result = result && (ext_pack_uint64 == other.ext_pack_uint64)
+    result = result && (ext_pack_sint64 == other.ext_pack_sint64)
+    result = result && (ext_pack_fixed64 == other.ext_pack_fixed64)
+    result = result && (ext_pack_sfixed64 == other.ext_pack_sfixed64)
+    result = result && (ext_pack_bool == other.ext_pack_bool)
+    result = result && (ext_pack_float == other.ext_pack_float)
+    result = result && (ext_pack_double == other.ext_pack_double)
+    result = result && (ext_pack_nested_enum == other.ext_pack_nested_enum)
+    result = result && (ext_map_int32_int32 == other.ext_map_int32_int32)
+    result = result && (ext_map_string_string == other.ext_map_string_string)
+    result = result && (ext_map_string_message == other.ext_map_string_message)
+    result = result && (ext_map_string_enum == other.ext_map_string_enum)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -1636,145 +1637,148 @@ class AllTypes(
       private val ext_map_string_enumAdapter: ProtoAdapter<Map<String, NestedEnum>> =
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, NestedEnum.ADAPTER)
 
-      override fun encodedSize(value: AllTypes): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(2, value.opt_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(3, value.opt_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.opt_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(5, value.opt_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(6, value.opt_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(7, value.opt_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(8, value.opt_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(9, value.opt_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(10, value.opt_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(11, value.opt_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(12, value.opt_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(13, value.opt_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(14, value.opt_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(15, value.opt_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(16, value.opt_nested_enum) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(17, value.opt_nested_message) +
-        ProtoAdapter.INT32.encodedSizeWithTag(101, value.req_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(102, value.req_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(103, value.req_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(104, value.req_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(105, value.req_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(106, value.req_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(107, value.req_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(108, value.req_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(109, value.req_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(110, value.req_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(111, value.req_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(112, value.req_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(113, value.req_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(114, value.req_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(115, value.req_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(116, value.req_nested_enum) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(117, value.req_nested_message) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(201, value.rep_int32) +
-        ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(202, value.rep_uint32) +
-        ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(203, value.rep_sint32) +
-        ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(204, value.rep_fixed32) +
-        ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(205, value.rep_sfixed32) +
-        ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(206, value.rep_int64) +
-        ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(207, value.rep_uint64) +
-        ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(208, value.rep_sint64) +
-        ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(209, value.rep_fixed64) +
-        ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(210, value.rep_sfixed64) +
-        ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(211, value.rep_bool) +
-        ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(212, value.rep_float) +
-        ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(213, value.rep_double) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(214, value.rep_string) +
-        ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(215, value.rep_bytes) +
-        NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(216, value.rep_nested_enum) +
-        NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(217, value.rep_nested_message) +
-        ProtoAdapter.INT32.asPacked().encodedSizeWithTag(301, value.pack_int32) +
-        ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(302, value.pack_uint32) +
-        ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(303, value.pack_sint32) +
-        ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(304, value.pack_fixed32) +
-        ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(305, value.pack_sfixed32) +
-        ProtoAdapter.INT64.asPacked().encodedSizeWithTag(306, value.pack_int64) +
-        ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(307, value.pack_uint64) +
-        ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(308, value.pack_sint64) +
-        ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(309, value.pack_fixed64) +
-        ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(310, value.pack_sfixed64) +
-        ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(311, value.pack_bool) +
-        ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(312, value.pack_float) +
-        ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(313, value.pack_double) +
-        NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(316, value.pack_nested_enum) +
-        ProtoAdapter.INT32.encodedSizeWithTag(401, value.default_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(402, value.default_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(403, value.default_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(404, value.default_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(405, value.default_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(406, value.default_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(407, value.default_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(408, value.default_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(409, value.default_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(410, value.default_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(411, value.default_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(412, value.default_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(413, value.default_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(414, value.default_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(415, value.default_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(416, value.default_nested_enum) +
-        map_int32_int32Adapter.encodedSizeWithTag(501, value.map_int32_int32) +
-        map_string_stringAdapter.encodedSizeWithTag(502, value.map_string_string) +
-        map_string_messageAdapter.encodedSizeWithTag(503, value.map_string_message) +
-        map_string_enumAdapter.encodedSizeWithTag(504, value.map_string_enum) +
-        ProtoAdapter.INT32.encodedSizeWithTag(1001, value.ext_opt_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(1002, value.ext_opt_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(1003, value.ext_opt_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(1004, value.ext_opt_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(1005, value.ext_opt_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(1006, value.ext_opt_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(1007, value.ext_opt_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(1008, value.ext_opt_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(1009, value.ext_opt_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(1010, value.ext_opt_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(1011, value.ext_opt_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(1012, value.ext_opt_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(1013, value.ext_opt_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(1014, value.ext_opt_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(1015, value.ext_opt_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(1016, value.ext_opt_nested_enum) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(1017, value.ext_opt_nested_message) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(1101, value.ext_rep_int32) +
-        ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(1102, value.ext_rep_uint32) +
-        ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(1103, value.ext_rep_sint32) +
-        ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(1104, value.ext_rep_fixed32) +
-        ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(1105, value.ext_rep_sfixed32) +
-        ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(1106, value.ext_rep_int64) +
-        ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(1107, value.ext_rep_uint64) +
-        ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(1108, value.ext_rep_sint64) +
-        ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(1109, value.ext_rep_fixed64) +
-        ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(1110, value.ext_rep_sfixed64) +
-        ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(1111, value.ext_rep_bool) +
-        ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(1112, value.ext_rep_float) +
-        ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(1113, value.ext_rep_double) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1114, value.ext_rep_string) +
-        ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(1115, value.ext_rep_bytes) +
-        NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(1116, value.ext_rep_nested_enum) +
-        NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(1117, value.ext_rep_nested_message) +
-        ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1201, value.ext_pack_int32) +
-        ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(1202, value.ext_pack_uint32) +
-        ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(1203, value.ext_pack_sint32) +
-        ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(1204, value.ext_pack_fixed32) +
-        ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(1205, value.ext_pack_sfixed32) +
-        ProtoAdapter.INT64.asPacked().encodedSizeWithTag(1206, value.ext_pack_int64) +
-        ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(1207, value.ext_pack_uint64) +
-        ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(1208, value.ext_pack_sint64) +
-        ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(1209, value.ext_pack_fixed64) +
-        ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(1210, value.ext_pack_sfixed64) +
-        ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(1211, value.ext_pack_bool) +
-        ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(1212, value.ext_pack_float) +
-        ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(1213, value.ext_pack_double) +
-        NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(1216, value.ext_pack_nested_enum) +
-        ext_map_int32_int32Adapter.encodedSizeWithTag(1301, value.ext_map_int32_int32) +
-        ext_map_string_stringAdapter.encodedSizeWithTag(1402, value.ext_map_string_string) +
-        ext_map_string_messageAdapter.encodedSizeWithTag(1503, value.ext_map_string_message) +
-        ext_map_string_enumAdapter.encodedSizeWithTag(1504, value.ext_map_string_enum) +
-        value.unknownFields.size
+      override fun encodedSize(value: AllTypes): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.opt_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(3, value.opt_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.opt_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5, value.opt_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(6, value.opt_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(7, value.opt_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(8, value.opt_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(9, value.opt_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(10, value.opt_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(11, value.opt_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(12, value.opt_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(13, value.opt_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(14, value.opt_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(15, value.opt_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(16, value.opt_nested_enum)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(17, value.opt_nested_message)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(101, value.req_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(102, value.req_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(103, value.req_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(104, value.req_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(105, value.req_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(106, value.req_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(107, value.req_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(108, value.req_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(109, value.req_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(110, value.req_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(111, value.req_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(112, value.req_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(113, value.req_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(114, value.req_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(115, value.req_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(116, value.req_nested_enum)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(117, value.req_nested_message)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(201, value.rep_int32)
+        size += ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(202, value.rep_uint32)
+        size += ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(203, value.rep_sint32)
+        size += ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(204, value.rep_fixed32)
+        size += ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(205, value.rep_sfixed32)
+        size += ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(206, value.rep_int64)
+        size += ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(207, value.rep_uint64)
+        size += ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(208, value.rep_sint64)
+        size += ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(209, value.rep_fixed64)
+        size += ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(210, value.rep_sfixed64)
+        size += ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(211, value.rep_bool)
+        size += ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(212, value.rep_float)
+        size += ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(213, value.rep_double)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(214, value.rep_string)
+        size += ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(215, value.rep_bytes)
+        size += NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(216, value.rep_nested_enum)
+        size += NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(217, value.rep_nested_message)
+        size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(301, value.pack_int32)
+        size += ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(302, value.pack_uint32)
+        size += ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(303, value.pack_sint32)
+        size += ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(304, value.pack_fixed32)
+        size += ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(305, value.pack_sfixed32)
+        size += ProtoAdapter.INT64.asPacked().encodedSizeWithTag(306, value.pack_int64)
+        size += ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(307, value.pack_uint64)
+        size += ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(308, value.pack_sint64)
+        size += ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(309, value.pack_fixed64)
+        size += ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(310, value.pack_sfixed64)
+        size += ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(311, value.pack_bool)
+        size += ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(312, value.pack_float)
+        size += ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(313, value.pack_double)
+        size += NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(316, value.pack_nested_enum)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(401, value.default_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(402, value.default_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(403, value.default_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(404, value.default_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(405, value.default_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(406, value.default_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(407, value.default_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(408, value.default_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(409, value.default_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(410, value.default_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(411, value.default_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(412, value.default_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(413, value.default_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(414, value.default_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(415, value.default_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(416, value.default_nested_enum)
+        size += map_int32_int32Adapter.encodedSizeWithTag(501, value.map_int32_int32)
+        size += map_string_stringAdapter.encodedSizeWithTag(502, value.map_string_string)
+        size += map_string_messageAdapter.encodedSizeWithTag(503, value.map_string_message)
+        size += map_string_enumAdapter.encodedSizeWithTag(504, value.map_string_enum)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1001, value.ext_opt_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(1002, value.ext_opt_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(1003, value.ext_opt_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(1004, value.ext_opt_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(1005, value.ext_opt_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(1006, value.ext_opt_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(1007, value.ext_opt_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(1008, value.ext_opt_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(1009, value.ext_opt_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(1010, value.ext_opt_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(1011, value.ext_opt_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(1012, value.ext_opt_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(1013, value.ext_opt_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1014, value.ext_opt_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(1015, value.ext_opt_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(1016, value.ext_opt_nested_enum)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(1017, value.ext_opt_nested_message)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(1101, value.ext_rep_int32)
+        size += ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(1102, value.ext_rep_uint32)
+        size += ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(1103, value.ext_rep_sint32)
+        size += ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(1104, value.ext_rep_fixed32)
+        size += ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(1105, value.ext_rep_sfixed32)
+        size += ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(1106, value.ext_rep_int64)
+        size += ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(1107, value.ext_rep_uint64)
+        size += ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(1108, value.ext_rep_sint64)
+        size += ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(1109, value.ext_rep_fixed64)
+        size += ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(1110, value.ext_rep_sfixed64)
+        size += ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(1111, value.ext_rep_bool)
+        size += ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(1112, value.ext_rep_float)
+        size += ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(1113, value.ext_rep_double)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1114, value.ext_rep_string)
+        size += ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(1115, value.ext_rep_bytes)
+        size += NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(1116, value.ext_rep_nested_enum)
+        size += NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(1117,
+            value.ext_rep_nested_message)
+        size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1201, value.ext_pack_int32)
+        size += ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(1202, value.ext_pack_uint32)
+        size += ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(1203, value.ext_pack_sint32)
+        size += ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(1204, value.ext_pack_fixed32)
+        size += ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(1205, value.ext_pack_sfixed32)
+        size += ProtoAdapter.INT64.asPacked().encodedSizeWithTag(1206, value.ext_pack_int64)
+        size += ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(1207, value.ext_pack_uint64)
+        size += ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(1208, value.ext_pack_sint64)
+        size += ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(1209, value.ext_pack_fixed64)
+        size += ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(1210, value.ext_pack_sfixed64)
+        size += ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(1211, value.ext_pack_bool)
+        size += ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(1212, value.ext_pack_float)
+        size += ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(1213, value.ext_pack_double)
+        size += NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(1216, value.ext_pack_nested_enum)
+        size += ext_map_int32_int32Adapter.encodedSizeWithTag(1301, value.ext_map_int32_int32)
+        size += ext_map_string_stringAdapter.encodedSizeWithTag(1402, value.ext_map_string_string)
+        size += ext_map_string_messageAdapter.encodedSizeWithTag(1503, value.ext_map_string_message)
+        size += ext_map_string_enumAdapter.encodedSizeWithTag(1504, value.ext_map_string_enum)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: AllTypes) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.opt_int32)
@@ -2424,8 +2428,9 @@ class AllTypes(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      return unknownFields == other.unknownFields
-          && a == other.a
+      var result = unknownFields == other.unknownFields
+      result = result && (a == other.a)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -2454,9 +2459,11 @@ class AllTypes(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes.NestedMessage"
       ) {
-        override fun encodedSize(value: NestedMessage): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.a) +
-          value.unknownFields.size
+        override fun encodedSize(value: NestedMessage): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: NestedMessage) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -972,145 +972,145 @@ class AllTypes(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is AllTypes) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (opt_int32 == other.opt_int32)
-    result = result && (opt_uint32 == other.opt_uint32)
-    result = result && (opt_sint32 == other.opt_sint32)
-    result = result && (opt_fixed32 == other.opt_fixed32)
-    result = result && (opt_sfixed32 == other.opt_sfixed32)
-    result = result && (opt_int64 == other.opt_int64)
-    result = result && (opt_uint64 == other.opt_uint64)
-    result = result && (opt_sint64 == other.opt_sint64)
-    result = result && (opt_fixed64 == other.opt_fixed64)
-    result = result && (opt_sfixed64 == other.opt_sfixed64)
-    result = result && (opt_bool == other.opt_bool)
-    result = result && (opt_float == other.opt_float)
-    result = result && (opt_double == other.opt_double)
-    result = result && (opt_string == other.opt_string)
-    result = result && (opt_bytes == other.opt_bytes)
-    result = result && (opt_nested_enum == other.opt_nested_enum)
-    result = result && (opt_nested_message == other.opt_nested_message)
-    result = result && (req_int32 == other.req_int32)
-    result = result && (req_uint32 == other.req_uint32)
-    result = result && (req_sint32 == other.req_sint32)
-    result = result && (req_fixed32 == other.req_fixed32)
-    result = result && (req_sfixed32 == other.req_sfixed32)
-    result = result && (req_int64 == other.req_int64)
-    result = result && (req_uint64 == other.req_uint64)
-    result = result && (req_sint64 == other.req_sint64)
-    result = result && (req_fixed64 == other.req_fixed64)
-    result = result && (req_sfixed64 == other.req_sfixed64)
-    result = result && (req_bool == other.req_bool)
-    result = result && (req_float == other.req_float)
-    result = result && (req_double == other.req_double)
-    result = result && (req_string == other.req_string)
-    result = result && (req_bytes == other.req_bytes)
-    result = result && (req_nested_enum == other.req_nested_enum)
-    result = result && (req_nested_message == other.req_nested_message)
-    result = result && (rep_int32 == other.rep_int32)
-    result = result && (rep_uint32 == other.rep_uint32)
-    result = result && (rep_sint32 == other.rep_sint32)
-    result = result && (rep_fixed32 == other.rep_fixed32)
-    result = result && (rep_sfixed32 == other.rep_sfixed32)
-    result = result && (rep_int64 == other.rep_int64)
-    result = result && (rep_uint64 == other.rep_uint64)
-    result = result && (rep_sint64 == other.rep_sint64)
-    result = result && (rep_fixed64 == other.rep_fixed64)
-    result = result && (rep_sfixed64 == other.rep_sfixed64)
-    result = result && (rep_bool == other.rep_bool)
-    result = result && (rep_float == other.rep_float)
-    result = result && (rep_double == other.rep_double)
-    result = result && (rep_string == other.rep_string)
-    result = result && (rep_bytes == other.rep_bytes)
-    result = result && (rep_nested_enum == other.rep_nested_enum)
-    result = result && (rep_nested_message == other.rep_nested_message)
-    result = result && (pack_int32 == other.pack_int32)
-    result = result && (pack_uint32 == other.pack_uint32)
-    result = result && (pack_sint32 == other.pack_sint32)
-    result = result && (pack_fixed32 == other.pack_fixed32)
-    result = result && (pack_sfixed32 == other.pack_sfixed32)
-    result = result && (pack_int64 == other.pack_int64)
-    result = result && (pack_uint64 == other.pack_uint64)
-    result = result && (pack_sint64 == other.pack_sint64)
-    result = result && (pack_fixed64 == other.pack_fixed64)
-    result = result && (pack_sfixed64 == other.pack_sfixed64)
-    result = result && (pack_bool == other.pack_bool)
-    result = result && (pack_float == other.pack_float)
-    result = result && (pack_double == other.pack_double)
-    result = result && (pack_nested_enum == other.pack_nested_enum)
-    result = result && (default_int32 == other.default_int32)
-    result = result && (default_uint32 == other.default_uint32)
-    result = result && (default_sint32 == other.default_sint32)
-    result = result && (default_fixed32 == other.default_fixed32)
-    result = result && (default_sfixed32 == other.default_sfixed32)
-    result = result && (default_int64 == other.default_int64)
-    result = result && (default_uint64 == other.default_uint64)
-    result = result && (default_sint64 == other.default_sint64)
-    result = result && (default_fixed64 == other.default_fixed64)
-    result = result && (default_sfixed64 == other.default_sfixed64)
-    result = result && (default_bool == other.default_bool)
-    result = result && (default_float == other.default_float)
-    result = result && (default_double == other.default_double)
-    result = result && (default_string == other.default_string)
-    result = result && (default_bytes == other.default_bytes)
-    result = result && (default_nested_enum == other.default_nested_enum)
-    result = result && (map_int32_int32 == other.map_int32_int32)
-    result = result && (map_string_string == other.map_string_string)
-    result = result && (map_string_message == other.map_string_message)
-    result = result && (map_string_enum == other.map_string_enum)
-    result = result && (ext_opt_int32 == other.ext_opt_int32)
-    result = result && (ext_opt_uint32 == other.ext_opt_uint32)
-    result = result && (ext_opt_sint32 == other.ext_opt_sint32)
-    result = result && (ext_opt_fixed32 == other.ext_opt_fixed32)
-    result = result && (ext_opt_sfixed32 == other.ext_opt_sfixed32)
-    result = result && (ext_opt_int64 == other.ext_opt_int64)
-    result = result && (ext_opt_uint64 == other.ext_opt_uint64)
-    result = result && (ext_opt_sint64 == other.ext_opt_sint64)
-    result = result && (ext_opt_fixed64 == other.ext_opt_fixed64)
-    result = result && (ext_opt_sfixed64 == other.ext_opt_sfixed64)
-    result = result && (ext_opt_bool == other.ext_opt_bool)
-    result = result && (ext_opt_float == other.ext_opt_float)
-    result = result && (ext_opt_double == other.ext_opt_double)
-    result = result && (ext_opt_string == other.ext_opt_string)
-    result = result && (ext_opt_bytes == other.ext_opt_bytes)
-    result = result && (ext_opt_nested_enum == other.ext_opt_nested_enum)
-    result = result && (ext_opt_nested_message == other.ext_opt_nested_message)
-    result = result && (ext_rep_int32 == other.ext_rep_int32)
-    result = result && (ext_rep_uint32 == other.ext_rep_uint32)
-    result = result && (ext_rep_sint32 == other.ext_rep_sint32)
-    result = result && (ext_rep_fixed32 == other.ext_rep_fixed32)
-    result = result && (ext_rep_sfixed32 == other.ext_rep_sfixed32)
-    result = result && (ext_rep_int64 == other.ext_rep_int64)
-    result = result && (ext_rep_uint64 == other.ext_rep_uint64)
-    result = result && (ext_rep_sint64 == other.ext_rep_sint64)
-    result = result && (ext_rep_fixed64 == other.ext_rep_fixed64)
-    result = result && (ext_rep_sfixed64 == other.ext_rep_sfixed64)
-    result = result && (ext_rep_bool == other.ext_rep_bool)
-    result = result && (ext_rep_float == other.ext_rep_float)
-    result = result && (ext_rep_double == other.ext_rep_double)
-    result = result && (ext_rep_string == other.ext_rep_string)
-    result = result && (ext_rep_bytes == other.ext_rep_bytes)
-    result = result && (ext_rep_nested_enum == other.ext_rep_nested_enum)
-    result = result && (ext_rep_nested_message == other.ext_rep_nested_message)
-    result = result && (ext_pack_int32 == other.ext_pack_int32)
-    result = result && (ext_pack_uint32 == other.ext_pack_uint32)
-    result = result && (ext_pack_sint32 == other.ext_pack_sint32)
-    result = result && (ext_pack_fixed32 == other.ext_pack_fixed32)
-    result = result && (ext_pack_sfixed32 == other.ext_pack_sfixed32)
-    result = result && (ext_pack_int64 == other.ext_pack_int64)
-    result = result && (ext_pack_uint64 == other.ext_pack_uint64)
-    result = result && (ext_pack_sint64 == other.ext_pack_sint64)
-    result = result && (ext_pack_fixed64 == other.ext_pack_fixed64)
-    result = result && (ext_pack_sfixed64 == other.ext_pack_sfixed64)
-    result = result && (ext_pack_bool == other.ext_pack_bool)
-    result = result && (ext_pack_float == other.ext_pack_float)
-    result = result && (ext_pack_double == other.ext_pack_double)
-    result = result && (ext_pack_nested_enum == other.ext_pack_nested_enum)
-    result = result && (ext_map_int32_int32 == other.ext_map_int32_int32)
-    result = result && (ext_map_string_string == other.ext_map_string_string)
-    result = result && (ext_map_string_message == other.ext_map_string_message)
-    result = result && (ext_map_string_enum == other.ext_map_string_enum)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (opt_int32 != other.opt_int32) return false
+    if (opt_uint32 != other.opt_uint32) return false
+    if (opt_sint32 != other.opt_sint32) return false
+    if (opt_fixed32 != other.opt_fixed32) return false
+    if (opt_sfixed32 != other.opt_sfixed32) return false
+    if (opt_int64 != other.opt_int64) return false
+    if (opt_uint64 != other.opt_uint64) return false
+    if (opt_sint64 != other.opt_sint64) return false
+    if (opt_fixed64 != other.opt_fixed64) return false
+    if (opt_sfixed64 != other.opt_sfixed64) return false
+    if (opt_bool != other.opt_bool) return false
+    if (opt_float != other.opt_float) return false
+    if (opt_double != other.opt_double) return false
+    if (opt_string != other.opt_string) return false
+    if (opt_bytes != other.opt_bytes) return false
+    if (opt_nested_enum != other.opt_nested_enum) return false
+    if (opt_nested_message != other.opt_nested_message) return false
+    if (req_int32 != other.req_int32) return false
+    if (req_uint32 != other.req_uint32) return false
+    if (req_sint32 != other.req_sint32) return false
+    if (req_fixed32 != other.req_fixed32) return false
+    if (req_sfixed32 != other.req_sfixed32) return false
+    if (req_int64 != other.req_int64) return false
+    if (req_uint64 != other.req_uint64) return false
+    if (req_sint64 != other.req_sint64) return false
+    if (req_fixed64 != other.req_fixed64) return false
+    if (req_sfixed64 != other.req_sfixed64) return false
+    if (req_bool != other.req_bool) return false
+    if (req_float != other.req_float) return false
+    if (req_double != other.req_double) return false
+    if (req_string != other.req_string) return false
+    if (req_bytes != other.req_bytes) return false
+    if (req_nested_enum != other.req_nested_enum) return false
+    if (req_nested_message != other.req_nested_message) return false
+    if (rep_int32 != other.rep_int32) return false
+    if (rep_uint32 != other.rep_uint32) return false
+    if (rep_sint32 != other.rep_sint32) return false
+    if (rep_fixed32 != other.rep_fixed32) return false
+    if (rep_sfixed32 != other.rep_sfixed32) return false
+    if (rep_int64 != other.rep_int64) return false
+    if (rep_uint64 != other.rep_uint64) return false
+    if (rep_sint64 != other.rep_sint64) return false
+    if (rep_fixed64 != other.rep_fixed64) return false
+    if (rep_sfixed64 != other.rep_sfixed64) return false
+    if (rep_bool != other.rep_bool) return false
+    if (rep_float != other.rep_float) return false
+    if (rep_double != other.rep_double) return false
+    if (rep_string != other.rep_string) return false
+    if (rep_bytes != other.rep_bytes) return false
+    if (rep_nested_enum != other.rep_nested_enum) return false
+    if (rep_nested_message != other.rep_nested_message) return false
+    if (pack_int32 != other.pack_int32) return false
+    if (pack_uint32 != other.pack_uint32) return false
+    if (pack_sint32 != other.pack_sint32) return false
+    if (pack_fixed32 != other.pack_fixed32) return false
+    if (pack_sfixed32 != other.pack_sfixed32) return false
+    if (pack_int64 != other.pack_int64) return false
+    if (pack_uint64 != other.pack_uint64) return false
+    if (pack_sint64 != other.pack_sint64) return false
+    if (pack_fixed64 != other.pack_fixed64) return false
+    if (pack_sfixed64 != other.pack_sfixed64) return false
+    if (pack_bool != other.pack_bool) return false
+    if (pack_float != other.pack_float) return false
+    if (pack_double != other.pack_double) return false
+    if (pack_nested_enum != other.pack_nested_enum) return false
+    if (default_int32 != other.default_int32) return false
+    if (default_uint32 != other.default_uint32) return false
+    if (default_sint32 != other.default_sint32) return false
+    if (default_fixed32 != other.default_fixed32) return false
+    if (default_sfixed32 != other.default_sfixed32) return false
+    if (default_int64 != other.default_int64) return false
+    if (default_uint64 != other.default_uint64) return false
+    if (default_sint64 != other.default_sint64) return false
+    if (default_fixed64 != other.default_fixed64) return false
+    if (default_sfixed64 != other.default_sfixed64) return false
+    if (default_bool != other.default_bool) return false
+    if (default_float != other.default_float) return false
+    if (default_double != other.default_double) return false
+    if (default_string != other.default_string) return false
+    if (default_bytes != other.default_bytes) return false
+    if (default_nested_enum != other.default_nested_enum) return false
+    if (map_int32_int32 != other.map_int32_int32) return false
+    if (map_string_string != other.map_string_string) return false
+    if (map_string_message != other.map_string_message) return false
+    if (map_string_enum != other.map_string_enum) return false
+    if (ext_opt_int32 != other.ext_opt_int32) return false
+    if (ext_opt_uint32 != other.ext_opt_uint32) return false
+    if (ext_opt_sint32 != other.ext_opt_sint32) return false
+    if (ext_opt_fixed32 != other.ext_opt_fixed32) return false
+    if (ext_opt_sfixed32 != other.ext_opt_sfixed32) return false
+    if (ext_opt_int64 != other.ext_opt_int64) return false
+    if (ext_opt_uint64 != other.ext_opt_uint64) return false
+    if (ext_opt_sint64 != other.ext_opt_sint64) return false
+    if (ext_opt_fixed64 != other.ext_opt_fixed64) return false
+    if (ext_opt_sfixed64 != other.ext_opt_sfixed64) return false
+    if (ext_opt_bool != other.ext_opt_bool) return false
+    if (ext_opt_float != other.ext_opt_float) return false
+    if (ext_opt_double != other.ext_opt_double) return false
+    if (ext_opt_string != other.ext_opt_string) return false
+    if (ext_opt_bytes != other.ext_opt_bytes) return false
+    if (ext_opt_nested_enum != other.ext_opt_nested_enum) return false
+    if (ext_opt_nested_message != other.ext_opt_nested_message) return false
+    if (ext_rep_int32 != other.ext_rep_int32) return false
+    if (ext_rep_uint32 != other.ext_rep_uint32) return false
+    if (ext_rep_sint32 != other.ext_rep_sint32) return false
+    if (ext_rep_fixed32 != other.ext_rep_fixed32) return false
+    if (ext_rep_sfixed32 != other.ext_rep_sfixed32) return false
+    if (ext_rep_int64 != other.ext_rep_int64) return false
+    if (ext_rep_uint64 != other.ext_rep_uint64) return false
+    if (ext_rep_sint64 != other.ext_rep_sint64) return false
+    if (ext_rep_fixed64 != other.ext_rep_fixed64) return false
+    if (ext_rep_sfixed64 != other.ext_rep_sfixed64) return false
+    if (ext_rep_bool != other.ext_rep_bool) return false
+    if (ext_rep_float != other.ext_rep_float) return false
+    if (ext_rep_double != other.ext_rep_double) return false
+    if (ext_rep_string != other.ext_rep_string) return false
+    if (ext_rep_bytes != other.ext_rep_bytes) return false
+    if (ext_rep_nested_enum != other.ext_rep_nested_enum) return false
+    if (ext_rep_nested_message != other.ext_rep_nested_message) return false
+    if (ext_pack_int32 != other.ext_pack_int32) return false
+    if (ext_pack_uint32 != other.ext_pack_uint32) return false
+    if (ext_pack_sint32 != other.ext_pack_sint32) return false
+    if (ext_pack_fixed32 != other.ext_pack_fixed32) return false
+    if (ext_pack_sfixed32 != other.ext_pack_sfixed32) return false
+    if (ext_pack_int64 != other.ext_pack_int64) return false
+    if (ext_pack_uint64 != other.ext_pack_uint64) return false
+    if (ext_pack_sint64 != other.ext_pack_sint64) return false
+    if (ext_pack_fixed64 != other.ext_pack_fixed64) return false
+    if (ext_pack_sfixed64 != other.ext_pack_sfixed64) return false
+    if (ext_pack_bool != other.ext_pack_bool) return false
+    if (ext_pack_float != other.ext_pack_float) return false
+    if (ext_pack_double != other.ext_pack_double) return false
+    if (ext_pack_nested_enum != other.ext_pack_nested_enum) return false
+    if (ext_map_int32_int32 != other.ext_map_int32_int32) return false
+    if (ext_map_string_string != other.ext_map_string_string) return false
+    if (ext_map_string_message != other.ext_map_string_message) return false
+    if (ext_map_string_enum != other.ext_map_string_enum) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -2428,9 +2428,9 @@ class AllTypes(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (a == other.a)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (a != other.a) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
@@ -30,8 +30,8 @@ class NoFields(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoFields) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
@@ -30,7 +30,8 @@ class NoFields(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoFields) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -46,8 +47,10 @@ class NoFields(
       NoFields::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.NoFields"
     ) {
-      override fun encodedSize(value: NoFields): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: NoFields): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NoFields) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
@@ -37,9 +37,9 @@ class OneBytesField(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneBytesField) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (opt_bytes == other.opt_bytes)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (opt_bytes != other.opt_bytes) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
@@ -37,8 +37,9 @@ class OneBytesField(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneBytesField) return false
-    return unknownFields == other.unknownFields
-        && opt_bytes == other.opt_bytes
+    var result = unknownFields == other.unknownFields
+    result = result && (opt_bytes == other.opt_bytes)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -67,9 +68,11 @@ class OneBytesField(
       OneBytesField::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.OneBytesField"
     ) {
-      override fun encodedSize(value: OneBytesField): Int = 
-        ProtoAdapter.BYTES.encodedSizeWithTag(1, value.opt_bytes) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneBytesField): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(1, value.opt_bytes)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneBytesField) {
         ProtoAdapter.BYTES.encodeWithTag(writer, 1, value.opt_bytes)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
@@ -37,9 +37,9 @@ class OneField(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneField) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (opt_int32 == other.opt_int32)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (opt_int32 != other.opt_int32) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
@@ -37,8 +37,9 @@ class OneField(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneField) return false
-    return unknownFields == other.unknownFields
-        && opt_int32 == other.opt_int32
+    var result = unknownFields == other.unknownFields
+    result = result && (opt_int32 == other.opt_int32)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -67,9 +68,11 @@ class OneField(
       OneField::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.OneField"
     ) {
-      override fun encodedSize(value: OneField): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneField): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneField) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.opt_int32)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
@@ -42,9 +42,10 @@ class Recursive(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Recursive) return false
-    return unknownFields == other.unknownFields
-        && value == other.value
-        && recursive == other.recursive
+    var result = unknownFields == other.unknownFields
+    result = result && (value == other.value)
+    result = result && (recursive == other.recursive)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -78,10 +79,12 @@ class Recursive(
       Recursive::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.Recursive"
     ) {
-      override fun encodedSize(value: Recursive): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.value) +
-        Recursive.ADAPTER.encodedSizeWithTag(2, value.recursive) +
-        value.unknownFields.size
+      override fun encodedSize(value: Recursive): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.value)
+        size += Recursive.ADAPTER.encodedSizeWithTag(2, value.recursive)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Recursive) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.value)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
@@ -42,10 +42,10 @@ class Recursive(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Recursive) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (value == other.value)
-    result = result && (recursive == other.recursive)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (value != other.value) return false
+    if (recursive != other.recursive) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -45,9 +45,10 @@ class ForeignMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ForeignMessage) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && j == other.j
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (j == other.j)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -81,10 +82,12 @@ class ForeignMessage(
       ForeignMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.foreign.ForeignMessage"
     ) {
-      override fun encodedSize(value: ForeignMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        ProtoAdapter.INT32.encodedSizeWithTag(100, value.j) +
-        value.unknownFields.size
+      override fun encodedSize(value: ForeignMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(100, value.j)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ForeignMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -45,10 +45,10 @@ class ForeignMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ForeignMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (j == other.j)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (j != other.j) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -39,8 +39,9 @@ class Mappy(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Mappy) return false
-    return unknownFields == other.unknownFields
-        && things == other.things
+    var result = unknownFields == other.unknownFields
+    result = result && (things == other.things)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -72,9 +73,11 @@ class Mappy(
       private val thingsAdapter: ProtoAdapter<Map<String, Thing>> =
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER)
 
-      override fun encodedSize(value: Mappy): Int = 
-        thingsAdapter.encodedSizeWithTag(1, value.things) +
-        value.unknownFields.size
+      override fun encodedSize(value: Mappy): Int {
+        var size = value.unknownFields.size
+        size += thingsAdapter.encodedSizeWithTag(1, value.things)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Mappy) {
         thingsAdapter.encodeWithTag(writer, 1, value.things)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -39,9 +39,9 @@ class Mappy(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Mappy) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (things == other.things)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (things != other.things) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -38,9 +38,9 @@ class Thing(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Thing) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -38,8 +38,9 @@ class Thing(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Thing) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -68,9 +69,11 @@ class Thing(
       Thing::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Thing"
     ) {
-      override fun encodedSize(value: Thing): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        value.unknownFields.size
+      override fun encodedSize(value: Thing): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Thing) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -83,13 +83,13 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (id == other.id)
-    result = result && (email == other.email)
-    result = result && (phone == other.phone)
-    result = result && (aliases == other.aliases)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (id != other.id) return false
+    if (email != other.email) return false
+    if (phone != other.phone) return false
+    if (aliases != other.aliases) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -246,10 +246,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (number == other.number)
-      result = result && (type == other.type)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (number != other.number) return false
+      if (type != other.type) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -83,12 +83,13 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && id == other.id
-        && email == other.email
-        && phone == other.phone
-        && aliases == other.aliases
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (id == other.id)
+    result = result && (email == other.email)
+    result = result && (phone == other.phone)
+    result = result && (aliases == other.aliases)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -131,13 +132,15 @@ class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person"
     ) {
-      override fun encodedSize(value: Person): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases) +
-        value.unknownFields.size
+      override fun encodedSize(value: Person): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Person) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -243,9 +246,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      return unknownFields == other.unknownFields
-          && number == other.number
-          && type == other.type
+      var result = unknownFields == other.unknownFields
+      result = result && (number == other.number)
+      result = result && (type == other.type)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -282,10 +286,12 @@ class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
       ) {
-        override fun encodedSize(value: PhoneNumber): Int = 
-          ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
-          PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-          value.unknownFields.size
+        override fun encodedSize(value: PhoneNumber): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
+          size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: PhoneNumber) {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
@@ -43,9 +43,10 @@ class NotRedacted(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NotRedacted) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
-        && b == other.b
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    result = result && (b == other.b)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -79,10 +80,12 @@ class NotRedacted(
       NotRedacted::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.NotRedacted"
     ) {
-      override fun encodedSize(value: NotRedacted): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.a) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.b) +
-        value.unknownFields.size
+      override fun encodedSize(value: NotRedacted): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.b)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NotRedacted) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
@@ -43,10 +43,10 @@ class NotRedacted(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NotRedacted) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    result = result && (b == other.b)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    if (b != other.b) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
@@ -57,12 +57,12 @@ class Redacted(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Redacted) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    result = result && (b == other.b)
-    result = result && (c == other.c)
-    result = result && (extension == other.extension)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    if (b != other.b) return false
+    if (c != other.c) return false
+    if (extension != other.extension) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/Redacted.kt
@@ -57,11 +57,12 @@ class Redacted(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Redacted) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
-        && b == other.b
-        && c == other.c
-        && extension == other.extension
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    result = result && (b == other.b)
+    result = result && (c == other.c)
+    result = result && (extension == other.extension)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -101,12 +102,14 @@ class Redacted(
       Redacted::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.Redacted"
     ) {
-      override fun encodedSize(value: Redacted): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.a) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.b) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.c) +
-        RedactedExtension.ADAPTER.encodedSizeWithTag(10, value.extension) +
-        value.unknownFields.size
+      override fun encodedSize(value: Redacted): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.b)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.c)
+        size += RedactedExtension.ADAPTER.encodedSizeWithTag(10, value.extension)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Redacted) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
@@ -48,10 +48,11 @@ class RedactedChild(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedChild) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
-        && b == other.b
-        && c == other.c
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    result = result && (b == other.b)
+    result = result && (c == other.c)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -88,11 +89,13 @@ class RedactedChild(
       RedactedChild::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedChild"
     ) {
-      override fun encodedSize(value: RedactedChild): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.a) +
-        Redacted.ADAPTER.encodedSizeWithTag(2, value.b) +
-        NotRedacted.ADAPTER.encodedSizeWithTag(3, value.c) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedChild): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
+        size += Redacted.ADAPTER.encodedSizeWithTag(2, value.b)
+        size += NotRedacted.ADAPTER.encodedSizeWithTag(3, value.c)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedChild) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
@@ -48,11 +48,11 @@ class RedactedChild(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedChild) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    result = result && (b == other.b)
-    result = result && (c == other.c)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    if (b != other.b) return false
+    if (c != other.c) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
@@ -37,8 +37,9 @@ class RedactedCycleA(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedCycleA) return false
-    return unknownFields == other.unknownFields
-        && b == other.b
+    var result = unknownFields == other.unknownFields
+    result = result && (b == other.b)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -67,9 +68,11 @@ class RedactedCycleA(
       RedactedCycleA::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedCycleA"
     ) {
-      override fun encodedSize(value: RedactedCycleA): Int = 
-        RedactedCycleB.ADAPTER.encodedSizeWithTag(1, value.b) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedCycleA): Int {
+        var size = value.unknownFields.size
+        size += RedactedCycleB.ADAPTER.encodedSizeWithTag(1, value.b)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedCycleA) {
         RedactedCycleB.ADAPTER.encodeWithTag(writer, 1, value.b)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
@@ -37,9 +37,9 @@ class RedactedCycleA(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedCycleA) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (b == other.b)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (b != other.b) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
@@ -37,9 +37,9 @@ class RedactedCycleB(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedCycleB) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
@@ -37,8 +37,9 @@ class RedactedCycleB(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedCycleB) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -67,9 +68,11 @@ class RedactedCycleB(
       RedactedCycleB::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedCycleB"
     ) {
-      override fun encodedSize(value: RedactedCycleB): Int = 
-        RedactedCycleA.ADAPTER.encodedSizeWithTag(1, value.a) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedCycleB): Int {
+        var size = value.unknownFields.size
+        size += RedactedCycleA.ADAPTER.encodedSizeWithTag(1, value.a)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedCycleB) {
         RedactedCycleA.ADAPTER.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
@@ -44,10 +44,10 @@ class RedactedExtension(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedExtension) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (d == other.d)
-    result = result && (e == other.e)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (d != other.d) return false
+    if (e != other.e) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
@@ -44,9 +44,10 @@ class RedactedExtension(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedExtension) return false
-    return unknownFields == other.unknownFields
-        && d == other.d
-        && e == other.e
+    var result = unknownFields == other.unknownFields
+    result = result && (d == other.d)
+    result = result && (e == other.e)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -80,10 +81,12 @@ class RedactedExtension(
       RedactedExtension::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedExtension"
     ) {
-      override fun encodedSize(value: RedactedExtension): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.d) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.e) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedExtension): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.d)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.e)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedExtension) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.d)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -50,9 +50,10 @@ class RedactedOneOf(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedOneOf) return false
-    return unknownFields == other.unknownFields
-        && b == other.b
-        && c == other.c
+    var result = unknownFields == other.unknownFields
+    result = result && (b == other.b)
+    result = result && (c == other.c)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -86,10 +87,12 @@ class RedactedOneOf(
       RedactedOneOf::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedOneOf"
     ) {
-      override fun encodedSize(value: RedactedOneOf): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.b) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.c) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedOneOf): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.b)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.c)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedOneOf) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.b)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -50,10 +50,10 @@ class RedactedOneOf(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedOneOf) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (b == other.b)
-    result = result && (c == other.c)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (b != other.b) return false
+    if (c != other.c) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -49,10 +49,10 @@ class RedactedRepeated(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedRepeated) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    result = result && (b == other.b)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    if (b != other.b) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -49,9 +49,10 @@ class RedactedRepeated(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedRepeated) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
-        && b == other.b
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    result = result && (b == other.b)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -85,10 +86,12 @@ class RedactedRepeated(
       RedactedRepeated::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedRepeated"
     ) {
-      override fun encodedSize(value: RedactedRepeated): Int = 
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1, value.a) +
-        Redacted.ADAPTER.asRepeated().encodedSizeWithTag(2, value.b) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedRepeated): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1, value.a)
+        size += Redacted.ADAPTER.asRepeated().encodedSizeWithTag(2, value.b)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedRepeated) {
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
@@ -40,9 +40,9 @@ class RedactedRequired(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedRequired) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
@@ -40,8 +40,9 @@ class RedactedRequired(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedRequired) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -70,9 +71,11 @@ class RedactedRequired(
       RedactedRequired::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedRequired"
     ) {
-      override fun encodedSize(value: RedactedRequired): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.a) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedRequired): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedRequired) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -80,13 +80,14 @@ class ExternalMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExternalMessage) return false
-    return unknownFields == other.unknownFields
-        && f == other.f
-        && fooext == other.fooext
-        && barext == other.barext
-        && bazext == other.bazext
-        && nested_message_ext == other.nested_message_ext
-        && nested_enum_ext == other.nested_enum_ext
+    var result = unknownFields == other.unknownFields
+    result = result && (f == other.f)
+    result = result && (fooext == other.fooext)
+    result = result && (barext == other.barext)
+    result = result && (bazext == other.bazext)
+    result = result && (nested_message_ext == other.nested_message_ext)
+    result = result && (nested_enum_ext == other.nested_enum_ext)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -135,14 +136,17 @@ class ExternalMessage(
       ExternalMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.ExternalMessage"
     ) {
-      override fun encodedSize(value: ExternalMessage): Int = 
-        ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.f) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(125, value.fooext) +
-        ProtoAdapter.INT32.encodedSizeWithTag(126, value.barext) +
-        ProtoAdapter.INT32.encodedSizeWithTag(127, value.bazext) +
-        SimpleMessage.NestedMessage.ADAPTER.encodedSizeWithTag(128, value.nested_message_ext) +
-        SimpleMessage.NestedEnum.ADAPTER.encodedSizeWithTag(129, value.nested_enum_ext) +
-        value.unknownFields.size
+      override fun encodedSize(value: ExternalMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.f)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(125, value.fooext)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(126, value.barext)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(127, value.bazext)
+        size += SimpleMessage.NestedMessage.ADAPTER.encodedSizeWithTag(128,
+            value.nested_message_ext)
+        size += SimpleMessage.NestedEnum.ADAPTER.encodedSizeWithTag(129, value.nested_enum_ext)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ExternalMessage) {
         ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.f)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -80,14 +80,14 @@ class ExternalMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExternalMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (f == other.f)
-    result = result && (fooext == other.fooext)
-    result = result && (barext == other.barext)
-    result = result && (bazext == other.bazext)
-    result = result && (nested_message_ext == other.nested_message_ext)
-    result = result && (nested_enum_ext == other.nested_enum_ext)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (f != other.f) return false
+    if (fooext != other.fooext) return false
+    if (barext != other.barext) return false
+    if (bazext != other.bazext) return false
+    if (nested_message_ext != other.nested_message_ext) return false
+    if (nested_enum_ext != other.nested_enum_ext) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -141,20 +141,20 @@ class SimpleMessage(
   override fun equals(other_: Any?): Boolean {
     if (other_ === this) return true
     if (other_ !is SimpleMessage) return false
-    var result_ = unknownFields == other_.unknownFields
-    result_ = result_ && (optional_int32 == other_.optional_int32)
-    result_ = result_ && (optional_nested_msg == other_.optional_nested_msg)
-    result_ = result_ && (optional_external_msg == other_.optional_external_msg)
-    result_ = result_ && (default_nested_enum == other_.default_nested_enum)
-    result_ = result_ && (required_int32 == other_.required_int32)
-    result_ = result_ && (repeated_double == other_.repeated_double)
-    result_ = result_ && (default_foreign_enum == other_.default_foreign_enum)
-    result_ = result_ && (no_default_foreign_enum == other_.no_default_foreign_enum)
-    result_ = result_ && (package_ == other_.package_)
-    result_ = result_ && (result == other_.result)
-    result_ = result_ && (other == other_.other)
-    result_ = result_ && (o == other_.o)
-    return result_
+    if (unknownFields != other_.unknownFields) return false
+    if (optional_int32 != other_.optional_int32) return false
+    if (optional_nested_msg != other_.optional_nested_msg) return false
+    if (optional_external_msg != other_.optional_external_msg) return false
+    if (default_nested_enum != other_.default_nested_enum) return false
+    if (required_int32 != other_.required_int32) return false
+    if (repeated_double != other_.repeated_double) return false
+    if (default_foreign_enum != other_.default_foreign_enum) return false
+    if (no_default_foreign_enum != other_.no_default_foreign_enum) return false
+    if (package_ != other_.package_) return false
+    if (result != other_.result) return false
+    if (other != other_.other) return false
+    if (o != other_.o) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -352,9 +352,9 @@ class SimpleMessage(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (bb == other.bb)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (bb != other.bb) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -141,19 +141,20 @@ class SimpleMessage(
   override fun equals(other_: Any?): Boolean {
     if (other_ === this) return true
     if (other_ !is SimpleMessage) return false
-    return unknownFields == other_.unknownFields
-        && optional_int32 == other_.optional_int32
-        && optional_nested_msg == other_.optional_nested_msg
-        && optional_external_msg == other_.optional_external_msg
-        && default_nested_enum == other_.default_nested_enum
-        && required_int32 == other_.required_int32
-        && repeated_double == other_.repeated_double
-        && default_foreign_enum == other_.default_foreign_enum
-        && no_default_foreign_enum == other_.no_default_foreign_enum
-        && package_ == other_.package_
-        && result == other_.result
-        && other == other_.other
-        && o == other_.o
+    var result_ = unknownFields == other_.unknownFields
+    result_ = result_ && (optional_int32 == other_.optional_int32)
+    result_ = result_ && (optional_nested_msg == other_.optional_nested_msg)
+    result_ = result_ && (optional_external_msg == other_.optional_external_msg)
+    result_ = result_ && (default_nested_enum == other_.default_nested_enum)
+    result_ = result_ && (required_int32 == other_.required_int32)
+    result_ = result_ && (repeated_double == other_.repeated_double)
+    result_ = result_ && (default_foreign_enum == other_.default_foreign_enum)
+    result_ = result_ && (no_default_foreign_enum == other_.no_default_foreign_enum)
+    result_ = result_ && (package_ == other_.package_)
+    result_ = result_ && (result == other_.result)
+    result_ = result_ && (other == other_.other)
+    result_ = result_ && (o == other_.o)
+    return result_
   }
 
   override fun hashCode(): Int {
@@ -230,20 +231,22 @@ class SimpleMessage(
       SimpleMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage"
     ) {
-      override fun encodedSize(value: SimpleMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.optional_int32) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(2, value.optional_nested_msg) +
-        ExternalMessage.ADAPTER.encodedSizeWithTag(3, value.optional_external_msg) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(4, value.default_nested_enum) +
-        ProtoAdapter.INT32.encodedSizeWithTag(5, value.required_int32) +
-        ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(6, value.repeated_double) +
-        ForeignEnum.ADAPTER.encodedSizeWithTag(7, value.default_foreign_enum) +
-        ForeignEnum.ADAPTER.encodedSizeWithTag(8, value.no_default_foreign_enum) +
-        ProtoAdapter.STRING.encodedSizeWithTag(9, value.package_) +
-        ProtoAdapter.STRING.encodedSizeWithTag(10, value.result) +
-        ProtoAdapter.STRING.encodedSizeWithTag(11, value.other) +
-        ProtoAdapter.STRING.encodedSizeWithTag(12, value.o) +
-        value.unknownFields.size
+      override fun encodedSize(value: SimpleMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.optional_int32)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(2, value.optional_nested_msg)
+        size += ExternalMessage.ADAPTER.encodedSizeWithTag(3, value.optional_external_msg)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(4, value.default_nested_enum)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(5, value.required_int32)
+        size += ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(6, value.repeated_double)
+        size += ForeignEnum.ADAPTER.encodedSizeWithTag(7, value.default_foreign_enum)
+        size += ForeignEnum.ADAPTER.encodedSizeWithTag(8, value.no_default_foreign_enum)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(9, value.package_)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(10, value.result)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(11, value.other)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(12, value.o)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: SimpleMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.optional_int32)
@@ -349,8 +352,9 @@ class SimpleMessage(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      return unknownFields == other.unknownFields
-          && bb == other.bb
+      var result = unknownFields == other.unknownFields
+      result = result && (bb == other.bb)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -379,9 +383,11 @@ class SimpleMessage(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage.NestedMessage"
       ) {
-        override fun encodedSize(value: NestedMessage): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.bb) +
-          value.unknownFields.size
+        override fun encodedSize(value: NestedMessage): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.bb)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: NestedMessage) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.bb)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -37,9 +37,9 @@ class NestedVersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionOne) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -37,8 +37,9 @@ class NestedVersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionOne) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -67,9 +68,11 @@ class NestedVersionOne(
       NestedVersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionOne"
     ) {
-      override fun encodedSize(value: NestedVersionOne): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        value.unknownFields.size
+      override fun encodedSize(value: NestedVersionOne): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NestedVersionOne) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -66,14 +66,14 @@ class NestedVersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionTwo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (v2_i == other.v2_i)
-    result = result && (v2_s == other.v2_s)
-    result = result && (v2_f32 == other.v2_f32)
-    result = result && (v2_f64 == other.v2_f64)
-    result = result && (v2_rs == other.v2_rs)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (v2_i != other.v2_i) return false
+    if (v2_s != other.v2_s) return false
+    if (v2_f32 != other.v2_f32) return false
+    if (v2_f64 != other.v2_f64) return false
+    if (v2_rs != other.v2_rs) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -66,13 +66,14 @@ class NestedVersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionTwo) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && v2_i == other.v2_i
-        && v2_s == other.v2_s
-        && v2_f32 == other.v2_f32
-        && v2_f64 == other.v2_f64
-        && v2_rs == other.v2_rs
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (v2_i == other.v2_i)
+    result = result && (v2_s == other.v2_s)
+    result = result && (v2_f32 == other.v2_f32)
+    result = result && (v2_f64 == other.v2_f64)
+    result = result && (v2_rs == other.v2_rs)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -118,14 +119,16 @@ class NestedVersionTwo(
       NestedVersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionTwo"
     ) {
-      override fun encodedSize(value: NestedVersionTwo): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs) +
-        value.unknownFields.size
+      override fun encodedSize(value: NestedVersionTwo): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NestedVersionTwo) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -47,11 +47,11 @@ class VersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionOne) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (obj == other.obj)
-    result = result && (en == other.en)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (obj != other.obj) return false
+    if (en != other.en) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -47,10 +47,11 @@ class VersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionOne) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && obj == other.obj
-        && en == other.en
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (obj == other.obj)
+    result = result && (en == other.en)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -87,11 +88,13 @@ class VersionOne(
       VersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionOne"
     ) {
-      override fun encodedSize(value: VersionOne): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        NestedVersionOne.ADAPTER.encodedSizeWithTag(7, value.obj) +
-        EnumVersionOne.ADAPTER.encodedSizeWithTag(8, value.en) +
-        value.unknownFields.size
+      override fun encodedSize(value: VersionOne): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += NestedVersionOne.ADAPTER.encodedSizeWithTag(7, value.obj)
+        size += EnumVersionOne.ADAPTER.encodedSizeWithTag(8, value.en)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: VersionOne) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -76,16 +76,16 @@ class VersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionTwo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (v2_i == other.v2_i)
-    result = result && (v2_s == other.v2_s)
-    result = result && (v2_f32 == other.v2_f32)
-    result = result && (v2_f64 == other.v2_f64)
-    result = result && (v2_rs == other.v2_rs)
-    result = result && (obj == other.obj)
-    result = result && (en == other.en)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (v2_i != other.v2_i) return false
+    if (v2_s != other.v2_s) return false
+    if (v2_f32 != other.v2_f32) return false
+    if (v2_f64 != other.v2_f64) return false
+    if (v2_rs != other.v2_rs) return false
+    if (obj != other.obj) return false
+    if (en != other.en) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -76,15 +76,16 @@ class VersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionTwo) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && v2_i == other.v2_i
-        && v2_s == other.v2_s
-        && v2_f32 == other.v2_f32
-        && v2_f64 == other.v2_f64
-        && v2_rs == other.v2_rs
-        && obj == other.obj
-        && en == other.en
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (v2_i == other.v2_i)
+    result = result && (v2_s == other.v2_s)
+    result = result && (v2_f32 == other.v2_f32)
+    result = result && (v2_f64 == other.v2_f64)
+    result = result && (v2_rs == other.v2_rs)
+    result = result && (obj == other.obj)
+    result = result && (en == other.en)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -136,16 +137,18 @@ class VersionTwo(
       VersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionTwo"
     ) {
-      override fun encodedSize(value: VersionTwo): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs) +
-        NestedVersionTwo.ADAPTER.encodedSizeWithTag(7, value.obj) +
-        EnumVersionTwo.ADAPTER.encodedSizeWithTag(8, value.en) +
-        value.unknownFields.size
+      override fun encodedSize(value: VersionTwo): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs)
+        size += NestedVersionTwo.ADAPTER.encodedSizeWithTag(7, value.obj)
+        size += EnumVersionTwo.ADAPTER.encodedSizeWithTag(8, value.en)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: VersionTwo) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -46,9 +46,10 @@ class UsesAny(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UsesAny) return false
-    return unknownFields == other.unknownFields
-        && just_one == other.just_one
-        && many_anys == other.many_anys
+    var result = unknownFields == other.unknownFields
+    result = result && (just_one == other.just_one)
+    result = result && (many_anys == other.many_anys)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -82,10 +83,12 @@ class UsesAny(
       UsesAny::class, 
       "type.googleapis.com/squareup.protos.usesany.UsesAny"
     ) {
-      override fun encodedSize(value: UsesAny): Int = 
-        AnyMessage.ADAPTER.encodedSizeWithTag(1, value.just_one) +
-        AnyMessage.ADAPTER.asRepeated().encodedSizeWithTag(2, value.many_anys) +
-        value.unknownFields.size
+      override fun encodedSize(value: UsesAny): Int {
+        var size = value.unknownFields.size
+        size += AnyMessage.ADAPTER.encodedSizeWithTag(1, value.just_one)
+        size += AnyMessage.ADAPTER.asRepeated().encodedSizeWithTag(2, value.many_anys)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: UsesAny) {
         AnyMessage.ADAPTER.encodeWithTag(writer, 1, value.just_one)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -46,10 +46,10 @@ class UsesAny(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UsesAny) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (just_one == other.just_one)
-    result = result && (many_anys == other.many_anys)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (just_one != other.just_one) return false
+    if (many_anys != other.many_anys) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
@@ -100,14 +100,15 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && id == other.id
-        && email == other.email
-        && phones == other.phones
-        && aliases == other.aliases
-        && foo == other.foo
-        && bar == other.bar
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (id == other.id)
+    result = result && (email == other.email)
+    result = result && (phones == other.phones)
+    result = result && (aliases == other.aliases)
+    result = result && (foo == other.foo)
+    result = result && (bar == other.bar)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -156,18 +157,20 @@ class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos3.kotlin.person.Person"
     ) {
-      override fun encodedSize(value: Person): Int = 
+      override fun encodedSize(value: Person): Int {
+        var size = value.unknownFields.size
         if (value.name == "") 0
-        else ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
+        else size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         if (value.id == 0) 0
-        else ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
+        else size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
         if (value.email == "") 0
-        else ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phones) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases) +
-        ProtoAdapter.INT32.encodedSizeWithTag(6, value.foo) +
-        ProtoAdapter.STRING.encodedSizeWithTag(7, value.bar) +
-        value.unknownFields.size
+        else size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phones)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(6, value.foo)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(7, value.bar)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Person) {
         if (value.name != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -282,9 +285,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      return unknownFields == other.unknownFields
-          && number == other.number
-          && type == other.type
+      var result = unknownFields == other.unknownFields
+      result = result && (number == other.number)
+      result = result && (type == other.type)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -318,12 +322,14 @@ class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos3.kotlin.person.Person.PhoneNumber"
       ) {
-        override fun encodedSize(value: PhoneNumber): Int = 
+        override fun encodedSize(value: PhoneNumber): Int {
+          var size = value.unknownFields.size
           if (value.number == "") 0
-          else ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
+          else size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
           if (value.type == PhoneType.MOBILE) 0
-          else PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-          value.unknownFields.size
+          else size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: PhoneNumber) {
           if (value.number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
@@ -100,15 +100,15 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (id == other.id)
-    result = result && (email == other.email)
-    result = result && (phones == other.phones)
-    result = result && (aliases == other.aliases)
-    result = result && (foo == other.foo)
-    result = result && (bar == other.bar)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (id != other.id) return false
+    if (email != other.email) return false
+    if (phones != other.phones) return false
+    if (aliases != other.aliases) return false
+    if (foo != other.foo) return false
+    if (bar != other.bar) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -285,10 +285,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (number == other.number)
-      result = result && (type == other.type)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (number != other.number) return false
+      if (type != other.type) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos3/kotlin/person/Person.kt
@@ -159,12 +159,9 @@ class Person(
     ) {
       override fun encodedSize(value: Person): Int {
         var size = value.unknownFields.size
-        if (value.name == "") 0
-        else size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
-        if (value.id == 0) 0
-        else size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
-        if (value.email == "") 0
-        else size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        if (value.name != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        if (value.id != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        if (value.email != "") size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
         size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phones)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
         size += ProtoAdapter.INT32.encodedSizeWithTag(6, value.foo)
@@ -324,10 +321,9 @@ class Person(
       ) {
         override fun encodedSize(value: PhoneNumber): Int {
           var size = value.unknownFields.size
-          if (value.number == "") 0
-          else size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
-          if (value.type == PhoneType.MOBILE) 0
-          else size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          if (value.number != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
+          if (value.type != PhoneType.MOBILE) size += PhoneType.ADAPTER.encodedSizeWithTag(2,
+              value.type)
           return size
         }
 

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -44,10 +44,10 @@ class EmbeddedMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EmbeddedMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (inner_repeated_number == other.inner_repeated_number)
-    result = result && (inner_number_after == other.inner_number_after)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (inner_repeated_number != other.inner_repeated_number) return false
+    if (inner_number_after != other.inner_number_after) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -44,9 +44,10 @@ class EmbeddedMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EmbeddedMessage) return false
-    return unknownFields == other.unknownFields
-        && inner_repeated_number == other.inner_repeated_number
-        && inner_number_after == other.inner_number_after
+    var result = unknownFields == other.unknownFields
+    result = result && (inner_repeated_number == other.inner_repeated_number)
+    result = result && (inner_number_after == other.inner_number_after)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -81,10 +82,12 @@ class EmbeddedMessage(
       EmbeddedMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage"
     ) {
-      override fun encodedSize(value: EmbeddedMessage): Int = 
-        ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.inner_repeated_number) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.inner_number_after) +
-        value.unknownFields.size
+      override fun encodedSize(value: EmbeddedMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.inner_repeated_number)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.inner_number_after)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EmbeddedMessage) {
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.inner_repeated_number)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -42,10 +42,10 @@ class OuterMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OuterMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (outer_number_before == other.outer_number_before)
-    result = result && (embedded_message == other.embedded_message)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (outer_number_before != other.outer_number_before) return false
+    if (embedded_message != other.embedded_message) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -42,9 +42,10 @@ class OuterMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OuterMessage) return false
-    return unknownFields == other.unknownFields
-        && outer_number_before == other.outer_number_before
-        && embedded_message == other.embedded_message
+    var result = unknownFields == other.unknownFields
+    result = result && (outer_number_before == other.outer_number_before)
+    result = result && (embedded_message == other.embedded_message)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -78,10 +79,12 @@ class OuterMessage(
       OuterMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage"
     ) {
-      override fun encodedSize(value: OuterMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.outer_number_before) +
-        EmbeddedMessage.ADAPTER.encodedSizeWithTag(2, value.embedded_message) +
-        value.unknownFields.size
+      override fun encodedSize(value: OuterMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.outer_number_before)
+        size += EmbeddedMessage.ADAPTER.encodedSizeWithTag(2, value.embedded_message)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OuterMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.outer_number_before)

--- a/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -84,13 +84,13 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (id == other.id)
-    result = result && (email == other.email)
-    result = result && (phone == other.phone)
-    result = result && (aliases == other.aliases)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (id != other.id) return false
+    if (email != other.email) return false
+    if (phone != other.phone) return false
+    if (aliases != other.aliases) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -250,10 +250,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (number == other.number)
-      result = result && (type == other.type)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (number != other.number) return false
+      if (type != other.type) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -84,12 +84,13 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && id == other.id
-        && email == other.email
-        && phone == other.phone
-        && aliases == other.aliases
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (id == other.id)
+    result = result && (email == other.email)
+    result = result && (phone == other.phone)
+    result = result && (aliases == other.aliases)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -132,13 +133,15 @@ class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person"
     ) {
-      override fun encodedSize(value: Person): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases) +
-        value.unknownFields.size
+      override fun encodedSize(value: Person): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Person) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -247,9 +250,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      return unknownFields == other.unknownFields
-          && number == other.number
-          && type == other.type
+      var result = unknownFields == other.unknownFields
+      result = result && (number == other.number)
+      result = result && (type == other.type)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -286,10 +290,12 @@ class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
       ) {
-        override fun encodedSize(value: PhoneNumber): Int = 
-          ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
-          PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-          value.unknownFields.size
+        override fun encodedSize(value: PhoneNumber): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
+          size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: PhoneNumber) {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
@@ -67,10 +67,11 @@ class ModelEvaluation(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ModelEvaluation) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && score == other.score
-        && models == other.models
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (score == other.score)
+    result = result && (models == other.models)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -143,11 +144,13 @@ class ModelEvaluation(
       private val modelsAdapter: ProtoAdapter<Map<String, ModelEvaluation>> =
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ModelEvaluation.ADAPTER)
 
-      override fun encodedSize(value: ModelEvaluation): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(2, value.score) +
-        modelsAdapter.encodedSizeWithTag(3, value.models) +
-        value.unknownFields.size
+      override fun encodedSize(value: ModelEvaluation): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(2, value.score)
+        size += modelsAdapter.encodedSizeWithTag(3, value.models)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ModelEvaluation) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
@@ -67,11 +67,11 @@ class ModelEvaluation(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ModelEvaluation) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (score == other.score)
-    result = result && (models == other.models)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (score != other.score) return false
+    if (models != other.models) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
@@ -117,17 +117,18 @@ class DescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && field == other.field
-        && extension == other.extension
-        && nested_type == other.nested_type
-        && enum_type == other.enum_type
-        && extension_range == other.extension_range
-        && oneof_decl == other.oneof_decl
-        && options == other.options
-        && reserved_range == other.reserved_range
-        && reserved_name == other.reserved_name
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (field == other.field)
+    result = result && (extension == other.extension)
+    result = result && (nested_type == other.nested_type)
+    result = result && (enum_type == other.enum_type)
+    result = result && (extension_range == other.extension_range)
+    result = result && (oneof_decl == other.oneof_decl)
+    result = result && (options == other.options)
+    result = result && (reserved_range == other.reserved_range)
+    result = result && (reserved_name == other.reserved_name)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -294,18 +295,20 @@ class DescriptorProto(
       DescriptorProto::class, 
       "type.googleapis.com/google.protobuf.DescriptorProto"
     ) {
-      override fun encodedSize(value: DescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.field) +
-        FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.extension) +
-        DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(3, value.nested_type) +
-        EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.enum_type) +
-        ExtensionRange.ADAPTER.asRepeated().encodedSizeWithTag(5, value.extension_range) +
-        OneofDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(8, value.oneof_decl) +
-        MessageOptions.ADAPTER.encodedSizeWithTag(7, value.options) +
-        ReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(9, value.reserved_range) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(10, value.reserved_name) +
-        value.unknownFields.size
+      override fun encodedSize(value: DescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.field)
+        size += FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.extension)
+        size += DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(3, value.nested_type)
+        size += EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.enum_type)
+        size += ExtensionRange.ADAPTER.asRepeated().encodedSizeWithTag(5, value.extension_range)
+        size += OneofDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(8, value.oneof_decl)
+        size += MessageOptions.ADAPTER.encodedSizeWithTag(7, value.options)
+        size += ReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(9, value.reserved_range)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(10, value.reserved_name)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: DescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -415,10 +418,11 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ExtensionRange) return false
-      return unknownFields == other.unknownFields
-          && start == other.start
-          && end == other.end
-          && options == other.options
+      var result = unknownFields == other.unknownFields
+      result = result && (start == other.start)
+      result = result && (end == other.end)
+      result = result && (options == other.options)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -494,11 +498,13 @@ class DescriptorProto(
         ExtensionRange::class, 
         "type.googleapis.com/google.protobuf.DescriptorProto.ExtensionRange"
       ) {
-        override fun encodedSize(value: ExtensionRange): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.start) +
-          ProtoAdapter.INT32.encodedSizeWithTag(2, value.end) +
-          ExtensionRangeOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-          value.unknownFields.size
+        override fun encodedSize(value: ExtensionRange): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.start)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.end)
+          size += ExtensionRangeOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: ExtensionRange) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.start)
@@ -572,9 +578,10 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ReservedRange) return false
-      return unknownFields == other.unknownFields
-          && start == other.start
-          && end == other.end
+      var result = unknownFields == other.unknownFields
+      result = result && (start == other.start)
+      result = result && (end == other.end)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -638,10 +645,12 @@ class DescriptorProto(
         ReservedRange::class, 
         "type.googleapis.com/google.protobuf.DescriptorProto.ReservedRange"
       ) {
-        override fun encodedSize(value: ReservedRange): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.start) +
-          ProtoAdapter.INT32.encodedSizeWithTag(2, value.end) +
-          value.unknownFields.size
+        override fun encodedSize(value: ReservedRange): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.start)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.end)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: ReservedRange) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.start)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
@@ -117,18 +117,18 @@ class DescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (field == other.field)
-    result = result && (extension == other.extension)
-    result = result && (nested_type == other.nested_type)
-    result = result && (enum_type == other.enum_type)
-    result = result && (extension_range == other.extension_range)
-    result = result && (oneof_decl == other.oneof_decl)
-    result = result && (options == other.options)
-    result = result && (reserved_range == other.reserved_range)
-    result = result && (reserved_name == other.reserved_name)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (field != other.field) return false
+    if (extension != other.extension) return false
+    if (nested_type != other.nested_type) return false
+    if (enum_type != other.enum_type) return false
+    if (extension_range != other.extension_range) return false
+    if (oneof_decl != other.oneof_decl) return false
+    if (options != other.options) return false
+    if (reserved_range != other.reserved_range) return false
+    if (reserved_name != other.reserved_name) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -418,11 +418,11 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ExtensionRange) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (start == other.start)
-      result = result && (end == other.end)
-      result = result && (options == other.options)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (start != other.start) return false
+      if (end != other.end) return false
+      if (options != other.options) return false
+      return true
     }
 
     override fun hashCode(): Int {
@@ -578,10 +578,10 @@ class DescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is ReservedRange) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (start == other.start)
-      result = result && (end == other.end)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (start != other.start) return false
+      if (end != other.end) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
@@ -82,13 +82,13 @@ class EnumDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (value == other.value)
-    result = result && (options == other.options)
-    result = result && (reserved_range == other.reserved_range)
-    result = result && (reserved_name == other.reserved_name)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (value != other.value) return false
+    if (options != other.options) return false
+    if (reserved_range != other.reserved_range) return false
+    if (reserved_name != other.reserved_name) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -289,10 +289,10 @@ class EnumDescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is EnumReservedRange) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (start == other.start)
-      result = result && (end == other.end)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (start != other.start) return false
+      if (end != other.end) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
@@ -82,12 +82,13 @@ class EnumDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && value == other.value
-        && options == other.options
-        && reserved_range == other.reserved_range
-        && reserved_name == other.reserved_name
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (value == other.value)
+    result = result && (options == other.options)
+    result = result && (reserved_range == other.reserved_range)
+    result = result && (reserved_name == other.reserved_name)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -194,13 +195,15 @@ class EnumDescriptorProto(
       EnumDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.EnumDescriptorProto"
     ) {
-      override fun encodedSize(value: EnumDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        EnumValueDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.value) +
-        EnumOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-        EnumReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(4, value.reserved_range) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.reserved_name) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += EnumValueDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.value)
+        size += EnumOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+        size += EnumReservedRange.ADAPTER.asRepeated().encodedSizeWithTag(4, value.reserved_range)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.reserved_name)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -286,9 +289,10 @@ class EnumDescriptorProto(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is EnumReservedRange) return false
-      return unknownFields == other.unknownFields
-          && start == other.start
-          && end == other.end
+      var result = unknownFields == other.unknownFields
+      result = result && (start == other.start)
+      result = result && (end == other.end)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -352,10 +356,12 @@ class EnumDescriptorProto(
         EnumReservedRange::class, 
         "type.googleapis.com/google.protobuf.EnumDescriptorProto.EnumReservedRange"
       ) {
-        override fun encodedSize(value: EnumReservedRange): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.start) +
-          ProtoAdapter.INT32.encodedSizeWithTag(2, value.end) +
-          value.unknownFields.size
+        override fun encodedSize(value: EnumReservedRange): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.start)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.end)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: EnumReservedRange) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.start)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
@@ -66,10 +66,11 @@ class EnumOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumOptions) return false
-    return unknownFields == other.unknownFields
-        && allow_alias == other.allow_alias
-        && deprecated == other.deprecated
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (allow_alias == other.allow_alias)
+    result = result && (deprecated == other.deprecated)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -156,12 +157,14 @@ class EnumOptions(
       EnumOptions::class, 
       "type.googleapis.com/google.protobuf.EnumOptions"
     ) {
-      override fun encodedSize(value: EnumOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(2, value.allow_alias) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.allow_alias)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 2, value.allow_alias)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
@@ -66,11 +66,11 @@ class EnumOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (allow_alias == other.allow_alias)
-    result = result && (deprecated == other.deprecated)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (allow_alias != other.allow_alias) return false
+    if (deprecated != other.deprecated) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
@@ -53,10 +53,11 @@ class EnumValueDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && number == other.number
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (number == other.number)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -128,11 +129,13 @@ class EnumValueDescriptorProto(
       EnumValueDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.EnumValueDescriptorProto"
     ) {
-      override fun encodedSize(value: EnumValueDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.number) +
-        EnumValueOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumValueDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.number)
+        size += EnumValueOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumValueDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueDescriptorProto.kt
@@ -53,11 +53,11 @@ class EnumValueDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (number == other.number)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (number != other.number) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
@@ -65,11 +65,11 @@ class EnumValueOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (deprecated == other.deprecated)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    result = result && (foreign_enum_value_option == other.foreign_enum_value_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (deprecated != other.deprecated) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    if (foreign_enum_value_option != other.foreign_enum_value_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
@@ -65,10 +65,11 @@ class EnumValueOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EnumValueOptions) return false
-    return unknownFields == other.unknownFields
-        && deprecated == other.deprecated
-        && uninterpreted_option == other.uninterpreted_option
-        && foreign_enum_value_option == other.foreign_enum_value_option
+    var result = unknownFields == other.unknownFields
+    result = result && (deprecated == other.deprecated)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    result = result && (foreign_enum_value_option == other.foreign_enum_value_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -153,12 +154,14 @@ class EnumValueOptions(
       EnumValueOptions::class, 
       "type.googleapis.com/google.protobuf.EnumValueOptions"
     ) {
-      override fun encodedSize(value: EnumValueOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(1, value.deprecated) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(70002, value.foreign_enum_value_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: EnumValueOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.deprecated)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(70002, value.foreign_enum_value_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EnumValueOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.deprecated)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
@@ -41,8 +41,9 @@ class ExtensionRangeOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExtensionRangeOptions) return false
-    return unknownFields == other.unknownFields
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -92,10 +93,12 @@ class ExtensionRangeOptions(
       ExtensionRangeOptions::class, 
       "type.googleapis.com/google.protobuf.ExtensionRangeOptions"
     ) {
-      override fun encodedSize(value: ExtensionRangeOptions): Int = 
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: ExtensionRangeOptions): Int {
+        var size = value.unknownFields.size
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ExtensionRangeOptions) {
         UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999,

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
@@ -41,9 +41,9 @@ class ExtensionRangeOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExtensionRangeOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
@@ -137,18 +137,18 @@ class FieldDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (number == other.number)
-    result = result && (label == other.label)
-    result = result && (type == other.type)
-    result = result && (type_name == other.type_name)
-    result = result && (extendee == other.extendee)
-    result = result && (default_value == other.default_value)
-    result = result && (oneof_index == other.oneof_index)
-    result = result && (json_name == other.json_name)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (number != other.number) return false
+    if (label != other.label) return false
+    if (type != other.type) return false
+    if (type_name != other.type_name) return false
+    if (extendee != other.extendee) return false
+    if (default_value != other.default_value) return false
+    if (oneof_index != other.oneof_index) return false
+    if (json_name != other.json_name) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldDescriptorProto.kt
@@ -137,17 +137,18 @@ class FieldDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && number == other.number
-        && label == other.label
-        && type == other.type
-        && type_name == other.type_name
-        && extendee == other.extendee
-        && default_value == other.default_value
-        && oneof_index == other.oneof_index
-        && json_name == other.json_name
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (number == other.number)
+    result = result && (label == other.label)
+    result = result && (type == other.type)
+    result = result && (type_name == other.type_name)
+    result = result && (extendee == other.extendee)
+    result = result && (default_value == other.default_value)
+    result = result && (oneof_index == other.oneof_index)
+    result = result && (json_name == other.json_name)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -334,18 +335,20 @@ class FieldDescriptorProto(
       FieldDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.FieldDescriptorProto"
     ) {
-      override fun encodedSize(value: FieldDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(3, value.number) +
-        Label.ADAPTER.encodedSizeWithTag(4, value.label) +
-        Type.ADAPTER.encodedSizeWithTag(5, value.type) +
-        ProtoAdapter.STRING.encodedSizeWithTag(6, value.type_name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.extendee) +
-        ProtoAdapter.STRING.encodedSizeWithTag(7, value.default_value) +
-        ProtoAdapter.INT32.encodedSizeWithTag(9, value.oneof_index) +
-        ProtoAdapter.STRING.encodedSizeWithTag(10, value.json_name) +
-        FieldOptions.ADAPTER.encodedSizeWithTag(8, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: FieldDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(3, value.number)
+        size += Label.ADAPTER.encodedSizeWithTag(4, value.label)
+        size += Type.ADAPTER.encodedSizeWithTag(5, value.type)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(6, value.type_name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.extendee)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(7, value.default_value)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(9, value.oneof_index)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(10, value.json_name)
+        size += FieldOptions.ADAPTER.encodedSizeWithTag(8, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FieldDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
@@ -163,15 +163,16 @@ class FieldOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldOptions) return false
-    return unknownFields == other.unknownFields
-        && ctype == other.ctype
-        && packed == other.packed
-        && jstype == other.jstype
-        && lazy == other.lazy
-        && deprecated == other.deprecated
-        && weak == other.weak
-        && uninterpreted_option == other.uninterpreted_option
-        && redacted == other.redacted
+    var result = unknownFields == other.unknownFields
+    result = result && (ctype == other.ctype)
+    result = result && (packed == other.packed)
+    result = result && (jstype == other.jstype)
+    result = result && (lazy == other.lazy)
+    result = result && (deprecated == other.deprecated)
+    result = result && (weak == other.weak)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    result = result && (redacted == other.redacted)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -387,17 +388,19 @@ class FieldOptions(
       FieldOptions::class, 
       "type.googleapis.com/google.protobuf.FieldOptions"
     ) {
-      override fun encodedSize(value: FieldOptions): Int = 
-        CType.ADAPTER.encodedSizeWithTag(1, value.ctype) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(2, value.packed) +
-        JSType.ADAPTER.encodedSizeWithTag(6, value.jstype) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(5, value.lazy) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(10, value.weak) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(22300, value.redacted) +
-        value.unknownFields.size
+      override fun encodedSize(value: FieldOptions): Int {
+        var size = value.unknownFields.size
+        size += CType.ADAPTER.encodedSizeWithTag(1, value.ctype)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.packed)
+        size += JSType.ADAPTER.encodedSizeWithTag(6, value.jstype)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(5, value.lazy)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(10, value.weak)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(22300, value.redacted)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FieldOptions) {
         CType.ADAPTER.encodeWithTag(writer, 1, value.ctype)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
@@ -163,16 +163,16 @@ class FieldOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FieldOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (ctype == other.ctype)
-    result = result && (packed == other.packed)
-    result = result && (jstype == other.jstype)
-    result = result && (lazy == other.lazy)
-    result = result && (deprecated == other.deprecated)
-    result = result && (weak == other.weak)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    result = result && (redacted == other.redacted)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (ctype != other.ctype) return false
+    if (packed != other.packed) return false
+    if (jstype != other.jstype) return false
+    if (lazy != other.lazy) return false
+    if (deprecated != other.deprecated) return false
+    if (weak != other.weak) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    if (redacted != other.redacted) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
@@ -156,19 +156,20 @@ class FileDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && package_ == other.package_
-        && dependency == other.dependency
-        && public_dependency == other.public_dependency
-        && weak_dependency == other.weak_dependency
-        && message_type == other.message_type
-        && enum_type == other.enum_type
-        && service == other.service
-        && extension == other.extension
-        && options == other.options
-        && source_code_info == other.source_code_info
-        && syntax == other.syntax
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (package_ == other.package_)
+    result = result && (dependency == other.dependency)
+    result = result && (public_dependency == other.public_dependency)
+    result = result && (weak_dependency == other.weak_dependency)
+    result = result && (message_type == other.message_type)
+    result = result && (enum_type == other.enum_type)
+    result = result && (service == other.service)
+    result = result && (extension == other.extension)
+    result = result && (options == other.options)
+    result = result && (source_code_info == other.source_code_info)
+    result = result && (syntax == other.syntax)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -384,20 +385,22 @@ class FileDescriptorProto(
       FileDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.FileDescriptorProto"
     ) {
-      override fun encodedSize(value: FileDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.package_) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(3, value.dependency) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(10, value.public_dependency) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(11, value.weak_dependency) +
-        DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.message_type) +
-        EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(5, value.enum_type) +
-        ServiceDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.service) +
-        FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(7, value.extension) +
-        FileOptions.ADAPTER.encodedSizeWithTag(8, value.options) +
-        SourceCodeInfo.ADAPTER.encodedSizeWithTag(9, value.source_code_info) +
-        ProtoAdapter.STRING.encodedSizeWithTag(12, value.syntax) +
-        value.unknownFields.size
+      override fun encodedSize(value: FileDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.package_)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(3, value.dependency)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(10, value.public_dependency)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(11, value.weak_dependency)
+        size += DescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(4, value.message_type)
+        size += EnumDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(5, value.enum_type)
+        size += ServiceDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(6, value.service)
+        size += FieldDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(7, value.extension)
+        size += FileOptions.ADAPTER.encodedSizeWithTag(8, value.options)
+        size += SourceCodeInfo.ADAPTER.encodedSizeWithTag(9, value.source_code_info)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(12, value.syntax)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FileDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
@@ -156,20 +156,20 @@ class FileDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (package_ == other.package_)
-    result = result && (dependency == other.dependency)
-    result = result && (public_dependency == other.public_dependency)
-    result = result && (weak_dependency == other.weak_dependency)
-    result = result && (message_type == other.message_type)
-    result = result && (enum_type == other.enum_type)
-    result = result && (service == other.service)
-    result = result && (extension == other.extension)
-    result = result && (options == other.options)
-    result = result && (source_code_info == other.source_code_info)
-    result = result && (syntax == other.syntax)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (package_ != other.package_) return false
+    if (dependency != other.dependency) return false
+    if (public_dependency != other.public_dependency) return false
+    if (weak_dependency != other.weak_dependency) return false
+    if (message_type != other.message_type) return false
+    if (enum_type != other.enum_type) return false
+    if (service != other.service) return false
+    if (extension != other.extension) return false
+    if (options != other.options) return false
+    if (source_code_info != other.source_code_info) return false
+    if (syntax != other.syntax) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
@@ -42,8 +42,9 @@ class FileDescriptorSet(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorSet) return false
-    return unknownFields == other.unknownFields
-        && file == other.file
+    var result = unknownFields == other.unknownFields
+    result = result && (file == other.file)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -88,9 +89,11 @@ class FileDescriptorSet(
       FileDescriptorSet::class, 
       "type.googleapis.com/google.protobuf.FileDescriptorSet"
     ) {
-      override fun encodedSize(value: FileDescriptorSet): Int = 
-        FileDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(1, value.file) +
-        value.unknownFields.size
+      override fun encodedSize(value: FileDescriptorSet): Int {
+        var size = value.unknownFields.size
+        size += FileDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(1, value.file)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FileDescriptorSet) {
         FileDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.file)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
@@ -42,9 +42,9 @@ class FileDescriptorSet(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileDescriptorSet) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (file == other.file)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (file != other.file) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileOptions.kt
@@ -314,28 +314,29 @@ class FileOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileOptions) return false
-    return unknownFields == other.unknownFields
-        && java_package == other.java_package
-        && java_outer_classname == other.java_outer_classname
-        && java_multiple_files == other.java_multiple_files
-        && java_generate_equals_and_hash == other.java_generate_equals_and_hash
-        && java_string_check_utf8 == other.java_string_check_utf8
-        && optimize_for == other.optimize_for
-        && go_package == other.go_package
-        && cc_generic_services == other.cc_generic_services
-        && java_generic_services == other.java_generic_services
-        && py_generic_services == other.py_generic_services
-        && php_generic_services == other.php_generic_services
-        && deprecated == other.deprecated
-        && cc_enable_arenas == other.cc_enable_arenas
-        && objc_class_prefix == other.objc_class_prefix
-        && csharp_namespace == other.csharp_namespace
-        && swift_prefix == other.swift_prefix
-        && php_class_prefix == other.php_class_prefix
-        && php_namespace == other.php_namespace
-        && php_metadata_namespace == other.php_metadata_namespace
-        && ruby_package == other.ruby_package
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (java_package == other.java_package)
+    result = result && (java_outer_classname == other.java_outer_classname)
+    result = result && (java_multiple_files == other.java_multiple_files)
+    result = result && (java_generate_equals_and_hash == other.java_generate_equals_and_hash)
+    result = result && (java_string_check_utf8 == other.java_string_check_utf8)
+    result = result && (optimize_for == other.optimize_for)
+    result = result && (go_package == other.go_package)
+    result = result && (cc_generic_services == other.cc_generic_services)
+    result = result && (java_generic_services == other.java_generic_services)
+    result = result && (py_generic_services == other.py_generic_services)
+    result = result && (php_generic_services == other.php_generic_services)
+    result = result && (deprecated == other.deprecated)
+    result = result && (cc_enable_arenas == other.cc_enable_arenas)
+    result = result && (objc_class_prefix == other.objc_class_prefix)
+    result = result && (csharp_namespace == other.csharp_namespace)
+    result = result && (swift_prefix == other.swift_prefix)
+    result = result && (php_class_prefix == other.php_class_prefix)
+    result = result && (php_namespace == other.php_namespace)
+    result = result && (php_metadata_namespace == other.php_metadata_namespace)
+    result = result && (ruby_package == other.ruby_package)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -749,30 +750,32 @@ class FileOptions(
       FileOptions::class, 
       "type.googleapis.com/google.protobuf.FileOptions"
     ) {
-      override fun encodedSize(value: FileOptions): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.java_package) +
-        ProtoAdapter.STRING.encodedSizeWithTag(8, value.java_outer_classname) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(10, value.java_multiple_files) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(20, value.java_generate_equals_and_hash) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(27, value.java_string_check_utf8) +
-        OptimizeMode.ADAPTER.encodedSizeWithTag(9, value.optimize_for) +
-        ProtoAdapter.STRING.encodedSizeWithTag(11, value.go_package) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(16, value.cc_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(17, value.java_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(18, value.py_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(42, value.php_generic_services) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(23, value.deprecated) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(31, value.cc_enable_arenas) +
-        ProtoAdapter.STRING.encodedSizeWithTag(36, value.objc_class_prefix) +
-        ProtoAdapter.STRING.encodedSizeWithTag(37, value.csharp_namespace) +
-        ProtoAdapter.STRING.encodedSizeWithTag(39, value.swift_prefix) +
-        ProtoAdapter.STRING.encodedSizeWithTag(40, value.php_class_prefix) +
-        ProtoAdapter.STRING.encodedSizeWithTag(41, value.php_namespace) +
-        ProtoAdapter.STRING.encodedSizeWithTag(44, value.php_metadata_namespace) +
-        ProtoAdapter.STRING.encodedSizeWithTag(45, value.ruby_package) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: FileOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.java_package)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(8, value.java_outer_classname)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(10, value.java_multiple_files)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(20, value.java_generate_equals_and_hash)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(27, value.java_string_check_utf8)
+        size += OptimizeMode.ADAPTER.encodedSizeWithTag(9, value.optimize_for)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(11, value.go_package)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(16, value.cc_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(17, value.java_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(18, value.py_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(42, value.php_generic_services)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(23, value.deprecated)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(31, value.cc_enable_arenas)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(36, value.objc_class_prefix)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(37, value.csharp_namespace)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(39, value.swift_prefix)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(40, value.php_class_prefix)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(41, value.php_namespace)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(44, value.php_metadata_namespace)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(45, value.ruby_package)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: FileOptions) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.java_package)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileOptions.kt
@@ -314,29 +314,29 @@ class FileOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is FileOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (java_package == other.java_package)
-    result = result && (java_outer_classname == other.java_outer_classname)
-    result = result && (java_multiple_files == other.java_multiple_files)
-    result = result && (java_generate_equals_and_hash == other.java_generate_equals_and_hash)
-    result = result && (java_string_check_utf8 == other.java_string_check_utf8)
-    result = result && (optimize_for == other.optimize_for)
-    result = result && (go_package == other.go_package)
-    result = result && (cc_generic_services == other.cc_generic_services)
-    result = result && (java_generic_services == other.java_generic_services)
-    result = result && (py_generic_services == other.py_generic_services)
-    result = result && (php_generic_services == other.php_generic_services)
-    result = result && (deprecated == other.deprecated)
-    result = result && (cc_enable_arenas == other.cc_enable_arenas)
-    result = result && (objc_class_prefix == other.objc_class_prefix)
-    result = result && (csharp_namespace == other.csharp_namespace)
-    result = result && (swift_prefix == other.swift_prefix)
-    result = result && (php_class_prefix == other.php_class_prefix)
-    result = result && (php_namespace == other.php_namespace)
-    result = result && (php_metadata_namespace == other.php_metadata_namespace)
-    result = result && (ruby_package == other.ruby_package)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (java_package != other.java_package) return false
+    if (java_outer_classname != other.java_outer_classname) return false
+    if (java_multiple_files != other.java_multiple_files) return false
+    if (java_generate_equals_and_hash != other.java_generate_equals_and_hash) return false
+    if (java_string_check_utf8 != other.java_string_check_utf8) return false
+    if (optimize_for != other.optimize_for) return false
+    if (go_package != other.go_package) return false
+    if (cc_generic_services != other.cc_generic_services) return false
+    if (java_generic_services != other.java_generic_services) return false
+    if (py_generic_services != other.py_generic_services) return false
+    if (php_generic_services != other.php_generic_services) return false
+    if (deprecated != other.deprecated) return false
+    if (cc_enable_arenas != other.cc_enable_arenas) return false
+    if (objc_class_prefix != other.objc_class_prefix) return false
+    if (csharp_namespace != other.csharp_namespace) return false
+    if (swift_prefix != other.swift_prefix) return false
+    if (php_class_prefix != other.php_class_prefix) return false
+    if (php_namespace != other.php_namespace) return false
+    if (php_metadata_namespace != other.php_metadata_namespace) return false
+    if (ruby_package != other.ruby_package) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
@@ -49,9 +49,9 @@ class GeneratedCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is GeneratedCodeInfo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (annotation == other.annotation)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (annotation != other.annotation) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -189,12 +189,12 @@ class GeneratedCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Annotation) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (path == other.path)
-      result = result && (source_file == other.source_file)
-      result = result && (begin == other.begin)
-      result = result && (end == other.end)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (path != other.path) return false
+      if (source_file != other.source_file) return false
+      if (begin != other.begin) return false
+      if (end != other.end) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
@@ -49,8 +49,9 @@ class GeneratedCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is GeneratedCodeInfo) return false
-    return unknownFields == other.unknownFields
-        && annotation == other.annotation
+    var result = unknownFields == other.unknownFields
+    result = result && (annotation == other.annotation)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -99,9 +100,11 @@ class GeneratedCodeInfo(
       GeneratedCodeInfo::class, 
       "type.googleapis.com/google.protobuf.GeneratedCodeInfo"
     ) {
-      override fun encodedSize(value: GeneratedCodeInfo): Int = 
-        Annotation.ADAPTER.asRepeated().encodedSizeWithTag(1, value.annotation) +
-        value.unknownFields.size
+      override fun encodedSize(value: GeneratedCodeInfo): Int {
+        var size = value.unknownFields.size
+        size += Annotation.ADAPTER.asRepeated().encodedSizeWithTag(1, value.annotation)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: GeneratedCodeInfo) {
         Annotation.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.annotation)
@@ -186,11 +189,12 @@ class GeneratedCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Annotation) return false
-      return unknownFields == other.unknownFields
-          && path == other.path
-          && source_file == other.source_file
-          && begin == other.begin
-          && end == other.end
+      var result = unknownFields == other.unknownFields
+      result = result && (path == other.path)
+      result = result && (source_file == other.source_file)
+      result = result && (begin == other.begin)
+      result = result && (end == other.end)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -289,12 +293,14 @@ class GeneratedCodeInfo(
         Annotation::class, 
         "type.googleapis.com/google.protobuf.GeneratedCodeInfo.Annotation"
       ) {
-        override fun encodedSize(value: Annotation): Int = 
-          ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path) +
-          ProtoAdapter.STRING.encodedSizeWithTag(2, value.source_file) +
-          ProtoAdapter.INT32.encodedSizeWithTag(3, value.begin) +
-          ProtoAdapter.INT32.encodedSizeWithTag(4, value.end) +
-          value.unknownFields.size
+        override fun encodedSize(value: Annotation): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path)
+          size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.source_file)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(3, value.begin)
+          size += ProtoAdapter.INT32.encodedSizeWithTag(4, value.end)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: Annotation) {
           ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.path)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
@@ -135,13 +135,14 @@ class MessageOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageOptions) return false
-    return unknownFields == other.unknownFields
-        && message_set_wire_format == other.message_set_wire_format
-        && no_standard_descriptor_accessor == other.no_standard_descriptor_accessor
-        && deprecated == other.deprecated
-        && map_entry == other.map_entry
-        && uninterpreted_option == other.uninterpreted_option
-        && foreign_message_option == other.foreign_message_option
+    var result = unknownFields == other.unknownFields
+    result = result && (message_set_wire_format == other.message_set_wire_format)
+    result = result && (no_standard_descriptor_accessor == other.no_standard_descriptor_accessor)
+    result = result && (deprecated == other.deprecated)
+    result = result && (map_entry == other.map_entry)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    result = result && (foreign_message_option == other.foreign_message_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -316,15 +317,17 @@ class MessageOptions(
       MessageOptions::class, 
       "type.googleapis.com/google.protobuf.MessageOptions"
     ) {
-      override fun encodedSize(value: MessageOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(1, value.message_set_wire_format) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(2, value.no_standard_descriptor_accessor) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(7, value.map_entry) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        ForeignMessage.ADAPTER.encodedSizeWithTag(50007, value.foreign_message_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: MessageOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.message_set_wire_format)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.no_standard_descriptor_accessor)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(3, value.deprecated)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(7, value.map_entry)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        size += ForeignMessage.ADAPTER.encodedSizeWithTag(50007, value.foreign_message_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MessageOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.message_set_wire_format)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
@@ -135,14 +135,14 @@ class MessageOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (message_set_wire_format == other.message_set_wire_format)
-    result = result && (no_standard_descriptor_accessor == other.no_standard_descriptor_accessor)
-    result = result && (deprecated == other.deprecated)
-    result = result && (map_entry == other.map_entry)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    result = result && (foreign_message_option == other.foreign_message_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (message_set_wire_format != other.message_set_wire_format) return false
+    if (no_standard_descriptor_accessor != other.no_standard_descriptor_accessor) return false
+    if (deprecated != other.deprecated) return false
+    if (map_entry != other.map_entry) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    if (foreign_message_option != other.foreign_message_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
@@ -84,13 +84,14 @@ class MethodDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && input_type == other.input_type
-        && output_type == other.output_type
-        && options == other.options
-        && client_streaming == other.client_streaming
-        && server_streaming == other.server_streaming
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (input_type == other.input_type)
+    result = result && (output_type == other.output_type)
+    result = result && (options == other.options)
+    result = result && (client_streaming == other.client_streaming)
+    result = result && (server_streaming == other.server_streaming)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -211,14 +212,16 @@ class MethodDescriptorProto(
       MethodDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.MethodDescriptorProto"
     ) {
-      override fun encodedSize(value: MethodDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.input_type) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.output_type) +
-        MethodOptions.ADAPTER.encodedSizeWithTag(4, value.options) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(5, value.client_streaming) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(6, value.server_streaming) +
-        value.unknownFields.size
+      override fun encodedSize(value: MethodDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.input_type)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.output_type)
+        size += MethodOptions.ADAPTER.encodedSizeWithTag(4, value.options)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(5, value.client_streaming)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(6, value.server_streaming)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MethodDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodDescriptorProto.kt
@@ -84,14 +84,14 @@ class MethodDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (input_type == other.input_type)
-    result = result && (output_type == other.output_type)
-    result = result && (options == other.options)
-    result = result && (client_streaming == other.client_streaming)
-    result = result && (server_streaming == other.server_streaming)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (input_type != other.input_type) return false
+    if (output_type != other.output_type) return false
+    if (options != other.options) return false
+    if (client_streaming != other.client_streaming) return false
+    if (server_streaming != other.server_streaming) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
@@ -69,10 +69,11 @@ class MethodOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodOptions) return false
-    return unknownFields == other.unknownFields
-        && deprecated == other.deprecated
-        && idempotency_level == other.idempotency_level
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (deprecated == other.deprecated)
+    result = result && (idempotency_level == other.idempotency_level)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -163,12 +164,14 @@ class MethodOptions(
       MethodOptions::class, 
       "type.googleapis.com/google.protobuf.MethodOptions"
     ) {
-      override fun encodedSize(value: MethodOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated) +
-        IdempotencyLevel.ADAPTER.encodedSizeWithTag(34, value.idempotency_level) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: MethodOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated)
+        size += IdempotencyLevel.ADAPTER.encodedSizeWithTag(34, value.idempotency_level)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MethodOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
@@ -69,11 +69,11 @@ class MethodOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MethodOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (deprecated == other.deprecated)
-    result = result && (idempotency_level == other.idempotency_level)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (deprecated != other.deprecated) return false
+    if (idempotency_level != other.idempotency_level) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
@@ -46,9 +46,10 @@ class OneofDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -106,10 +107,12 @@ class OneofDescriptorProto(
       OneofDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.OneofDescriptorProto"
     ) {
-      override fun encodedSize(value: OneofDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        OneofOptions.ADAPTER.encodedSizeWithTag(2, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneofDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += OneofOptions.ADAPTER.encodedSizeWithTag(2, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneofDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofDescriptorProto.kt
@@ -46,10 +46,10 @@ class OneofDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
@@ -41,9 +41,9 @@ class OneofOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
@@ -41,8 +41,9 @@ class OneofOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneofOptions) return false
-    return unknownFields == other.unknownFields
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -92,10 +93,12 @@ class OneofOptions(
       OneofOptions::class, 
       "type.googleapis.com/google.protobuf.OneofOptions"
     ) {
-      override fun encodedSize(value: OneofOptions): Int = 
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneofOptions): Int {
+        var size = value.unknownFields.size
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneofOptions) {
         UninterpretedOption.ADAPTER.asRepeated().encodeWithTag(writer, 999,

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
@@ -57,11 +57,11 @@ class ServiceDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceDescriptorProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (method == other.method)
-    result = result && (options == other.options)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (method != other.method) return false
+    if (options != other.options) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
@@ -57,10 +57,11 @@ class ServiceDescriptorProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceDescriptorProto) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && method == other.method
-        && options == other.options
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (method == other.method)
+    result = result && (options == other.options)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -132,11 +133,13 @@ class ServiceDescriptorProto(
       ServiceDescriptorProto::class, 
       "type.googleapis.com/google.protobuf.ServiceDescriptorProto"
     ) {
-      override fun encodedSize(value: ServiceDescriptorProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        MethodDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.method) +
-        ServiceOptions.ADAPTER.encodedSizeWithTag(3, value.options) +
-        value.unknownFields.size
+      override fun encodedSize(value: ServiceDescriptorProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += MethodDescriptorProto.ADAPTER.asRepeated().encodedSizeWithTag(2, value.method)
+        size += ServiceOptions.ADAPTER.encodedSizeWithTag(3, value.options)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ServiceDescriptorProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
@@ -59,9 +59,10 @@ class ServiceOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceOptions) return false
-    return unknownFields == other.unknownFields
-        && deprecated == other.deprecated
-        && uninterpreted_option == other.uninterpreted_option
+    var result = unknownFields == other.unknownFields
+    result = result && (deprecated == other.deprecated)
+    result = result && (uninterpreted_option == other.uninterpreted_option)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -136,11 +137,13 @@ class ServiceOptions(
       ServiceOptions::class, 
       "type.googleapis.com/google.protobuf.ServiceOptions"
     ) {
-      override fun encodedSize(value: ServiceOptions): Int = 
-        ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated) +
-        UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
-            value.uninterpreted_option) +
-        value.unknownFields.size
+      override fun encodedSize(value: ServiceOptions): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(33, value.deprecated)
+        size += UninterpretedOption.ADAPTER.asRepeated().encodedSizeWithTag(999,
+            value.uninterpreted_option)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ServiceOptions) {
         ProtoAdapter.BOOL.encodeWithTag(writer, 33, value.deprecated)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
@@ -59,10 +59,10 @@ class ServiceOptions(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ServiceOptions) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (deprecated == other.deprecated)
-    result = result && (uninterpreted_option == other.uninterpreted_option)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (deprecated != other.deprecated) return false
+    if (uninterpreted_option != other.uninterpreted_option) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
@@ -91,9 +91,9 @@ class SourceCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SourceCodeInfo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (location == other.location)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (location != other.location) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -346,13 +346,13 @@ class SourceCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Location) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (path == other.path)
-      result = result && (span == other.span)
-      result = result && (leading_comments == other.leading_comments)
-      result = result && (trailing_comments == other.trailing_comments)
-      result = result && (leading_detached_comments == other.leading_detached_comments)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (path != other.path) return false
+      if (span != other.span) return false
+      if (leading_comments != other.leading_comments) return false
+      if (trailing_comments != other.trailing_comments) return false
+      if (leading_detached_comments != other.leading_detached_comments) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
@@ -91,8 +91,9 @@ class SourceCodeInfo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SourceCodeInfo) return false
-    return unknownFields == other.unknownFields
-        && location == other.location
+    var result = unknownFields == other.unknownFields
+    result = result && (location == other.location)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -182,9 +183,11 @@ class SourceCodeInfo(
       SourceCodeInfo::class, 
       "type.googleapis.com/google.protobuf.SourceCodeInfo"
     ) {
-      override fun encodedSize(value: SourceCodeInfo): Int = 
-        Location.ADAPTER.asRepeated().encodedSizeWithTag(1, value.location) +
-        value.unknownFields.size
+      override fun encodedSize(value: SourceCodeInfo): Int {
+        var size = value.unknownFields.size
+        size += Location.ADAPTER.asRepeated().encodedSizeWithTag(1, value.location)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: SourceCodeInfo) {
         Location.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.location)
@@ -343,12 +346,13 @@ class SourceCodeInfo(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is Location) return false
-      return unknownFields == other.unknownFields
-          && path == other.path
-          && span == other.span
-          && leading_comments == other.leading_comments
-          && trailing_comments == other.trailing_comments
-          && leading_detached_comments == other.leading_detached_comments
+      var result = unknownFields == other.unknownFields
+      result = result && (path == other.path)
+      result = result && (span == other.span)
+      result = result && (leading_comments == other.leading_comments)
+      result = result && (trailing_comments == other.trailing_comments)
+      result = result && (leading_detached_comments == other.leading_detached_comments)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -529,13 +533,16 @@ class SourceCodeInfo(
         Location::class, 
         "type.googleapis.com/google.protobuf.SourceCodeInfo.Location"
       ) {
-        override fun encodedSize(value: Location): Int = 
-          ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path) +
-          ProtoAdapter.INT32.asPacked().encodedSizeWithTag(2, value.span) +
-          ProtoAdapter.STRING.encodedSizeWithTag(3, value.leading_comments) +
-          ProtoAdapter.STRING.encodedSizeWithTag(4, value.trailing_comments) +
-          ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.leading_detached_comments) +
-          value.unknownFields.size
+        override fun encodedSize(value: Location): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.path)
+          size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(2, value.span)
+          size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.leading_comments)
+          size += ProtoAdapter.STRING.encodedSizeWithTag(4, value.trailing_comments)
+          size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6,
+              value.leading_detached_comments)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: Location) {
           ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.path)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
@@ -97,14 +97,15 @@ class UninterpretedOption(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UninterpretedOption) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && identifier_value == other.identifier_value
-        && positive_int_value == other.positive_int_value
-        && negative_int_value == other.negative_int_value
-        && double_value == other.double_value
-        && string_value == other.string_value
-        && aggregate_value == other.aggregate_value
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (identifier_value == other.identifier_value)
+    result = result && (positive_int_value == other.positive_int_value)
+    result = result && (negative_int_value == other.negative_int_value)
+    result = result && (double_value == other.double_value)
+    result = result && (string_value == other.string_value)
+    result = result && (aggregate_value == other.aggregate_value)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -228,15 +229,17 @@ class UninterpretedOption(
       UninterpretedOption::class, 
       "type.googleapis.com/google.protobuf.UninterpretedOption"
     ) {
-      override fun encodedSize(value: UninterpretedOption): Int = 
-        NamePart.ADAPTER.asRepeated().encodedSizeWithTag(2, value.name) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.identifier_value) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(4, value.positive_int_value) +
-        ProtoAdapter.INT64.encodedSizeWithTag(5, value.negative_int_value) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(6, value.double_value) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(7, value.string_value) +
-        ProtoAdapter.STRING.encodedSizeWithTag(8, value.aggregate_value) +
-        value.unknownFields.size
+      override fun encodedSize(value: UninterpretedOption): Int {
+        var size = value.unknownFields.size
+        size += NamePart.ADAPTER.asRepeated().encodedSizeWithTag(2, value.name)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.identifier_value)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(4, value.positive_int_value)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(5, value.negative_int_value)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(6, value.double_value)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(7, value.string_value)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(8, value.aggregate_value)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: UninterpretedOption) {
         NamePart.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.name)
@@ -323,9 +326,10 @@ class UninterpretedOption(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NamePart) return false
-      return unknownFields == other.unknownFields
-          && name_part == other.name_part
-          && is_extension == other.is_extension
+      var result = unknownFields == other.unknownFields
+      result = result && (name_part == other.name_part)
+      result = result && (is_extension == other.is_extension)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -383,10 +387,12 @@ class UninterpretedOption(
         NamePart::class, 
         "type.googleapis.com/google.protobuf.UninterpretedOption.NamePart"
       ) {
-        override fun encodedSize(value: NamePart): Int = 
-          ProtoAdapter.STRING.encodedSizeWithTag(1, value.name_part) +
-          ProtoAdapter.BOOL.encodedSizeWithTag(2, value.is_extension) +
-          value.unknownFields.size
+        override fun encodedSize(value: NamePart): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name_part)
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(2, value.is_extension)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: NamePart) {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name_part)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
@@ -97,15 +97,15 @@ class UninterpretedOption(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UninterpretedOption) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (identifier_value == other.identifier_value)
-    result = result && (positive_int_value == other.positive_int_value)
-    result = result && (negative_int_value == other.negative_int_value)
-    result = result && (double_value == other.double_value)
-    result = result && (string_value == other.string_value)
-    result = result && (aggregate_value == other.aggregate_value)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (identifier_value != other.identifier_value) return false
+    if (positive_int_value != other.positive_int_value) return false
+    if (negative_int_value != other.negative_int_value) return false
+    if (double_value != other.double_value) return false
+    if (string_value != other.string_value) return false
+    if (aggregate_value != other.aggregate_value) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -326,10 +326,10 @@ class UninterpretedOption(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NamePart) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (name_part == other.name_part)
-      result = result && (is_extension == other.is_extension)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (name_part != other.name_part) return false
+      if (is_extension != other.is_extension) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -38,8 +38,9 @@ class DeprecatedProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DeprecatedProto) return false
-    return unknownFields == other.unknownFields
-        && foo == other.foo
+    var result = unknownFields == other.unknownFields
+    result = result && (foo == other.foo)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -84,9 +85,11 @@ class DeprecatedProto(
       DeprecatedProto::class, 
       "type.googleapis.com/squareup.protos.kotlin.DeprecatedProto"
     ) {
-      override fun encodedSize(value: DeprecatedProto): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo) +
-        value.unknownFields.size
+      override fun encodedSize(value: DeprecatedProto): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: DeprecatedProto) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -38,9 +38,9 @@ class DeprecatedProto(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is DeprecatedProto) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (foo == other.foo)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (foo != other.foo) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -45,9 +45,10 @@ class MessageUsingMultipleEnums(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageUsingMultipleEnums) return false
-    return unknownFields == other.unknownFields
-        && a == other.a
-        && b == other.b
+    var result = unknownFields == other.unknownFields
+    result = result && (a == other.a)
+    result = result && (b == other.b)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -107,10 +108,12 @@ class MessageUsingMultipleEnums(
       MessageUsingMultipleEnums::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageUsingMultipleEnums"
     ) {
-      override fun encodedSize(value: MessageUsingMultipleEnums): Int = 
-        MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a) +
-        OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b) +
-        value.unknownFields.size
+      override fun encodedSize(value: MessageUsingMultipleEnums): Int {
+        var size = value.unknownFields.size
+        size += MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a)
+        size += OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums) {
         MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -45,10 +45,10 @@ class MessageUsingMultipleEnums(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageUsingMultipleEnums) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (a == other.a)
-    result = result && (b == other.b)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (a != other.a) return false
+    if (b != other.b) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -29,8 +29,8 @@ class MessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageWithStatus) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -29,7 +29,8 @@ class MessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is MessageWithStatus) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -52,8 +53,10 @@ class MessageWithStatus(
       MessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageWithStatus"
     ) {
-      override fun encodedSize(value: MessageWithStatus): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: MessageWithStatus): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: MessageWithStatus) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -26,8 +26,8 @@ class NoFields(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoFields) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -26,7 +26,8 @@ class NoFields(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoFields) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -48,8 +49,10 @@ class NoFields(
       NoFields::class, 
       "type.googleapis.com/squareup.protos.kotlin.NoFields"
     ) {
-      override fun encodedSize(value: NoFields): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: NoFields): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NoFields) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -69,11 +69,11 @@ class OneOfMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneOfMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (foo == other.foo)
-    result = result && (bar == other.bar)
-    result = result && (baz == other.baz)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (foo != other.foo) return false
+    if (bar != other.bar) return false
+    if (baz != other.baz) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -69,10 +69,11 @@ class OneOfMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OneOfMessage) return false
-    return unknownFields == other.unknownFields
-        && foo == other.foo
-        && bar == other.bar
-        && baz == other.baz
+    var result = unknownFields == other.unknownFields
+    result = result && (foo == other.foo)
+    result = result && (bar == other.bar)
+    result = result && (baz == other.baz)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -157,11 +158,13 @@ class OneOfMessage(
       OneOfMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.oneof.OneOfMessage"
     ) {
-      override fun encodedSize(value: OneOfMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar) +
-        ProtoAdapter.STRING.encodedSizeWithTag(4, value.baz) +
-        value.unknownFields.size
+      override fun encodedSize(value: OneOfMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(4, value.baz)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OneOfMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -29,8 +29,8 @@ class OtherMessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OtherMessageWithStatus) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -29,7 +29,8 @@ class OtherMessageWithStatus(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OtherMessageWithStatus) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -53,8 +54,10 @@ class OtherMessageWithStatus(
       OtherMessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.OtherMessageWithStatus"
     ) {
-      override fun encodedSize(value: OtherMessageWithStatus): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: OtherMessageWithStatus): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
@@ -39,9 +39,9 @@ class Percents(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Percents) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (text == other.text)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (text != other.text) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
@@ -39,8 +39,9 @@ class Percents(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Percents) return false
-    return unknownFields == other.unknownFields
-        && text == other.text
+    var result = unknownFields == other.unknownFields
+    result = result && (text == other.text)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -87,9 +88,11 @@ class Percents(
       Percents::class, 
       "type.googleapis.com/squareup.protos.kotlin.Percents"
     ) {
-      override fun encodedSize(value: Percents): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.text) +
-        value.unknownFields.size
+      override fun encodedSize(value: Percents): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.text)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Percents) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.text)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -1243,144 +1243,145 @@ class AllTypes(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is AllTypes) return false
-    return unknownFields == other.unknownFields
-        && opt_int32 == other.opt_int32
-        && opt_uint32 == other.opt_uint32
-        && opt_sint32 == other.opt_sint32
-        && opt_fixed32 == other.opt_fixed32
-        && opt_sfixed32 == other.opt_sfixed32
-        && opt_int64 == other.opt_int64
-        && opt_uint64 == other.opt_uint64
-        && opt_sint64 == other.opt_sint64
-        && opt_fixed64 == other.opt_fixed64
-        && opt_sfixed64 == other.opt_sfixed64
-        && opt_bool == other.opt_bool
-        && opt_float == other.opt_float
-        && opt_double == other.opt_double
-        && opt_string == other.opt_string
-        && opt_bytes == other.opt_bytes
-        && opt_nested_enum == other.opt_nested_enum
-        && opt_nested_message == other.opt_nested_message
-        && req_int32 == other.req_int32
-        && req_uint32 == other.req_uint32
-        && req_sint32 == other.req_sint32
-        && req_fixed32 == other.req_fixed32
-        && req_sfixed32 == other.req_sfixed32
-        && req_int64 == other.req_int64
-        && req_uint64 == other.req_uint64
-        && req_sint64 == other.req_sint64
-        && req_fixed64 == other.req_fixed64
-        && req_sfixed64 == other.req_sfixed64
-        && req_bool == other.req_bool
-        && req_float == other.req_float
-        && req_double == other.req_double
-        && req_string == other.req_string
-        && req_bytes == other.req_bytes
-        && req_nested_enum == other.req_nested_enum
-        && req_nested_message == other.req_nested_message
-        && rep_int32 == other.rep_int32
-        && rep_uint32 == other.rep_uint32
-        && rep_sint32 == other.rep_sint32
-        && rep_fixed32 == other.rep_fixed32
-        && rep_sfixed32 == other.rep_sfixed32
-        && rep_int64 == other.rep_int64
-        && rep_uint64 == other.rep_uint64
-        && rep_sint64 == other.rep_sint64
-        && rep_fixed64 == other.rep_fixed64
-        && rep_sfixed64 == other.rep_sfixed64
-        && rep_bool == other.rep_bool
-        && rep_float == other.rep_float
-        && rep_double == other.rep_double
-        && rep_string == other.rep_string
-        && rep_bytes == other.rep_bytes
-        && rep_nested_enum == other.rep_nested_enum
-        && rep_nested_message == other.rep_nested_message
-        && pack_int32 == other.pack_int32
-        && pack_uint32 == other.pack_uint32
-        && pack_sint32 == other.pack_sint32
-        && pack_fixed32 == other.pack_fixed32
-        && pack_sfixed32 == other.pack_sfixed32
-        && pack_int64 == other.pack_int64
-        && pack_uint64 == other.pack_uint64
-        && pack_sint64 == other.pack_sint64
-        && pack_fixed64 == other.pack_fixed64
-        && pack_sfixed64 == other.pack_sfixed64
-        && pack_bool == other.pack_bool
-        && pack_float == other.pack_float
-        && pack_double == other.pack_double
-        && pack_nested_enum == other.pack_nested_enum
-        && default_int32 == other.default_int32
-        && default_uint32 == other.default_uint32
-        && default_sint32 == other.default_sint32
-        && default_fixed32 == other.default_fixed32
-        && default_sfixed32 == other.default_sfixed32
-        && default_int64 == other.default_int64
-        && default_uint64 == other.default_uint64
-        && default_sint64 == other.default_sint64
-        && default_fixed64 == other.default_fixed64
-        && default_sfixed64 == other.default_sfixed64
-        && default_bool == other.default_bool
-        && default_float == other.default_float
-        && default_double == other.default_double
-        && default_string == other.default_string
-        && default_bytes == other.default_bytes
-        && default_nested_enum == other.default_nested_enum
-        && map_int32_int32 == other.map_int32_int32
-        && map_string_string == other.map_string_string
-        && map_string_message == other.map_string_message
-        && map_string_enum == other.map_string_enum
-        && ext_opt_int32 == other.ext_opt_int32
-        && ext_opt_uint32 == other.ext_opt_uint32
-        && ext_opt_sint32 == other.ext_opt_sint32
-        && ext_opt_fixed32 == other.ext_opt_fixed32
-        && ext_opt_sfixed32 == other.ext_opt_sfixed32
-        && ext_opt_int64 == other.ext_opt_int64
-        && ext_opt_uint64 == other.ext_opt_uint64
-        && ext_opt_sint64 == other.ext_opt_sint64
-        && ext_opt_fixed64 == other.ext_opt_fixed64
-        && ext_opt_sfixed64 == other.ext_opt_sfixed64
-        && ext_opt_bool == other.ext_opt_bool
-        && ext_opt_float == other.ext_opt_float
-        && ext_opt_double == other.ext_opt_double
-        && ext_opt_string == other.ext_opt_string
-        && ext_opt_bytes == other.ext_opt_bytes
-        && ext_opt_nested_enum == other.ext_opt_nested_enum
-        && ext_opt_nested_message == other.ext_opt_nested_message
-        && ext_rep_int32 == other.ext_rep_int32
-        && ext_rep_uint32 == other.ext_rep_uint32
-        && ext_rep_sint32 == other.ext_rep_sint32
-        && ext_rep_fixed32 == other.ext_rep_fixed32
-        && ext_rep_sfixed32 == other.ext_rep_sfixed32
-        && ext_rep_int64 == other.ext_rep_int64
-        && ext_rep_uint64 == other.ext_rep_uint64
-        && ext_rep_sint64 == other.ext_rep_sint64
-        && ext_rep_fixed64 == other.ext_rep_fixed64
-        && ext_rep_sfixed64 == other.ext_rep_sfixed64
-        && ext_rep_bool == other.ext_rep_bool
-        && ext_rep_float == other.ext_rep_float
-        && ext_rep_double == other.ext_rep_double
-        && ext_rep_string == other.ext_rep_string
-        && ext_rep_bytes == other.ext_rep_bytes
-        && ext_rep_nested_enum == other.ext_rep_nested_enum
-        && ext_rep_nested_message == other.ext_rep_nested_message
-        && ext_pack_int32 == other.ext_pack_int32
-        && ext_pack_uint32 == other.ext_pack_uint32
-        && ext_pack_sint32 == other.ext_pack_sint32
-        && ext_pack_fixed32 == other.ext_pack_fixed32
-        && ext_pack_sfixed32 == other.ext_pack_sfixed32
-        && ext_pack_int64 == other.ext_pack_int64
-        && ext_pack_uint64 == other.ext_pack_uint64
-        && ext_pack_sint64 == other.ext_pack_sint64
-        && ext_pack_fixed64 == other.ext_pack_fixed64
-        && ext_pack_sfixed64 == other.ext_pack_sfixed64
-        && ext_pack_bool == other.ext_pack_bool
-        && ext_pack_float == other.ext_pack_float
-        && ext_pack_double == other.ext_pack_double
-        && ext_pack_nested_enum == other.ext_pack_nested_enum
-        && ext_map_int32_int32 == other.ext_map_int32_int32
-        && ext_map_string_string == other.ext_map_string_string
-        && ext_map_string_message == other.ext_map_string_message
-        && ext_map_string_enum == other.ext_map_string_enum
+    var result = unknownFields == other.unknownFields
+    result = result && (opt_int32 == other.opt_int32)
+    result = result && (opt_uint32 == other.opt_uint32)
+    result = result && (opt_sint32 == other.opt_sint32)
+    result = result && (opt_fixed32 == other.opt_fixed32)
+    result = result && (opt_sfixed32 == other.opt_sfixed32)
+    result = result && (opt_int64 == other.opt_int64)
+    result = result && (opt_uint64 == other.opt_uint64)
+    result = result && (opt_sint64 == other.opt_sint64)
+    result = result && (opt_fixed64 == other.opt_fixed64)
+    result = result && (opt_sfixed64 == other.opt_sfixed64)
+    result = result && (opt_bool == other.opt_bool)
+    result = result && (opt_float == other.opt_float)
+    result = result && (opt_double == other.opt_double)
+    result = result && (opt_string == other.opt_string)
+    result = result && (opt_bytes == other.opt_bytes)
+    result = result && (opt_nested_enum == other.opt_nested_enum)
+    result = result && (opt_nested_message == other.opt_nested_message)
+    result = result && (req_int32 == other.req_int32)
+    result = result && (req_uint32 == other.req_uint32)
+    result = result && (req_sint32 == other.req_sint32)
+    result = result && (req_fixed32 == other.req_fixed32)
+    result = result && (req_sfixed32 == other.req_sfixed32)
+    result = result && (req_int64 == other.req_int64)
+    result = result && (req_uint64 == other.req_uint64)
+    result = result && (req_sint64 == other.req_sint64)
+    result = result && (req_fixed64 == other.req_fixed64)
+    result = result && (req_sfixed64 == other.req_sfixed64)
+    result = result && (req_bool == other.req_bool)
+    result = result && (req_float == other.req_float)
+    result = result && (req_double == other.req_double)
+    result = result && (req_string == other.req_string)
+    result = result && (req_bytes == other.req_bytes)
+    result = result && (req_nested_enum == other.req_nested_enum)
+    result = result && (req_nested_message == other.req_nested_message)
+    result = result && (rep_int32 == other.rep_int32)
+    result = result && (rep_uint32 == other.rep_uint32)
+    result = result && (rep_sint32 == other.rep_sint32)
+    result = result && (rep_fixed32 == other.rep_fixed32)
+    result = result && (rep_sfixed32 == other.rep_sfixed32)
+    result = result && (rep_int64 == other.rep_int64)
+    result = result && (rep_uint64 == other.rep_uint64)
+    result = result && (rep_sint64 == other.rep_sint64)
+    result = result && (rep_fixed64 == other.rep_fixed64)
+    result = result && (rep_sfixed64 == other.rep_sfixed64)
+    result = result && (rep_bool == other.rep_bool)
+    result = result && (rep_float == other.rep_float)
+    result = result && (rep_double == other.rep_double)
+    result = result && (rep_string == other.rep_string)
+    result = result && (rep_bytes == other.rep_bytes)
+    result = result && (rep_nested_enum == other.rep_nested_enum)
+    result = result && (rep_nested_message == other.rep_nested_message)
+    result = result && (pack_int32 == other.pack_int32)
+    result = result && (pack_uint32 == other.pack_uint32)
+    result = result && (pack_sint32 == other.pack_sint32)
+    result = result && (pack_fixed32 == other.pack_fixed32)
+    result = result && (pack_sfixed32 == other.pack_sfixed32)
+    result = result && (pack_int64 == other.pack_int64)
+    result = result && (pack_uint64 == other.pack_uint64)
+    result = result && (pack_sint64 == other.pack_sint64)
+    result = result && (pack_fixed64 == other.pack_fixed64)
+    result = result && (pack_sfixed64 == other.pack_sfixed64)
+    result = result && (pack_bool == other.pack_bool)
+    result = result && (pack_float == other.pack_float)
+    result = result && (pack_double == other.pack_double)
+    result = result && (pack_nested_enum == other.pack_nested_enum)
+    result = result && (default_int32 == other.default_int32)
+    result = result && (default_uint32 == other.default_uint32)
+    result = result && (default_sint32 == other.default_sint32)
+    result = result && (default_fixed32 == other.default_fixed32)
+    result = result && (default_sfixed32 == other.default_sfixed32)
+    result = result && (default_int64 == other.default_int64)
+    result = result && (default_uint64 == other.default_uint64)
+    result = result && (default_sint64 == other.default_sint64)
+    result = result && (default_fixed64 == other.default_fixed64)
+    result = result && (default_sfixed64 == other.default_sfixed64)
+    result = result && (default_bool == other.default_bool)
+    result = result && (default_float == other.default_float)
+    result = result && (default_double == other.default_double)
+    result = result && (default_string == other.default_string)
+    result = result && (default_bytes == other.default_bytes)
+    result = result && (default_nested_enum == other.default_nested_enum)
+    result = result && (map_int32_int32 == other.map_int32_int32)
+    result = result && (map_string_string == other.map_string_string)
+    result = result && (map_string_message == other.map_string_message)
+    result = result && (map_string_enum == other.map_string_enum)
+    result = result && (ext_opt_int32 == other.ext_opt_int32)
+    result = result && (ext_opt_uint32 == other.ext_opt_uint32)
+    result = result && (ext_opt_sint32 == other.ext_opt_sint32)
+    result = result && (ext_opt_fixed32 == other.ext_opt_fixed32)
+    result = result && (ext_opt_sfixed32 == other.ext_opt_sfixed32)
+    result = result && (ext_opt_int64 == other.ext_opt_int64)
+    result = result && (ext_opt_uint64 == other.ext_opt_uint64)
+    result = result && (ext_opt_sint64 == other.ext_opt_sint64)
+    result = result && (ext_opt_fixed64 == other.ext_opt_fixed64)
+    result = result && (ext_opt_sfixed64 == other.ext_opt_sfixed64)
+    result = result && (ext_opt_bool == other.ext_opt_bool)
+    result = result && (ext_opt_float == other.ext_opt_float)
+    result = result && (ext_opt_double == other.ext_opt_double)
+    result = result && (ext_opt_string == other.ext_opt_string)
+    result = result && (ext_opt_bytes == other.ext_opt_bytes)
+    result = result && (ext_opt_nested_enum == other.ext_opt_nested_enum)
+    result = result && (ext_opt_nested_message == other.ext_opt_nested_message)
+    result = result && (ext_rep_int32 == other.ext_rep_int32)
+    result = result && (ext_rep_uint32 == other.ext_rep_uint32)
+    result = result && (ext_rep_sint32 == other.ext_rep_sint32)
+    result = result && (ext_rep_fixed32 == other.ext_rep_fixed32)
+    result = result && (ext_rep_sfixed32 == other.ext_rep_sfixed32)
+    result = result && (ext_rep_int64 == other.ext_rep_int64)
+    result = result && (ext_rep_uint64 == other.ext_rep_uint64)
+    result = result && (ext_rep_sint64 == other.ext_rep_sint64)
+    result = result && (ext_rep_fixed64 == other.ext_rep_fixed64)
+    result = result && (ext_rep_sfixed64 == other.ext_rep_sfixed64)
+    result = result && (ext_rep_bool == other.ext_rep_bool)
+    result = result && (ext_rep_float == other.ext_rep_float)
+    result = result && (ext_rep_double == other.ext_rep_double)
+    result = result && (ext_rep_string == other.ext_rep_string)
+    result = result && (ext_rep_bytes == other.ext_rep_bytes)
+    result = result && (ext_rep_nested_enum == other.ext_rep_nested_enum)
+    result = result && (ext_rep_nested_message == other.ext_rep_nested_message)
+    result = result && (ext_pack_int32 == other.ext_pack_int32)
+    result = result && (ext_pack_uint32 == other.ext_pack_uint32)
+    result = result && (ext_pack_sint32 == other.ext_pack_sint32)
+    result = result && (ext_pack_fixed32 == other.ext_pack_fixed32)
+    result = result && (ext_pack_sfixed32 == other.ext_pack_sfixed32)
+    result = result && (ext_pack_int64 == other.ext_pack_int64)
+    result = result && (ext_pack_uint64 == other.ext_pack_uint64)
+    result = result && (ext_pack_sint64 == other.ext_pack_sint64)
+    result = result && (ext_pack_fixed64 == other.ext_pack_fixed64)
+    result = result && (ext_pack_sfixed64 == other.ext_pack_sfixed64)
+    result = result && (ext_pack_bool == other.ext_pack_bool)
+    result = result && (ext_pack_float == other.ext_pack_float)
+    result = result && (ext_pack_double == other.ext_pack_double)
+    result = result && (ext_pack_nested_enum == other.ext_pack_nested_enum)
+    result = result && (ext_map_int32_int32 == other.ext_map_int32_int32)
+    result = result && (ext_map_string_string == other.ext_map_string_string)
+    result = result && (ext_map_string_message == other.ext_map_string_message)
+    result = result && (ext_map_string_enum == other.ext_map_string_enum)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -3210,145 +3211,148 @@ class AllTypes(
       private val ext_map_string_enumAdapter: ProtoAdapter<Map<String, NestedEnum>> =
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, NestedEnum.ADAPTER)
 
-      override fun encodedSize(value: AllTypes): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(2, value.opt_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(3, value.opt_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.opt_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(5, value.opt_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(6, value.opt_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(7, value.opt_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(8, value.opt_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(9, value.opt_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(10, value.opt_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(11, value.opt_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(12, value.opt_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(13, value.opt_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(14, value.opt_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(15, value.opt_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(16, value.opt_nested_enum) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(17, value.opt_nested_message) +
-        ProtoAdapter.INT32.encodedSizeWithTag(101, value.req_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(102, value.req_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(103, value.req_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(104, value.req_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(105, value.req_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(106, value.req_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(107, value.req_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(108, value.req_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(109, value.req_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(110, value.req_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(111, value.req_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(112, value.req_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(113, value.req_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(114, value.req_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(115, value.req_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(116, value.req_nested_enum) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(117, value.req_nested_message) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(201, value.rep_int32) +
-        ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(202, value.rep_uint32) +
-        ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(203, value.rep_sint32) +
-        ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(204, value.rep_fixed32) +
-        ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(205, value.rep_sfixed32) +
-        ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(206, value.rep_int64) +
-        ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(207, value.rep_uint64) +
-        ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(208, value.rep_sint64) +
-        ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(209, value.rep_fixed64) +
-        ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(210, value.rep_sfixed64) +
-        ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(211, value.rep_bool) +
-        ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(212, value.rep_float) +
-        ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(213, value.rep_double) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(214, value.rep_string) +
-        ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(215, value.rep_bytes) +
-        NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(216, value.rep_nested_enum) +
-        NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(217, value.rep_nested_message) +
-        ProtoAdapter.INT32.asPacked().encodedSizeWithTag(301, value.pack_int32) +
-        ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(302, value.pack_uint32) +
-        ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(303, value.pack_sint32) +
-        ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(304, value.pack_fixed32) +
-        ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(305, value.pack_sfixed32) +
-        ProtoAdapter.INT64.asPacked().encodedSizeWithTag(306, value.pack_int64) +
-        ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(307, value.pack_uint64) +
-        ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(308, value.pack_sint64) +
-        ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(309, value.pack_fixed64) +
-        ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(310, value.pack_sfixed64) +
-        ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(311, value.pack_bool) +
-        ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(312, value.pack_float) +
-        ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(313, value.pack_double) +
-        NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(316, value.pack_nested_enum) +
-        ProtoAdapter.INT32.encodedSizeWithTag(401, value.default_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(402, value.default_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(403, value.default_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(404, value.default_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(405, value.default_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(406, value.default_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(407, value.default_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(408, value.default_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(409, value.default_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(410, value.default_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(411, value.default_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(412, value.default_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(413, value.default_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(414, value.default_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(415, value.default_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(416, value.default_nested_enum) +
-        map_int32_int32Adapter.encodedSizeWithTag(501, value.map_int32_int32) +
-        map_string_stringAdapter.encodedSizeWithTag(502, value.map_string_string) +
-        map_string_messageAdapter.encodedSizeWithTag(503, value.map_string_message) +
-        map_string_enumAdapter.encodedSizeWithTag(504, value.map_string_enum) +
-        ProtoAdapter.INT32.encodedSizeWithTag(1001, value.ext_opt_int32) +
-        ProtoAdapter.UINT32.encodedSizeWithTag(1002, value.ext_opt_uint32) +
-        ProtoAdapter.SINT32.encodedSizeWithTag(1003, value.ext_opt_sint32) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(1004, value.ext_opt_fixed32) +
-        ProtoAdapter.SFIXED32.encodedSizeWithTag(1005, value.ext_opt_sfixed32) +
-        ProtoAdapter.INT64.encodedSizeWithTag(1006, value.ext_opt_int64) +
-        ProtoAdapter.UINT64.encodedSizeWithTag(1007, value.ext_opt_uint64) +
-        ProtoAdapter.SINT64.encodedSizeWithTag(1008, value.ext_opt_sint64) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(1009, value.ext_opt_fixed64) +
-        ProtoAdapter.SFIXED64.encodedSizeWithTag(1010, value.ext_opt_sfixed64) +
-        ProtoAdapter.BOOL.encodedSizeWithTag(1011, value.ext_opt_bool) +
-        ProtoAdapter.FLOAT.encodedSizeWithTag(1012, value.ext_opt_float) +
-        ProtoAdapter.DOUBLE.encodedSizeWithTag(1013, value.ext_opt_double) +
-        ProtoAdapter.STRING.encodedSizeWithTag(1014, value.ext_opt_string) +
-        ProtoAdapter.BYTES.encodedSizeWithTag(1015, value.ext_opt_bytes) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(1016, value.ext_opt_nested_enum) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(1017, value.ext_opt_nested_message) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(1101, value.ext_rep_int32) +
-        ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(1102, value.ext_rep_uint32) +
-        ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(1103, value.ext_rep_sint32) +
-        ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(1104, value.ext_rep_fixed32) +
-        ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(1105, value.ext_rep_sfixed32) +
-        ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(1106, value.ext_rep_int64) +
-        ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(1107, value.ext_rep_uint64) +
-        ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(1108, value.ext_rep_sint64) +
-        ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(1109, value.ext_rep_fixed64) +
-        ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(1110, value.ext_rep_sfixed64) +
-        ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(1111, value.ext_rep_bool) +
-        ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(1112, value.ext_rep_float) +
-        ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(1113, value.ext_rep_double) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1114, value.ext_rep_string) +
-        ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(1115, value.ext_rep_bytes) +
-        NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(1116, value.ext_rep_nested_enum) +
-        NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(1117, value.ext_rep_nested_message) +
-        ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1201, value.ext_pack_int32) +
-        ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(1202, value.ext_pack_uint32) +
-        ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(1203, value.ext_pack_sint32) +
-        ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(1204, value.ext_pack_fixed32) +
-        ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(1205, value.ext_pack_sfixed32) +
-        ProtoAdapter.INT64.asPacked().encodedSizeWithTag(1206, value.ext_pack_int64) +
-        ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(1207, value.ext_pack_uint64) +
-        ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(1208, value.ext_pack_sint64) +
-        ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(1209, value.ext_pack_fixed64) +
-        ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(1210, value.ext_pack_sfixed64) +
-        ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(1211, value.ext_pack_bool) +
-        ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(1212, value.ext_pack_float) +
-        ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(1213, value.ext_pack_double) +
-        NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(1216, value.ext_pack_nested_enum) +
-        ext_map_int32_int32Adapter.encodedSizeWithTag(1301, value.ext_map_int32_int32) +
-        ext_map_string_stringAdapter.encodedSizeWithTag(1402, value.ext_map_string_string) +
-        ext_map_string_messageAdapter.encodedSizeWithTag(1503, value.ext_map_string_message) +
-        ext_map_string_enumAdapter.encodedSizeWithTag(1504, value.ext_map_string_enum) +
-        value.unknownFields.size
+      override fun encodedSize(value: AllTypes): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.opt_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(3, value.opt_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.opt_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5, value.opt_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(6, value.opt_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(7, value.opt_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(8, value.opt_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(9, value.opt_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(10, value.opt_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(11, value.opt_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(12, value.opt_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(13, value.opt_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(14, value.opt_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(15, value.opt_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(16, value.opt_nested_enum)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(17, value.opt_nested_message)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(101, value.req_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(102, value.req_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(103, value.req_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(104, value.req_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(105, value.req_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(106, value.req_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(107, value.req_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(108, value.req_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(109, value.req_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(110, value.req_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(111, value.req_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(112, value.req_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(113, value.req_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(114, value.req_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(115, value.req_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(116, value.req_nested_enum)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(117, value.req_nested_message)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(201, value.rep_int32)
+        size += ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(202, value.rep_uint32)
+        size += ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(203, value.rep_sint32)
+        size += ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(204, value.rep_fixed32)
+        size += ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(205, value.rep_sfixed32)
+        size += ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(206, value.rep_int64)
+        size += ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(207, value.rep_uint64)
+        size += ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(208, value.rep_sint64)
+        size += ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(209, value.rep_fixed64)
+        size += ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(210, value.rep_sfixed64)
+        size += ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(211, value.rep_bool)
+        size += ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(212, value.rep_float)
+        size += ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(213, value.rep_double)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(214, value.rep_string)
+        size += ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(215, value.rep_bytes)
+        size += NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(216, value.rep_nested_enum)
+        size += NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(217, value.rep_nested_message)
+        size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(301, value.pack_int32)
+        size += ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(302, value.pack_uint32)
+        size += ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(303, value.pack_sint32)
+        size += ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(304, value.pack_fixed32)
+        size += ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(305, value.pack_sfixed32)
+        size += ProtoAdapter.INT64.asPacked().encodedSizeWithTag(306, value.pack_int64)
+        size += ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(307, value.pack_uint64)
+        size += ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(308, value.pack_sint64)
+        size += ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(309, value.pack_fixed64)
+        size += ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(310, value.pack_sfixed64)
+        size += ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(311, value.pack_bool)
+        size += ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(312, value.pack_float)
+        size += ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(313, value.pack_double)
+        size += NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(316, value.pack_nested_enum)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(401, value.default_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(402, value.default_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(403, value.default_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(404, value.default_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(405, value.default_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(406, value.default_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(407, value.default_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(408, value.default_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(409, value.default_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(410, value.default_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(411, value.default_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(412, value.default_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(413, value.default_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(414, value.default_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(415, value.default_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(416, value.default_nested_enum)
+        size += map_int32_int32Adapter.encodedSizeWithTag(501, value.map_int32_int32)
+        size += map_string_stringAdapter.encodedSizeWithTag(502, value.map_string_string)
+        size += map_string_messageAdapter.encodedSizeWithTag(503, value.map_string_message)
+        size += map_string_enumAdapter.encodedSizeWithTag(504, value.map_string_enum)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1001, value.ext_opt_int32)
+        size += ProtoAdapter.UINT32.encodedSizeWithTag(1002, value.ext_opt_uint32)
+        size += ProtoAdapter.SINT32.encodedSizeWithTag(1003, value.ext_opt_sint32)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(1004, value.ext_opt_fixed32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(1005, value.ext_opt_sfixed32)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(1006, value.ext_opt_int64)
+        size += ProtoAdapter.UINT64.encodedSizeWithTag(1007, value.ext_opt_uint64)
+        size += ProtoAdapter.SINT64.encodedSizeWithTag(1008, value.ext_opt_sint64)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(1009, value.ext_opt_fixed64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(1010, value.ext_opt_sfixed64)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(1011, value.ext_opt_bool)
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(1012, value.ext_opt_float)
+        size += ProtoAdapter.DOUBLE.encodedSizeWithTag(1013, value.ext_opt_double)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1014, value.ext_opt_string)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(1015, value.ext_opt_bytes)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(1016, value.ext_opt_nested_enum)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(1017, value.ext_opt_nested_message)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(1101, value.ext_rep_int32)
+        size += ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(1102, value.ext_rep_uint32)
+        size += ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(1103, value.ext_rep_sint32)
+        size += ProtoAdapter.FIXED32.asRepeated().encodedSizeWithTag(1104, value.ext_rep_fixed32)
+        size += ProtoAdapter.SFIXED32.asRepeated().encodedSizeWithTag(1105, value.ext_rep_sfixed32)
+        size += ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(1106, value.ext_rep_int64)
+        size += ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(1107, value.ext_rep_uint64)
+        size += ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(1108, value.ext_rep_sint64)
+        size += ProtoAdapter.FIXED64.asRepeated().encodedSizeWithTag(1109, value.ext_rep_fixed64)
+        size += ProtoAdapter.SFIXED64.asRepeated().encodedSizeWithTag(1110, value.ext_rep_sfixed64)
+        size += ProtoAdapter.BOOL.asRepeated().encodedSizeWithTag(1111, value.ext_rep_bool)
+        size += ProtoAdapter.FLOAT.asRepeated().encodedSizeWithTag(1112, value.ext_rep_float)
+        size += ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(1113, value.ext_rep_double)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1114, value.ext_rep_string)
+        size += ProtoAdapter.BYTES.asRepeated().encodedSizeWithTag(1115, value.ext_rep_bytes)
+        size += NestedEnum.ADAPTER.asRepeated().encodedSizeWithTag(1116, value.ext_rep_nested_enum)
+        size += NestedMessage.ADAPTER.asRepeated().encodedSizeWithTag(1117,
+            value.ext_rep_nested_message)
+        size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1201, value.ext_pack_int32)
+        size += ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(1202, value.ext_pack_uint32)
+        size += ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(1203, value.ext_pack_sint32)
+        size += ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(1204, value.ext_pack_fixed32)
+        size += ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(1205, value.ext_pack_sfixed32)
+        size += ProtoAdapter.INT64.asPacked().encodedSizeWithTag(1206, value.ext_pack_int64)
+        size += ProtoAdapter.UINT64.asPacked().encodedSizeWithTag(1207, value.ext_pack_uint64)
+        size += ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(1208, value.ext_pack_sint64)
+        size += ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(1209, value.ext_pack_fixed64)
+        size += ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(1210, value.ext_pack_sfixed64)
+        size += ProtoAdapter.BOOL.asPacked().encodedSizeWithTag(1211, value.ext_pack_bool)
+        size += ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(1212, value.ext_pack_float)
+        size += ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(1213, value.ext_pack_double)
+        size += NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(1216, value.ext_pack_nested_enum)
+        size += ext_map_int32_int32Adapter.encodedSizeWithTag(1301, value.ext_map_int32_int32)
+        size += ext_map_string_stringAdapter.encodedSizeWithTag(1402, value.ext_map_string_string)
+        size += ext_map_string_messageAdapter.encodedSizeWithTag(1503, value.ext_map_string_message)
+        size += ext_map_string_enumAdapter.encodedSizeWithTag(1504, value.ext_map_string_enum)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: AllTypes) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.opt_int32)
@@ -4000,8 +4004,9 @@ class AllTypes(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      return unknownFields == other.unknownFields
-          && a == other.a
+      var result = unknownFields == other.unknownFields
+      result = result && (a == other.a)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -4045,9 +4050,11 @@ class AllTypes(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes.NestedMessage"
       ) {
-        override fun encodedSize(value: NestedMessage): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.a) +
-          value.unknownFields.size
+        override fun encodedSize(value: NestedMessage): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: NestedMessage) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -1243,145 +1243,145 @@ class AllTypes(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is AllTypes) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (opt_int32 == other.opt_int32)
-    result = result && (opt_uint32 == other.opt_uint32)
-    result = result && (opt_sint32 == other.opt_sint32)
-    result = result && (opt_fixed32 == other.opt_fixed32)
-    result = result && (opt_sfixed32 == other.opt_sfixed32)
-    result = result && (opt_int64 == other.opt_int64)
-    result = result && (opt_uint64 == other.opt_uint64)
-    result = result && (opt_sint64 == other.opt_sint64)
-    result = result && (opt_fixed64 == other.opt_fixed64)
-    result = result && (opt_sfixed64 == other.opt_sfixed64)
-    result = result && (opt_bool == other.opt_bool)
-    result = result && (opt_float == other.opt_float)
-    result = result && (opt_double == other.opt_double)
-    result = result && (opt_string == other.opt_string)
-    result = result && (opt_bytes == other.opt_bytes)
-    result = result && (opt_nested_enum == other.opt_nested_enum)
-    result = result && (opt_nested_message == other.opt_nested_message)
-    result = result && (req_int32 == other.req_int32)
-    result = result && (req_uint32 == other.req_uint32)
-    result = result && (req_sint32 == other.req_sint32)
-    result = result && (req_fixed32 == other.req_fixed32)
-    result = result && (req_sfixed32 == other.req_sfixed32)
-    result = result && (req_int64 == other.req_int64)
-    result = result && (req_uint64 == other.req_uint64)
-    result = result && (req_sint64 == other.req_sint64)
-    result = result && (req_fixed64 == other.req_fixed64)
-    result = result && (req_sfixed64 == other.req_sfixed64)
-    result = result && (req_bool == other.req_bool)
-    result = result && (req_float == other.req_float)
-    result = result && (req_double == other.req_double)
-    result = result && (req_string == other.req_string)
-    result = result && (req_bytes == other.req_bytes)
-    result = result && (req_nested_enum == other.req_nested_enum)
-    result = result && (req_nested_message == other.req_nested_message)
-    result = result && (rep_int32 == other.rep_int32)
-    result = result && (rep_uint32 == other.rep_uint32)
-    result = result && (rep_sint32 == other.rep_sint32)
-    result = result && (rep_fixed32 == other.rep_fixed32)
-    result = result && (rep_sfixed32 == other.rep_sfixed32)
-    result = result && (rep_int64 == other.rep_int64)
-    result = result && (rep_uint64 == other.rep_uint64)
-    result = result && (rep_sint64 == other.rep_sint64)
-    result = result && (rep_fixed64 == other.rep_fixed64)
-    result = result && (rep_sfixed64 == other.rep_sfixed64)
-    result = result && (rep_bool == other.rep_bool)
-    result = result && (rep_float == other.rep_float)
-    result = result && (rep_double == other.rep_double)
-    result = result && (rep_string == other.rep_string)
-    result = result && (rep_bytes == other.rep_bytes)
-    result = result && (rep_nested_enum == other.rep_nested_enum)
-    result = result && (rep_nested_message == other.rep_nested_message)
-    result = result && (pack_int32 == other.pack_int32)
-    result = result && (pack_uint32 == other.pack_uint32)
-    result = result && (pack_sint32 == other.pack_sint32)
-    result = result && (pack_fixed32 == other.pack_fixed32)
-    result = result && (pack_sfixed32 == other.pack_sfixed32)
-    result = result && (pack_int64 == other.pack_int64)
-    result = result && (pack_uint64 == other.pack_uint64)
-    result = result && (pack_sint64 == other.pack_sint64)
-    result = result && (pack_fixed64 == other.pack_fixed64)
-    result = result && (pack_sfixed64 == other.pack_sfixed64)
-    result = result && (pack_bool == other.pack_bool)
-    result = result && (pack_float == other.pack_float)
-    result = result && (pack_double == other.pack_double)
-    result = result && (pack_nested_enum == other.pack_nested_enum)
-    result = result && (default_int32 == other.default_int32)
-    result = result && (default_uint32 == other.default_uint32)
-    result = result && (default_sint32 == other.default_sint32)
-    result = result && (default_fixed32 == other.default_fixed32)
-    result = result && (default_sfixed32 == other.default_sfixed32)
-    result = result && (default_int64 == other.default_int64)
-    result = result && (default_uint64 == other.default_uint64)
-    result = result && (default_sint64 == other.default_sint64)
-    result = result && (default_fixed64 == other.default_fixed64)
-    result = result && (default_sfixed64 == other.default_sfixed64)
-    result = result && (default_bool == other.default_bool)
-    result = result && (default_float == other.default_float)
-    result = result && (default_double == other.default_double)
-    result = result && (default_string == other.default_string)
-    result = result && (default_bytes == other.default_bytes)
-    result = result && (default_nested_enum == other.default_nested_enum)
-    result = result && (map_int32_int32 == other.map_int32_int32)
-    result = result && (map_string_string == other.map_string_string)
-    result = result && (map_string_message == other.map_string_message)
-    result = result && (map_string_enum == other.map_string_enum)
-    result = result && (ext_opt_int32 == other.ext_opt_int32)
-    result = result && (ext_opt_uint32 == other.ext_opt_uint32)
-    result = result && (ext_opt_sint32 == other.ext_opt_sint32)
-    result = result && (ext_opt_fixed32 == other.ext_opt_fixed32)
-    result = result && (ext_opt_sfixed32 == other.ext_opt_sfixed32)
-    result = result && (ext_opt_int64 == other.ext_opt_int64)
-    result = result && (ext_opt_uint64 == other.ext_opt_uint64)
-    result = result && (ext_opt_sint64 == other.ext_opt_sint64)
-    result = result && (ext_opt_fixed64 == other.ext_opt_fixed64)
-    result = result && (ext_opt_sfixed64 == other.ext_opt_sfixed64)
-    result = result && (ext_opt_bool == other.ext_opt_bool)
-    result = result && (ext_opt_float == other.ext_opt_float)
-    result = result && (ext_opt_double == other.ext_opt_double)
-    result = result && (ext_opt_string == other.ext_opt_string)
-    result = result && (ext_opt_bytes == other.ext_opt_bytes)
-    result = result && (ext_opt_nested_enum == other.ext_opt_nested_enum)
-    result = result && (ext_opt_nested_message == other.ext_opt_nested_message)
-    result = result && (ext_rep_int32 == other.ext_rep_int32)
-    result = result && (ext_rep_uint32 == other.ext_rep_uint32)
-    result = result && (ext_rep_sint32 == other.ext_rep_sint32)
-    result = result && (ext_rep_fixed32 == other.ext_rep_fixed32)
-    result = result && (ext_rep_sfixed32 == other.ext_rep_sfixed32)
-    result = result && (ext_rep_int64 == other.ext_rep_int64)
-    result = result && (ext_rep_uint64 == other.ext_rep_uint64)
-    result = result && (ext_rep_sint64 == other.ext_rep_sint64)
-    result = result && (ext_rep_fixed64 == other.ext_rep_fixed64)
-    result = result && (ext_rep_sfixed64 == other.ext_rep_sfixed64)
-    result = result && (ext_rep_bool == other.ext_rep_bool)
-    result = result && (ext_rep_float == other.ext_rep_float)
-    result = result && (ext_rep_double == other.ext_rep_double)
-    result = result && (ext_rep_string == other.ext_rep_string)
-    result = result && (ext_rep_bytes == other.ext_rep_bytes)
-    result = result && (ext_rep_nested_enum == other.ext_rep_nested_enum)
-    result = result && (ext_rep_nested_message == other.ext_rep_nested_message)
-    result = result && (ext_pack_int32 == other.ext_pack_int32)
-    result = result && (ext_pack_uint32 == other.ext_pack_uint32)
-    result = result && (ext_pack_sint32 == other.ext_pack_sint32)
-    result = result && (ext_pack_fixed32 == other.ext_pack_fixed32)
-    result = result && (ext_pack_sfixed32 == other.ext_pack_sfixed32)
-    result = result && (ext_pack_int64 == other.ext_pack_int64)
-    result = result && (ext_pack_uint64 == other.ext_pack_uint64)
-    result = result && (ext_pack_sint64 == other.ext_pack_sint64)
-    result = result && (ext_pack_fixed64 == other.ext_pack_fixed64)
-    result = result && (ext_pack_sfixed64 == other.ext_pack_sfixed64)
-    result = result && (ext_pack_bool == other.ext_pack_bool)
-    result = result && (ext_pack_float == other.ext_pack_float)
-    result = result && (ext_pack_double == other.ext_pack_double)
-    result = result && (ext_pack_nested_enum == other.ext_pack_nested_enum)
-    result = result && (ext_map_int32_int32 == other.ext_map_int32_int32)
-    result = result && (ext_map_string_string == other.ext_map_string_string)
-    result = result && (ext_map_string_message == other.ext_map_string_message)
-    result = result && (ext_map_string_enum == other.ext_map_string_enum)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (opt_int32 != other.opt_int32) return false
+    if (opt_uint32 != other.opt_uint32) return false
+    if (opt_sint32 != other.opt_sint32) return false
+    if (opt_fixed32 != other.opt_fixed32) return false
+    if (opt_sfixed32 != other.opt_sfixed32) return false
+    if (opt_int64 != other.opt_int64) return false
+    if (opt_uint64 != other.opt_uint64) return false
+    if (opt_sint64 != other.opt_sint64) return false
+    if (opt_fixed64 != other.opt_fixed64) return false
+    if (opt_sfixed64 != other.opt_sfixed64) return false
+    if (opt_bool != other.opt_bool) return false
+    if (opt_float != other.opt_float) return false
+    if (opt_double != other.opt_double) return false
+    if (opt_string != other.opt_string) return false
+    if (opt_bytes != other.opt_bytes) return false
+    if (opt_nested_enum != other.opt_nested_enum) return false
+    if (opt_nested_message != other.opt_nested_message) return false
+    if (req_int32 != other.req_int32) return false
+    if (req_uint32 != other.req_uint32) return false
+    if (req_sint32 != other.req_sint32) return false
+    if (req_fixed32 != other.req_fixed32) return false
+    if (req_sfixed32 != other.req_sfixed32) return false
+    if (req_int64 != other.req_int64) return false
+    if (req_uint64 != other.req_uint64) return false
+    if (req_sint64 != other.req_sint64) return false
+    if (req_fixed64 != other.req_fixed64) return false
+    if (req_sfixed64 != other.req_sfixed64) return false
+    if (req_bool != other.req_bool) return false
+    if (req_float != other.req_float) return false
+    if (req_double != other.req_double) return false
+    if (req_string != other.req_string) return false
+    if (req_bytes != other.req_bytes) return false
+    if (req_nested_enum != other.req_nested_enum) return false
+    if (req_nested_message != other.req_nested_message) return false
+    if (rep_int32 != other.rep_int32) return false
+    if (rep_uint32 != other.rep_uint32) return false
+    if (rep_sint32 != other.rep_sint32) return false
+    if (rep_fixed32 != other.rep_fixed32) return false
+    if (rep_sfixed32 != other.rep_sfixed32) return false
+    if (rep_int64 != other.rep_int64) return false
+    if (rep_uint64 != other.rep_uint64) return false
+    if (rep_sint64 != other.rep_sint64) return false
+    if (rep_fixed64 != other.rep_fixed64) return false
+    if (rep_sfixed64 != other.rep_sfixed64) return false
+    if (rep_bool != other.rep_bool) return false
+    if (rep_float != other.rep_float) return false
+    if (rep_double != other.rep_double) return false
+    if (rep_string != other.rep_string) return false
+    if (rep_bytes != other.rep_bytes) return false
+    if (rep_nested_enum != other.rep_nested_enum) return false
+    if (rep_nested_message != other.rep_nested_message) return false
+    if (pack_int32 != other.pack_int32) return false
+    if (pack_uint32 != other.pack_uint32) return false
+    if (pack_sint32 != other.pack_sint32) return false
+    if (pack_fixed32 != other.pack_fixed32) return false
+    if (pack_sfixed32 != other.pack_sfixed32) return false
+    if (pack_int64 != other.pack_int64) return false
+    if (pack_uint64 != other.pack_uint64) return false
+    if (pack_sint64 != other.pack_sint64) return false
+    if (pack_fixed64 != other.pack_fixed64) return false
+    if (pack_sfixed64 != other.pack_sfixed64) return false
+    if (pack_bool != other.pack_bool) return false
+    if (pack_float != other.pack_float) return false
+    if (pack_double != other.pack_double) return false
+    if (pack_nested_enum != other.pack_nested_enum) return false
+    if (default_int32 != other.default_int32) return false
+    if (default_uint32 != other.default_uint32) return false
+    if (default_sint32 != other.default_sint32) return false
+    if (default_fixed32 != other.default_fixed32) return false
+    if (default_sfixed32 != other.default_sfixed32) return false
+    if (default_int64 != other.default_int64) return false
+    if (default_uint64 != other.default_uint64) return false
+    if (default_sint64 != other.default_sint64) return false
+    if (default_fixed64 != other.default_fixed64) return false
+    if (default_sfixed64 != other.default_sfixed64) return false
+    if (default_bool != other.default_bool) return false
+    if (default_float != other.default_float) return false
+    if (default_double != other.default_double) return false
+    if (default_string != other.default_string) return false
+    if (default_bytes != other.default_bytes) return false
+    if (default_nested_enum != other.default_nested_enum) return false
+    if (map_int32_int32 != other.map_int32_int32) return false
+    if (map_string_string != other.map_string_string) return false
+    if (map_string_message != other.map_string_message) return false
+    if (map_string_enum != other.map_string_enum) return false
+    if (ext_opt_int32 != other.ext_opt_int32) return false
+    if (ext_opt_uint32 != other.ext_opt_uint32) return false
+    if (ext_opt_sint32 != other.ext_opt_sint32) return false
+    if (ext_opt_fixed32 != other.ext_opt_fixed32) return false
+    if (ext_opt_sfixed32 != other.ext_opt_sfixed32) return false
+    if (ext_opt_int64 != other.ext_opt_int64) return false
+    if (ext_opt_uint64 != other.ext_opt_uint64) return false
+    if (ext_opt_sint64 != other.ext_opt_sint64) return false
+    if (ext_opt_fixed64 != other.ext_opt_fixed64) return false
+    if (ext_opt_sfixed64 != other.ext_opt_sfixed64) return false
+    if (ext_opt_bool != other.ext_opt_bool) return false
+    if (ext_opt_float != other.ext_opt_float) return false
+    if (ext_opt_double != other.ext_opt_double) return false
+    if (ext_opt_string != other.ext_opt_string) return false
+    if (ext_opt_bytes != other.ext_opt_bytes) return false
+    if (ext_opt_nested_enum != other.ext_opt_nested_enum) return false
+    if (ext_opt_nested_message != other.ext_opt_nested_message) return false
+    if (ext_rep_int32 != other.ext_rep_int32) return false
+    if (ext_rep_uint32 != other.ext_rep_uint32) return false
+    if (ext_rep_sint32 != other.ext_rep_sint32) return false
+    if (ext_rep_fixed32 != other.ext_rep_fixed32) return false
+    if (ext_rep_sfixed32 != other.ext_rep_sfixed32) return false
+    if (ext_rep_int64 != other.ext_rep_int64) return false
+    if (ext_rep_uint64 != other.ext_rep_uint64) return false
+    if (ext_rep_sint64 != other.ext_rep_sint64) return false
+    if (ext_rep_fixed64 != other.ext_rep_fixed64) return false
+    if (ext_rep_sfixed64 != other.ext_rep_sfixed64) return false
+    if (ext_rep_bool != other.ext_rep_bool) return false
+    if (ext_rep_float != other.ext_rep_float) return false
+    if (ext_rep_double != other.ext_rep_double) return false
+    if (ext_rep_string != other.ext_rep_string) return false
+    if (ext_rep_bytes != other.ext_rep_bytes) return false
+    if (ext_rep_nested_enum != other.ext_rep_nested_enum) return false
+    if (ext_rep_nested_message != other.ext_rep_nested_message) return false
+    if (ext_pack_int32 != other.ext_pack_int32) return false
+    if (ext_pack_uint32 != other.ext_pack_uint32) return false
+    if (ext_pack_sint32 != other.ext_pack_sint32) return false
+    if (ext_pack_fixed32 != other.ext_pack_fixed32) return false
+    if (ext_pack_sfixed32 != other.ext_pack_sfixed32) return false
+    if (ext_pack_int64 != other.ext_pack_int64) return false
+    if (ext_pack_uint64 != other.ext_pack_uint64) return false
+    if (ext_pack_sint64 != other.ext_pack_sint64) return false
+    if (ext_pack_fixed64 != other.ext_pack_fixed64) return false
+    if (ext_pack_sfixed64 != other.ext_pack_sfixed64) return false
+    if (ext_pack_bool != other.ext_pack_bool) return false
+    if (ext_pack_float != other.ext_pack_float) return false
+    if (ext_pack_double != other.ext_pack_double) return false
+    if (ext_pack_nested_enum != other.ext_pack_nested_enum) return false
+    if (ext_map_int32_int32 != other.ext_map_int32_int32) return false
+    if (ext_map_string_string != other.ext_map_string_string) return false
+    if (ext_map_string_message != other.ext_map_string_message) return false
+    if (ext_map_string_enum != other.ext_map_string_enum) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -4004,9 +4004,9 @@ class AllTypes(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (a == other.a)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (a != other.a) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -45,9 +45,10 @@ class ForeignMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ForeignMessage) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && j == other.j
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (j == other.j)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -105,10 +106,12 @@ class ForeignMessage(
       ForeignMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.foreign.ForeignMessage"
     ) {
-      override fun encodedSize(value: ForeignMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        ProtoAdapter.INT32.encodedSizeWithTag(100, value.j) +
-        value.unknownFields.size
+      override fun encodedSize(value: ForeignMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(100, value.j)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ForeignMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -45,10 +45,10 @@ class ForeignMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ForeignMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (j == other.j)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (j != other.j) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -37,8 +37,9 @@ class Mappy(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Mappy) return false
-    return unknownFields == other.unknownFields
-        && things == other.things
+    var result = unknownFields == other.unknownFields
+    result = result && (things == other.things)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -85,9 +86,11 @@ class Mappy(
       private val thingsAdapter: ProtoAdapter<Map<String, Thing>> =
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER)
 
-      override fun encodedSize(value: Mappy): Int = 
-        thingsAdapter.encodedSizeWithTag(1, value.things) +
-        value.unknownFields.size
+      override fun encodedSize(value: Mappy): Int {
+        var size = value.unknownFields.size
+        size += thingsAdapter.encodedSizeWithTag(1, value.things)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Mappy) {
         thingsAdapter.encodeWithTag(writer, 1, value.things)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -37,9 +37,9 @@ class Mappy(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Mappy) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (things == other.things)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (things != other.things) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -36,8 +36,9 @@ class Thing(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Thing) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -81,9 +82,11 @@ class Thing(
       Thing::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Thing"
     ) {
-      override fun encodedSize(value: Thing): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        value.unknownFields.size
+      override fun encodedSize(value: Thing): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Thing) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -36,9 +36,9 @@ class Thing(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Thing) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -90,13 +90,13 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    result = result && (id == other.id)
-    result = result && (email == other.email)
-    result = result && (phone == other.phone)
-    result = result && (aliases == other.aliases)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    if (id != other.id) return false
+    if (email != other.email) return false
+    if (phone != other.phone) return false
+    if (aliases != other.aliases) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -322,10 +322,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (number == other.number)
-      result = result && (type == other.type)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (number != other.number) return false
+      if (type != other.type) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -90,12 +90,13 @@ class Person(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Person) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
-        && id == other.id
-        && email == other.email
-        && phone == other.phone
-        && aliases == other.aliases
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    result = result && (id == other.id)
+    result = result && (email == other.email)
+    result = result && (phone == other.phone)
+    result = result && (aliases == other.aliases)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -203,13 +204,15 @@ class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person"
     ) {
-      override fun encodedSize(value: Person): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.id) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.email) +
-        PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases) +
-        value.unknownFields.size
+      override fun encodedSize(value: Person): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Person) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
@@ -319,9 +322,10 @@ class Person(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is PhoneNumber) return false
-      return unknownFields == other.unknownFields
-          && number == other.number
-          && type == other.type
+      var result = unknownFields == other.unknownFields
+      result = result && (number == other.number)
+      result = result && (type == other.type)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -388,10 +392,12 @@ class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
       ) {
-        override fun encodedSize(value: PhoneNumber): Int = 
-          ProtoAdapter.STRING.encodedSizeWithTag(1, value.number) +
-          PhoneType.ADAPTER.encodedSizeWithTag(2, value.type) +
-          value.unknownFields.size
+        override fun encodedSize(value: PhoneNumber): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
+          size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: PhoneNumber) {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -50,9 +50,10 @@ class RedactedOneOf(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedOneOf) return false
-    return unknownFields == other.unknownFields
-        && b == other.b
-        && c == other.c
+    var result = unknownFields == other.unknownFields
+    result = result && (b == other.b)
+    result = result && (c == other.c)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -112,10 +113,12 @@ class RedactedOneOf(
       RedactedOneOf::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedOneOf"
     ) {
-      override fun encodedSize(value: RedactedOneOf): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.b) +
-        ProtoAdapter.STRING.encodedSizeWithTag(2, value.c) +
-        value.unknownFields.size
+      override fun encodedSize(value: RedactedOneOf): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.b)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.c)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: RedactedOneOf) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.b)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -50,10 +50,10 @@ class RedactedOneOf(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is RedactedOneOf) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (b == other.b)
-    result = result && (c == other.c)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (b != other.b) return false
+    if (c != other.c) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
@@ -38,8 +38,9 @@ class Repeated(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Repeated) return false
-    return unknownFields == other.unknownFields
-        && things == other.things
+    var result = unknownFields == other.unknownFields
+    result = result && (things == other.things)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -84,9 +85,11 @@ class Repeated(
       Repeated::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.repeated.Repeated"
     ) {
-      override fun encodedSize(value: Repeated): Int = 
-        Thing.ADAPTER.asRepeated().encodedSizeWithTag(1, value.things) +
-        value.unknownFields.size
+      override fun encodedSize(value: Repeated): Int {
+        var size = value.unknownFields.size
+        size += Thing.ADAPTER.asRepeated().encodedSizeWithTag(1, value.things)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Repeated) {
         Thing.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.things)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
@@ -38,9 +38,9 @@ class Repeated(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Repeated) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (things == other.things)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (things != other.things) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
@@ -36,8 +36,9 @@ class Thing(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Thing) return false
-    return unknownFields == other.unknownFields
-        && name == other.name
+    var result = unknownFields == other.unknownFields
+    result = result && (name == other.name)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -81,9 +82,11 @@ class Thing(
       Thing::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.repeated.Thing"
     ) {
-      override fun encodedSize(value: Thing): Int = 
-        ProtoAdapter.STRING.encodedSizeWithTag(1, value.name) +
-        value.unknownFields.size
+      override fun encodedSize(value: Thing): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: Thing) {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
@@ -36,9 +36,9 @@ class Thing(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is Thing) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (name == other.name)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (name != other.name) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
@@ -30,8 +30,8 @@ class NoPackageRequest(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoPackageRequest) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
@@ -30,7 +30,8 @@ class NoPackageRequest(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoPackageRequest) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -47,8 +48,10 @@ class NoPackageRequest(
       NoPackageRequest::class, 
       "type.googleapis.com/NoPackageRequest"
     ) {
-      override fun encodedSize(value: NoPackageRequest): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: NoPackageRequest): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NoPackageRequest) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
@@ -30,7 +30,8 @@ class NoPackageResponse(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoPackageResponse) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -47,8 +48,10 @@ class NoPackageResponse(
       NoPackageResponse::class, 
       "type.googleapis.com/NoPackageResponse"
     ) {
-      override fun encodedSize(value: NoPackageResponse): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: NoPackageResponse): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NoPackageResponse) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
@@ -30,8 +30,8 @@ class NoPackageResponse(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NoPackageResponse) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
@@ -30,8 +30,8 @@ class SomeRequest(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SomeRequest) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
@@ -30,7 +30,8 @@ class SomeRequest(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SomeRequest) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -46,8 +47,10 @@ class SomeRequest(
       SomeRequest::class, 
       "type.googleapis.com/squareup.protos.kotlin.SomeRequest"
     ) {
-      override fun encodedSize(value: SomeRequest): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: SomeRequest): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: SomeRequest) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
@@ -30,7 +30,8 @@ class SomeResponse(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SomeResponse) return false
-    return unknownFields == other.unknownFields
+    var result = unknownFields == other.unknownFields
+    return result
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()
@@ -47,8 +48,10 @@ class SomeResponse(
       SomeResponse::class, 
       "type.googleapis.com/squareup.protos.kotlin.SomeResponse"
     ) {
-      override fun encodedSize(value: SomeResponse): Int = 
-        value.unknownFields.size
+      override fun encodedSize(value: SomeResponse): Int {
+        var size = value.unknownFields.size
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: SomeResponse) {
         writer.writeBytes(value.unknownFields)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
@@ -30,8 +30,8 @@ class SomeResponse(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SomeResponse) return false
-    var result = unknownFields == other.unknownFields
-    return result
+    if (unknownFields != other.unknownFields) return false
+    return true
   }
 
   override fun hashCode(): Int = unknownFields.hashCode()

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -89,14 +89,14 @@ class ExternalMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExternalMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (f == other.f)
-    result = result && (fooext == other.fooext)
-    result = result && (barext == other.barext)
-    result = result && (bazext == other.bazext)
-    result = result && (nested_message_ext == other.nested_message_ext)
-    result = result && (nested_enum_ext == other.nested_enum_ext)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (f != other.f) return false
+    if (fooext != other.fooext) return false
+    if (barext != other.barext) return false
+    if (bazext != other.bazext) return false
+    if (nested_message_ext != other.nested_message_ext) return false
+    if (nested_enum_ext != other.nested_enum_ext) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -89,13 +89,14 @@ class ExternalMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is ExternalMessage) return false
-    return unknownFields == other.unknownFields
-        && f == other.f
-        && fooext == other.fooext
-        && barext == other.barext
-        && bazext == other.bazext
-        && nested_message_ext == other.nested_message_ext
-        && nested_enum_ext == other.nested_enum_ext
+    var result = unknownFields == other.unknownFields
+    result = result && (f == other.f)
+    result = result && (fooext == other.fooext)
+    result = result && (barext == other.barext)
+    result = result && (bazext == other.bazext)
+    result = result && (nested_message_ext == other.nested_message_ext)
+    result = result && (nested_enum_ext == other.nested_enum_ext)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -205,14 +206,17 @@ class ExternalMessage(
       ExternalMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.ExternalMessage"
     ) {
-      override fun encodedSize(value: ExternalMessage): Int = 
-        ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.f) +
-        ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(125, value.fooext) +
-        ProtoAdapter.INT32.encodedSizeWithTag(126, value.barext) +
-        ProtoAdapter.INT32.encodedSizeWithTag(127, value.bazext) +
-        SimpleMessage.NestedMessage.ADAPTER.encodedSizeWithTag(128, value.nested_message_ext) +
-        SimpleMessage.NestedEnum.ADAPTER.encodedSizeWithTag(129, value.nested_enum_ext) +
-        value.unknownFields.size
+      override fun encodedSize(value: ExternalMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.f)
+        size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(125, value.fooext)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(126, value.barext)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(127, value.bazext)
+        size += SimpleMessage.NestedMessage.ADAPTER.encodedSizeWithTag(128,
+            value.nested_message_ext)
+        size += SimpleMessage.NestedEnum.ADAPTER.encodedSizeWithTag(129, value.nested_enum_ext)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: ExternalMessage) {
         ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.f)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -163,20 +163,20 @@ class SimpleMessage(
   override fun equals(other_: Any?): Boolean {
     if (other_ === this) return true
     if (other_ !is SimpleMessage) return false
-    var result_ = unknownFields == other_.unknownFields
-    result_ = result_ && (optional_int32 == other_.optional_int32)
-    result_ = result_ && (optional_nested_msg == other_.optional_nested_msg)
-    result_ = result_ && (optional_external_msg == other_.optional_external_msg)
-    result_ = result_ && (default_nested_enum == other_.default_nested_enum)
-    result_ = result_ && (required_int32 == other_.required_int32)
-    result_ = result_ && (repeated_double == other_.repeated_double)
-    result_ = result_ && (default_foreign_enum == other_.default_foreign_enum)
-    result_ = result_ && (no_default_foreign_enum == other_.no_default_foreign_enum)
-    result_ = result_ && (package_ == other_.package_)
-    result_ = result_ && (result == other_.result)
-    result_ = result_ && (other == other_.other)
-    result_ = result_ && (o == other_.o)
-    return result_
+    if (unknownFields != other_.unknownFields) return false
+    if (optional_int32 != other_.optional_int32) return false
+    if (optional_nested_msg != other_.optional_nested_msg) return false
+    if (optional_external_msg != other_.optional_external_msg) return false
+    if (default_nested_enum != other_.default_nested_enum) return false
+    if (required_int32 != other_.required_int32) return false
+    if (repeated_double != other_.repeated_double) return false
+    if (default_foreign_enum != other_.default_foreign_enum) return false
+    if (no_default_foreign_enum != other_.no_default_foreign_enum) return false
+    if (package_ != other_.package_) return false
+    if (result != other_.result) return false
+    if (other != other_.other) return false
+    if (o != other_.o) return false
+    return true
   }
 
   override fun hashCode(): Int {
@@ -527,9 +527,9 @@ class SimpleMessage(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      var result = unknownFields == other.unknownFields
-      result = result && (bb == other.bb)
-      return result
+      if (unknownFields != other.unknownFields) return false
+      if (bb != other.bb) return false
+      return true
     }
 
     override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -163,19 +163,20 @@ class SimpleMessage(
   override fun equals(other_: Any?): Boolean {
     if (other_ === this) return true
     if (other_ !is SimpleMessage) return false
-    return unknownFields == other_.unknownFields
-        && optional_int32 == other_.optional_int32
-        && optional_nested_msg == other_.optional_nested_msg
-        && optional_external_msg == other_.optional_external_msg
-        && default_nested_enum == other_.default_nested_enum
-        && required_int32 == other_.required_int32
-        && repeated_double == other_.repeated_double
-        && default_foreign_enum == other_.default_foreign_enum
-        && no_default_foreign_enum == other_.no_default_foreign_enum
-        && package_ == other_.package_
-        && result == other_.result
-        && other == other_.other
-        && o == other_.o
+    var result_ = unknownFields == other_.unknownFields
+    result_ = result_ && (optional_int32 == other_.optional_int32)
+    result_ = result_ && (optional_nested_msg == other_.optional_nested_msg)
+    result_ = result_ && (optional_external_msg == other_.optional_external_msg)
+    result_ = result_ && (default_nested_enum == other_.default_nested_enum)
+    result_ = result_ && (required_int32 == other_.required_int32)
+    result_ = result_ && (repeated_double == other_.repeated_double)
+    result_ = result_ && (default_foreign_enum == other_.default_foreign_enum)
+    result_ = result_ && (no_default_foreign_enum == other_.no_default_foreign_enum)
+    result_ = result_ && (package_ == other_.package_)
+    result_ = result_ && (result == other_.result)
+    result_ = result_ && (other == other_.other)
+    result_ = result_ && (o == other_.o)
+    return result_
   }
 
   override fun hashCode(): Int {
@@ -403,20 +404,22 @@ class SimpleMessage(
       SimpleMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage"
     ) {
-      override fun encodedSize(value: SimpleMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.optional_int32) +
-        NestedMessage.ADAPTER.encodedSizeWithTag(2, value.optional_nested_msg) +
-        ExternalMessage.ADAPTER.encodedSizeWithTag(3, value.optional_external_msg) +
-        NestedEnum.ADAPTER.encodedSizeWithTag(4, value.default_nested_enum) +
-        ProtoAdapter.INT32.encodedSizeWithTag(5, value.required_int32) +
-        ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(6, value.repeated_double) +
-        ForeignEnum.ADAPTER.encodedSizeWithTag(7, value.default_foreign_enum) +
-        ForeignEnum.ADAPTER.encodedSizeWithTag(8, value.no_default_foreign_enum) +
-        ProtoAdapter.STRING.encodedSizeWithTag(9, value.package_) +
-        ProtoAdapter.STRING.encodedSizeWithTag(10, value.result) +
-        ProtoAdapter.STRING.encodedSizeWithTag(11, value.other) +
-        ProtoAdapter.STRING.encodedSizeWithTag(12, value.o) +
-        value.unknownFields.size
+      override fun encodedSize(value: SimpleMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.optional_int32)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(2, value.optional_nested_msg)
+        size += ExternalMessage.ADAPTER.encodedSizeWithTag(3, value.optional_external_msg)
+        size += NestedEnum.ADAPTER.encodedSizeWithTag(4, value.default_nested_enum)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(5, value.required_int32)
+        size += ProtoAdapter.DOUBLE.asRepeated().encodedSizeWithTag(6, value.repeated_double)
+        size += ForeignEnum.ADAPTER.encodedSizeWithTag(7, value.default_foreign_enum)
+        size += ForeignEnum.ADAPTER.encodedSizeWithTag(8, value.no_default_foreign_enum)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(9, value.package_)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(10, value.result)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(11, value.other)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(12, value.o)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: SimpleMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.optional_int32)
@@ -524,8 +527,9 @@ class SimpleMessage(
     override fun equals(other: Any?): Boolean {
       if (other === this) return true
       if (other !is NestedMessage) return false
-      return unknownFields == other.unknownFields
-          && bb == other.bb
+      var result = unknownFields == other.unknownFields
+      result = result && (bb == other.bb)
+      return result
     }
 
     override fun hashCode(): Int {
@@ -572,9 +576,11 @@ class SimpleMessage(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage.NestedMessage"
       ) {
-        override fun encodedSize(value: NestedMessage): Int = 
-          ProtoAdapter.INT32.encodedSizeWithTag(1, value.bb) +
-          value.unknownFields.size
+        override fun encodedSize(value: NestedMessage): Int {
+          var size = value.unknownFields.size
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.bb)
+          return size
+        }
 
         override fun encode(writer: ProtoWriter, value: NestedMessage) {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.bb)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -35,8 +35,9 @@ class NestedVersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionOne) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -80,9 +81,11 @@ class NestedVersionOne(
       NestedVersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionOne"
     ) {
-      override fun encodedSize(value: NestedVersionOne): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        value.unknownFields.size
+      override fun encodedSize(value: NestedVersionOne): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NestedVersionOne) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -35,9 +35,9 @@ class NestedVersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionOne) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -75,13 +75,14 @@ class NestedVersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionTwo) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && v2_i == other.v2_i
-        && v2_s == other.v2_s
-        && v2_f32 == other.v2_f32
-        && v2_f64 == other.v2_f64
-        && v2_rs == other.v2_rs
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (v2_i == other.v2_i)
+    result = result && (v2_s == other.v2_s)
+    result = result && (v2_f32 == other.v2_f32)
+    result = result && (v2_f64 == other.v2_f64)
+    result = result && (v2_rs == other.v2_rs)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -188,14 +189,16 @@ class NestedVersionTwo(
       NestedVersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionTwo"
     ) {
-      override fun encodedSize(value: NestedVersionTwo): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs) +
-        value.unknownFields.size
+      override fun encodedSize(value: NestedVersionTwo): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: NestedVersionTwo) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -75,14 +75,14 @@ class NestedVersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is NestedVersionTwo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (v2_i == other.v2_i)
-    result = result && (v2_s == other.v2_s)
-    result = result && (v2_f32 == other.v2_f32)
-    result = result && (v2_f64 == other.v2_f64)
-    result = result && (v2_rs == other.v2_rs)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (v2_i != other.v2_i) return false
+    if (v2_s != other.v2_s) return false
+    if (v2_f32 != other.v2_f32) return false
+    if (v2_f64 != other.v2_f64) return false
+    if (v2_rs != other.v2_rs) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -49,10 +49,11 @@ class VersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionOne) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && obj == other.obj
-        && en == other.en
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (obj == other.obj)
+    result = result && (en == other.en)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -122,11 +123,13 @@ class VersionOne(
       VersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionOne"
     ) {
-      override fun encodedSize(value: VersionOne): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        NestedVersionOne.ADAPTER.encodedSizeWithTag(7, value.obj) +
-        EnumVersionOne.ADAPTER.encodedSizeWithTag(8, value.en) +
-        value.unknownFields.size
+      override fun encodedSize(value: VersionOne): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += NestedVersionOne.ADAPTER.encodedSizeWithTag(7, value.obj)
+        size += EnumVersionOne.ADAPTER.encodedSizeWithTag(8, value.en)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: VersionOne) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -49,11 +49,11 @@ class VersionOne(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionOne) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (obj == other.obj)
-    result = result && (en == other.en)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (obj != other.obj) return false
+    if (en != other.en) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -89,16 +89,16 @@ class VersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionTwo) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (i == other.i)
-    result = result && (v2_i == other.v2_i)
-    result = result && (v2_s == other.v2_s)
-    result = result && (v2_f32 == other.v2_f32)
-    result = result && (v2_f64 == other.v2_f64)
-    result = result && (v2_rs == other.v2_rs)
-    result = result && (obj == other.obj)
-    result = result && (en == other.en)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (i != other.i) return false
+    if (v2_i != other.v2_i) return false
+    if (v2_s != other.v2_s) return false
+    if (v2_f32 != other.v2_f32) return false
+    if (v2_f64 != other.v2_f64) return false
+    if (v2_rs != other.v2_rs) return false
+    if (obj != other.obj) return false
+    if (en != other.en) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -89,15 +89,16 @@ class VersionTwo(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is VersionTwo) return false
-    return unknownFields == other.unknownFields
-        && i == other.i
-        && v2_i == other.v2_i
-        && v2_s == other.v2_s
-        && v2_f32 == other.v2_f32
-        && v2_f64 == other.v2_f64
-        && v2_rs == other.v2_rs
-        && obj == other.obj
-        && en == other.en
+    var result = unknownFields == other.unknownFields
+    result = result && (i == other.i)
+    result = result && (v2_i == other.v2_i)
+    result = result && (v2_s == other.v2_s)
+    result = result && (v2_f32 == other.v2_f32)
+    result = result && (v2_f64 == other.v2_f64)
+    result = result && (v2_rs == other.v2_rs)
+    result = result && (obj == other.obj)
+    result = result && (en == other.en)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -228,16 +229,18 @@ class VersionTwo(
       VersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionTwo"
     ) {
-      override fun encodedSize(value: VersionTwo): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.i) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i) +
-        ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s) +
-        ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32) +
-        ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64) +
-        ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs) +
-        NestedVersionTwo.ADAPTER.encodedSizeWithTag(7, value.obj) +
-        EnumVersionTwo.ADAPTER.encodedSizeWithTag(8, value.en) +
-        value.unknownFields.size
+      override fun encodedSize(value: VersionTwo): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.v2_s)
+        size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.v2_f32)
+        size += ProtoAdapter.FIXED64.encodedSizeWithTag(5, value.v2_f64)
+        size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(6, value.v2_rs)
+        size += NestedVersionTwo.ADAPTER.encodedSizeWithTag(7, value.obj)
+        size += EnumVersionTwo.ADAPTER.encodedSizeWithTag(8, value.en)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: VersionTwo) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -47,9 +47,10 @@ class UsesAny(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UsesAny) return false
-    return unknownFields == other.unknownFields
-        && just_one == other.just_one
-        && many_anys == other.many_anys
+    var result = unknownFields == other.unknownFields
+    result = result && (just_one == other.just_one)
+    result = result && (many_anys == other.many_anys)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -108,10 +109,12 @@ class UsesAny(
       UsesAny::class, 
       "type.googleapis.com/squareup.protos.usesany.UsesAny"
     ) {
-      override fun encodedSize(value: UsesAny): Int = 
-        AnyMessage.ADAPTER.encodedSizeWithTag(1, value.just_one) +
-        AnyMessage.ADAPTER.asRepeated().encodedSizeWithTag(2, value.many_anys) +
-        value.unknownFields.size
+      override fun encodedSize(value: UsesAny): Int {
+        var size = value.unknownFields.size
+        size += AnyMessage.ADAPTER.encodedSizeWithTag(1, value.just_one)
+        size += AnyMessage.ADAPTER.asRepeated().encodedSizeWithTag(2, value.many_anys)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: UsesAny) {
         AnyMessage.ADAPTER.encodeWithTag(writer, 1, value.just_one)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -47,10 +47,10 @@ class UsesAny(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is UsesAny) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (just_one == other.just_one)
-    result = result && (many_anys == other.many_anys)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (just_one != other.just_one) return false
+    if (many_anys != other.many_anys) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -45,9 +45,10 @@ class EmbeddedMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EmbeddedMessage) return false
-    return unknownFields == other.unknownFields
-        && inner_repeated_number == other.inner_repeated_number
-        && inner_number_after == other.inner_number_after
+    var result = unknownFields == other.unknownFields
+    result = result && (inner_repeated_number == other.inner_repeated_number)
+    result = result && (inner_number_after == other.inner_number_after)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -107,10 +108,12 @@ class EmbeddedMessage(
       EmbeddedMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage"
     ) {
-      override fun encodedSize(value: EmbeddedMessage): Int = 
-        ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.inner_repeated_number) +
-        ProtoAdapter.INT32.encodedSizeWithTag(2, value.inner_number_after) +
-        value.unknownFields.size
+      override fun encodedSize(value: EmbeddedMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.inner_repeated_number)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.inner_number_after)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: EmbeddedMessage) {
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.inner_repeated_number)

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -45,10 +45,10 @@ class EmbeddedMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is EmbeddedMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (inner_repeated_number == other.inner_repeated_number)
-    result = result && (inner_number_after == other.inner_number_after)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (inner_repeated_number != other.inner_repeated_number) return false
+    if (inner_number_after != other.inner_number_after) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -42,10 +42,10 @@ class OuterMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OuterMessage) return false
-    var result = unknownFields == other.unknownFields
-    result = result && (outer_number_before == other.outer_number_before)
-    result = result && (embedded_message == other.embedded_message)
-    return result
+    if (unknownFields != other.unknownFields) return false
+    if (outer_number_before != other.outer_number_before) return false
+    if (embedded_message != other.embedded_message) return false
+    return true
   }
 
   override fun hashCode(): Int {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -42,9 +42,10 @@ class OuterMessage(
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is OuterMessage) return false
-    return unknownFields == other.unknownFields
-        && outer_number_before == other.outer_number_before
-        && embedded_message == other.embedded_message
+    var result = unknownFields == other.unknownFields
+    result = result && (outer_number_before == other.outer_number_before)
+    result = result && (embedded_message == other.embedded_message)
+    return result
   }
 
   override fun hashCode(): Int {
@@ -102,10 +103,12 @@ class OuterMessage(
       OuterMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage"
     ) {
-      override fun encodedSize(value: OuterMessage): Int = 
-        ProtoAdapter.INT32.encodedSizeWithTag(1, value.outer_number_before) +
-        EmbeddedMessage.ADAPTER.encodedSizeWithTag(2, value.embedded_message) +
-        value.unknownFields.size
+      override fun encodedSize(value: OuterMessage): Int {
+        var size = value.unknownFields.size
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.outer_number_before)
+        size += EmbeddedMessage.ADAPTER.encodedSizeWithTag(2, value.embedded_message)
+        return size
+      }
 
       override fun encode(writer: ProtoWriter, value: OuterMessage) {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.outer_number_before)


### PR DESCRIPTION
It does not generate long expressions in equals and encodeSize functions anymore.

Equals before my change
```
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SimpleMessage) return false
     return unknownFields == other.unknownFields
         && optional_int32 == other.optional_int32
  }
```
Equals after my change
```
   override fun equals(other: Any?): Boolean {
     if (other === this) return true
     if (other !is SimpleMessage) return false
     var result unknownFields == other.unknownFields
     result = result && (optional_int32 == other.optional_int32)
     return result
   }
```

encodeSize is changed in the same way. It uses local variable to accumulate result of sum

Fixes #1575 