### PR TITLE
Use extensions for sourceSets

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -82,7 +82,7 @@ open class JavaOutput @Inject constructor() : WireOutput() {
       it.dependsOn(wireTask)
     }
     if (kotlin) {
-      val sourceSetContainer = project.property("sourceSets") as SourceSetContainer
+      val sourceSetContainer = project.extensions.getByName("sourceSets") as SourceSetContainer
       val mainSourceSet = sourceSetContainer.getByName("main") as SourceSet
       mainSourceSet.java.srcDirs(out)
 

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -64,7 +64,7 @@ class WirePlugin : Plugin<Project> {
 
     project.afterEvaluate {
       if (logger.isDebugEnabled) {
-        sourceSetContainer = project.property("sourceSets") as SourceSetContainer
+        sourceSetContainer = project.extensions.getByName("sourceSets") as SourceSetContainer
         sourceSetContainer.forEach {
           logger.debug("source set: ${it.name}")
         }


### PR DESCRIPTION
While it technically works to access extensions via `property()`, this is a sort of wonky Gradle behavior where `property()` calls will try properties, extensions, extra properties, and even _tasks_ to try to fulfill the request. This makes the extension lookup explicit, since that's where `sourceSets` are defined.