### PR TITLE
Throw on unresolved options

### DIFF
--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.kt
@@ -140,6 +140,7 @@ class WireCompilerErrorTest {
           |multiple enums share constant QUIX:
           |  1. com.squareup.protos.test.Bar.QUIX (/source/test.proto:4:3)
           |  2. com.squareup.protos.test.Bar2.QUIX (/source/test.proto:10:3)
+          |  for file /source/test.proto
           """.trimMargin())
   }
 

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -492,6 +492,28 @@ class WireRunTest {
   }
 
   @Test
+  fun optionsOnlyValidatedForPathFiles() {
+    writeBlueProto()
+    fs.add("polygons/src/main/proto/squareup/polygons/triangle.proto", """
+          |syntax = "proto2";
+          |package squareup.polygons;
+          |option (unicorn) = true; // No such option!
+          |message Triangle {
+          |}
+          """.trimMargin())
+    val wireRun = WireRun(
+        sourcePath = listOf(Location.get("colors/src/main/proto")),
+        protoPath = listOf(Location.get("polygons/src/main/proto")),
+        targets = listOf(JavaTarget(outDirectory = "generated/java"))
+    )
+    wireRun.execute(fs, logger)
+    assertThat(fs.find("generated")).containsExactly(
+        "generated/java/squareup/colors/Blue.java")
+    assertThat(fs.get("generated/java/squareup/colors/Blue.java"))
+        .contains("public final class Blue extends Message")
+  }
+
+  @Test
   fun customOnly() {
     writeBlueProto()
     writeRedProto()

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
@@ -30,8 +30,8 @@ class EnclosingType internal constructor(
     get() = Options(Options.MESSAGE_OPTIONS, listOf())
 
   override fun linkMembers(linker: Linker) {}
-  override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
-    nestedTypes.forEach { it.linkOptions(linker, syntaxRules) }
+  override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules, validate: Boolean) {
+    nestedTypes.forEach { it.linkOptions(linker, syntaxRules, validate) }
   }
 
   override fun validate(linker: Linker, syntaxRules: SyntaxRules) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
@@ -27,7 +27,10 @@ class EnumConstant private constructor(
   internal fun toElement() =
     EnumConstantElement(location, name, tag, documentation, options.elements)
 
-  internal fun linkOptions(linker: Linker) = options.link(linker)
+  internal fun linkOptions(linker: Linker) {
+    val linker = linker.withContext(this)
+    options.link(linker)
+  }
 
   internal fun retainAll(
     schema: Schema,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
@@ -27,9 +27,9 @@ class EnumConstant private constructor(
   internal fun toElement() =
     EnumConstantElement(location, name, tag, documentation, options.elements)
 
-  internal fun linkOptions(linker: Linker) {
+  internal fun linkOptions(linker: Linker, validate: Boolean) {
     val linker = linker.withContext(this)
-    options.link(linker)
+    options.link(linker, validate)
   }
 
   internal fun retainAll(

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -44,11 +44,11 @@ class EnumType private constructor(
 
   override fun linkMembers(linker: Linker) {}
 
-  override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
+  override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules, validate: Boolean) {
     val linker = linker.withContext(this)
-    options.link(linker)
+    options.link(linker, validate = validate)
     for (constant in constants) {
-      constant.linkOptions(linker)
+      constant.linkOptions(linker, validate)
     }
     allowAlias = options.get(ALLOW_ALIAS)
   }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -45,6 +45,7 @@ class EnumType private constructor(
   override fun linkMembers(linker: Linker) {}
 
   override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
+    val linker = linker.withContext(this)
     options.link(linker)
     for (constant in constants) {
       constant.linkOptions(linker)

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -98,9 +98,9 @@ class Field private constructor(
     type = linker.withContext(this).resolveType(elementType)
   }
 
-  fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
+  fun linkOptions(linker: Linker, syntaxRules: SyntaxRules, validate: Boolean) {
     val linker = linker.withContext(this)
-    options.link(linker)
+    options.link(linker, validate)
     deprecated = options.get(DEPRECATED)
     val packed = options.get(PACKED)
         ?: if (syntaxRules.isPackedByDefault(type!!, label)) PACKED_OPTION_ELEMENT.value else null

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileLinker.kt
@@ -120,21 +120,21 @@ internal class FileLinker(
    * This requires traversal of members of imported types! This may potentially include non-direct
    * dependencies!
    */
-  fun linkOptions(syntaxRules: SyntaxRules) {
-    requireFileOptionsLinked()
+  fun linkOptions(syntaxRules: SyntaxRules, validate: Boolean) {
+    requireFileOptionsLinked(validate)
     for (type in protoFile.types) {
-      type.linkOptions(linker, syntaxRules)
+      type.linkOptions(linker, syntaxRules, validate)
     }
     for (service in protoFile.services) {
-      service.linkOptions(linker)
+      service.linkOptions(linker, validate)
     }
   }
 
-  fun requireFileOptionsLinked() {
+  fun requireFileOptionsLinked(validate: Boolean) {
     if (fileOptionsLinked) return
     fileOptionsLinked = true
 
-    protoFile.linkOptions(linker)
+    protoFile.linkOptions(linker, validate)
   }
 
   fun validate(syntaxRules: SyntaxRules) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -473,6 +473,10 @@ class Linker {
           error.append("$prefix message ${context.type} (${context.location})")
         }
 
+        is EnumConstant -> {
+          error.append("$prefix constant ${context.name} (${context.location})")
+        }
+
         is EnumType -> {
           error.append("$prefix enum ${context.type} (${context.location})")
         }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -94,14 +94,14 @@ class Linker {
     for (fileLinker in sourceFiles) {
       // TODO(benoit) Create a map to cache those.
       val syntaxRules = SyntaxRules.get(fileLinker.protoFile.syntax)
-      fileLinker.linkOptions(syntaxRules)
+      fileLinker.linkOptions(syntaxRules, validate = true)
     }
 
     // For compactness we'd prefer to link the options of source files only. But we link file
     // options on referenced files to make sure that java_package is populated.
     while (fileOptionsQueue.isNotEmpty()) {
       val fileLinker = fileOptionsQueue.poll()!!
-      fileLinker.requireFileOptionsLinked()
+      fileLinker.requireFileOptionsLinked(validate = false)
     }
 
     for (fileLinker in sourceFiles) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -449,6 +449,10 @@ class Linker {
     val error = StringBuilder()
     error.append(message)
 
+    val contextStack = this.contextStack.toMutableList()
+    if (contextStack.any { it !is ProtoFile }) {
+      contextStack.removeAll { it is ProtoFile }
+    }
     for (i in contextStack.indices.reversed()) {
       val context = contextStack[i]
       val prefix = if (i == contextStack.size - 1) "\n  for" else "\n  in"
@@ -487,6 +491,10 @@ class Linker {
 
         is Extensions -> {
           error.append("$prefix extensions (${context.location})")
+        }
+
+        is ProtoFile -> {
+          error.append("$prefix file ${context.location}")
         }
       }
     }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -118,21 +118,21 @@ class MessageType private constructor(
     }
   }
 
-  override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
+  override fun linkOptions(linker: Linker, syntaxRules: SyntaxRules, validate: Boolean) {
     val linker = linker.withContext(this)
     for (nestedType in nestedTypes) {
-      nestedType.linkOptions(linker, syntaxRules)
+      nestedType.linkOptions(linker, syntaxRules, validate)
     }
     for (field in declaredFields) {
-      field.linkOptions(linker, syntaxRules)
+      field.linkOptions(linker, syntaxRules, validate)
     }
     for (field in extensionFields) {
-      field.linkOptions(linker, syntaxRules)
+      field.linkOptions(linker, syntaxRules, validate)
     }
     for (oneOf in oneOfs) {
-      oneOf.linkOptions(linker, syntaxRules)
+      oneOf.linkOptions(linker, syntaxRules, validate)
     }
-    options.link(linker)
+    options.link(linker, validate)
   }
 
   override fun validate(linker: Linker, syntaxRules: SyntaxRules) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/OneOf.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/OneOf.kt
@@ -29,9 +29,9 @@ class OneOf private constructor(
     }
   }
 
-  fun linkOptions(linker: Linker, syntaxRules: SyntaxRules) {
+  fun linkOptions(linker: Linker, syntaxRules: SyntaxRules, validate: Boolean) {
     for (field in fields) {
-      field.linkOptions(linker, syntaxRules)
+      field.linkOptions(linker, syntaxRules, validate)
     }
   }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -60,12 +60,13 @@ class Options(
     }
   }
 
-  fun link(linker: Linker) {
+  fun link(linker: Linker, validate: Boolean) {
     var entries: List<LinkedOptionEntry> = emptyList()
 
     for (option in optionElements) {
-      val canonicalOption: List<LinkedOptionEntry> = canonicalizeOption(linker, optionType, option)
-          ?: continue
+      val canonicalOption: List<LinkedOptionEntry> =
+          canonicalizeOption(linker, optionType, option, validate)
+              ?: continue
 
       entries = union(linker, entries, canonicalOption)
     }
@@ -75,7 +76,8 @@ class Options(
   private fun canonicalizeOption(
     linker: Linker,
     extensionType: ProtoType,
-    option: OptionElement
+    option: OptionElement,
+    validate: Boolean
   ): List<LinkedOptionEntry>? {
     val type = linker.getForOptions(extensionType) as? MessageType
         ?: return null // No known extensions for the given extension type.
@@ -96,7 +98,9 @@ class Options(
         path = resolveFieldPath(packageName + "." + option.name, extensionsForType.keys)
       }
       if (path == null) {
-        linker.addError("unable to resolve option ${option.name}")
+        if (validate) {
+          linker.addError("unable to resolve option ${option.name}")
+        }
         return null // Unable to find the root of this field path.
       }
       field = extensionsForType[path[0]]

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -96,6 +96,7 @@ class Options(
         path = resolveFieldPath(packageName + "." + option.name, extensionsForType.keys)
       }
       if (path == null) {
+        linker.addError("unable to resolve option ${option.name}")
         return null // Unable to find the root of this field path.
       }
       field = extensionsForType[path[0]]

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -171,8 +171,8 @@ class ProtoFile private constructor(
     }
   }
 
-  fun linkOptions(linker: Linker) {
-    options.link(linker)
+  fun linkOptions(linker: Linker, validate: Boolean) {
+    options.link(linker, validate)
     javaPackage = options.get(JAVA_PACKAGE)
   }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Rpc.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Rpc.kt
@@ -42,9 +42,9 @@ class Rpc private constructor(
     responseType = linker.resolveMessageType(responseTypeElement)
   }
 
-  fun linkOptions(linker: Linker) {
+  fun linkOptions(linker: Linker, validate: Boolean) {
     val linker = linker.withContext(this)
-    options.link(linker)
+    options.link(linker, validate)
   }
 
   fun validate(linker: Linker) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Service.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Service.kt
@@ -69,13 +69,12 @@ class Service private constructor(
     }
   }
 
-  fun linkOptions(linker: Linker) {
-    var linker = linker
-    linker = linker.withContext(this)
+  fun linkOptions(linker: Linker, validate: Boolean) {
+    var linker = linker.withContext(this)
     for (rpc in rpcs) {
-      rpc.linkOptions(linker)
+      rpc.linkOptions(linker, validate)
     }
-    options.link(linker)
+    options.link(linker, validate)
   }
 
   fun validate(linker: Linker) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
@@ -31,7 +31,7 @@ abstract class Type {
   abstract val nestedTypes: List<Type>
   abstract val syntax: Syntax
   abstract fun linkMembers(linker: Linker)
-  abstract fun linkOptions(linker: Linker, syntaxRules: SyntaxRules)
+  abstract fun linkOptions(linker: Linker, syntaxRules: SyntaxRules, validate: Boolean)
   abstract fun validate(linker: Linker, syntaxRules: SyntaxRules)
   abstract fun retainAll(schema: Schema, markSet: MarkSet): Type?
 

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
@@ -1966,4 +1966,25 @@ class SchemaTest {
       )
     }
   }
+
+  @Test
+  fun unresolvedFileOption() {
+    try {
+      RepoBuilder()
+          .add("message.proto", """
+               |
+               |option (unicorn) = true;
+               |message Message {}
+               """.trimMargin()
+          )
+          .schema()
+      fail()
+    } catch (expected: SchemaException) {
+      assertThat(expected).hasMessage("""
+            |unable to resolve option unicorn
+            |  for file /source/message.proto
+            """.trimMargin()
+      )
+    }
+  }
 }

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
@@ -1901,4 +1901,69 @@ class SchemaTest {
         .schema()
     assertThat(schema.getType("wire.Foo")).isNotNull()
   }
+
+  @Test
+  fun unresolvedFieldOption() {
+    try {
+      RepoBuilder()
+          .add("message.proto", """
+               |message Message {
+               |  optional string name = 1 [(unicorn) = true];
+               |}
+               """.trimMargin()
+          )
+          .schema()
+      fail()
+    } catch (expected: SchemaException) {
+      assertThat(expected).hasMessage("""
+            |unable to resolve option unicorn
+            |  for field name (/source/message.proto:2:3)
+            |  in message Message (/source/message.proto:1:1)
+            """.trimMargin()
+      )
+    }
+  }
+
+  @Test
+  fun unresolvedEnumValueOption() {
+    try {
+      RepoBuilder()
+          .add("enum.proto", """
+               |enum Enum {
+               |  A = 1 [(unicorn) = true];
+               |}
+               """.trimMargin()
+          )
+          .schema()
+      fail()
+    } catch (expected: SchemaException) {
+      assertThat(expected).hasMessage("""
+            |unable to resolve option unicorn
+            |  for constant A (/source/enum.proto:2:3)
+            |  in enum Enum (/source/enum.proto:1:1)
+            """.trimMargin()
+      )
+    }
+  }
+
+  @Test
+  fun unresolvedMessageOption() {
+    try {
+      RepoBuilder()
+          .add("message.proto", """
+               |message Message {
+               |  option (unicorn) = true;
+               |}
+               """.trimMargin()
+          )
+          .schema()
+      fail()
+    } catch (expected: SchemaException) {
+      assertThat(expected).hasMessage("""
+            |unable to resolve option unicorn
+            |  for message Message (/source/message.proto:1:1)
+            """.trimMargin()
+      )
+    }
+  }
 }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -12,7 +12,6 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
-import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.AssertionError
@@ -66,7 +65,8 @@ class FooBar(
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
-    label = WireField.Label.REPEATED
+    label = WireField.Label.REPEATED,
+    redacted = true
   )
   val nested: List<FooBar> = emptyList(),
   /**
@@ -136,7 +136,7 @@ class FooBar(
     if (qux != null) result += """qux=$qux"""
     if (fred.isNotEmpty()) result += """fred=$fred"""
     if (daisy != null) result += """daisy=$daisy"""
-    if (nested.isNotEmpty()) result += """nested=$nested"""
+    if (nested.isNotEmpty()) result += """nested=██"""
     if (ext != null) result += """ext=$ext"""
     if (rep.isNotEmpty()) result += """rep=$rep"""
     return result.joinToString(prefix = "FooBar{", separator = ", ", postfix = "}")
@@ -238,7 +238,7 @@ class FooBar(
 
       override fun redact(value: FooBar): FooBar = value.copy(
         baz = value.baz?.let(Nested.ADAPTER::redact),
-        nested = value.nested.redactElements(FooBar.ADAPTER),
+        nested = emptyList(),
         unknownFields = ByteString.EMPTY
       )
     }
@@ -414,18 +414,19 @@ class FooBar(
   enum class FooBarBazEnum(
     override val value: Int,
     val enum_value_option: Int?,
-    val complex_enum_value_option: More?
+    val complex_enum_value_option: More?,
+    val foreign_enum_value_option: Boolean?
   ) : WireEnum {
     FOO(1, 17, More(
       serial = listOf(
         99,
         199
       )
-    )),
+    ), null),
 
-    BAR(2, null, null),
+    BAR(2, null, null, true),
 
-    BAZ(3, 18, null);
+    BAZ(3, 18, null, false);
 
     companion object {
       @JvmField

--- a/wire-library/wire-tests/src/commonTest/proto/kotlin/custom_options.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/kotlin/custom_options.proto
@@ -24,17 +24,17 @@ import "option_redacted.proto";
 message FooBar {
   extensions 100 to 200;
 
-  optional int32 foo = 1 [my_field_option_one = 17];
-  optional string bar = 2 [my_field_option_two = 33.5];
-  optional Nested baz = 3 [my_field_option_three = BAR];
-  optional uint64 qux = 4 [my_field_option_one = 18, my_field_option_two = 34.5];
-  repeated float fred = 5 [my_field_option_four = {
+  optional int32 foo = 1 [squareup.protos.custom_options.my_field_option_one = 17];
+  optional string bar = 2 [squareup.protos.custom_options.my_field_option_two = 33.5];
+  optional Nested baz = 3 [squareup.protos.custom_options.my_field_option_three = BAR];
+  optional uint64 qux = 4 [squareup.protos.custom_options.my_field_option_one = 18, squareup.protos.custom_options.my_field_option_two = 34.5];
+  repeated float fred = 5 [squareup.protos.custom_options.my_field_option_four = {
       foo: 11, bar: "22", baz: { value: BAR }, fred : [444.0, 555.0],
       nested: { foo: 33, fred: [100.0, 200.0] }
-  }, my_field_option_two = 99.9];
-  optional double daisy = 6 [my_field_option_four.baz.value = FOO];
+  }, squareup.protos.custom_options.my_field_option_two = 99.9];
+  optional double daisy = 6 [squareup.protos.custom_options.my_field_option_four.baz.value = FOO];
 
-  repeated FooBar nested = 7 [(squareup.protos.redacted_option.redacted) = true];
+  repeated FooBar nested = 7 [(squareup.protos.kotlin.redacted_option.redacted) = true];
 
   message Nested {
     optional FooBarBazEnum value = 1;
@@ -47,8 +47,8 @@ message FooBar {
   enum FooBarBazEnum {
     option enum_option = true;
     FOO = 1 [enum_value_option=17, complex_enum_value_option={ serial: [ 99, 199 ] }];
-    BAR = 2 [squareup.protos.foreign.foreign_enum_value_option=true];
-    BAZ = 3 [enum_value_option=18, squareup.protos.foreign.foreign_enum_value_option=false];
+    BAR = 2 [squareup.protos.kotlin.foreign.foreign_enum_value_option=true];
+    BAZ = 3 [enum_value_option=18, squareup.protos.kotlin.foreign.foreign_enum_value_option=false];
   }
 }
 
@@ -96,7 +96,7 @@ message MessageWithOptions {
     nested: { foo: 33, fred: [100.0, 200.0] }
   };
   option (my_message_option_four) = FOO;
-  option (squareup.protos.foreign.foreign_message_option).i = 9876;
+  option (squareup.protos.kotlin.foreign.foreign_message_option).i = 9876;
   option (my_message_option_five) = {
     [squareup.protos.custom_options.ext]: BAZ,
     [squareup.protos.custom_options.rep]: FOO,


### PR DESCRIPTION
This is what Protoc does.
I think we should just turn it on without going through an option.
It might break some schema but as we can see in the files I had to fix, something like `redacted` could be NOT applied without nobody noticing it. It actually happened a few days ago internally.
