### PR TITLE
Execute WireRun in the scope of the Closer

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -120,7 +120,7 @@ class WireCompiler internal constructor(
       )
     }
 
-    val wireRun = Closer.create().use { closer ->
+    Closer.create().use { closer ->
       val sources = protoPaths.map { fs.getPath(it) }
       val directories = directoryPaths(closer, sources)
 
@@ -136,7 +136,7 @@ class WireCompiler internal constructor(
         protoPath = listOf()
       }
 
-      return@use WireRun(
+      val wireRun = WireRun(
           sourcePath = sourcePath,
           protoPath = protoPath,
           treeShakingRoots = treeShakingRoots,
@@ -144,9 +144,9 @@ class WireCompiler internal constructor(
           targets = targets,
           proto3Preview = proto3Preview == "UNSUPPORTED"
       )
-    }
 
-    wireRun.execute(fs, log)
+      wireRun.execute(fs, log)
+    }
   }
 
   /**
@@ -160,7 +160,7 @@ class WireCompiler internal constructor(
       directories[source] = when {
         Files.isRegularFile(source) -> {
           val sourceFs = FileSystems.newFileSystem(source, javaClass.classLoader)
-              .also { closer.register(it) }
+          closer.register(sourceFs)
           sourceFs.rootDirectories.single()
         }
         else -> source


### PR DESCRIPTION
When directoryPaths encouters a zip it opens it as an FS, registers the FS as a closable, and returns a path pointer inside the zip. This is aggregated into a list of paths which is handed to WireRun. Historically, the closer is then closed before executing, but that would render the paths to zips as unusable. Instead, execute the WireRun inside the context of the closer to ensure those paths remain valid.