### PR TITLE
Timestamps from proto3

### DIFF
--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -132,6 +132,7 @@ public final class JavaGenerator {
           .put(ProtoType.UINT64, (ClassName) TypeName.LONG.box())
           .put(ProtoType.ANY, ClassName.get("com.squareup.wire", "AnyMessage"))
           .put(ProtoType.DURATION, ClassName.get("com.squareup.wire", "Duration"))
+          .put(ProtoType.TIMESTAMP, ClassName.get("com.squareup.wire", "Instant"))
           .put(ProtoType.EMPTY, ClassName.get("kotlin", "Unit"))
           .put(FIELD_OPTIONS, ClassName.get("com.google.protobuf", "FieldOptions"))
           .put(ENUM_OPTIONS, ClassName.get("com.google.protobuf", "EnumOptions"))

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1261,6 +1261,9 @@ class KotlinGenerator private constructor(
       this == ProtoType.DURATION -> {
         CodeBlock.of("%T${adapterFieldDelimiterName}DURATION", ProtoAdapter::class)
       }
+      this == ProtoType.TIMESTAMP -> {
+        CodeBlock.of("%T${adapterFieldDelimiterName}INSTANT", ProtoAdapter::class)
+      }
       this == ProtoType.EMPTY -> {
         CodeBlock.of("%T${adapterFieldDelimiterName}EMPTY", ProtoAdapter::class)
       }
@@ -1288,6 +1291,7 @@ class KotlinGenerator private constructor(
   private fun ProtoType.adapterString() = when {
     isScalar -> ProtoAdapter::class.java.name + '#' + simpleName.toUpperCase(Locale.US)
     this == ProtoType.DURATION -> ProtoAdapter::class.java.name + "#DURATION"
+    this == ProtoType.TIMESTAMP -> ProtoAdapter::class.java.name + "#INSTANT"
     this == ProtoType.EMPTY -> ProtoAdapter::class.java.name + "#EMPTY"
     this == ProtoType.STRUCT_MAP -> ProtoAdapter::class.java.name + "#STRUCT_MAP"
     this == ProtoType.STRUCT_VALUE -> ProtoAdapter::class.java.name + "#STRUCT_VALUE"
@@ -1606,6 +1610,7 @@ class KotlinGenerator private constructor(
         ProtoType.UINT64 to LONG,
         ProtoType.ANY to ClassName("com.squareup.wire", "AnyMessage"),
         ProtoType.DURATION to ClassName("com.squareup.wire", "Duration"),
+        ProtoType.TIMESTAMP to ClassName("com.squareup.wire", "Instant"),
         ProtoType.EMPTY to ClassName("kotlin", "Unit"),
         ProtoType.STRUCT_MAP to ClassName("kotlin.collections", "Map")
             .parameterizedBy(ClassName("kotlin", "String"), STAR).copy(nullable = true),

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/InstantJsonAdapter.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/InstantJsonAdapter.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonDataException
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+import java.time.chrono.IsoChronology
+import java.time.format.DateTimeFormatter
+import java.time.format.DateTimeFormatter.ISO_INSTANT
+import java.time.format.DateTimeFormatter.ISO_OFFSET_DATE_TIME
+import java.time.format.DateTimeFormatterBuilder
+import java.time.format.DateTimeParseException
+import java.time.format.ResolverStyle.STRICT
+
+/**
+ * Encode an instant as a JSON string like "1950-01-01T00:00:00Z". From the spec:
+ *
+ * > Uses RFC 3339, where generated output will always be Z-normalized and uses 0, 3, 6 or 9
+ * > fractional digits. Offsets other than "Z" are also accepted.
+ */
+internal object InstantJsonAdapter : JsonAdapter<Instant>() {
+  override fun toJson(out: JsonWriter, instant: Instant?) {
+    val string = instantToString(instant)
+    out.value(string)
+  }
+
+  internal fun instantToString(instant: Instant?) = ISO_INSTANT.format(instant!!)
+
+  override fun fromJson(input: JsonReader): Instant? {
+    val string = input.nextString()
+    try {
+      return stringToInstant(string)
+    } catch (_: DateTimeParseException) {
+      throw JsonDataException("not an instant: $string at path ${input.path}")
+    }
+  }
+
+  internal fun stringToInstant(string: String?): java.time.Instant? {
+    val parsed = ISO_OFFSET_DATE_TIME.parse(string)
+    return Instant.from(parsed)
+  }
+}

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
@@ -109,28 +109,20 @@ class WireJsonAdapterFactory private constructor(
       }
     }
 
-    if (annotations.isNotEmpty()) {
-      return null
-    }
-    if (rawType == ByteString::class.java) {
-      return BYTE_STRING_JSON_ADAPTER
-    }
-    if (rawType == AnyMessage::class.java) {
-      return AnyMessageJsonAdapter(moshi, typeUrlToAdapter)
-    }
-    if (rawType == Duration::class.java) {
-      return DurationJsonAdapter.nullSafe()
-    }
-    if (rawType == Any::class.java ||
-        rawType == Unit::class.java ||
-        type.isMapStringStar() ||
-        type.isListStar()) {
-      return StructJsonAdapter.serializeNulls()
-    }
-    return if (Message::class.java.isAssignableFrom(rawType)) {
-      MessageJsonAdapter<Nothing, Nothing>(moshi, type)
-    } else {
-      null
+    return when {
+      annotations.isNotEmpty() -> null
+      rawType == ByteString::class.java -> BYTE_STRING_JSON_ADAPTER
+      rawType == AnyMessage::class.java -> AnyMessageJsonAdapter(moshi, typeUrlToAdapter)
+      rawType == Duration::class.java -> DurationJsonAdapter.nullSafe()
+      rawType == Instant::class.java -> InstantJsonAdapter.nullSafe()
+      rawType == Any::class.java -> StructJsonAdapter.serializeNulls()
+      rawType == Unit::class.java -> StructJsonAdapter.serializeNulls()
+      type.isMapStringStar() -> StructJsonAdapter.serializeNulls()
+      type.isListStar() -> StructJsonAdapter.serializeNulls()
+      Message::class.java.isAssignableFrom(rawType) -> {
+        MessageJsonAdapter<Nothing, Nothing>(moshi, type)
+      }
+      else -> null
     }
   }
 

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/InstantJsonAdapterTest.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/InstantJsonAdapterTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.wire.InstantJsonAdapter.instantToString
+import com.squareup.wire.InstantJsonAdapter.stringToInstant
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class InstantJsonAdapterTest {
+  @Test fun `instant to string`() {
+    assertThat(instantToString(ofEpochSecond(0L, 250_000_000L)))
+        .isEqualTo("1970-01-01T00:00:00.250Z")
+    assertThat(instantToString(ofEpochSecond(0L, 250_000L)))
+        .isEqualTo("1970-01-01T00:00:00.000250Z")
+    assertThat(instantToString(ofEpochSecond(0L, 250L)))
+        .isEqualTo("1970-01-01T00:00:00.000000250Z")
+    assertThat(instantToString(ofEpochSecond(0L, 1L)))
+        .isEqualTo("1970-01-01T00:00:00.000000001Z")
+  }
+
+  @Test fun `string to instant`() {
+    assertThat(stringToInstant("0001-01-01T00:00:00Z"))
+        .isEqualTo(ofEpochSecond(-62_135_596_800L, 0L))
+    assertThat(stringToInstant("9999-12-31T23:59:59.999999999Z"))
+        .isEqualTo(ofEpochSecond(253_402_300_799, 999_999_999L))
+    assertThat(stringToInstant("1970-01-01T00:00:00.250Z"))
+        .isEqualTo(ofEpochSecond(0L, 250_000_000L))
+    assertThat(stringToInstant("1970-01-01T00:00:00.000250Z"))
+        .isEqualTo(ofEpochSecond(0L, 250_000L))
+    assertThat(stringToInstant("1970-01-01T00:00:00.000000250Z"))
+        .isEqualTo(ofEpochSecond(0L, 250L))
+    assertThat(stringToInstant("1970-01-01T00:00:00.000000001Z"))
+        .isEqualTo(ofEpochSecond(0L, 1L))
+    assertThat(stringToInstant("1970-01-01T01:00:00+02:00"))
+        .isEqualTo(ofEpochSecond(-3_600L, 0L))
+    assertThat(stringToInstant("1970-01-01T01:00:00-02:00"))
+        .isEqualTo(ofEpochSecond(10_800L, 0L))
+  }
+}

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/Duration.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/Duration.kt
@@ -31,4 +31,4 @@ expect class Duration {
   fun getNano(): Int
 }
 
-expect fun durationOfSeconds(seconds: Long, nanoAdjustment: Long): Duration
+expect fun durationOfSeconds(seconds: Long, nano: Long): Duration

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/Instant.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/Instant.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+/**
+ * This represents a timestamp, though we use the name 'instant' in the runtime because that's what
+ * the JVM libraries use, and 'Timestamp' means something else on that platform.
+ */
+expect class Instant {
+
+  /**
+   * Returns the number of seconds since the UNIX epoch (1970-01-01T00:00:00Z) if this value is
+   * positive, or until the UNIX epoch if this value is negative.
+   *
+   * For example, this value will be -1 for the instant 1969-12-31T23:59:59Z, and 1 for the instant
+   * 1970-01-01T00:00:01Z.
+   */
+  fun getEpochSecond(): Long
+
+  /**
+   * Returns a value in the range `[0..1,000,000,000)` indicating the fraction of a second that is
+   * added to [getEpochSecond].
+   */
+  fun getNano(): Int
+}
+
+expect fun ofEpochSecond(epochSecond: Long, nano: Long): Instant

--- a/wire-library/wire-runtime/src/commonTest/kotlin/com/squareup/wire/InstantTest.kt
+++ b/wire-library/wire-runtime/src/commonTest/kotlin/com/squareup/wire/InstantTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InstantTest {
+  @Test fun positiveValues() {
+    val wireMessage = ofEpochSecond(1L, 200_000_000L)
+    assertEquals(1L, wireMessage.getEpochSecond())
+    assertEquals(200_000_000, wireMessage.getNano())
+  }
+
+  @Test fun zero() {
+    val wireMessage = ofEpochSecond(0L, 0L)
+    assertEquals(0L, wireMessage.getEpochSecond())
+    assertEquals(0, wireMessage.getNano())
+  }
+
+  @Test fun negativeNearZero() {
+    val wireMessage = ofEpochSecond(0L, -200_000_000L)
+    assertEquals(-1L, wireMessage.getEpochSecond())
+    assertEquals(800_000_000, wireMessage.getNano())
+  }
+
+  @Test fun negativeValues() {
+    val wireMessage = ofEpochSecond(-1L, -200_000_000L)
+    assertEquals(-2L, wireMessage.getEpochSecond())
+    assertEquals(800_000_000, wireMessage.getNano())
+  }
+}

--- a/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/Instant.kt
+++ b/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/Instant.kt
@@ -20,19 +20,16 @@ import com.squareup.wire.internal.addExactLong
 import com.squareup.wire.internal.floorDivLong
 import com.squareup.wire.internal.floorModLong
 
-actual class Duration internal constructor(
-  private val seconds: Long,
+actual class Instant internal constructor(
+  private val epochSeconds: Long,
   private val nanos: Int
 ) {
-  actual fun getSeconds(): Long = seconds
+  actual fun getEpochSecond(): Long = epochSeconds
   actual fun getNano(): Int = nanos
 }
 
-actual fun durationOfSeconds(
-  seconds: Long,
-  nano: Long
-): Duration {
-  val secs = addExactLong(seconds, floorDivLong(nano, NANOS_PER_SECOND))
+actual fun ofEpochSecond(epochSecond: Long, nano: Long): Instant {
+  val secs = addExactLong(epochSecond, floorDivLong(nano, NANOS_PER_SECOND))
   val nos = floorModLong(nano, NANOS_PER_SECOND).toInt()
-  return Duration(secs, nos)
+  return Instant(secs, nos)
 }

--- a/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -164,6 +164,7 @@ actual abstract class ProtoAdapter<E> actual constructor(
     actual val BYTES: ProtoAdapter<ByteString> = commonBytes()
     actual val STRING: ProtoAdapter<String> = commonString()
     actual val DURATION: ProtoAdapter<Duration> = commonDuration()
+    actual val INSTANT: ProtoAdapter<Instant> = commonInstant()
     actual val EMPTY: ProtoAdapter<Unit> = commonEmpty()
     actual val STRUCT_MAP: ProtoAdapter<Map<String, *>?> = commonStructMap()
     actual val STRUCT_LIST: ProtoAdapter<List<*>?> = commonStructList()

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/Duration.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/Duration.kt
@@ -18,6 +18,6 @@ package com.squareup.wire
 actual typealias Duration = java.time.Duration
 
 @Suppress("NOTHING_TO_INLINE")
-actual inline fun durationOfSeconds(seconds: Long, nanoAdjustment: Long): Duration {
-  return Duration.ofSeconds(seconds, nanoAdjustment)
+actual inline fun durationOfSeconds(seconds: Long, nano: Long): Duration {
+  return Duration.ofSeconds(seconds, nano)
 }

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/Instant.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/Instant.kt
@@ -15,24 +15,9 @@
  */
 package com.squareup.wire
 
-import com.squareup.wire.internal.NANOS_PER_SECOND
-import com.squareup.wire.internal.addExactLong
-import com.squareup.wire.internal.floorDivLong
-import com.squareup.wire.internal.floorModLong
+actual typealias Instant = java.time.Instant
 
-actual class Duration internal constructor(
-  private val seconds: Long,
-  private val nanos: Int
-) {
-  actual fun getSeconds(): Long = seconds
-  actual fun getNano(): Int = nanos
-}
-
-actual fun durationOfSeconds(
-  seconds: Long,
-  nano: Long
-): Duration {
-  val secs = addExactLong(seconds, floorDivLong(nano, NANOS_PER_SECOND))
-  val nos = floorModLong(nano, NANOS_PER_SECOND).toInt()
-  return Duration(secs, nos)
+@Suppress("NOTHING_TO_INLINE")
+actual inline fun ofEpochSecond(epochSecond: Long, nano: Long): Instant {
+  return Instant.ofEpochSecond(epochSecond, nano)
 }

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -216,6 +216,7 @@ actual abstract class ProtoAdapter<E> actual constructor(
     @JvmField actual val BYTES: ProtoAdapter<ByteString> = commonBytes()
     @JvmField actual val STRING: ProtoAdapter<String> = commonString()
     @JvmField actual val DURATION: ProtoAdapter<Duration> = commonDuration()
+    @JvmField actual val INSTANT: ProtoAdapter<Instant> = commonInstant()
     @JvmField actual val EMPTY: ProtoAdapter<Unit> = commonEmpty()
     @JvmField actual val STRUCT_MAP: ProtoAdapter<Map<String, *>?> = commonStructMap()
     @JvmField actual val STRUCT_LIST: ProtoAdapter<List<*>?> = commonStructList()

--- a/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/Duration.kt
+++ b/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/Duration.kt
@@ -30,9 +30,9 @@ actual class Duration internal constructor(
 
 actual fun durationOfSeconds(
   seconds: Long,
-  nanoAdjustment: Long
+  nano: Long
 ): Duration {
-  val s = addExactLong(seconds, floorDivLong(nanoAdjustment, NANOS_PER_SECOND))
-  val ns = floorModLong(nanoAdjustment, NANOS_PER_SECOND).toInt()
+  val s = addExactLong(seconds, floorDivLong(nano, NANOS_PER_SECOND))
+  val ns = floorModLong(nano, NANOS_PER_SECOND).toInt()
   return Duration(s, ns)
 }

--- a/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/Instant.kt
+++ b/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/Instant.kt
@@ -20,19 +20,16 @@ import com.squareup.wire.internal.addExactLong
 import com.squareup.wire.internal.floorDivLong
 import com.squareup.wire.internal.floorModLong
 
-actual class Duration internal constructor(
-  private val seconds: Long,
+actual class Instant internal constructor(
+  private val epochSeconds: Long,
   private val nanos: Int
 ) {
-  actual fun getSeconds(): Long = seconds
+  actual fun getEpochSecond(): Long = epochSeconds
   actual fun getNano(): Int = nanos
 }
 
-actual fun durationOfSeconds(
-  seconds: Long,
-  nano: Long
-): Duration {
-  val secs = addExactLong(seconds, floorDivLong(nano, NANOS_PER_SECOND))
+actual fun ofEpochSecond(epochSecond: Long, nano: Long): Instant {
+  val secs = addExactLong(epochSecond, floorDivLong(nano, NANOS_PER_SECOND))
   val nos = floorModLong(nano, NANOS_PER_SECOND).toInt()
-  return Duration(secs, nos)
+  return Instant(secs, nos)
 }

--- a/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -164,6 +164,7 @@ actual abstract class ProtoAdapter<E> actual constructor(
     actual val BYTES: ProtoAdapter<ByteString> = commonBytes()
     actual val STRING: ProtoAdapter<String> = commonString()
     actual val DURATION: ProtoAdapter<Duration> = commonDuration()
+    actual val INSTANT: ProtoAdapter<Instant> = commonInstant()
     actual val EMPTY: ProtoAdapter<Unit> = commonEmpty()
     actual val STRUCT_MAP: ProtoAdapter<Map<String, *>?> = commonStructMap()
     actual val STRUCT_LIST: ProtoAdapter<List<*>?> = commonStructList()

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
@@ -113,6 +113,7 @@ class ProtoType {
     @JvmField val UINT64 = ProtoType(true, "uint64")
     @JvmField val ANY = ProtoType(false, "google.protobuf.Any")
     @JvmField val DURATION = ProtoType(false, "google.protobuf.Duration")
+    @JvmField val TIMESTAMP = ProtoType(false, "google.protobuf.Timestamp")
     @JvmField val EMPTY = ProtoType(false, "google.protobuf.Empty")
     @JvmField val STRUCT_MAP = ProtoType(false, "google.protobuf.Struct")
     @JvmField val STRUCT_VALUE = ProtoType(false, "google.protobuf.Value")

--- a/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
+++ b/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
@@ -35,6 +35,7 @@ actual object CoreLoader : Loader {
   private const val DURATION_PROTO = "google/protobuf/duration.proto"
   private const val EMPTY_PROTO = "google/protobuf/empty.proto"
   private const val STRUCT_PROTO = "google/protobuf/struct.proto"
+  private const val TIMESTAMP_PROTO = "google/protobuf/timestamp.proto"
   private const val WIRE_EXTENSIONS_PROTO = "wire/extensions.proto"
 
   /** A special base directory used for Wire's built-in .proto files. */
@@ -65,6 +66,7 @@ actual object CoreLoader : Loader {
         path == DURATION_PROTO ||
         path == EMPTY_PROTO ||
         path == STRUCT_PROTO ||
+        path == TIMESTAMP_PROTO ||
         path == WIRE_EXTENSIONS_PROTO
   }
 }

--- a/wire-library/wire-schema/src/jvmMain/resources/google/protobuf/timestamp.proto
+++ b/wire-library/wire-schema/src/jvmMain/resources/google/protobuf/timestamp.proto
@@ -1,0 +1,111 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option cc_enable_arenas = true;
+option go_package = "github.com/golang/protobuf/ptypes/timestamp";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "TimestampProto";
+option java_multiple_files = true;
+option java_generate_equals_and_hash = true;
+option objc_class_prefix = "GPB";
+
+// A Timestamp represents a point in time independent of any time zone
+// or calendar, represented as seconds and fractions of seconds at
+// nanosecond resolution in UTC Epoch time. It is encoded using the
+// Proleptic Gregorian Calendar which extends the Gregorian calendar
+// backwards to year one. It is encoded assuming all minutes are 60
+// seconds long, i.e. leap seconds are "smeared" so that no leap second
+// table is needed for interpretation. Range is from
+// 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z.
+// By restricting to that range, we ensure that we can convert to
+// and from  RFC 3339 date strings.
+// See [https://www.ietf.org/rfc/rfc3339.txt](https://www.ietf.org/rfc/rfc3339.txt).
+//
+// Example 1: Compute Timestamp from POSIX `time()`.
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(time(NULL));
+//     timestamp.set_nanos(0);
+//
+// Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+//
+//     struct timeval tv;
+//     gettimeofday(&tv, NULL);
+//
+//     Timestamp timestamp;
+//     timestamp.set_seconds(tv.tv_sec);
+//     timestamp.set_nanos(tv.tv_usec * 1000);
+//
+// Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+//
+//     FILETIME ft;
+//     GetSystemTimeAsFileTime(&ft);
+//     UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+//
+//     // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+//     // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+//     Timestamp timestamp;
+//     timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+//     timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+//
+// Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+//
+//     long millis = System.currentTimeMillis();
+//
+//     Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+//         .setNanos((int) ((millis % 1000) * 1000000)).build();
+//
+//
+// Example 5: Compute Timestamp from current time in Python.
+//
+//     now = time.time()
+//     seconds = int(now)
+//     nanos = int((now - seconds) * 10**9)
+//     timestamp = Timestamp(seconds=seconds, nanos=nanos)
+//
+//
+message Timestamp {
+
+  // Represents seconds of UTC time since Unix epoch
+  // 1970-01-01T00:00:00Z. Must be from from 0001-01-01T00:00:00Z to
+  // 9999-12-31T23:59:59Z inclusive.
+  int64 seconds = 1;
+
+  // Non-negative fractions of a second at nanosecond resolution. Negative
+  // second values with fractions must still have non-negative nanos values
+  // that count forward in time. Must be from 0 to 999,999,999
+  // inclusive.
+  int32 nanos = 2;
+}

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
@@ -6,6 +6,7 @@ import com.squareup.wire.AnyMessage
 import com.squareup.wire.Duration
 import com.squareup.wire.EnumAdapter
 import com.squareup.wire.FieldEncoding
+import com.squareup.wire.Instant
 import com.squareup.wire.Message
 import com.squareup.wire.ProtoAdapter
 import com.squareup.wire.ProtoReader
@@ -200,6 +201,12 @@ class AllTypes(
   )
   val empty: Unit? = null,
   @field:WireField(
+    tag = 25,
+    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
+    label = WireField.Label.OMIT_IDENTITY
+  )
+  val timestamp: Instant? = null,
+  @field:WireField(
     tag = 201,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
@@ -367,6 +374,13 @@ class AllTypes(
     jsonName = "repEmpty"
   )
   val rep_empty: List<Unit> = emptyList(),
+  @field:WireField(
+    tag = 225,
+    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
+    label = WireField.Label.REPEATED,
+    jsonName = "repTimestamp"
+  )
+  val rep_timestamp: List<Instant> = emptyList(),
   @field:WireField(
     tag = 301,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
@@ -550,6 +564,13 @@ class AllTypes(
   )
   val map_int32_empty: Map<Int, Unit> = emptyMap(),
   @field:WireField(
+    tag = 525,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
+    jsonName = "mapInt32Timestamp"
+  )
+  val map_int32_timestamp: Map<Int, Instant> = emptyMap(),
+  @field:WireField(
     tag = 601,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "oneofString"
@@ -601,12 +622,18 @@ class AllTypes(
     jsonName = "oneofEmpty"
   )
   val oneof_empty: Unit? = null,
+  @field:WireField(
+    tag = 625,
+    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
+    jsonName = "oneofTimestamp"
+  )
+  val oneof_timestamp: Instant? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<AllTypes, Nothing>(ADAPTER, unknownFields) {
   init {
     require(countNonNull(oneof_string, oneof_int32, oneof_nested_message, oneof_any, oneof_duration,
-        oneof_struct, oneof_list_value, oneof_empty) <= 1) {
-      "At most one of oneof_string, oneof_int32, oneof_nested_message, oneof_any, oneof_duration, oneof_struct, oneof_list_value, oneof_empty may be non-null"
+        oneof_struct, oneof_list_value, oneof_empty, oneof_timestamp) <= 1) {
+      "At most one of oneof_string, oneof_int32, oneof_nested_message, oneof_any, oneof_duration, oneof_struct, oneof_list_value, oneof_empty, oneof_timestamp may be non-null"
     }
   }
 
@@ -644,6 +671,7 @@ class AllTypes(
     if (value != other.value) return false
     if (null_value != other.null_value) return false
     if (empty != other.empty) return false
+    if (timestamp != other.timestamp) return false
     if (rep_int32 != other.rep_int32) return false
     if (rep_uint32 != other.rep_uint32) return false
     if (rep_sint32 != other.rep_sint32) return false
@@ -668,6 +696,7 @@ class AllTypes(
     if (rep_value != other.rep_value) return false
     if (rep_null_value != other.rep_null_value) return false
     if (rep_empty != other.rep_empty) return false
+    if (rep_timestamp != other.rep_timestamp) return false
     if (pack_int32 != other.pack_int32) return false
     if (pack_uint32 != other.pack_uint32) return false
     if (pack_sint32 != other.pack_sint32) return false
@@ -694,6 +723,7 @@ class AllTypes(
     if (map_int32_value != other.map_int32_value) return false
     if (map_int32_null_value != other.map_int32_null_value) return false
     if (map_int32_empty != other.map_int32_empty) return false
+    if (map_int32_timestamp != other.map_int32_timestamp) return false
     if (oneof_string != other.oneof_string) return false
     if (oneof_int32 != other.oneof_int32) return false
     if (oneof_nested_message != other.oneof_nested_message) return false
@@ -702,6 +732,7 @@ class AllTypes(
     if (oneof_struct != other.oneof_struct) return false
     if (oneof_list_value != other.oneof_list_value) return false
     if (oneof_empty != other.oneof_empty) return false
+    if (oneof_timestamp != other.oneof_timestamp) return false
     return true
   }
 
@@ -733,6 +764,7 @@ class AllTypes(
       result = result * 37 + value.hashCode()
       result = result * 37 + null_value.hashCode()
       result = result * 37 + empty.hashCode()
+      result = result * 37 + timestamp.hashCode()
       result = result * 37 + rep_int32.hashCode()
       result = result * 37 + rep_uint32.hashCode()
       result = result * 37 + rep_sint32.hashCode()
@@ -757,6 +789,7 @@ class AllTypes(
       result = result * 37 + rep_value.hashCode()
       result = result * 37 + rep_null_value.hashCode()
       result = result * 37 + rep_empty.hashCode()
+      result = result * 37 + rep_timestamp.hashCode()
       result = result * 37 + pack_int32.hashCode()
       result = result * 37 + pack_uint32.hashCode()
       result = result * 37 + pack_sint32.hashCode()
@@ -783,6 +816,7 @@ class AllTypes(
       result = result * 37 + map_int32_value.hashCode()
       result = result * 37 + map_int32_null_value.hashCode()
       result = result * 37 + map_int32_empty.hashCode()
+      result = result * 37 + map_int32_timestamp.hashCode()
       result = result * 37 + oneof_string.hashCode()
       result = result * 37 + oneof_int32.hashCode()
       result = result * 37 + oneof_nested_message.hashCode()
@@ -791,6 +825,7 @@ class AllTypes(
       result = result * 37 + oneof_struct.hashCode()
       result = result * 37 + oneof_list_value.hashCode()
       result = result * 37 + oneof_empty.hashCode()
+      result = result * 37 + oneof_timestamp.hashCode()
       super.hashCode = result
     }
     return result
@@ -822,6 +857,7 @@ class AllTypes(
     if (value != null) result += """value=$value"""
     if (null_value != null) result += """null_value=$null_value"""
     if (empty != null) result += """empty=$empty"""
+    if (timestamp != null) result += """timestamp=$timestamp"""
     if (rep_int32.isNotEmpty()) result += """rep_int32=$rep_int32"""
     if (rep_uint32.isNotEmpty()) result += """rep_uint32=$rep_uint32"""
     if (rep_sint32.isNotEmpty()) result += """rep_sint32=$rep_sint32"""
@@ -846,6 +882,7 @@ class AllTypes(
     if (rep_value.isNotEmpty()) result += """rep_value=$rep_value"""
     if (rep_null_value.isNotEmpty()) result += """rep_null_value=$rep_null_value"""
     if (rep_empty.isNotEmpty()) result += """rep_empty=$rep_empty"""
+    if (rep_timestamp.isNotEmpty()) result += """rep_timestamp=$rep_timestamp"""
     if (pack_int32.isNotEmpty()) result += """pack_int32=$pack_int32"""
     if (pack_uint32.isNotEmpty()) result += """pack_uint32=$pack_uint32"""
     if (pack_sint32.isNotEmpty()) result += """pack_sint32=$pack_sint32"""
@@ -874,6 +911,7 @@ class AllTypes(
     if (map_int32_null_value.isNotEmpty()) result +=
         """map_int32_null_value=$map_int32_null_value"""
     if (map_int32_empty.isNotEmpty()) result += """map_int32_empty=$map_int32_empty"""
+    if (map_int32_timestamp.isNotEmpty()) result += """map_int32_timestamp=$map_int32_timestamp"""
     if (oneof_string != null) result += """oneof_string=${sanitize(oneof_string)}"""
     if (oneof_int32 != null) result += """oneof_int32=$oneof_int32"""
     if (oneof_nested_message != null) result += """oneof_nested_message=$oneof_nested_message"""
@@ -882,6 +920,7 @@ class AllTypes(
     if (oneof_struct != null) result += """oneof_struct=$oneof_struct"""
     if (oneof_list_value != null) result += """oneof_list_value=$oneof_list_value"""
     if (oneof_empty != null) result += """oneof_empty=$oneof_empty"""
+    if (oneof_timestamp != null) result += """oneof_timestamp=$oneof_timestamp"""
     return result.joinToString(prefix = "AllTypes{", separator = ", ", postfix = "}")
   }
 
@@ -910,6 +949,7 @@ class AllTypes(
     value: Any? = this.value,
     null_value: Nothing? = this.null_value,
     empty: Unit? = this.empty,
+    timestamp: Instant? = this.timestamp,
     rep_int32: List<Int> = this.rep_int32,
     rep_uint32: List<Int> = this.rep_uint32,
     rep_sint32: List<Int> = this.rep_sint32,
@@ -934,6 +974,7 @@ class AllTypes(
     rep_value: List<Any?> = this.rep_value,
     rep_null_value: List<Nothing?> = this.rep_null_value,
     rep_empty: List<Unit> = this.rep_empty,
+    rep_timestamp: List<Instant> = this.rep_timestamp,
     pack_int32: List<Int> = this.pack_int32,
     pack_uint32: List<Int> = this.pack_uint32,
     pack_sint32: List<Int> = this.pack_sint32,
@@ -960,6 +1001,7 @@ class AllTypes(
     map_int32_value: Map<Int, Any?> = this.map_int32_value,
     map_int32_null_value: Map<Int, Nothing?> = this.map_int32_null_value,
     map_int32_empty: Map<Int, Unit> = this.map_int32_empty,
+    map_int32_timestamp: Map<Int, Instant> = this.map_int32_timestamp,
     oneof_string: String? = this.oneof_string,
     oneof_int32: Int? = this.oneof_int32,
     oneof_nested_message: NestedMessage? = this.oneof_nested_message,
@@ -968,22 +1010,24 @@ class AllTypes(
     oneof_struct: Map<String, *>? = this.oneof_struct,
     oneof_list_value: List<*>? = this.oneof_list_value,
     oneof_empty: Unit? = this.oneof_empty,
+    oneof_timestamp: Instant? = this.oneof_timestamp,
     unknownFields: ByteString = this.unknownFields
   ): AllTypes = AllTypes(proto3_kotlin_int32, proto3_kotlin_uint32, proto3_kotlin_sint32,
       proto3_kotlin_fixed32, proto3_kotlin_sfixed32, proto3_kotlin_int64, proto3_kotlin_uint64,
       proto3_kotlin_sint64, proto3_kotlin_fixed64, proto3_kotlin_sfixed64, proto3_kotlin_bool,
       proto3_kotlin_float, proto3_kotlin_double, proto3_kotlin_string, proto3_kotlin_bytes,
       nested_enum, nested_message, any, duration, struct, list_value, value, null_value, empty,
-      rep_int32, rep_uint32, rep_sint32, rep_fixed32, rep_sfixed32, rep_int64, rep_uint64,
-      rep_sint64, rep_fixed64, rep_sfixed64, rep_bool, rep_float, rep_double, rep_string, rep_bytes,
-      rep_nested_enum, rep_nested_message, rep_any, rep_duration, rep_struct, rep_list_value,
-      rep_value, rep_null_value, rep_empty, pack_int32, pack_uint32, pack_sint32, pack_fixed32,
-      pack_sfixed32, pack_int64, pack_uint64, pack_sint64, pack_fixed64, pack_sfixed64, pack_bool,
-      pack_float, pack_double, pack_nested_enum, pack_null_value, map_int32_int32,
-      map_string_string, map_string_message, map_string_enum, map_int32_any, map_int32_duration,
-      map_int32_struct, map_int32_list_value, map_int32_value, map_int32_null_value,
-      map_int32_empty, oneof_string, oneof_int32, oneof_nested_message, oneof_any, oneof_duration,
-      oneof_struct, oneof_list_value, oneof_empty, unknownFields)
+      timestamp, rep_int32, rep_uint32, rep_sint32, rep_fixed32, rep_sfixed32, rep_int64,
+      rep_uint64, rep_sint64, rep_fixed64, rep_sfixed64, rep_bool, rep_float, rep_double,
+      rep_string, rep_bytes, rep_nested_enum, rep_nested_message, rep_any, rep_duration, rep_struct,
+      rep_list_value, rep_value, rep_null_value, rep_empty, rep_timestamp, pack_int32, pack_uint32,
+      pack_sint32, pack_fixed32, pack_sfixed32, pack_int64, pack_uint64, pack_sint64, pack_fixed64,
+      pack_sfixed64, pack_bool, pack_float, pack_double, pack_nested_enum, pack_null_value,
+      map_int32_int32, map_string_string, map_string_message, map_string_enum, map_int32_any,
+      map_int32_duration, map_int32_struct, map_int32_list_value, map_int32_value,
+      map_int32_null_value, map_int32_empty, map_int32_timestamp, oneof_string, oneof_int32,
+      oneof_nested_message, oneof_any, oneof_duration, oneof_struct, oneof_list_value, oneof_empty,
+      oneof_timestamp, unknownFields)
 
   companion object {
     @JvmField
@@ -1024,6 +1068,9 @@ class AllTypes(
 
       private val map_int32_emptyAdapter: ProtoAdapter<Map<Int, Unit>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.EMPTY) }
+
+      private val map_int32_timestampAdapter: ProtoAdapter<Map<Int, Instant>> by lazy {
+          ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INSTANT) }
 
       override fun encodedSize(value: AllTypes): Int {
         var size = value.unknownFields.size
@@ -1073,6 +1120,8 @@ class AllTypes(
         if (value.null_value != null) size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(23,
             value.null_value)
         if (value.empty != null) size += ProtoAdapter.EMPTY.encodedSizeWithTag(24, value.empty)
+        if (value.timestamp != null) size += ProtoAdapter.INSTANT.encodedSizeWithTag(25,
+            value.timestamp)
         size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(201, value.rep_int32)
         size += ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(202, value.rep_uint32)
         size += ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(203, value.rep_sint32)
@@ -1097,6 +1146,7 @@ class AllTypes(
         size += ProtoAdapter.STRUCT_VALUE.asRepeated().encodedSizeWithTag(222, value.rep_value)
         size += ProtoAdapter.STRUCT_NULL.asRepeated().encodedSizeWithTag(223, value.rep_null_value)
         size += ProtoAdapter.EMPTY.asRepeated().encodedSizeWithTag(224, value.rep_empty)
+        size += ProtoAdapter.INSTANT.asRepeated().encodedSizeWithTag(225, value.rep_timestamp)
         size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(301, value.pack_int32)
         size += ProtoAdapter.UINT32.asPacked().encodedSizeWithTag(302, value.pack_uint32)
         size += ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(303, value.pack_sint32)
@@ -1123,6 +1173,7 @@ class AllTypes(
         size += map_int32_valueAdapter.encodedSizeWithTag(522, value.map_int32_value)
         size += map_int32_null_valueAdapter.encodedSizeWithTag(523, value.map_int32_null_value)
         size += map_int32_emptyAdapter.encodedSizeWithTag(524, value.map_int32_empty)
+        size += map_int32_timestampAdapter.encodedSizeWithTag(525, value.map_int32_timestamp)
         size += ProtoAdapter.STRING.encodedSizeWithTag(601, value.oneof_string)
         size += ProtoAdapter.INT32.encodedSizeWithTag(602, value.oneof_int32)
         size += NestedMessage.ADAPTER.encodedSizeWithTag(603, value.oneof_nested_message)
@@ -1131,6 +1182,7 @@ class AllTypes(
         size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(620, value.oneof_struct)
         size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(621, value.oneof_list_value)
         size += ProtoAdapter.EMPTY.encodedSizeWithTag(624, value.oneof_empty)
+        size += ProtoAdapter.INSTANT.encodedSizeWithTag(625, value.oneof_timestamp)
         return size
       }
 
@@ -1178,6 +1230,7 @@ class AllTypes(
         if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 23,
             value.null_value)
         if (value.empty != null) ProtoAdapter.EMPTY.encodeWithTag(writer, 24, value.empty)
+        if (value.timestamp != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 25, value.timestamp)
         ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32)
         ProtoAdapter.UINT32.asRepeated().encodeWithTag(writer, 202, value.rep_uint32)
         ProtoAdapter.SINT32.asRepeated().encodeWithTag(writer, 203, value.rep_sint32)
@@ -1202,6 +1255,7 @@ class AllTypes(
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 222, value.rep_value)
         ProtoAdapter.STRUCT_NULL.asRepeated().encodeWithTag(writer, 223, value.rep_null_value)
         ProtoAdapter.EMPTY.asRepeated().encodeWithTag(writer, 224, value.rep_empty)
+        ProtoAdapter.INSTANT.asRepeated().encodeWithTag(writer, 225, value.rep_timestamp)
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 301, value.pack_int32)
         ProtoAdapter.UINT32.asPacked().encodeWithTag(writer, 302, value.pack_uint32)
         ProtoAdapter.SINT32.asPacked().encodeWithTag(writer, 303, value.pack_sint32)
@@ -1228,6 +1282,7 @@ class AllTypes(
         map_int32_valueAdapter.encodeWithTag(writer, 522, value.map_int32_value)
         map_int32_null_valueAdapter.encodeWithTag(writer, 523, value.map_int32_null_value)
         map_int32_emptyAdapter.encodeWithTag(writer, 524, value.map_int32_empty)
+        map_int32_timestampAdapter.encodeWithTag(writer, 525, value.map_int32_timestamp)
         ProtoAdapter.STRING.encodeWithTag(writer, 601, value.oneof_string)
         ProtoAdapter.INT32.encodeWithTag(writer, 602, value.oneof_int32)
         NestedMessage.ADAPTER.encodeWithTag(writer, 603, value.oneof_nested_message)
@@ -1236,6 +1291,7 @@ class AllTypes(
         ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 620, value.oneof_struct)
         ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 621, value.oneof_list_value)
         ProtoAdapter.EMPTY.encodeWithTag(writer, 624, value.oneof_empty)
+        ProtoAdapter.INSTANT.encodeWithTag(writer, 625, value.oneof_timestamp)
         writer.writeBytes(value.unknownFields)
       }
 
@@ -1264,6 +1320,7 @@ class AllTypes(
         var value: Any? = null
         var null_value: Nothing? = null
         var empty: Unit? = null
+        var timestamp: Instant? = null
         val rep_int32 = mutableListOf<Int>()
         val rep_uint32 = mutableListOf<Int>()
         val rep_sint32 = mutableListOf<Int>()
@@ -1288,6 +1345,7 @@ class AllTypes(
         val rep_value = mutableListOf<Any?>()
         val rep_null_value = mutableListOf<Nothing?>()
         val rep_empty = mutableListOf<Unit>()
+        val rep_timestamp = mutableListOf<Instant>()
         val pack_int32 = mutableListOf<Int>()
         val pack_uint32 = mutableListOf<Int>()
         val pack_sint32 = mutableListOf<Int>()
@@ -1314,6 +1372,7 @@ class AllTypes(
         val map_int32_value = mutableMapOf<Int, Any?>()
         val map_int32_null_value = mutableMapOf<Int, Nothing?>()
         val map_int32_empty = mutableMapOf<Int, Unit>()
+        val map_int32_timestamp = mutableMapOf<Int, Instant>()
         var oneof_string: String? = null
         var oneof_int32: Int? = null
         var oneof_nested_message: NestedMessage? = null
@@ -1322,6 +1381,7 @@ class AllTypes(
         var oneof_struct: Map<String, *>? = null
         var oneof_list_value: List<*>? = null
         var oneof_empty: Unit? = null
+        var oneof_timestamp: Instant? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> proto3_kotlin_int32 = ProtoAdapter.INT32.decode(reader)
@@ -1356,6 +1416,7 @@ class AllTypes(
               reader.addUnknownField(tag, FieldEncoding.VARINT, e.value.toLong())
             }
             24 -> empty = ProtoAdapter.EMPTY.decode(reader)
+            25 -> timestamp = ProtoAdapter.INSTANT.decode(reader)
             201 -> rep_int32.add(ProtoAdapter.INT32.decode(reader))
             202 -> rep_uint32.add(ProtoAdapter.UINT32.decode(reader))
             203 -> rep_sint32.add(ProtoAdapter.SINT32.decode(reader))
@@ -1388,6 +1449,7 @@ class AllTypes(
               reader.addUnknownField(tag, FieldEncoding.VARINT, e.value.toLong())
             }
             224 -> rep_empty.add(ProtoAdapter.EMPTY.decode(reader))
+            225 -> rep_timestamp.add(ProtoAdapter.INSTANT.decode(reader))
             301 -> pack_int32.add(ProtoAdapter.INT32.decode(reader))
             302 -> pack_uint32.add(ProtoAdapter.UINT32.decode(reader))
             303 -> pack_sint32.add(ProtoAdapter.SINT32.decode(reader))
@@ -1422,6 +1484,7 @@ class AllTypes(
             522 -> map_int32_value.putAll(map_int32_valueAdapter.decode(reader))
             523 -> map_int32_null_value.putAll(map_int32_null_valueAdapter.decode(reader))
             524 -> map_int32_empty.putAll(map_int32_emptyAdapter.decode(reader))
+            525 -> map_int32_timestamp.putAll(map_int32_timestampAdapter.decode(reader))
             601 -> oneof_string = ProtoAdapter.STRING.decode(reader)
             602 -> oneof_int32 = ProtoAdapter.INT32.decode(reader)
             603 -> oneof_nested_message = NestedMessage.ADAPTER.decode(reader)
@@ -1430,6 +1493,7 @@ class AllTypes(
             620 -> oneof_struct = ProtoAdapter.STRUCT_MAP.decode(reader)
             621 -> oneof_list_value = ProtoAdapter.STRUCT_LIST.decode(reader)
             624 -> oneof_empty = ProtoAdapter.EMPTY.decode(reader)
+            625 -> oneof_timestamp = ProtoAdapter.INSTANT.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -1458,6 +1522,7 @@ class AllTypes(
           value = value,
           null_value = null_value,
           empty = empty,
+          timestamp = timestamp,
           rep_int32 = rep_int32,
           rep_uint32 = rep_uint32,
           rep_sint32 = rep_sint32,
@@ -1482,6 +1547,7 @@ class AllTypes(
           rep_value = rep_value,
           rep_null_value = rep_null_value,
           rep_empty = rep_empty,
+          rep_timestamp = rep_timestamp,
           pack_int32 = pack_int32,
           pack_uint32 = pack_uint32,
           pack_sint32 = pack_sint32,
@@ -1508,6 +1574,7 @@ class AllTypes(
           map_int32_value = map_int32_value,
           map_int32_null_value = map_int32_null_value,
           map_int32_empty = map_int32_empty,
+          map_int32_timestamp = map_int32_timestamp,
           oneof_string = oneof_string,
           oneof_int32 = oneof_int32,
           oneof_nested_message = oneof_nested_message,
@@ -1516,6 +1583,7 @@ class AllTypes(
           oneof_struct = oneof_struct,
           oneof_list_value = oneof_list_value,
           oneof_empty = oneof_empty,
+          oneof_timestamp = oneof_timestamp,
           unknownFields = unknownFields
         )
       }
@@ -1528,6 +1596,7 @@ class AllTypes(
         list_value = value.list_value?.let(ProtoAdapter.STRUCT_LIST::redact),
         value = value.value?.let(ProtoAdapter.STRUCT_VALUE::redact),
         empty = value.empty?.let(ProtoAdapter.EMPTY::redact),
+        timestamp = value.timestamp?.let(ProtoAdapter.INSTANT::redact),
         rep_nested_message = value.rep_nested_message.redactElements(NestedMessage.ADAPTER),
         rep_any = value.rep_any.redactElements(AnyMessage.ADAPTER),
         rep_duration = value.rep_duration.redactElements(ProtoAdapter.DURATION),
@@ -1535,6 +1604,7 @@ class AllTypes(
         rep_list_value = value.rep_list_value.redactElements(ProtoAdapter.STRUCT_LIST),
         rep_value = value.rep_value.redactElements(ProtoAdapter.STRUCT_VALUE),
         rep_empty = value.rep_empty.redactElements(ProtoAdapter.EMPTY),
+        rep_timestamp = value.rep_timestamp.redactElements(ProtoAdapter.INSTANT),
         map_string_message = value.map_string_message.redactElements(NestedMessage.ADAPTER),
         map_int32_any = value.map_int32_any.redactElements(AnyMessage.ADAPTER),
         map_int32_duration = value.map_int32_duration.redactElements(ProtoAdapter.DURATION),
@@ -1542,12 +1612,14 @@ class AllTypes(
         map_int32_list_value = value.map_int32_list_value.redactElements(ProtoAdapter.STRUCT_LIST),
         map_int32_value = value.map_int32_value.redactElements(ProtoAdapter.STRUCT_VALUE),
         map_int32_empty = value.map_int32_empty.redactElements(ProtoAdapter.EMPTY),
+        map_int32_timestamp = value.map_int32_timestamp.redactElements(ProtoAdapter.INSTANT),
         oneof_nested_message = value.oneof_nested_message?.let(NestedMessage.ADAPTER::redact),
         oneof_any = value.oneof_any?.let(AnyMessage.ADAPTER::redact),
         oneof_duration = value.oneof_duration?.let(ProtoAdapter.DURATION::redact),
         oneof_struct = value.oneof_struct?.let(ProtoAdapter.STRUCT_MAP::redact),
         oneof_list_value = value.oneof_list_value?.let(ProtoAdapter.STRUCT_LIST::redact),
         oneof_empty = value.oneof_empty?.let(ProtoAdapter.EMPTY::redact),
+        oneof_timestamp = value.oneof_timestamp?.let(ProtoAdapter.INSTANT::redact),
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto3/kotlin/all_types.proto
+++ b/wire-library/wire-tests/src/commonTest/proto3/kotlin/all_types.proto
@@ -21,6 +21,7 @@ import "google/protobuf/any.proto";
 import "google/protobuf/duration.proto";
 import "google/protobuf/empty.proto";
 import "google/protobuf/struct.proto";
+import "google/protobuf/timestamp.proto";
 
 option java_package = "com.squareup.wire.proto3.kotlin.all_types";
 
@@ -58,6 +59,7 @@ message AllTypes {
   google.protobuf.Value value = 22;
   google.protobuf.NullValue null_value = 23;
   google.protobuf.Empty empty = 24;
+  google.protobuf.Timestamp timestamp = 25;
 
   repeated int32 rep_int32 = 201 [packed = false];
   repeated uint32 rep_uint32 = 202 [packed = false];
@@ -83,6 +85,7 @@ message AllTypes {
   repeated google.protobuf.Value rep_value = 222;
   repeated google.protobuf.NullValue rep_null_value = 223 [packed = false];
   repeated google.protobuf.Empty rep_empty = 224;
+  repeated google.protobuf.Timestamp rep_timestamp = 225;
 
   repeated int32 pack_int32 = 301 [packed = true];
   repeated uint32 pack_uint32 = 302 [packed = true];
@@ -111,6 +114,7 @@ message AllTypes {
   map<int32, google.protobuf.Value> map_int32_value = 522;
   map<int32, google.protobuf.NullValue> map_int32_null_value = 523;
   map<int32, google.protobuf.Empty> map_int32_empty = 524;
+  map<int32, google.protobuf.Timestamp> map_int32_timestamp = 525;
 
   // We don't support `Value` and `NullValue` in oneof's.
   oneof choice {
@@ -124,5 +128,6 @@ message AllTypes {
     // google.protobuf.Value oneof_value = 622;
     // google.protobuf.NullValue oneof_null_value = 623;
     google.protobuf.Empty oneof_empty = 624;
+    google.protobuf.Timestamp oneof_timestamp = 625;
   }
 }

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/pizza/pizza.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/pizza/pizza.proto
@@ -20,6 +20,7 @@ package squareup.proto3.pizza;
 import 'google/protobuf/any.proto';
 import 'google/protobuf/duration.proto';
 import 'google/protobuf/struct.proto';
+import 'google/protobuf/timestamp.proto';
 
 message PizzaDelivery {
   string phone_number = 1;
@@ -28,6 +29,7 @@ message PizzaDelivery {
   google.protobuf.Any promotion = 4;
   google.protobuf.Duration delivered_within_or_free = 5;
   google.protobuf.Struct loyalty = 6;
+  google.protobuf.Timestamp ordered_at = 7;
 }
 
 message Pizza {

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InstantRoundTripTest.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InstantRoundTripTest.kt
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.google.protobuf.Timestamp
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class InstantRoundTripTest {
+  @Test fun `positive values`() {
+    val googleMessage = Timestamp.newBuilder()
+        .setSeconds(1L)
+        .setNanos(200_000_000)
+        .build()
+
+    val wireMessage = ofEpochSecond(1L, 200_000_000L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.INSTANT.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.INSTANT.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.INSTANT.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+
+  @Test fun `zero`() {
+    val googleMessage = Timestamp.newBuilder()
+        .setSeconds(0L)
+        .setNanos(0)
+        .build()
+
+    val wireMessage = ofEpochSecond(0L, 0L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.INSTANT.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.INSTANT.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.INSTANT.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+
+  @Test fun `negative near zero`() {
+    val googleMessage = Timestamp.newBuilder()
+        .setSeconds(-1L)
+        .setNanos(800_000_000)
+        .build()
+
+    val wireMessage = ofEpochSecond(0L, -200_000_000L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.INSTANT.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.INSTANT.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.INSTANT.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+
+  @Test fun `negative values`() {
+    val googleMessage = Timestamp.newBuilder()
+        .setSeconds(-2L)
+        .setNanos(800_000_000)
+        .build()
+
+    val wireMessage = ofEpochSecond(-1L, -200_000_000L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.INSTANT.encode(wireMessage)).isEqualTo(googleMessageBytes)
+    assertThat(ProtoAdapter.INSTANT.decode(googleMessageBytes)).isEqualTo(wireMessage)
+    assertThat(ProtoAdapter.INSTANT.encodedSize(wireMessage)).isEqualTo(googleMessageBytes.size)
+  }
+
+  @Test fun `decode proto with nanos too high`() {
+    val googleMessage = Timestamp.newBuilder()
+        .setSeconds(2L)
+        .setNanos(2_000_000_000)
+        .build()
+
+    val wireMessage = ofEpochSecond(4L, 0L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.INSTANT.decode(googleMessageBytes)).isEqualTo(wireMessage)
+  }
+
+  @Test fun `decode proto with nanos too low`() {
+    val googleMessage = Timestamp.newBuilder()
+        .setSeconds(2L)
+        .setNanos(-1)
+        .build()
+
+    val wireMessage = ofEpochSecond(1L, 999_999_999L)
+
+    val googleMessageBytes = googleMessage.toByteArray()
+    assertThat(ProtoAdapter.INSTANT.decode(googleMessageBytes)).isEqualTo(wireMessage)
+  }
+}


### PR DESCRIPTION
These are mapped to java.time.Instant on the JVM, and we've used
the name 'Instant' instead of 'Timestamp' throughout the runtime.