### PR TITLE
TypeMover

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Schema.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Schema.kt
@@ -39,7 +39,7 @@ class Schema internal constructor(protoFiles: Iterable<ProtoFile>) {
   }
 
   /** Returns the proto file at [path], or null if this schema has no such file.  */
-  fun protoFile(path: String): ProtoFile? = protoFiles.first { it.location.path == path }
+  fun protoFile(path: String): ProtoFile? = protoFiles.firstOrNull { it.location.path == path }
 
   /** Returns the proto file containing this [protoType], or null if there isn't such file.  */
   fun protoFile(protoType: ProtoType): ProtoFile? = protoFilesIndex[protoType]

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/TypeMover.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/TypeMover.kt
@@ -1,0 +1,208 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema.internal
+
+import com.squareup.wire.schema.Field
+import com.squareup.wire.schema.MessageType
+import com.squareup.wire.schema.ProtoFile
+import com.squareup.wire.schema.ProtoType
+import com.squareup.wire.schema.Schema
+import com.squareup.wire.schema.Type
+
+/**
+ * Refactor a schema by moving a proto type declaration.
+ *
+ * This class attempts to avoid making unnecessary changes to the target schema. For example, it
+ * won't remove unused imports if they are unrelated to the types being moved.
+ */
+internal class TypeMover(
+  private val oldSchema: Schema,
+  private val moves: List<Move>
+) {
+  /** The working copy of proto files. This is mutated as we perform the moves. */
+  private val pathToFile = oldSchema.protoFiles.associateBy { it.location.path }.toMutableMap()
+
+  /** Paths that have had types added or removed. */
+  private val sourceAndTargetPaths = mutableSetOf<String>()
+
+  /** Indexes for import updates. */
+  private val typeToPath = mutableMapOf<ProtoType, String>()
+  private val pathToTypes = mutableMapOf<String, Set<ProtoType>>()
+
+  /** Errors accumulated by this move. */
+  private val errors = mutableListOf<String>()
+
+  fun move(): Schema {
+    // Move the types.
+    for (move in moves) {
+      val targetPath = move.targetPath
+
+      val oldSourceProtoFile: ProtoFile? = oldSchema.protoFile(move.type)
+      if (oldSourceProtoFile == null) {
+        errors += "cannot move ${move.type}, it isn't in this schema"
+        continue
+      }
+
+      val sourceTypes = oldSourceProtoFile.types.toMutableList()
+      val typeIndex = sourceTypes.indexOfFirst { it.type == move.type }
+      val movedType = sourceTypes.removeAt(typeIndex)
+
+      val newSourceProtoFile = oldSourceProtoFile.copy(types = sourceTypes)
+      pathToFile[newSourceProtoFile.location.path] = newSourceProtoFile
+
+      val targetProtoFile = oldSchema.protoFile(targetPath)
+          ?: oldSourceProtoFile.emptyCopy(targetPath)
+      val newTargetProtoFile = targetProtoFile.copy(types = targetProtoFile.types + movedType)
+      pathToFile[newTargetProtoFile.location.path] = newTargetProtoFile
+
+      sourceAndTargetPaths += newSourceProtoFile.location.path
+      sourceAndTargetPaths += newTargetProtoFile.location.path
+    }
+
+    // Build an index of types and paths so we know what's where when fixing imports.
+    for ((path, protoFile) in pathToFile) {
+      val declaredTypes = mutableSetOf<ProtoType>()
+      protoFile.collectDeclaredTypes(declaredTypes)
+      pathToTypes[path] = declaredTypes
+      for (protoType in declaredTypes) {
+        typeToPath[protoType] = path
+      }
+    }
+
+    // Fix imports.
+    val updatedProtoFiles = pathToFile.values.map { it.fixImports() }
+
+    checkForErrors()
+
+    return Schema(updatedProtoFiles)
+  }
+
+  private fun ProtoFile.fixImports(): ProtoFile {
+    if (location.path !in sourceAndTargetPaths &&
+        sourceAndTargetPaths.none { it in imports || it in publicImports }) {
+      return this // This file isn't impacted. Skip it.
+    }
+
+    val referencedTypes = mutableSetOf<ProtoType>()
+    collectReferencedTypes(referencedTypes)
+
+    val definitelyNeed = mutableSetOf<ProtoType>()
+    val possiblyDrop = mutableSetOf<ProtoType>()
+
+    for (move in moves) {
+      if (move.type in referencedTypes) {
+        definitelyNeed += move.type
+      } else {
+        possiblyDrop += move.type
+      }
+
+      // If this file is where the type moved from, we might not need imports for the type's use.
+      if (oldSchema.protoFile(move.type)!!.location.path == location.path) {
+        getType(move).collectReferencedTypes(possiblyDrop)
+      }
+
+      // If this file is where the type moved to, we'll need imports for the type's use.
+      if (location.path == move.targetPath) {
+        getType(move).collectReferencedTypes(definitelyNeed)
+      }
+    }
+
+    // Promote the possible drop list into a definite drop list.
+    val obsoleteImports = mutableSetOf<String>()
+    for (type in possiblyDrop) {
+      val path = typeToPath[type] ?: continue // Probably a built-in type like string.
+      val otherTypesInFile = pathToTypes[path]!!
+      if (otherTypesInFile.any { it in referencedTypes }) continue // Still needed.
+      obsoleteImports.add(path)
+    }
+
+    // Rewrite the imports.
+    val newImports = imports.toMutableList()
+    val newPublicImports = publicImports.toMutableList()
+    for (requiredType in definitelyNeed) {
+      val path = typeToPath[requiredType] ?: continue // Built-in type like string or int32.
+      if (path == location.path) continue // Don't import self!
+      if (path in newImports || path in publicImports) continue // Already imported.
+      newImports += path
+    }
+    newImports.removeAll(obsoleteImports)
+    newPublicImports.removeAll(obsoleteImports)
+
+    return copy(
+        imports = newImports,
+        publicImports = newPublicImports
+    )
+  }
+
+  /** Returns the type that moved. */
+  private fun getType(move: Move): Type {
+    return pathToFile[move.targetPath]!!.types.first { it.type == move.type }
+  }
+
+  private fun ProtoFile.collectReferencedTypes(sink: MutableSet<ProtoType>) {
+    for (type in types) {
+      type.collectReferencedTypes(sink)
+    }
+  }
+
+  private fun Type.collectReferencedTypes(sink: MutableSet<ProtoType>) {
+    for (type in nestedTypes) {
+      type.collectReferencedTypes(sink)
+    }
+    if (this is MessageType) {
+      for (field in fieldsAndOneOfFields) {
+        field.collectReferencedTypes(sink)
+      }
+    }
+  }
+
+  private fun Field.collectReferencedTypes(sink: MutableSet<ProtoType>) {
+    sink.add(type!!)
+  }
+
+  private fun ProtoFile.collectDeclaredTypes(sink: MutableSet<ProtoType>) {
+    for (type in types) {
+      type.collectDeclaredTypes(sink)
+    }
+  }
+
+  private fun Type.collectDeclaredTypes(sink: MutableSet<ProtoType>) {
+    sink.add(type)
+    for (type in nestedTypes) {
+      type.collectDeclaredTypes(sink)
+    }
+  }
+
+  private fun ProtoFile.emptyCopy(path: String): ProtoFile {
+    return copy(
+        location = location.copy(path = path),
+        imports = listOf(),
+        publicImports = listOf(),
+        types = listOf(),
+        services = listOf(),
+        extendList = listOf()
+    )
+  }
+
+  private fun checkForErrors() {
+    require(errors.isEmpty()) { errors.joinToString(separator = "\n") }
+  }
+}
+
+internal class Move(
+  val type: ProtoType,
+  val targetPath: String
+)

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/TypeMoverTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/TypeMoverTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema.internal
+
+import com.squareup.wire.schema.ProtoType
+import com.squareup.wire.schema.RepoBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class TypeMoverTest {
+  /**
+   * Move a type from one schema to another.
+   *
+   * This move triggers 3 import changes:
+   *
+   *  * Adding an import from the source file to the target file. (espresso.proto)
+   *  * Removing an import from the source file that was only used by the target type. (roast.proto)
+   *  * Adding an import to the target file required by the target type (roast.proto).
+   */
+  @Test fun `move type to new file`() {
+    val oldSchema = RepoBuilder()
+        .add("cafe/cafe.proto", """
+            |syntax = "proto2";
+            |
+            |package cafe;
+            |
+            |import "cafe/roast.proto";
+            |
+            |message CafeDrink {
+            |  optional int32 size_ounces = 1;
+            |  repeated EspressoShot shots = 2;
+            |}
+            |
+            |message EspressoShot {
+            |  optional Roast roast = 1;
+            |  optional bool decaf = 2;
+            |}
+            """.trimMargin()
+        )
+        .add("cafe/roast.proto", """
+            |syntax = "proto2";
+            |
+            |package cafe;
+            |
+            |enum Roast {
+            |  MEDIUM = 1;
+            |  DARK = 2;
+            |}
+            """.trimMargin()
+        )
+        .schema()
+
+    val newSchema = TypeMover(oldSchema,
+        listOf(Move(ProtoType.get("cafe", "EspressoShot"), "cafe/espresso.proto"))
+    ).move()
+
+    assertThat(newSchema.protoFile("cafe/cafe.proto")!!.toSchema()).isEqualTo("""
+        |// cafe/cafe.proto
+        |syntax = "proto2";
+        |package cafe;
+        |
+        |import "cafe/espresso.proto";
+        |
+        |message CafeDrink {
+        |  optional int32 size_ounces = 1;
+        |
+        |  repeated EspressoShot shots = 2;
+        |}
+        |""".trimMargin()
+    )
+    assertThat(newSchema.protoFile("cafe/espresso.proto")!!.toSchema()).isEqualTo("""
+        |// cafe/espresso.proto
+        |syntax = "proto2";
+        |package cafe;
+        |
+        |import "cafe/roast.proto";
+        |
+        |message EspressoShot {
+        |  optional Roast roast = 1;
+        |
+        |  optional bool decaf = 2;
+        |}
+        |""".trimMargin()
+    )
+  }
+
+  @Test fun `move type to existing file`() {
+    val oldSchema = RepoBuilder()
+        .add("cafe/cafe.proto", """
+            |syntax = "proto2";
+            |
+            |package cafe;
+            |
+            |import "cafe/roast.proto";
+            |
+            |message CafeDrink {
+            |  optional int32 size_ounces = 1;
+            |  repeated EspressoShot shots = 2;
+            |}
+            |
+            |message EspressoShot {
+            |  optional Roast roast = 1;
+            |  optional bool decaf = 2;
+            |}
+            """.trimMargin()
+        )
+        .add("cafe/roast.proto", """
+            |syntax = "proto2";
+            |
+            |package cafe;
+            |
+            |enum Roast {
+            |  MEDIUM = 1;
+            |  DARK = 2;
+            |}
+            """.trimMargin()
+        )
+        .schema()
+
+    val newSchema = TypeMover(oldSchema,
+        listOf(Move(ProtoType.get("cafe", "EspressoShot"), "cafe/roast.proto"))
+    ).move()
+
+    assertThat(newSchema.protoFile("cafe/cafe.proto")!!.toSchema()).isEqualTo("""
+        |// cafe/cafe.proto
+        |syntax = "proto2";
+        |package cafe;
+        |
+        |import "cafe/roast.proto";
+        |
+        |message CafeDrink {
+        |  optional int32 size_ounces = 1;
+        |
+        |  repeated EspressoShot shots = 2;
+        |}
+        |""".trimMargin()
+    )
+    assertThat(newSchema.protoFile("cafe/roast.proto")!!.toSchema()).isEqualTo("""
+        |// cafe/roast.proto
+        |syntax = "proto2";
+        |package cafe;
+        |
+        |enum Roast {
+        |  MEDIUM = 1;
+        |  DARK = 2;
+        |}
+        |
+        |message EspressoShot {
+        |  optional Roast roast = 1;
+        |
+        |  optional bool decaf = 2;
+        |}
+        |""".trimMargin()
+    )
+  }
+}


### PR DESCRIPTION
This is an early implementation of automated proto refactoring. It has
some limitations

 - Doesn't collect referenced types exhaustively. This needs work.
   In particular, we don't discover types used in options, or in
   map fields.

 - Supports moving types between files. Does not support changes to
   package names, which requires more aggressive rewriting of code
   that references the moved type.