### PR TITLE
Don't modify buildscipt in child project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,7 @@ buildscript {
     classpath deps.plugins.mavenPublish
     classpath deps.animalSniffer.gradle
     classpath deps.androidGradlePlugin
+    classpath deps.protobuf.gradlePlugin
   }
 
   repositories {

--- a/wire-protoc-compatibility-tests/build.gradle
+++ b/wire-protoc-compatibility-tests/build.gradle
@@ -1,17 +1,5 @@
-buildscript {
-  dependencies {
-    classpath deps.protobuf.gradlePlugin
-  }
-
-  repositories {
-    mavenCentral()
-    gradlePluginPortal()
-  }
-}
-
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'ru.vyarus.animalsniffer'
 apply plugin: 'com.google.protobuf'
 apply plugin: 'com.squareup.wire'
 
@@ -46,17 +34,6 @@ wire {
 sourceSets {
   test.java.srcDirs += 'build/generated/source/proto/main/java'
   test.java.srcDirs += 'build/generated/source/wire/'
-}
-
-jar {
-  manifest {
-    attributes('Automatic-Module-Name': 'wire-protoc-compatibility-tests')
-  }
-}
-
-animalsniffer {
-  sourceSets = [sourceSets.main]
-  ignore 'com.squareup.wire.internal'
 }
 
 dependencies {


### PR DESCRIPTION
Set up classpath for protoc compatibility tests in the root.

Also remove its use of animal sniffer and setting a module name since this artifact is not deployed.