### PR TITLE
Make lists and maps immutable from Kotlin

### DIFF
--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -26,14 +27,16 @@ import okio.ByteString
  * Not used in the RPC.  Instead, this is here for the form serialized to disk.
  */
 class FeatureDatabase(
+  feature: List<Feature> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<FeatureDatabase, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     adapter = "routeguide.Feature#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val feature: List<Feature> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<FeatureDatabase, Nothing>(ADAPTER, unknownFields) {
+  val feature: List<Feature> = immutableCopyOf("feature", feature)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/GsonNoAdapterTest.java
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/GsonNoAdapterTest.java
@@ -94,8 +94,8 @@ public class GsonNoAdapterTest {
         .picture_urls(Arrays.asList("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67"))
         .build();
     String json = "{"
-        + "\"name\":\"Stegosaurus\","
         + "\"picture_urls\":[\"http://goo.gl/LD5KY5\",\"http://goo.gl/VYRM67\"],"
+        + "\"name\":\"Stegosaurus\","
         + "\"length_meters\":9.0,"
         + "\"mass_kilograms\":5000.0,"
         + "\"period\":\"JURASSIC\""
@@ -142,8 +142,8 @@ public class GsonNoAdapterTest {
             ByteString.EMPTY
         );
     String json = "{"
-        + "\"name\":\"Stegosaurus\","
         + "\"picture_urls\":[\"http://goo.gl/LD5KY5\",\"http://goo.gl/VYRM67\"],"
+        + "\"name\":\"Stegosaurus\","
         + "\"length_meters\":9.0,"
         + "\"mass_kilograms\":5000.0,"
         + "\"period\":\"JURASSIC\""

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import com.squareup.wire.proto2.geology.javainteropkotlin.Period
 import kotlin.Any
@@ -32,16 +33,7 @@ class Dinosaur(
   )
   @JvmField
   val name: String? = null,
-  /**
-   * URLs with images of this dinosaur.
-   */
-  @field:WireField(
-    tag = 2,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val picture_urls: List<String> = emptyList(),
+  picture_urls: List<String> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
@@ -62,6 +54,17 @@ class Dinosaur(
   val period: Period? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Dinosaur, Dinosaur.Builder>(ADAPTER, unknownFields) {
+  /**
+   * URLs with images of this dinosaur.
+   */
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import com.squareup.wire.proto2.geology.kotlin.Period
 import kotlin.Any
@@ -34,15 +35,7 @@ class Dinosaur(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val name: String? = null,
-  /**
-   * URLs with images of this dinosaur.
-   */
-  @field:WireField(
-    tag = 2,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  val picture_urls: List<String> = emptyList(),
+  picture_urls: List<String> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
@@ -60,6 +53,16 @@ class Dinosaur(
   val period: Period? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Dinosaur, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * URLs with images of this dinosaur.
+   */
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -39,6 +40,10 @@ class KeywordKotlin(
   )
   @JvmField
   val when_: Int,
+  fun_: Map<String, String> = emptyMap(),
+  return_: List<Boolean> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<KeywordKotlin, KeywordKotlin.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 3,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
@@ -46,7 +51,8 @@ class KeywordKotlin(
     declaredName = "fun"
   )
   @JvmField
-  val fun_: Map<String, String> = emptyMap(),
+  val fun_: Map<String, String> = immutableCopyOf("fun_", fun_)
+
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
@@ -54,9 +60,8 @@ class KeywordKotlin(
     declaredName = "return"
   )
   @JvmField
-  val return_: List<Boolean> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<KeywordKotlin, KeywordKotlin.Builder>(ADAPTER, unknownFields) {
+  val return_: List<Boolean> = immutableCopyOf("return_", return_)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.object_ = object_

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1390,7 +1390,10 @@ public final class JavaGenerator {
         result.addParameter(param.build());
       }
 
-      if (isStruct(field.getType())) {
+      if (field.getType().isMap() && isStruct(field.getType().getValueType())) {
+        result.addStatement("this.$1L = $2T.immutableCopyOfMapWithStructValues($1S, $3L)",
+            fieldName, Internal.class, fieldAccessName);
+      } else if (isStruct(field.getType())) {
         result.addStatement("this.$1L = $2T.immutableCopyOfStruct($1S, $3L)", fieldName,
             Internal.class, fieldAccessName);
       } else if (field.isRepeated() || field.getType().isMap()) {

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import com.squareup.wire.proto2.geology.javainteropkotlin.Period
 import kotlin.Any
@@ -32,16 +33,7 @@ class Dinosaur(
   )
   @JvmField
   val name: String? = null,
-  /**
-   * URLs with images of this dinosaur.
-   */
-  @field:WireField(
-    tag = 2,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val picture_urls: List<String> = emptyList(),
+  picture_urls: List<String> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
@@ -62,6 +54,17 @@ class Dinosaur(
   val period: Period? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Dinosaur, Dinosaur.Builder>(ADAPTER, unknownFields) {
+  /**
+   * URLs with images of this dinosaur.
+   */
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import com.squareup.wire.proto2.geology.kotlin.Period
 import kotlin.Any
@@ -34,15 +35,7 @@ class Dinosaur(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val name: String? = null,
-  /**
-   * URLs with images of this dinosaur.
-   */
-  @field:WireField(
-    tag = 2,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  val picture_urls: List<String> = emptyList(),
+  picture_urls: List<String> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
@@ -60,6 +53,16 @@ class Dinosaur(
   val period: Period? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Dinosaur, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * URLs with images of this dinosaur.
+   */
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -59,6 +60,9 @@ class Person(
   )
   @JvmField
   val email: String? = null,
+  phone: List<PhoneNumber> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Person, Person.Builder>(ADAPTER, unknownFields) {
   /**
    * A list of the customer's phone numbers.
    */
@@ -68,9 +72,8 @@ class Person(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val phone: List<PhoneNumber> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Person, Person.Builder>(ADAPTER, unknownFields) {
+  val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -59,6 +60,9 @@ class Person(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val email: String? = null,
+  phone: List<PhoneNumber> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Person, Nothing>(ADAPTER, unknownFields) {
   /**
    * A list of the customer's phone numbers.
    */
@@ -67,9 +71,8 @@ class Person(
     adapter = "com.squareup.wire.proto2.person.kotlin.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val phone: List<PhoneNumber> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Person, Nothing>(ADAPTER, unknownFields) {
+  val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -39,6 +40,10 @@ class KeywordKotlin(
   )
   @JvmField
   val when_: Int,
+  fun_: Map<String, String> = emptyMap(),
+  return_: List<Boolean> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<KeywordKotlin, KeywordKotlin.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 3,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
@@ -46,7 +51,8 @@ class KeywordKotlin(
     declaredName = "fun"
   )
   @JvmField
-  val fun_: Map<String, String> = emptyMap(),
+  val fun_: Map<String, String> = immutableCopyOf("fun_", fun_)
+
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
@@ -54,9 +60,8 @@ class KeywordKotlin(
     declaredName = "return"
   )
   @JvmField
-  val return_: List<Boolean> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<KeywordKotlin, KeywordKotlin.Builder>(ADAPTER, unknownFields) {
+  val return_: List<Boolean> = immutableCopyOf("return_", return_)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.object_ = object_

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Internal.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Internal.kt
@@ -64,15 +64,25 @@ fun <T> immutableCopyOf(name: String, list: List<T>): List<T> {
   return result as List<T>
 }
 
-fun <K, V> immutableCopyOf(name: String, map: Map<K?, V?>): Map<K, V> {
+fun <K, V> immutableCopyOf(name: String, map: Map<K, V>): Map<K, V> {
   if (map.isEmpty()) {
     return emptyMap()
   }
   val result = LinkedHashMap(map)
   // Check after the map has been copied to defend against races.
-  require(null !in result.keys) { "$name.containsKey(null)" }
-  require(null !in result.values) { "$name.containsValue(null)" }
-  return (result as MutableMap<K, V>).toUnmodifiableMap()
+  require(null !in (result.keys as Collection<K?>)) { "$name.containsKey(null)" }
+  require(null !in (result.values as Collection<V?>)) { "$name.containsValue(null)" }
+  return result.toUnmodifiableMap()
+}
+
+/** Confirms the values of [map] are structs and returns an immutable copy. */
+fun <K, V> immutableCopyOfMapWithStructValues(name: String, map: Map<K, V>): Map<K, V> {
+  val copy = mutableMapOf<K, Any?>()
+  for ((k, v) in map) {
+    require(k != null) { "$name.containsKey(null)" }
+    copy[k] = immutableCopyOfStruct(name, v)
+  }
+  return copy.toUnmodifiableMap() as Map<K, V>
 }
 
 /** Confirms [value] is a struct and returns an immutable copy. */

--- a/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/IgnoreNative.kt
+++ b/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/IgnoreNative.kt
@@ -1,0 +1,4 @@
+package com.squareup.wire
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+expect annotation class IgnoreNative()

--- a/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/KotlinListTest.kt
+++ b/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/KotlinListTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.wire.protos.kotlin.person.Person
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.fail
+
+class KotlinListTest {
+  @Test fun listsAreImmutable() {
+    val list = mutableListOf("a", "b")
+
+    val person = Person(id = 0, name = "name", aliases = list)
+    if (person.aliases is MutableList<*>) {
+      try {
+        (person.aliases as MutableList<*>).clear()
+        fail()
+      } catch (_: UnsupportedOperationException) {
+        // Mutation failed as expected.
+      }
+    }
+
+    // Mutate the values used to create the map. Wire should have defensive copies.
+    list.clear()
+    assertEquals(listOf("a", "b"), person.aliases)
+  }
+}

--- a/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/KotlinMapTest.kt
+++ b/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/KotlinMapTest.kt
@@ -22,6 +22,7 @@ import okio.ByteString.Companion.decodeHex
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
+import kotlin.test.fail
 
 class KotlinMapTest {
   private val adapter = Mappy.ADAPTER
@@ -37,6 +38,22 @@ class KotlinMapTest {
 
     val empty = adapter.decode(ByteArray(0))
     assertNotNull(empty.things)
+  }
+
+  @Test fun mapsAreImmutable() {
+    val map = mutableMapOf("one" to Thing("One"))
+
+    val mappy = Mappy(things = map)
+    try {
+      (mappy.things as MutableMap<*, *>).clear()
+      fail()
+    } catch (_: UnsupportedOperationException) {
+      // Mutation failed as expected.
+    }
+
+    // Mutate the values used to create the map. Wire should have defensive copies.
+    map.clear()
+    assertEquals(mapOf("one" to Thing("One")), mappy.things)
   }
 
   companion object {

--- a/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/KotlinMapTest.kt
+++ b/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/KotlinMapTest.kt
@@ -40,6 +40,8 @@ class KotlinMapTest {
     assertNotNull(empty.things)
   }
 
+  @IgnoreJs
+  @IgnoreNative
   @Test fun mapsAreImmutable() {
     val map = mutableMapOf("one" to Thing("One"))
 

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -34,53 +35,70 @@ class DescriptorProto(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val name: String? = null,
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val field: List<FieldDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 6,
-    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val extension: List<FieldDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 3,
-    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val nested_type: List<DescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 4,
-    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val enum_type: List<EnumDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 5,
-    adapter = "com.google.protobuf.DescriptorProto${'$'}ExtensionRange#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val extension_range: List<ExtensionRange> = emptyList(),
-  @field:WireField(
-    tag = 8,
-    adapter = "com.google.protobuf.OneofDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val oneof_decl: List<OneofDescriptorProto> = emptyList(),
+  field: List<FieldDescriptorProto> = emptyList(),
+  extension: List<FieldDescriptorProto> = emptyList(),
+  nested_type: List<DescriptorProto> = emptyList(),
+  enum_type: List<EnumDescriptorProto> = emptyList(),
+  extension_range: List<ExtensionRange> = emptyList(),
+  oneof_decl: List<OneofDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 7,
     adapter = "com.google.protobuf.MessageOptions#ADAPTER"
   )
   val options: MessageOptions? = null,
+  reserved_range: List<ReservedRange> = emptyList(),
+  reserved_name: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<DescriptorProto, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val field: List<FieldDescriptorProto> = immutableCopyOf("field", field)
+
+  @field:WireField(
+    tag = 6,
+    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val extension: List<FieldDescriptorProto> = immutableCopyOf("extension", extension)
+
+  @field:WireField(
+    tag = 3,
+    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val nested_type: List<DescriptorProto> = immutableCopyOf("nested_type", nested_type)
+
+  @field:WireField(
+    tag = 4,
+    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val enum_type: List<EnumDescriptorProto> = immutableCopyOf("enum_type", enum_type)
+
+  @field:WireField(
+    tag = 5,
+    adapter = "com.google.protobuf.DescriptorProto${'$'}ExtensionRange#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val extension_range: List<ExtensionRange> = immutableCopyOf("extension_range", extension_range)
+
+  @field:WireField(
+    tag = 8,
+    adapter = "com.google.protobuf.OneofDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val oneof_decl: List<OneofDescriptorProto> = immutableCopyOf("oneof_decl", oneof_decl)
+
   @field:WireField(
     tag = 9,
     adapter = "com.google.protobuf.DescriptorProto${'$'}ReservedRange#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val reserved_range: List<ReservedRange> = emptyList(),
+  val reserved_range: List<ReservedRange> = immutableCopyOf("reserved_range", reserved_range)
+
   /**
    * Reserved field names, which may not be used by fields in the same message.
    * A given name may only be reserved once.
@@ -90,9 +108,8 @@ class DescriptorProto(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
-  val reserved_name: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<DescriptorProto, Nothing>(ADAPTER, unknownFields) {
+  val reserved_name: List<String> = immutableCopyOf("reserved_name", reserved_name)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -34,17 +35,23 @@ class EnumDescriptorProto(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val name: String? = null,
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.EnumValueDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val value: List<EnumValueDescriptorProto> = emptyList(),
+  value: List<EnumValueDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.google.protobuf.EnumOptions#ADAPTER"
   )
   val options: EnumOptions? = null,
+  reserved_range: List<EnumReservedRange> = emptyList(),
+  reserved_name: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<EnumDescriptorProto, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.EnumValueDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val value: List<EnumValueDescriptorProto> = immutableCopyOf("value", value)
+
   /**
    * Range of reserved numeric values. Reserved numeric values may not be used
    * by enum values in the same enum declaration. Reserved ranges may not
@@ -55,7 +62,8 @@ class EnumDescriptorProto(
     adapter = "com.google.protobuf.EnumDescriptorProto${'$'}EnumReservedRange#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val reserved_range: List<EnumReservedRange> = emptyList(),
+  val reserved_range: List<EnumReservedRange> = immutableCopyOf("reserved_range", reserved_range)
+
   /**
    * Reserved enum value names, which may not be reused. A given name may only
    * be reserved once.
@@ -65,9 +73,8 @@ class EnumDescriptorProto(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
-  val reserved_name: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<EnumDescriptorProto, Nothing>(ADAPTER, unknownFields) {
+  val reserved_name: List<String> = immutableCopyOf("reserved_name", reserved_name)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -44,15 +45,7 @@ class EnumOptions(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   val deprecated: Boolean? = null,
-  /**
-   * The parser stores options it doesn't recognize here. See above.
-   */
-  @field:WireField(
-    tag = 999,
-    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
   /**
    * Extension source: custom_options.proto
    */
@@ -63,6 +56,17 @@ class EnumOptions(
   val enum_option: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<EnumOptions, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @field:WireField(
+    tag = 999,
+    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.protos.custom_options.FooBar
 import kotlin.Any
@@ -36,15 +37,7 @@ class EnumValueOptions(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   val deprecated: Boolean? = null,
-  /**
-   * The parser stores options it doesn't recognize here. See above.
-   */
-  @field:WireField(
-    tag = 999,
-    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
   /**
    * Extension source: custom_options.proto
    */
@@ -71,6 +64,17 @@ class EnumValueOptions(
   val foreign_enum_value_option: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<EnumValueOptions, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @field:WireField(
+    tag = 999,
+    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -23,6 +24,9 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class ExtensionRangeOptions(
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<ExtensionRangeOptions, Nothing>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -31,9 +35,9 @@ class ExtensionRangeOptions(
     adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<ExtensionRangeOptions, Nothing>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.protos.custom_options.FooBar
 import kotlin.Any
@@ -125,15 +126,7 @@ class FieldOptions(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   val weak: Boolean? = null,
-  /**
-   * The parser stores options it doesn't recognize here. See above.
-   */
-  @field:WireField(
-    tag = 999,
-    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
   /**
    * Extension source: custom_options.proto
    */
@@ -177,6 +170,17 @@ class FieldOptions(
   val redacted: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<FieldOptions, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @field:WireField(
+    tag = 999,
+    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -45,61 +46,13 @@ class FileDescriptorProto(
     declaredName = "package"
   )
   val package_: String? = null,
-  /**
-   * Names of files imported by this file.
-   */
-  @field:WireField(
-    tag = 3,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  val dependency: List<String> = emptyList(),
-  /**
-   * Indexes of the public imported files in the dependency list above.
-   */
-  @field:WireField(
-    tag = 10,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  val public_dependency: List<Int> = emptyList(),
-  /**
-   * Indexes of the weak imported files in the dependency list.
-   * For Google-internal migration only. Do not use.
-   */
-  @field:WireField(
-    tag = 11,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  val weak_dependency: List<Int> = emptyList(),
-  /**
-   * All top-level definitions in this file.
-   */
-  @field:WireField(
-    tag = 4,
-    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val message_type: List<DescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 5,
-    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val enum_type: List<EnumDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 6,
-    adapter = "com.google.protobuf.ServiceDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val service: List<ServiceDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 7,
-    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val extension: List<FieldDescriptorProto> = emptyList(),
+  dependency: List<String> = emptyList(),
+  public_dependency: List<Int> = emptyList(),
+  weak_dependency: List<Int> = emptyList(),
+  message_type: List<DescriptorProto> = emptyList(),
+  enum_type: List<EnumDescriptorProto> = emptyList(),
+  service: List<ServiceDescriptorProto> = emptyList(),
+  extension: List<FieldDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 8,
     adapter = "com.google.protobuf.FileOptions#ADAPTER"
@@ -127,6 +80,68 @@ class FileDescriptorProto(
   val syntax: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<FileDescriptorProto, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * Names of files imported by this file.
+   */
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  val dependency: List<String> = immutableCopyOf("dependency", dependency)
+
+  /**
+   * Indexes of the public imported files in the dependency list above.
+   */
+  @field:WireField(
+    tag = 10,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  val public_dependency: List<Int> = immutableCopyOf("public_dependency", public_dependency)
+
+  /**
+   * Indexes of the weak imported files in the dependency list.
+   * For Google-internal migration only. Do not use.
+   */
+  @field:WireField(
+    tag = 11,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  val weak_dependency: List<Int> = immutableCopyOf("weak_dependency", weak_dependency)
+
+  /**
+   * All top-level definitions in this file.
+   */
+  @field:WireField(
+    tag = 4,
+    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val message_type: List<DescriptorProto> = immutableCopyOf("message_type", message_type)
+
+  @field:WireField(
+    tag = 5,
+    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val enum_type: List<EnumDescriptorProto> = immutableCopyOf("enum_type", enum_type)
+
+  @field:WireField(
+    tag = 6,
+    adapter = "com.google.protobuf.ServiceDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val service: List<ServiceDescriptorProto> = immutableCopyOf("service", service)
+
+  @field:WireField(
+    tag = 7,
+    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val extension: List<FieldDescriptorProto> = immutableCopyOf("extension", extension)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -27,14 +28,16 @@ import okio.ByteString
  * files it parses.
  */
 class FileDescriptorSet(
+  file: List<FileDescriptorProto> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<FileDescriptorSet, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     adapter = "com.google.protobuf.FileDescriptorProto#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val file: List<FileDescriptorProto> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<FileDescriptorSet, Nothing>(ADAPTER, unknownFields) {
+  val file: List<FileDescriptorProto> = immutableCopyOf("file", file)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/FileOptions.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -100,11 +101,11 @@ class FileOptions(
   /**
    * This option does nothing.
    */
+  @Deprecated(message = "java_generate_equals_and_hash is deprecated")
   @field:WireField(
     tag = 20,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
-  @Deprecated(message = "java_generate_equals_and_hash is deprecated")
   val java_generate_equals_and_hash: Boolean? = null,
   /**
    * If set true, then the Java2 code generator will generate code that
@@ -255,6 +256,9 @@ class FileOptions(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val ruby_package: String? = null,
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<FileOptions, Nothing>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here.
    * See the documentation for the "Options" section above.
@@ -264,9 +268,9 @@ class FileOptions(
     adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<FileOptions, Nothing>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -31,6 +32,9 @@ import okio.ByteString
  * source file, but may contain references to different source .proto files.
  */
 class GeneratedCodeInfo(
+  annotation: List<Annotation> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<GeneratedCodeInfo, Nothing>(ADAPTER, unknownFields) {
   /**
    * An Annotation connects some span of text in generated code to an element
    * of its generating .proto file.
@@ -40,9 +44,8 @@ class GeneratedCodeInfo(
     adapter = "com.google.protobuf.GeneratedCodeInfo${'$'}Annotation#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val annotation: List<Annotation> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<GeneratedCodeInfo, Nothing>(ADAPTER, unknownFields) {
+  val annotation: List<Annotation> = immutableCopyOf("annotation", annotation)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN
@@ -118,16 +121,7 @@ class GeneratedCodeInfo(
   }
 
   class Annotation(
-    /**
-     * Identifies the element in the original source .proto file. This field
-     * is formatted the same as SourceCodeInfo.Location.path.
-     */
-    @field:WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
-    )
-    val path: List<Int> = emptyList(),
+    path: List<Int> = emptyList(),
     /**
      * Identifies the filesystem path to the original source .proto.
      */
@@ -157,6 +151,17 @@ class GeneratedCodeInfo(
     val end: Int? = null,
     unknownFields: ByteString = ByteString.EMPTY
   ) : Message<Annotation, Nothing>(ADAPTER, unknownFields) {
+    /**
+     * Identifies the element in the original source .proto file. This field
+     * is formatted the same as SourceCodeInfo.Location.path.
+     */
+    @field:WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+    )
+    val path: List<Int> = immutableCopyOf("path", path)
+
     @Deprecated(
       message = "Shouldn't be used in Kotlin",
       level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.protos.custom_options.FooBar
 import com.squareup.wire.protos.kotlin.foreign.ForeignMessage
@@ -101,15 +102,7 @@ class MessageOptions(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   val map_entry: Boolean? = null,
-  /**
-   * The parser stores options it doesn't recognize here. See above.
-   */
-  @field:WireField(
-    tag = 999,
-    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
   /**
    * Extension source: custom_options.proto
    */
@@ -168,6 +161,17 @@ class MessageOptions(
   val foreign_message_option: ForeignMessage? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<MessageOptions, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @field:WireField(
+    tag = 999,
+    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -48,6 +49,9 @@ class MethodOptions(
     adapter = "com.google.protobuf.MethodOptions${'$'}IdempotencyLevel#ADAPTER"
   )
   val idempotency_level: IdempotencyLevel? = null,
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<MethodOptions, Nothing>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -56,9 +60,9 @@ class MethodOptions(
     adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<MethodOptions, Nothing>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -23,6 +24,9 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class OneofOptions(
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<OneofOptions, Nothing>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -31,9 +35,9 @@ class OneofOptions(
     adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<OneofOptions, Nothing>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -33,12 +34,7 @@ class ServiceDescriptorProto(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val name: String? = null,
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.MethodDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val method: List<MethodDescriptorProto> = emptyList(),
+  method: List<MethodDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.google.protobuf.ServiceOptions#ADAPTER"
@@ -46,6 +42,13 @@ class ServiceDescriptorProto(
   val options: ServiceOptions? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<ServiceDescriptorProto, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.MethodDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val method: List<MethodDescriptorProto> = immutableCopyOf("method", method)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -39,6 +40,9 @@ class ServiceOptions(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   val deprecated: Boolean? = null,
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<ServiceOptions, Nothing>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -47,9 +51,9 @@ class ServiceOptions(
     adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<ServiceOptions, Nothing>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -32,6 +33,9 @@ import okio.ByteString
  * FileDescriptorProto was generated.
  */
 class SourceCodeInfo(
+  location: List<Location> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<SourceCodeInfo, Nothing>(ADAPTER, unknownFields) {
   /**
    * A Location identifies a piece of source code in a .proto file which
    * corresponds to a particular definition.  This information is intended
@@ -82,9 +86,8 @@ class SourceCodeInfo(
     adapter = "com.google.protobuf.SourceCodeInfo${'$'}Location#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val location: List<Location> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<SourceCodeInfo, Nothing>(ADAPTER, unknownFields) {
+  val location: List<Location> = immutableCopyOf("location", location)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN
@@ -160,50 +163,8 @@ class SourceCodeInfo(
   }
 
   class Location(
-    /**
-     * Identifies which part of the FileDescriptorProto was defined at this
-     * location.
-     *
-     * Each element is a field number or an index.  They form a path from
-     * the root FileDescriptorProto to the place where the definition.  For
-     * example, this path:
-     *   [ 4, 3, 2, 7, 1 ]
-     * refers to:
-     *   file.message_type(3)  // 4, 3
-     *       .field(7)         // 2, 7
-     *       .name()           // 1
-     * This is because FileDescriptorProto.message_type has field number 4:
-     *   repeated DescriptorProto message_type = 4;
-     * and DescriptorProto.field has field number 2:
-     *   repeated FieldDescriptorProto field = 2;
-     * and FieldDescriptorProto.name has field number 1:
-     *   optional string name = 1;
-     *
-     * Thus, the above path gives the location of a field name.  If we removed
-     * the last element:
-     *   [ 4, 3, 2, 7 ]
-     * this path refers to the whole field declaration (from the beginning
-     * of the label to the terminating semicolon).
-     */
-    @field:WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
-    )
-    val path: List<Int> = emptyList(),
-    /**
-     * Always has exactly three or four elements: start line, start column,
-     * end line (optional, otherwise assumed same as start line), end column.
-     * These are packed into a single field for efficiency.  Note that line
-     * and column numbers are zero-based -- typically you will want to add
-     * 1 to each before displaying to a user.
-     */
-    @field:WireField(
-      tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
-    )
-    val span: List<Int> = emptyList(),
+    path: List<Int> = emptyList(),
+    span: List<Int> = emptyList(),
     /**
      * If this SourceCodeInfo represents a complete declaration, these are any
      * comments appearing before and after the declaration which appear to be
@@ -263,14 +224,63 @@ class SourceCodeInfo(
       adapter = "com.squareup.wire.ProtoAdapter#STRING"
     )
     val trailing_comments: String? = null,
+    leading_detached_comments: List<String> = emptyList(),
+    unknownFields: ByteString = ByteString.EMPTY
+  ) : Message<Location, Nothing>(ADAPTER, unknownFields) {
+    /**
+     * Identifies which part of the FileDescriptorProto was defined at this
+     * location.
+     *
+     * Each element is a field number or an index.  They form a path from
+     * the root FileDescriptorProto to the place where the definition.  For
+     * example, this path:
+     *   [ 4, 3, 2, 7, 1 ]
+     * refers to:
+     *   file.message_type(3)  // 4, 3
+     *       .field(7)         // 2, 7
+     *       .name()           // 1
+     * This is because FileDescriptorProto.message_type has field number 4:
+     *   repeated DescriptorProto message_type = 4;
+     * and DescriptorProto.field has field number 2:
+     *   repeated FieldDescriptorProto field = 2;
+     * and FieldDescriptorProto.name has field number 1:
+     *   optional string name = 1;
+     *
+     * Thus, the above path gives the location of a field name.  If we removed
+     * the last element:
+     *   [ 4, 3, 2, 7 ]
+     * this path refers to the whole field declaration (from the beginning
+     * of the label to the terminating semicolon).
+     */
+    @field:WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+    )
+    val path: List<Int> = immutableCopyOf("path", path)
+
+    /**
+     * Always has exactly three or four elements: start line, start column,
+     * end line (optional, otherwise assumed same as start line), end column.
+     * These are packed into a single field for efficiency.  Note that line
+     * and column numbers are zero-based -- typically you will want to add
+     * 1 to each before displaying to a user.
+     */
+    @field:WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+    )
+    val span: List<Int> = immutableCopyOf("span", span)
+
     @field:WireField(
       tag = 6,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REPEATED
     )
-    val leading_detached_comments: List<String> = emptyList(),
-    unknownFields: ByteString = ByteString.EMPTY
-  ) : Message<Location, Nothing>(ADAPTER, unknownFields) {
+    val leading_detached_comments: List<String> = immutableCopyOf("leading_detached_comments",
+        leading_detached_comments)
+
     @Deprecated(
       message = "Shouldn't be used in Kotlin",
       level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -37,12 +38,7 @@ import okio.ByteString
  * in them.
  */
 class UninterpretedOption(
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.UninterpretedOption${'$'}NamePart#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val name: List<NamePart> = emptyList(),
+  name: List<NamePart> = emptyList(),
   /**
    * The value of the uninterpreted option, in whatever type the tokenizer
    * identified it as during parsing. Exactly one of these should be set.
@@ -79,6 +75,13 @@ class UninterpretedOption(
   val aggregate_value: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<UninterpretedOption, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.UninterpretedOption${'$'}NamePart#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val name: List<NamePart> = immutableCopyOf("name", name)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
@@ -16,6 +16,8 @@ import com.squareup.wire.Syntax.PROTO_3
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.countNonNull
+import com.squareup.wire.internal.immutableCopyOf
+import com.squareup.wire.internal.immutableCopyOfMapWithStructValues
 import com.squareup.wire.internal.immutableCopyOfStruct
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -187,340 +189,58 @@ class AllTypes(
     label = WireField.Label.OMIT_IDENTITY
   )
   val timestamp: Instant? = null,
-  @field:WireField(
-    tag = 201,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED,
-    jsonName = "repInt32"
-  )
-  val rep_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 202,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.REPEATED,
-    jsonName = "repUint32"
-  )
-  val rep_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 203,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.REPEATED,
-    jsonName = "repSint32"
-  )
-  val rep_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 204,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.REPEATED,
-    jsonName = "repFixed32"
-  )
-  val rep_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 205,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.REPEATED,
-    jsonName = "repSfixed32"
-  )
-  val rep_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 206,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.REPEATED,
-    jsonName = "repInt64"
-  )
-  val rep_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 207,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.REPEATED,
-    jsonName = "repUint64"
-  )
-  val rep_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 208,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.REPEATED,
-    jsonName = "repSint64"
-  )
-  val rep_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 209,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.REPEATED,
-    jsonName = "repFixed64"
-  )
-  val rep_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 210,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.REPEATED,
-    jsonName = "repSfixed64"
-  )
-  val rep_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 211,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.REPEATED,
-    jsonName = "repBool"
-  )
-  val rep_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 212,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.REPEATED,
-    jsonName = "repFloat"
-  )
-  val rep_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 213,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.REPEATED,
-    jsonName = "repDouble"
-  )
-  val rep_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 214,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED,
-    jsonName = "repString"
-  )
-  val rep_string: List<String> = emptyList(),
-  @field:WireField(
-    tag = 215,
-    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-    label = WireField.Label.REPEATED,
-    jsonName = "repBytes"
-  )
-  val rep_bytes: List<ByteString> = emptyList(),
-  @field:WireField(
-    tag = 216,
-    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.REPEATED,
-    jsonName = "repNestedEnum"
-  )
-  val rep_nested_enum: List<NestedEnum> = emptyList(),
-  @field:WireField(
-    tag = 217,
-    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
-    label = WireField.Label.REPEATED,
-    jsonName = "repNestedMessage"
-  )
-  val rep_nested_message: List<NestedMessage> = emptyList(),
-  @field:WireField(
-    tag = 218,
-    adapter = "com.squareup.wire.AnyMessage#ADAPTER",
-    label = WireField.Label.REPEATED,
-    jsonName = "repAny"
-  )
-  val rep_any: List<AnyMessage> = emptyList(),
-  @field:WireField(
-    tag = 219,
-    adapter = "com.squareup.wire.ProtoAdapter#DURATION",
-    label = WireField.Label.REPEATED,
-    jsonName = "repDuration"
-  )
-  val rep_duration: List<Duration> = emptyList(),
+  rep_int32: List<Int> = emptyList(),
+  rep_uint32: List<Int> = emptyList(),
+  rep_sint32: List<Int> = emptyList(),
+  rep_fixed32: List<Int> = emptyList(),
+  rep_sfixed32: List<Int> = emptyList(),
+  rep_int64: List<Long> = emptyList(),
+  rep_uint64: List<Long> = emptyList(),
+  rep_sint64: List<Long> = emptyList(),
+  rep_fixed64: List<Long> = emptyList(),
+  rep_sfixed64: List<Long> = emptyList(),
+  rep_bool: List<Boolean> = emptyList(),
+  rep_float: List<Float> = emptyList(),
+  rep_double: List<Double> = emptyList(),
+  rep_string: List<String> = emptyList(),
+  rep_bytes: List<ByteString> = emptyList(),
+  rep_nested_enum: List<NestedEnum> = emptyList(),
+  rep_nested_message: List<NestedMessage> = emptyList(),
+  rep_any: List<AnyMessage> = emptyList(),
+  rep_duration: List<Duration> = emptyList(),
   rep_struct: List<Map<String, *>?> = emptyList(),
   rep_list_value: List<List<*>?> = emptyList(),
   rep_value: List<Any?> = emptyList(),
   rep_null_value: List<Nothing?> = emptyList(),
-  @field:WireField(
-    tag = 224,
-    adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
-    label = WireField.Label.REPEATED,
-    jsonName = "repEmpty"
-  )
-  val rep_empty: List<Unit> = emptyList(),
-  @field:WireField(
-    tag = 225,
-    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
-    label = WireField.Label.REPEATED,
-    jsonName = "repTimestamp"
-  )
-  val rep_timestamp: List<Instant> = emptyList(),
-  @field:WireField(
-    tag = 301,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED,
-    jsonName = "packInt32"
-  )
-  val pack_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 302,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.PACKED,
-    jsonName = "packUint32"
-  )
-  val pack_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 303,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.PACKED,
-    jsonName = "packSint32"
-  )
-  val pack_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 304,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.PACKED,
-    jsonName = "packFixed32"
-  )
-  val pack_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 305,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.PACKED,
-    jsonName = "packSfixed32"
-  )
-  val pack_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 306,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.PACKED,
-    jsonName = "packInt64"
-  )
-  val pack_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 307,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.PACKED,
-    jsonName = "packUint64"
-  )
-  val pack_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 308,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.PACKED,
-    jsonName = "packSint64"
-  )
-  val pack_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 309,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.PACKED,
-    jsonName = "packFixed64"
-  )
-  val pack_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 310,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.PACKED,
-    jsonName = "packSfixed64"
-  )
-  val pack_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 311,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.PACKED,
-    jsonName = "packBool"
-  )
-  val pack_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 312,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.PACKED,
-    jsonName = "packFloat"
-  )
-  val pack_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 313,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.PACKED,
-    jsonName = "packDouble"
-  )
-  val pack_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 316,
-    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.PACKED,
-    jsonName = "packNestedEnum"
-  )
-  val pack_nested_enum: List<NestedEnum> = emptyList(),
+  rep_empty: List<Unit> = emptyList(),
+  rep_timestamp: List<Instant> = emptyList(),
+  pack_int32: List<Int> = emptyList(),
+  pack_uint32: List<Int> = emptyList(),
+  pack_sint32: List<Int> = emptyList(),
+  pack_fixed32: List<Int> = emptyList(),
+  pack_sfixed32: List<Int> = emptyList(),
+  pack_int64: List<Long> = emptyList(),
+  pack_uint64: List<Long> = emptyList(),
+  pack_sint64: List<Long> = emptyList(),
+  pack_fixed64: List<Long> = emptyList(),
+  pack_sfixed64: List<Long> = emptyList(),
+  pack_bool: List<Boolean> = emptyList(),
+  pack_float: List<Float> = emptyList(),
+  pack_double: List<Double> = emptyList(),
+  pack_nested_enum: List<NestedEnum> = emptyList(),
   pack_null_value: List<Nothing?> = emptyList(),
-  @field:WireField(
-    tag = 501,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    jsonName = "mapInt32Int32"
-  )
-  val map_int32_int32: Map<Int, Int> = emptyMap(),
-  @field:WireField(
-    tag = 502,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    jsonName = "mapStringString"
-  )
-  val map_string_string: Map<String, String> = emptyMap(),
-  @field:WireField(
-    tag = 503,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
-    jsonName = "mapStringMessage"
-  )
-  val map_string_message: Map<String, NestedMessage> = emptyMap(),
-  @field:WireField(
-    tag = 504,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
-    jsonName = "mapStringEnum"
-  )
-  val map_string_enum: Map<String, NestedEnum> = emptyMap(),
-  @field:WireField(
-    tag = 518,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.AnyMessage#ADAPTER",
-    jsonName = "mapInt32Any"
-  )
-  val map_int32_any: Map<Int, AnyMessage> = emptyMap(),
-  @field:WireField(
-    tag = 519,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#DURATION",
-    jsonName = "mapInt32Duration"
-  )
-  val map_int32_duration: Map<Int, Duration> = emptyMap(),
-  @field:WireField(
-    tag = 520,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
-    jsonName = "mapInt32Struct"
-  )
-  val map_int32_struct: Map<Int, Map<String, *>?> = emptyMap(),
-  @field:WireField(
-    tag = 521,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
-    jsonName = "mapInt32ListValue"
-  )
-  val map_int32_list_value: Map<Int, List<*>?> = emptyMap(),
-  @field:WireField(
-    tag = 522,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
-    jsonName = "mapInt32Value"
-  )
-  val map_int32_value: Map<Int, Any?> = emptyMap(),
-  @field:WireField(
-    tag = 523,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
-    jsonName = "mapInt32NullValue"
-  )
-  val map_int32_null_value: Map<Int, Nothing?> = emptyMap(),
-  @field:WireField(
-    tag = 524,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
-    jsonName = "mapInt32Empty"
-  )
-  val map_int32_empty: Map<Int, Unit> = emptyMap(),
-  @field:WireField(
-    tag = 525,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
-    jsonName = "mapInt32Timestamp"
-  )
-  val map_int32_timestamp: Map<Int, Instant> = emptyMap(),
+  map_int32_int32: Map<Int, Int> = emptyMap(),
+  map_string_string: Map<String, String> = emptyMap(),
+  map_string_message: Map<String, NestedMessage> = emptyMap(),
+  map_string_enum: Map<String, NestedEnum> = emptyMap(),
+  map_int32_any: Map<Int, AnyMessage> = emptyMap(),
+  map_int32_duration: Map<Int, Duration> = emptyMap(),
+  map_int32_struct: Map<Int, Map<String, *>?> = emptyMap(),
+  map_int32_list_value: Map<Int, List<*>?> = emptyMap(),
+  map_int32_value: Map<Int, Any?> = emptyMap(),
+  map_int32_null_value: Map<Int, Nothing?> = emptyMap(),
+  map_int32_empty: Map<Int, Unit> = emptyMap(),
+  map_int32_timestamp: Map<Int, Instant> = emptyMap(),
   @field:WireField(
     tag = 601,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
@@ -602,6 +322,159 @@ class AllTypes(
   val null_value: Nothing? = immutableCopyOfStruct("null_value", null_value)
 
   @field:WireField(
+    tag = 201,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED,
+    jsonName = "repInt32"
+  )
+  val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
+
+  @field:WireField(
+    tag = 202,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.REPEATED,
+    jsonName = "repUint32"
+  )
+  val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
+
+  @field:WireField(
+    tag = 203,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.REPEATED,
+    jsonName = "repSint32"
+  )
+  val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
+
+  @field:WireField(
+    tag = 204,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.REPEATED,
+    jsonName = "repFixed32"
+  )
+  val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
+
+  @field:WireField(
+    tag = 205,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.REPEATED,
+    jsonName = "repSfixed32"
+  )
+  val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
+
+  @field:WireField(
+    tag = 206,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.REPEATED,
+    jsonName = "repInt64"
+  )
+  val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
+
+  @field:WireField(
+    tag = 207,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.REPEATED,
+    jsonName = "repUint64"
+  )
+  val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
+
+  @field:WireField(
+    tag = 208,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.REPEATED,
+    jsonName = "repSint64"
+  )
+  val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
+
+  @field:WireField(
+    tag = 209,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.REPEATED,
+    jsonName = "repFixed64"
+  )
+  val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
+
+  @field:WireField(
+    tag = 210,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.REPEATED,
+    jsonName = "repSfixed64"
+  )
+  val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
+
+  @field:WireField(
+    tag = 211,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.REPEATED,
+    jsonName = "repBool"
+  )
+  val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
+
+  @field:WireField(
+    tag = 212,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.REPEATED,
+    jsonName = "repFloat"
+  )
+  val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
+
+  @field:WireField(
+    tag = 213,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.REPEATED,
+    jsonName = "repDouble"
+  )
+  val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
+
+  @field:WireField(
+    tag = 214,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED,
+    jsonName = "repString"
+  )
+  val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
+
+  @field:WireField(
+    tag = 215,
+    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    label = WireField.Label.REPEATED,
+    jsonName = "repBytes"
+  )
+  val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
+
+  @field:WireField(
+    tag = 216,
+    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.REPEATED,
+    jsonName = "repNestedEnum"
+  )
+  val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
+
+  @field:WireField(
+    tag = 217,
+    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
+    label = WireField.Label.REPEATED,
+    jsonName = "repNestedMessage"
+  )
+  val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
+      rep_nested_message)
+
+  @field:WireField(
+    tag = 218,
+    adapter = "com.squareup.wire.AnyMessage#ADAPTER",
+    label = WireField.Label.REPEATED,
+    jsonName = "repAny"
+  )
+  val rep_any: List<AnyMessage> = immutableCopyOf("rep_any", rep_any)
+
+  @field:WireField(
+    tag = 219,
+    adapter = "com.squareup.wire.ProtoAdapter#DURATION",
+    label = WireField.Label.REPEATED,
+    jsonName = "repDuration"
+  )
+  val rep_duration: List<Duration> = immutableCopyOf("rep_duration", rep_duration)
+
+  @field:WireField(
     tag = 220,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.REPEATED,
@@ -634,12 +507,244 @@ class AllTypes(
   val rep_null_value: List<Nothing?> = immutableCopyOfStruct("rep_null_value", rep_null_value)
 
   @field:WireField(
+    tag = 224,
+    adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
+    label = WireField.Label.REPEATED,
+    jsonName = "repEmpty"
+  )
+  val rep_empty: List<Unit> = immutableCopyOf("rep_empty", rep_empty)
+
+  @field:WireField(
+    tag = 225,
+    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
+    label = WireField.Label.REPEATED,
+    jsonName = "repTimestamp"
+  )
+  val rep_timestamp: List<Instant> = immutableCopyOf("rep_timestamp", rep_timestamp)
+
+  @field:WireField(
+    tag = 301,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED,
+    jsonName = "packInt32"
+  )
+  val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
+
+  @field:WireField(
+    tag = 302,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.PACKED,
+    jsonName = "packUint32"
+  )
+  val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
+
+  @field:WireField(
+    tag = 303,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.PACKED,
+    jsonName = "packSint32"
+  )
+  val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
+
+  @field:WireField(
+    tag = 304,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.PACKED,
+    jsonName = "packFixed32"
+  )
+  val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
+
+  @field:WireField(
+    tag = 305,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.PACKED,
+    jsonName = "packSfixed32"
+  )
+  val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
+
+  @field:WireField(
+    tag = 306,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.PACKED,
+    jsonName = "packInt64"
+  )
+  val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
+
+  @field:WireField(
+    tag = 307,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.PACKED,
+    jsonName = "packUint64"
+  )
+  val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
+
+  @field:WireField(
+    tag = 308,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.PACKED,
+    jsonName = "packSint64"
+  )
+  val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
+
+  @field:WireField(
+    tag = 309,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.PACKED,
+    jsonName = "packFixed64"
+  )
+  val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
+
+  @field:WireField(
+    tag = 310,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.PACKED,
+    jsonName = "packSfixed64"
+  )
+  val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
+
+  @field:WireField(
+    tag = 311,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.PACKED,
+    jsonName = "packBool"
+  )
+  val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
+
+  @field:WireField(
+    tag = 312,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.PACKED,
+    jsonName = "packFloat"
+  )
+  val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
+
+  @field:WireField(
+    tag = 313,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.PACKED,
+    jsonName = "packDouble"
+  )
+  val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
+
+  @field:WireField(
+    tag = 316,
+    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.PACKED,
+    jsonName = "packNestedEnum"
+  )
+  val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum", pack_nested_enum)
+
+  @field:WireField(
     tag = 323,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     label = WireField.Label.PACKED,
     jsonName = "packNullValue"
   )
   val pack_null_value: List<Nothing?> = immutableCopyOfStruct("pack_null_value", pack_null_value)
+
+  @field:WireField(
+    tag = 501,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    jsonName = "mapInt32Int32"
+  )
+  val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
+
+  @field:WireField(
+    tag = 502,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    jsonName = "mapStringString"
+  )
+  val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
+      map_string_string)
+
+  @field:WireField(
+    tag = 503,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
+    jsonName = "mapStringMessage"
+  )
+  val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
+      map_string_message)
+
+  @field:WireField(
+    tag = 504,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
+    jsonName = "mapStringEnum"
+  )
+  val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum", map_string_enum)
+
+  @field:WireField(
+    tag = 518,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.AnyMessage#ADAPTER",
+    jsonName = "mapInt32Any"
+  )
+  val map_int32_any: Map<Int, AnyMessage> = immutableCopyOf("map_int32_any", map_int32_any)
+
+  @field:WireField(
+    tag = 519,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#DURATION",
+    jsonName = "mapInt32Duration"
+  )
+  val map_int32_duration: Map<Int, Duration> = immutableCopyOf("map_int32_duration",
+      map_int32_duration)
+
+  @field:WireField(
+    tag = 520,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
+    jsonName = "mapInt32Struct"
+  )
+  val map_int32_struct: Map<Int, Map<String, *>?> =
+      immutableCopyOfMapWithStructValues("map_int32_struct", map_int32_struct)
+
+  @field:WireField(
+    tag = 521,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
+    jsonName = "mapInt32ListValue"
+  )
+  val map_int32_list_value: Map<Int, List<*>?> =
+      immutableCopyOfMapWithStructValues("map_int32_list_value", map_int32_list_value)
+
+  @field:WireField(
+    tag = 522,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
+    jsonName = "mapInt32Value"
+  )
+  val map_int32_value: Map<Int, Any?> = immutableCopyOfMapWithStructValues("map_int32_value",
+      map_int32_value)
+
+  @field:WireField(
+    tag = 523,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
+    jsonName = "mapInt32NullValue"
+  )
+  val map_int32_null_value: Map<Int, Nothing?> =
+      immutableCopyOfMapWithStructValues("map_int32_null_value", map_int32_null_value)
+
+  @field:WireField(
+    tag = 524,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
+    jsonName = "mapInt32Empty"
+  )
+  val map_int32_empty: Map<Int, Unit> = immutableCopyOf("map_int32_empty", map_int32_empty)
+
+  @field:WireField(
+    tag = 525,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
+    jsonName = "mapInt32Timestamp"
+  )
+  val map_int32_timestamp: Map<Int, Instant> = immutableCopyOf("map_int32_timestamp",
+      map_int32_timestamp)
 
   @field:WireField(
     tag = 620,

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_3
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.countNonNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -60,21 +61,8 @@ class Person(
     label = WireField.Label.OMIT_IDENTITY
   )
   val email: String = "",
-  /**
-   * A list of the customer's phone numbers.
-   */
-  @field:WireField(
-    tag = 4,
-    adapter = "com.squareup.wire.proto3.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val phones: List<PhoneNumber> = emptyList(),
-  @field:WireField(
-    tag = 5,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  val aliases: List<String> = emptyList(),
+  phones: List<PhoneNumber> = emptyList(),
+  aliases: List<String> = emptyList(),
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#INT32"
@@ -87,6 +75,23 @@ class Person(
   val bar: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Person, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * A list of the customer's phone numbers.
+   */
+  @field:WireField(
+    tag = 4,
+    adapter = "com.squareup.wire.proto3.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val phones: List<PhoneNumber> = immutableCopyOf("phones", phones)
+
+  @field:WireField(
+    tag = 5,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  val aliases: List<String> = immutableCopyOf("aliases", aliases)
+
   init {
     require(countNonNull(foo, bar) <= 1) {
       "At most one of foo, bar may be non-null"

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.AssertionError
@@ -51,24 +52,13 @@ class FooBar(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   val qux: Long? = null,
-  @field:WireField(
-    tag = 5,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.REPEATED
-  )
-  val fred: List<Float> = emptyList(),
+  fred: List<Float> = emptyList(),
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   val daisy: Double? = null,
-  @field:WireField(
-    tag = 7,
-    adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
-    label = WireField.Label.REPEATED,
-    redacted = true
-  )
-  val nested: List<FooBar> = emptyList(),
+  nested: List<FooBar> = emptyList(),
   /**
    * Extension source: custom_options.proto
    */
@@ -77,6 +67,24 @@ class FooBar(
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER"
   )
   val ext: FooBarBazEnum? = null,
+  rep: List<FooBarBazEnum> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<FooBar, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 5,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.REPEATED
+  )
+  val fred: List<Float> = immutableCopyOf("fred", fred)
+
+  @field:WireField(
+    tag = 7,
+    adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
+    label = WireField.Label.REPEATED,
+    redacted = true
+  )
+  val nested: List<FooBar> = immutableCopyOf("nested", nested)
+
   /**
    * Extension source: custom_options.proto
    */
@@ -85,9 +93,8 @@ class FooBar(
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val rep: List<FooBarBazEnum> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<FooBar, Nothing>(ADAPTER, unknownFields) {
+  val rep: List<FooBarBazEnum> = immutableCopyOf("rep", rep)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN
@@ -332,14 +339,16 @@ class FooBar(
   }
 
   class More(
+    serial: List<Int> = emptyList(),
+    unknownFields: ByteString = ByteString.EMPTY
+  ) : Message<More, Nothing>(ADAPTER, unknownFields) {
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED
     )
-    val serial: List<Int> = emptyList(),
-    unknownFields: ByteString = ByteString.EMPTY
-  ) : Message<More, Nothing>(ADAPTER, unknownFields) {
+    val serial: List<Int> = immutableCopyOf("serial", serial)
+
     @Deprecated(
       message = "Shouldn't be used in Kotlin",
       level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -23,11 +23,11 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class DeprecatedProto(
+  @Deprecated(message = "foo is deprecated")
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
-  @Deprecated(message = "foo is deprecated")
   val foo: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<DeprecatedProto, Nothing>(ADAPTER, unknownFields) {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -223,192 +224,37 @@ class AllTypes(
     label = WireField.Label.REQUIRED
   )
   val req_nested_message: NestedMessage,
-  @field:WireField(
-    tag = 201,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  val rep_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 202,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.REPEATED
-  )
-  val rep_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 203,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.REPEATED
-  )
-  val rep_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 204,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.REPEATED
-  )
-  val rep_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 205,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.REPEATED
-  )
-  val rep_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 206,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.REPEATED
-  )
-  val rep_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 207,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.REPEATED
-  )
-  val rep_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 208,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.REPEATED
-  )
-  val rep_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 209,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.REPEATED
-  )
-  val rep_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 210,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.REPEATED
-  )
-  val rep_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 211,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.REPEATED
-  )
-  val rep_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 212,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.REPEATED
-  )
-  val rep_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 213,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.REPEATED
-  )
-  val rep_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 214,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  val rep_string: List<String> = emptyList(),
-  @field:WireField(
-    tag = 215,
-    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-    label = WireField.Label.REPEATED
-  )
-  val rep_bytes: List<ByteString> = emptyList(),
-  @field:WireField(
-    tag = 216,
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val rep_nested_enum: List<NestedEnum> = emptyList(),
-  @field:WireField(
-    tag = 217,
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  val rep_nested_message: List<NestedMessage> = emptyList(),
-  @field:WireField(
-    tag = 301,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED
-  )
-  val pack_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 302,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.PACKED
-  )
-  val pack_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 303,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.PACKED
-  )
-  val pack_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 304,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.PACKED
-  )
-  val pack_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 305,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.PACKED
-  )
-  val pack_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 306,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.PACKED
-  )
-  val pack_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 307,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.PACKED
-  )
-  val pack_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 308,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.PACKED
-  )
-  val pack_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 309,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.PACKED
-  )
-  val pack_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 310,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.PACKED
-  )
-  val pack_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 311,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.PACKED
-  )
-  val pack_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 312,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.PACKED
-  )
-  val pack_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 313,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.PACKED
-  )
-  val pack_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 316,
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.PACKED
-  )
-  val pack_nested_enum: List<NestedEnum> = emptyList(),
+  rep_int32: List<Int> = emptyList(),
+  rep_uint32: List<Int> = emptyList(),
+  rep_sint32: List<Int> = emptyList(),
+  rep_fixed32: List<Int> = emptyList(),
+  rep_sfixed32: List<Int> = emptyList(),
+  rep_int64: List<Long> = emptyList(),
+  rep_uint64: List<Long> = emptyList(),
+  rep_sint64: List<Long> = emptyList(),
+  rep_fixed64: List<Long> = emptyList(),
+  rep_sfixed64: List<Long> = emptyList(),
+  rep_bool: List<Boolean> = emptyList(),
+  rep_float: List<Float> = emptyList(),
+  rep_double: List<Double> = emptyList(),
+  rep_string: List<String> = emptyList(),
+  rep_bytes: List<ByteString> = emptyList(),
+  rep_nested_enum: List<NestedEnum> = emptyList(),
+  rep_nested_message: List<NestedMessage> = emptyList(),
+  pack_int32: List<Int> = emptyList(),
+  pack_uint32: List<Int> = emptyList(),
+  pack_sint32: List<Int> = emptyList(),
+  pack_fixed32: List<Int> = emptyList(),
+  pack_sfixed32: List<Int> = emptyList(),
+  pack_int64: List<Long> = emptyList(),
+  pack_uint64: List<Long> = emptyList(),
+  pack_sint64: List<Long> = emptyList(),
+  pack_fixed64: List<Long> = emptyList(),
+  pack_sfixed64: List<Long> = emptyList(),
+  pack_bool: List<Boolean> = emptyList(),
+  pack_float: List<Float> = emptyList(),
+  pack_double: List<Double> = emptyList(),
+  pack_nested_enum: List<NestedEnum> = emptyList(),
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT32"
@@ -489,30 +335,10 @@ class AllTypes(
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER"
   )
   val default_nested_enum: NestedEnum? = null,
-  @field:WireField(
-    tag = 501,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#INT32"
-  )
-  val map_int32_int32: Map<Int, Int> = emptyMap(),
-  @field:WireField(
-    tag = 502,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.ProtoAdapter#STRING"
-  )
-  val map_string_string: Map<String, String> = emptyMap(),
-  @field:WireField(
-    tag = 503,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER"
-  )
-  val map_string_message: Map<String, NestedMessage> = emptyMap(),
-  @field:WireField(
-    tag = 504,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER"
-  )
-  val map_string_enum: Map<String, NestedEnum> = emptyMap(),
+  map_int32_int32: Map<Int, Int> = emptyMap(),
+  map_string_string: Map<String, String> = emptyMap(),
+  map_string_message: Map<String, NestedMessage> = emptyMap(),
+  map_string_enum: Map<String, NestedEnum> = emptyMap(),
   /**
    * Extension source: all_types.proto
    */
@@ -649,6 +475,287 @@ class AllTypes(
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER"
   )
   val ext_opt_nested_message: NestedMessage? = null,
+  ext_rep_int32: List<Int> = emptyList(),
+  ext_rep_uint32: List<Int> = emptyList(),
+  ext_rep_sint32: List<Int> = emptyList(),
+  ext_rep_fixed32: List<Int> = emptyList(),
+  ext_rep_sfixed32: List<Int> = emptyList(),
+  ext_rep_int64: List<Long> = emptyList(),
+  ext_rep_uint64: List<Long> = emptyList(),
+  ext_rep_sint64: List<Long> = emptyList(),
+  ext_rep_fixed64: List<Long> = emptyList(),
+  ext_rep_sfixed64: List<Long> = emptyList(),
+  ext_rep_bool: List<Boolean> = emptyList(),
+  ext_rep_float: List<Float> = emptyList(),
+  ext_rep_double: List<Double> = emptyList(),
+  ext_rep_string: List<String> = emptyList(),
+  ext_rep_bytes: List<ByteString> = emptyList(),
+  ext_rep_nested_enum: List<NestedEnum> = emptyList(),
+  ext_rep_nested_message: List<NestedMessage> = emptyList(),
+  ext_pack_int32: List<Int> = emptyList(),
+  ext_pack_uint32: List<Int> = emptyList(),
+  ext_pack_sint32: List<Int> = emptyList(),
+  ext_pack_fixed32: List<Int> = emptyList(),
+  ext_pack_sfixed32: List<Int> = emptyList(),
+  ext_pack_int64: List<Long> = emptyList(),
+  ext_pack_uint64: List<Long> = emptyList(),
+  ext_pack_sint64: List<Long> = emptyList(),
+  ext_pack_fixed64: List<Long> = emptyList(),
+  ext_pack_sfixed64: List<Long> = emptyList(),
+  ext_pack_bool: List<Boolean> = emptyList(),
+  ext_pack_float: List<Float> = emptyList(),
+  ext_pack_double: List<Double> = emptyList(),
+  ext_pack_nested_enum: List<NestedEnum> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<AllTypes, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 201,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
+
+  @field:WireField(
+    tag = 202,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.REPEATED
+  )
+  val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
+
+  @field:WireField(
+    tag = 203,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.REPEATED
+  )
+  val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
+
+  @field:WireField(
+    tag = 204,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.REPEATED
+  )
+  val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
+
+  @field:WireField(
+    tag = 205,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.REPEATED
+  )
+  val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
+
+  @field:WireField(
+    tag = 206,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.REPEATED
+  )
+  val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
+
+  @field:WireField(
+    tag = 207,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.REPEATED
+  )
+  val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
+
+  @field:WireField(
+    tag = 208,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.REPEATED
+  )
+  val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
+
+  @field:WireField(
+    tag = 209,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.REPEATED
+  )
+  val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
+
+  @field:WireField(
+    tag = 210,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.REPEATED
+  )
+  val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
+
+  @field:WireField(
+    tag = 211,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.REPEATED
+  )
+  val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
+
+  @field:WireField(
+    tag = 212,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.REPEATED
+  )
+  val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
+
+  @field:WireField(
+    tag = 213,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.REPEATED
+  )
+  val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
+
+  @field:WireField(
+    tag = 214,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
+
+  @field:WireField(
+    tag = 215,
+    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    label = WireField.Label.REPEATED
+  )
+  val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
+
+  @field:WireField(
+    tag = 216,
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
+
+  @field:WireField(
+    tag = 217,
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
+      rep_nested_message)
+
+  @field:WireField(
+    tag = 301,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED
+  )
+  val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
+
+  @field:WireField(
+    tag = 302,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.PACKED
+  )
+  val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
+
+  @field:WireField(
+    tag = 303,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.PACKED
+  )
+  val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
+
+  @field:WireField(
+    tag = 304,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.PACKED
+  )
+  val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
+
+  @field:WireField(
+    tag = 305,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.PACKED
+  )
+  val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
+
+  @field:WireField(
+    tag = 306,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.PACKED
+  )
+  val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
+
+  @field:WireField(
+    tag = 307,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.PACKED
+  )
+  val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
+
+  @field:WireField(
+    tag = 308,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.PACKED
+  )
+  val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
+
+  @field:WireField(
+    tag = 309,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.PACKED
+  )
+  val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
+
+  @field:WireField(
+    tag = 310,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.PACKED
+  )
+  val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
+
+  @field:WireField(
+    tag = 311,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.PACKED
+  )
+  val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
+
+  @field:WireField(
+    tag = 312,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.PACKED
+  )
+  val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
+
+  @field:WireField(
+    tag = 313,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.PACKED
+  )
+  val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
+
+  @field:WireField(
+    tag = 316,
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.PACKED
+  )
+  val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum", pack_nested_enum)
+
+  @field:WireField(
+    tag = 501,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
+
+  @field:WireField(
+    tag = 502,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
+      map_string_string)
+
+  @field:WireField(
+    tag = 503,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER"
+  )
+  val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
+      map_string_message)
+
+  @field:WireField(
+    tag = 504,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER"
+  )
+  val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum", map_string_enum)
+
   /**
    * Extension source: all_types.proto
    */
@@ -657,7 +764,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_int32: List<Int> = emptyList(),
+  val ext_rep_int32: List<Int> = immutableCopyOf("ext_rep_int32", ext_rep_int32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -666,7 +774,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_uint32: List<Int> = emptyList(),
+  val ext_rep_uint32: List<Int> = immutableCopyOf("ext_rep_uint32", ext_rep_uint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -675,7 +784,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_sint32: List<Int> = emptyList(),
+  val ext_rep_sint32: List<Int> = immutableCopyOf("ext_rep_sint32", ext_rep_sint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -684,7 +794,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_fixed32: List<Int> = emptyList(),
+  val ext_rep_fixed32: List<Int> = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -693,7 +804,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_sfixed32: List<Int> = emptyList(),
+  val ext_rep_sfixed32: List<Int> = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -702,7 +814,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_int64: List<Long> = emptyList(),
+  val ext_rep_int64: List<Long> = immutableCopyOf("ext_rep_int64", ext_rep_int64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -711,7 +824,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_uint64: List<Long> = emptyList(),
+  val ext_rep_uint64: List<Long> = immutableCopyOf("ext_rep_uint64", ext_rep_uint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -720,7 +834,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_sint64: List<Long> = emptyList(),
+  val ext_rep_sint64: List<Long> = immutableCopyOf("ext_rep_sint64", ext_rep_sint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -729,7 +844,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_fixed64: List<Long> = emptyList(),
+  val ext_rep_fixed64: List<Long> = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -738,7 +854,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_sfixed64: List<Long> = emptyList(),
+  val ext_rep_sfixed64: List<Long> = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -747,7 +864,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_bool: List<Boolean> = emptyList(),
+  val ext_rep_bool: List<Boolean> = immutableCopyOf("ext_rep_bool", ext_rep_bool)
+
   /**
    * Extension source: all_types.proto
    */
@@ -756,7 +874,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_float: List<Float> = emptyList(),
+  val ext_rep_float: List<Float> = immutableCopyOf("ext_rep_float", ext_rep_float)
+
   /**
    * Extension source: all_types.proto
    */
@@ -765,7 +884,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_double: List<Double> = emptyList(),
+  val ext_rep_double: List<Double> = immutableCopyOf("ext_rep_double", ext_rep_double)
+
   /**
    * Extension source: all_types.proto
    */
@@ -774,7 +894,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_string: List<String> = emptyList(),
+  val ext_rep_string: List<String> = immutableCopyOf("ext_rep_string", ext_rep_string)
+
   /**
    * Extension source: all_types.proto
    */
@@ -783,7 +904,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_bytes: List<ByteString> = emptyList(),
+  val ext_rep_bytes: List<ByteString> = immutableCopyOf("ext_rep_bytes", ext_rep_bytes)
+
   /**
    * Extension source: all_types.proto
    */
@@ -792,7 +914,9 @@ class AllTypes(
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_nested_enum: List<NestedEnum> = emptyList(),
+  val ext_rep_nested_enum: List<NestedEnum> = immutableCopyOf("ext_rep_nested_enum",
+      ext_rep_nested_enum)
+
   /**
    * Extension source: all_types.proto
    */
@@ -801,7 +925,9 @@ class AllTypes(
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val ext_rep_nested_message: List<NestedMessage> = emptyList(),
+  val ext_rep_nested_message: List<NestedMessage> = immutableCopyOf("ext_rep_nested_message",
+      ext_rep_nested_message)
+
   /**
    * Extension source: all_types.proto
    */
@@ -810,7 +936,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED
   )
-  val ext_pack_int32: List<Int> = emptyList(),
+  val ext_pack_int32: List<Int> = immutableCopyOf("ext_pack_int32", ext_pack_int32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -819,7 +946,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED
   )
-  val ext_pack_uint32: List<Int> = emptyList(),
+  val ext_pack_uint32: List<Int> = immutableCopyOf("ext_pack_uint32", ext_pack_uint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -828,7 +956,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED
   )
-  val ext_pack_sint32: List<Int> = emptyList(),
+  val ext_pack_sint32: List<Int> = immutableCopyOf("ext_pack_sint32", ext_pack_sint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -837,7 +966,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED
   )
-  val ext_pack_fixed32: List<Int> = emptyList(),
+  val ext_pack_fixed32: List<Int> = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -846,7 +976,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED
   )
-  val ext_pack_sfixed32: List<Int> = emptyList(),
+  val ext_pack_sfixed32: List<Int> = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -855,7 +986,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED
   )
-  val ext_pack_int64: List<Long> = emptyList(),
+  val ext_pack_int64: List<Long> = immutableCopyOf("ext_pack_int64", ext_pack_int64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -864,7 +996,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED
   )
-  val ext_pack_uint64: List<Long> = emptyList(),
+  val ext_pack_uint64: List<Long> = immutableCopyOf("ext_pack_uint64", ext_pack_uint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -873,7 +1006,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED
   )
-  val ext_pack_sint64: List<Long> = emptyList(),
+  val ext_pack_sint64: List<Long> = immutableCopyOf("ext_pack_sint64", ext_pack_sint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -882,7 +1016,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED
   )
-  val ext_pack_fixed64: List<Long> = emptyList(),
+  val ext_pack_fixed64: List<Long> = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -891,7 +1026,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED
   )
-  val ext_pack_sfixed64: List<Long> = emptyList(),
+  val ext_pack_sfixed64: List<Long> = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -900,7 +1036,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED
   )
-  val ext_pack_bool: List<Boolean> = emptyList(),
+  val ext_pack_bool: List<Boolean> = immutableCopyOf("ext_pack_bool", ext_pack_bool)
+
   /**
    * Extension source: all_types.proto
    */
@@ -909,7 +1046,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED
   )
-  val ext_pack_float: List<Float> = emptyList(),
+  val ext_pack_float: List<Float> = immutableCopyOf("ext_pack_float", ext_pack_float)
+
   /**
    * Extension source: all_types.proto
    */
@@ -918,7 +1056,8 @@ class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED
   )
-  val ext_pack_double: List<Double> = emptyList(),
+  val ext_pack_double: List<Double> = immutableCopyOf("ext_pack_double", ext_pack_double)
+
   /**
    * Extension source: all_types.proto
    */
@@ -927,9 +1066,9 @@ class AllTypes(
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED
   )
-  val ext_pack_nested_enum: List<NestedEnum> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<AllTypes, Nothing>(ADAPTER, unknownFields) {
+  val ext_pack_nested_enum: List<NestedEnum> = immutableCopyOf("ext_pack_nested_enum",
+      ext_pack_nested_enum)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -24,14 +25,16 @@ import kotlin.lazy
 import okio.ByteString
 
 class Mappy(
+  things: Map<String, Thing> = emptyMap(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Mappy, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER"
   )
-  val things: Map<String, Thing> = emptyMap(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Mappy, Nothing>(ADAPTER, unknownFields) {
+  val things: Map<String, Thing> = immutableCopyOf("things", things)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -59,6 +60,10 @@ class Person(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val email: String? = null,
+  phone: List<PhoneNumber> = emptyList(),
+  aliases: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Person, Nothing>(ADAPTER, unknownFields) {
   /**
    * A list of the customer's phone numbers.
    */
@@ -67,15 +72,15 @@ class Person(
     adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val phone: List<PhoneNumber> = emptyList(),
+  val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
+
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
-  val aliases: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Person, Nothing>(ADAPTER, unknownFields) {
+  val aliases: List<String> = immutableCopyOf("aliases", aliases)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -23,13 +24,18 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class RedactedRepeated(
+  a: List<String> = emptyList(),
+  b: List<Redacted> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<RedactedRepeated, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
     redacted = true
   )
-  val a: List<String> = emptyList(),
+  val a: List<String> = immutableCopyOf("a", a)
+
   /**
    * Values in the repeated type need redacting.
    */
@@ -38,9 +44,8 @@ class RedactedRepeated(
     adapter = "com.squareup.wire.protos.kotlin.redacted.Redacted#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val b: List<Redacted> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<RedactedRepeated, Nothing>(ADAPTER, unknownFields) {
+  val b: List<Redacted> = immutableCopyOf("b", b)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import kotlin.Any
 import kotlin.AssertionError
 import kotlin.Boolean
@@ -29,15 +30,7 @@ class ExternalMessage(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   val f: Float? = null,
-  /**
-   * Extension source: simple_message.proto
-   */
-  @field:WireField(
-    tag = 125,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  val fooext: List<Int> = emptyList(),
+  fooext: List<Int> = emptyList(),
   /**
    * Extension source: simple_message.proto
    */
@@ -72,6 +65,16 @@ class ExternalMessage(
   val nested_enum_ext: SimpleMessage.NestedEnum? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<ExternalMessage, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * Extension source: simple_message.proto
+   */
+  @field:WireField(
+    tag = 125,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  val fooext: List<Int> = immutableCopyOf("fooext", fooext)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -12,6 +12,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.sanitize
 import com.squareup.wire.protos.kotlin.foreign.ForeignEnum
@@ -45,11 +46,11 @@ class SimpleMessage(
   /**
    * An optional NestedMessage, *deprecated&#42;//
    */
+  @Deprecated(message = "optional_nested_msg is deprecated")
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedMessage#ADAPTER"
   )
-  @Deprecated(message = "optional_nested_msg is deprecated")
   val optional_nested_msg: NestedMessage? = null,
   /**
    * An optional ExternalMessage
@@ -73,16 +74,7 @@ class SimpleMessage(
     label = WireField.Label.REQUIRED
   )
   val required_int32: Int,
-  /**
-   * A repeated double, deprecated
-   */
-  @field:WireField(
-    tag = 6,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.REPEATED
-  )
-  @Deprecated(message = "repeated_double is deprecated")
-  val repeated_double: List<Double> = emptyList(),
+  repeated_double: List<Double> = emptyList(),
   /**
    * enum from another package with an explicit default
    */
@@ -134,6 +126,17 @@ class SimpleMessage(
   val o: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<SimpleMessage, Nothing>(ADAPTER, unknownFields) {
+  /**
+   * A repeated double, deprecated
+   */
+  @Deprecated(message = "repeated_double is deprecated")
+  @field:WireField(
+    tag = 6,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.REPEATED
+  )
+  val repeated_double: List<Double> = immutableCopyOf("repeated_double", repeated_double)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.AssertionError
@@ -50,14 +51,16 @@ class NestedVersionTwo(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   val v2_f64: Long? = null,
+  v2_rs: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<NestedVersionTwo, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
-  val v2_rs: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<NestedVersionTwo, Nothing>(ADAPTER, unknownFields) {
+  val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.AssertionError
@@ -50,12 +51,7 @@ class VersionTwo(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   val v2_f64: Long? = null,
-  @field:WireField(
-    tag = 6,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  val v2_rs: List<String> = emptyList(),
+  v2_rs: List<String> = emptyList(),
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.NestedVersionTwo#ADAPTER"
@@ -68,6 +64,13 @@ class VersionTwo(
   val en: EnumVersionTwo? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<VersionTwo, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 6,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.AssertionError
@@ -30,14 +31,16 @@ class UsesAny(
     adapter = "com.squareup.wire.AnyMessage#ADAPTER"
   )
   val just_one: AnyMessage? = null,
+  many_anys: List<AnyMessage> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<UsesAny, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val many_anys: List<AnyMessage> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<UsesAny, Nothing>(ADAPTER, unknownFields) {
+  val many_anys: List<AnyMessage> = immutableCopyOf("many_anys", many_anys)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import kotlin.Any
 import kotlin.AssertionError
 import kotlin.Boolean
@@ -23,12 +24,7 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class EmbeddedMessage(
-  @field:WireField(
-    tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED
-  )
-  val inner_repeated_number: List<Int> = emptyList(),
+  inner_repeated_number: List<Int> = emptyList(),
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32"
@@ -36,6 +32,14 @@ class EmbeddedMessage(
   val inner_number_after: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<EmbeddedMessage, Nothing>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED
+  )
+  val inner_repeated_number: List<Int> = immutableCopyOf("inner_repeated_number",
+      inner_repeated_number)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/jsTest/kotlin/com/squareup/wire/IgnoreNative.kt
+++ b/wire-library/wire-tests/src/jsTest/kotlin/com/squareup/wire/IgnoreNative.kt
@@ -1,0 +1,3 @@
+package com.squareup.wire
+
+actual annotation class IgnoreNative

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/all_types/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/all_types/AllTypes.java
@@ -813,10 +813,10 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     this.map_string_enum = Internal.immutableCopyOf("map_string_enum", builder.map_string_enum);
     this.map_int32_any = Internal.immutableCopyOf("map_int32_any", builder.map_int32_any);
     this.map_int32_duration = Internal.immutableCopyOf("map_int32_duration", builder.map_int32_duration);
-    this.map_int32_struct = Internal.immutableCopyOf("map_int32_struct", builder.map_int32_struct);
-    this.map_int32_list_value = Internal.immutableCopyOf("map_int32_list_value", builder.map_int32_list_value);
-    this.map_int32_value = Internal.immutableCopyOf("map_int32_value", builder.map_int32_value);
-    this.map_int32_null_value = Internal.immutableCopyOf("map_int32_null_value", builder.map_int32_null_value);
+    this.map_int32_struct = Internal.immutableCopyOfMapWithStructValues("map_int32_struct", builder.map_int32_struct);
+    this.map_int32_list_value = Internal.immutableCopyOfMapWithStructValues("map_int32_list_value", builder.map_int32_list_value);
+    this.map_int32_value = Internal.immutableCopyOfMapWithStructValues("map_int32_value", builder.map_int32_value);
+    this.map_int32_null_value = Internal.immutableCopyOfMapWithStructValues("map_int32_null_value", builder.map_int32_null_value);
     this.map_int32_empty = Internal.immutableCopyOf("map_int32_empty", builder.map_int32_empty);
     this.map_int32_timestamp = Internal.immutableCopyOf("map_int32_timestamp", builder.map_int32_timestamp);
     this.oneof_string = builder.oneof_string;

--- a/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllStructs.java
+++ b/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllStructs.java
@@ -187,10 +187,10 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
     this.rep_list = Internal.immutableCopyOfStruct("rep_list", builder.rep_list);
     this.rep_value_a = Internal.immutableCopyOfStruct("rep_value_a", builder.rep_value_a);
     this.rep_null_value = Internal.immutableCopyOfStruct("rep_null_value", builder.rep_null_value);
-    this.map_int32_struct = Internal.immutableCopyOf("map_int32_struct", builder.map_int32_struct);
-    this.map_int32_list = Internal.immutableCopyOf("map_int32_list", builder.map_int32_list);
-    this.map_int32_value_a = Internal.immutableCopyOf("map_int32_value_a", builder.map_int32_value_a);
-    this.map_int32_null_value = Internal.immutableCopyOf("map_int32_null_value", builder.map_int32_null_value);
+    this.map_int32_struct = Internal.immutableCopyOfMapWithStructValues("map_int32_struct", builder.map_int32_struct);
+    this.map_int32_list = Internal.immutableCopyOfMapWithStructValues("map_int32_list", builder.map_int32_list);
+    this.map_int32_value_a = Internal.immutableCopyOfMapWithStructValues("map_int32_value_a", builder.map_int32_value_a);
+    this.map_int32_null_value = Internal.immutableCopyOfMapWithStructValues("map_int32_null_value", builder.map_int32_null_value);
     this.oneof_struct = Internal.immutableCopyOfStruct("oneof_struct", builder.oneof_struct);
     this.oneof_list = Internal.immutableCopyOfStruct("oneof_list", builder.oneof_list);
   }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -14,6 +14,7 @@ import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
 import com.squareup.wire.internal.countNonNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -255,223 +256,37 @@ class AllTypes(
   )
   @JvmField
   val req_nested_message: NestedMessage,
-  @field:WireField(
-    tag = 201,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 202,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 203,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 204,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 205,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 206,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 207,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 208,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 209,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 210,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 211,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 212,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 213,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 214,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_string: List<String> = emptyList(),
-  @field:WireField(
-    tag = 215,
-    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_bytes: List<ByteString> = emptyList(),
-  @field:WireField(
-    tag = 216,
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_nested_enum: List<NestedEnum> = emptyList(),
-  @field:WireField(
-    tag = 217,
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_nested_message: List<NestedMessage> = emptyList(),
-  @field:WireField(
-    tag = 301,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 302,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 303,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 304,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 305,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 306,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 307,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 308,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 309,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 310,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 311,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 312,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 313,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 316,
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_nested_enum: List<NestedEnum> = emptyList(),
+  rep_int32: List<Int> = emptyList(),
+  rep_uint32: List<Int> = emptyList(),
+  rep_sint32: List<Int> = emptyList(),
+  rep_fixed32: List<Int> = emptyList(),
+  rep_sfixed32: List<Int> = emptyList(),
+  rep_int64: List<Long> = emptyList(),
+  rep_uint64: List<Long> = emptyList(),
+  rep_sint64: List<Long> = emptyList(),
+  rep_fixed64: List<Long> = emptyList(),
+  rep_sfixed64: List<Long> = emptyList(),
+  rep_bool: List<Boolean> = emptyList(),
+  rep_float: List<Float> = emptyList(),
+  rep_double: List<Double> = emptyList(),
+  rep_string: List<String> = emptyList(),
+  rep_bytes: List<ByteString> = emptyList(),
+  rep_nested_enum: List<NestedEnum> = emptyList(),
+  rep_nested_message: List<NestedMessage> = emptyList(),
+  pack_int32: List<Int> = emptyList(),
+  pack_uint32: List<Int> = emptyList(),
+  pack_sint32: List<Int> = emptyList(),
+  pack_fixed32: List<Int> = emptyList(),
+  pack_sfixed32: List<Int> = emptyList(),
+  pack_int64: List<Long> = emptyList(),
+  pack_uint64: List<Long> = emptyList(),
+  pack_sint64: List<Long> = emptyList(),
+  pack_fixed64: List<Long> = emptyList(),
+  pack_sfixed64: List<Long> = emptyList(),
+  pack_bool: List<Boolean> = emptyList(),
+  pack_float: List<Float> = emptyList(),
+  pack_double: List<Double> = emptyList(),
+  pack_nested_enum: List<NestedEnum> = emptyList(),
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT32"
@@ -568,34 +383,10 @@ class AllTypes(
   )
   @JvmField
   val default_nested_enum: NestedEnum? = null,
-  @field:WireField(
-    tag = 501,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#INT32"
-  )
-  @JvmField
-  val map_int32_int32: Map<Int, Int> = emptyMap(),
-  @field:WireField(
-    tag = 502,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.ProtoAdapter#STRING"
-  )
-  @JvmField
-  val map_string_string: Map<String, String> = emptyMap(),
-  @field:WireField(
-    tag = 503,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER"
-  )
-  @JvmField
-  val map_string_message: Map<String, NestedMessage> = emptyMap(),
-  @field:WireField(
-    tag = 504,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER"
-  )
-  @JvmField
-  val map_string_enum: Map<String, NestedEnum> = emptyMap(),
+  map_int32_int32: Map<Int, Int> = emptyMap(),
+  map_string_string: Map<String, String> = emptyMap(),
+  map_string_message: Map<String, NestedMessage> = emptyMap(),
+  map_string_enum: Map<String, NestedEnum> = emptyMap(),
   /**
    * Extension source: all_types.proto
    */
@@ -749,316 +540,37 @@ class AllTypes(
   )
   @JvmField
   val ext_opt_nested_message: NestedMessage? = null,
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1101,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_int32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1102,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_uint32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1103,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_sint32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1104,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_fixed32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1105,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_sfixed32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1106,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_int64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1107,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_uint64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1108,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_sint64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1109,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_fixed64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1110,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_sfixed64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1111,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_bool: List<Boolean> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1112,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_float: List<Float> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1113,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_double: List<Double> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1114,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_string: List<String> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1115,
-    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_bytes: List<ByteString> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1116,
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_nested_enum: List<NestedEnum> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1117,
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val ext_rep_nested_message: List<NestedMessage> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1201,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_int32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1202,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_uint32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1203,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_sint32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1204,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_fixed32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1205,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_sfixed32: List<Int> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1206,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_int64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1207,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_uint64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1208,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_sint64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1209,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_fixed64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1210,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_sfixed64: List<Long> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1211,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_bool: List<Boolean> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1212,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_float: List<Float> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1213,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_double: List<Double> = emptyList(),
-  /**
-   * Extension source: all_types.proto
-   */
-  @field:WireField(
-    tag = 1216,
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val ext_pack_nested_enum: List<NestedEnum> = emptyList(),
+  ext_rep_int32: List<Int> = emptyList(),
+  ext_rep_uint32: List<Int> = emptyList(),
+  ext_rep_sint32: List<Int> = emptyList(),
+  ext_rep_fixed32: List<Int> = emptyList(),
+  ext_rep_sfixed32: List<Int> = emptyList(),
+  ext_rep_int64: List<Long> = emptyList(),
+  ext_rep_uint64: List<Long> = emptyList(),
+  ext_rep_sint64: List<Long> = emptyList(),
+  ext_rep_fixed64: List<Long> = emptyList(),
+  ext_rep_sfixed64: List<Long> = emptyList(),
+  ext_rep_bool: List<Boolean> = emptyList(),
+  ext_rep_float: List<Float> = emptyList(),
+  ext_rep_double: List<Double> = emptyList(),
+  ext_rep_string: List<String> = emptyList(),
+  ext_rep_bytes: List<ByteString> = emptyList(),
+  ext_rep_nested_enum: List<NestedEnum> = emptyList(),
+  ext_rep_nested_message: List<NestedMessage> = emptyList(),
+  ext_pack_int32: List<Int> = emptyList(),
+  ext_pack_uint32: List<Int> = emptyList(),
+  ext_pack_sint32: List<Int> = emptyList(),
+  ext_pack_fixed32: List<Int> = emptyList(),
+  ext_pack_sfixed32: List<Int> = emptyList(),
+  ext_pack_int64: List<Long> = emptyList(),
+  ext_pack_uint64: List<Long> = emptyList(),
+  ext_pack_sint64: List<Long> = emptyList(),
+  ext_pack_fixed64: List<Long> = emptyList(),
+  ext_pack_sfixed64: List<Long> = emptyList(),
+  ext_pack_bool: List<Boolean> = emptyList(),
+  ext_pack_float: List<Float> = emptyList(),
+  ext_pack_double: List<Double> = emptyList(),
+  ext_pack_nested_enum: List<NestedEnum> = emptyList(),
   @field:WireField(
     tag = 601,
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
@@ -1079,6 +591,633 @@ class AllTypes(
   val oneof_nested_message: NestedMessage? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<AllTypes, AllTypes.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 201,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
+
+  @field:WireField(
+    tag = 202,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
+
+  @field:WireField(
+    tag = 203,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
+
+  @field:WireField(
+    tag = 204,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
+
+  @field:WireField(
+    tag = 205,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
+
+  @field:WireField(
+    tag = 206,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
+
+  @field:WireField(
+    tag = 207,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
+
+  @field:WireField(
+    tag = 208,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
+
+  @field:WireField(
+    tag = 209,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
+
+  @field:WireField(
+    tag = 210,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
+
+  @field:WireField(
+    tag = 211,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
+
+  @field:WireField(
+    tag = 212,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
+
+  @field:WireField(
+    tag = 213,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
+
+  @field:WireField(
+    tag = 214,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
+
+  @field:WireField(
+    tag = 215,
+    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
+
+  @field:WireField(
+    tag = 216,
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
+
+  @field:WireField(
+    tag = 217,
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
+      rep_nested_message)
+
+  @field:WireField(
+    tag = 301,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
+
+  @field:WireField(
+    tag = 302,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
+
+  @field:WireField(
+    tag = 303,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
+
+  @field:WireField(
+    tag = 304,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
+
+  @field:WireField(
+    tag = 305,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
+
+  @field:WireField(
+    tag = 306,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
+
+  @field:WireField(
+    tag = 307,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
+
+  @field:WireField(
+    tag = 308,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
+
+  @field:WireField(
+    tag = 309,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
+
+  @field:WireField(
+    tag = 310,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
+
+  @field:WireField(
+    tag = 311,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
+
+  @field:WireField(
+    tag = 312,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
+
+  @field:WireField(
+    tag = 313,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
+
+  @field:WireField(
+    tag = 316,
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum", pack_nested_enum)
+
+  @field:WireField(
+    tag = 501,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  @JvmField
+  val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
+
+  @field:WireField(
+    tag = 502,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
+      map_string_string)
+
+  @field:WireField(
+    tag = 503,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER"
+  )
+  @JvmField
+  val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
+      map_string_message)
+
+  @field:WireField(
+    tag = 504,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER"
+  )
+  @JvmField
+  val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum", map_string_enum)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1101,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_int32: List<Int> = immutableCopyOf("ext_rep_int32", ext_rep_int32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1102,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_uint32: List<Int> = immutableCopyOf("ext_rep_uint32", ext_rep_uint32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1103,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_sint32: List<Int> = immutableCopyOf("ext_rep_sint32", ext_rep_sint32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1104,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_fixed32: List<Int> = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1105,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_sfixed32: List<Int> = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1106,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_int64: List<Long> = immutableCopyOf("ext_rep_int64", ext_rep_int64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1107,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_uint64: List<Long> = immutableCopyOf("ext_rep_uint64", ext_rep_uint64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1108,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_sint64: List<Long> = immutableCopyOf("ext_rep_sint64", ext_rep_sint64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1109,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_fixed64: List<Long> = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1110,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_sfixed64: List<Long> = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1111,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_bool: List<Boolean> = immutableCopyOf("ext_rep_bool", ext_rep_bool)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1112,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_float: List<Float> = immutableCopyOf("ext_rep_float", ext_rep_float)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1113,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_double: List<Double> = immutableCopyOf("ext_rep_double", ext_rep_double)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1114,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_string: List<String> = immutableCopyOf("ext_rep_string", ext_rep_string)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1115,
+    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_bytes: List<ByteString> = immutableCopyOf("ext_rep_bytes", ext_rep_bytes)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1116,
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_nested_enum: List<NestedEnum> = immutableCopyOf("ext_rep_nested_enum",
+      ext_rep_nested_enum)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1117,
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val ext_rep_nested_message: List<NestedMessage> = immutableCopyOf("ext_rep_nested_message",
+      ext_rep_nested_message)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1201,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_int32: List<Int> = immutableCopyOf("ext_pack_int32", ext_pack_int32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1202,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_uint32: List<Int> = immutableCopyOf("ext_pack_uint32", ext_pack_uint32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1203,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_sint32: List<Int> = immutableCopyOf("ext_pack_sint32", ext_pack_sint32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1204,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_fixed32: List<Int> = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1205,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_sfixed32: List<Int> = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1206,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_int64: List<Long> = immutableCopyOf("ext_pack_int64", ext_pack_int64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1207,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_uint64: List<Long> = immutableCopyOf("ext_pack_uint64", ext_pack_uint64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1208,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_sint64: List<Long> = immutableCopyOf("ext_pack_sint64", ext_pack_sint64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1209,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_fixed64: List<Long> = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1210,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_sfixed64: List<Long> = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1211,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_bool: List<Boolean> = immutableCopyOf("ext_pack_bool", ext_pack_bool)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1212,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_float: List<Float> = immutableCopyOf("ext_pack_float", ext_pack_float)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1213,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_double: List<Double> = immutableCopyOf("ext_pack_double", ext_pack_double)
+
+  /**
+   * Extension source: all_types.proto
+   */
+  @field:WireField(
+    tag = 1216,
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val ext_pack_nested_enum: List<NestedEnum> = immutableCopyOf("ext_pack_nested_enum",
+      ext_pack_nested_enum)
+
   init {
     require(countNonNull(oneof_string, oneof_int32, oneof_nested_message) <= 1) {
       "At most one of oneof_string, oneof_int32, oneof_nested_message may be non-null"

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.Syntax.PROTO_3
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
 import com.squareup.wire.internal.countNonNull
+import com.squareup.wire.internal.immutableCopyOfMapWithStructValues
 import com.squareup.wire.internal.immutableCopyOfStruct
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
@@ -39,38 +40,10 @@ class AllStructs(
   rep_list: List<List<*>?> = emptyList(),
   rep_value_a: List<Any?> = emptyList(),
   rep_null_value: List<Nothing?> = emptyList(),
-  @field:WireField(
-    tag = 301,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
-    jsonName = "mapInt32Struct"
-  )
-  @JvmField
-  val map_int32_struct: Map<Int, Map<String, *>?> = emptyMap(),
-  @field:WireField(
-    tag = 302,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
-    jsonName = "mapInt32List"
-  )
-  @JvmField
-  val map_int32_list: Map<Int, List<*>?> = emptyMap(),
-  @field:WireField(
-    tag = 303,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
-    jsonName = "mapInt32ValueA"
-  )
-  @JvmField
-  val map_int32_value_a: Map<Int, Any?> = emptyMap(),
-  @field:WireField(
-    tag = 304,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
-    jsonName = "mapInt32NullValue"
-  )
-  @JvmField
-  val map_int32_null_value: Map<Int, Nothing?> = emptyMap(),
+  map_int32_struct: Map<Int, Map<String, *>?> = emptyMap(),
+  map_int32_list: Map<Int, List<*>?> = emptyMap(),
+  map_int32_value_a: Map<Int, Any?> = emptyMap(),
+  map_int32_null_value: Map<Int, Nothing?> = emptyMap(),
   oneof_struct: Map<String, *>? = null,
   oneof_list: List<*>? = null,
   unknownFields: ByteString = ByteString.EMPTY
@@ -189,6 +162,46 @@ class AllStructs(
   )
   @JvmField
   val rep_null_value: List<Nothing?> = immutableCopyOfStruct("rep_null_value", rep_null_value)
+
+  @field:WireField(
+    tag = 301,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
+    jsonName = "mapInt32Struct"
+  )
+  @JvmField
+  val map_int32_struct: Map<Int, Map<String, *>?> =
+      immutableCopyOfMapWithStructValues("map_int32_struct", map_int32_struct)
+
+  @field:WireField(
+    tag = 302,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
+    jsonName = "mapInt32List"
+  )
+  @JvmField
+  val map_int32_list: Map<Int, List<*>?> = immutableCopyOfMapWithStructValues("map_int32_list",
+      map_int32_list)
+
+  @field:WireField(
+    tag = 303,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
+    jsonName = "mapInt32ValueA"
+  )
+  @JvmField
+  val map_int32_value_a: Map<Int, Any?> = immutableCopyOfMapWithStructValues("map_int32_value_a",
+      map_int32_value_a)
+
+  @field:WireField(
+    tag = 304,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
+    jsonName = "mapInt32NullValue"
+  )
+  @JvmField
+  val map_int32_null_value: Map<Int, Nothing?> =
+      immutableCopyOfMapWithStructValues("map_int32_null_value", map_int32_null_value)
 
   @field:WireField(
     tag = 201,

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_3
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.Boolean
@@ -32,14 +33,7 @@ class CamelCase(
   )
   @JvmField
   val nested__message: NestedCamelCase? = null,
-  @field:WireField(
-    tag = 2,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED,
-    jsonName = "RepInt32"
-  )
-  @JvmField
-  val _Rep_int32: List<Int> = emptyList(),
+  _Rep_int32: List<Int> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
@@ -48,6 +42,18 @@ class CamelCase(
   )
   @JvmField
   val IDitIt_my_wAy: String = "",
+  map_int32_Int32: Map<Int, Int> = emptyMap(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<CamelCase, CamelCase.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED,
+    jsonName = "RepInt32"
+  )
+  @JvmField
+  val _Rep_int32: List<Int> = immutableCopyOf("_Rep_int32", _Rep_int32)
+
   @field:WireField(
     tag = 4,
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
@@ -55,9 +61,8 @@ class CamelCase(
     jsonName = "mapInt32Int32"
   )
   @JvmField
-  val map_int32_Int32: Map<Int, Int> = emptyMap(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<CamelCase, CamelCase.Builder>(ADAPTER, unknownFields) {
+  val map_int32_Int32: Map<Int, Int> = immutableCopyOf("map_int32_Int32", map_int32_Int32)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.nested__message = nested__message

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_3
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.Boolean
@@ -20,15 +21,17 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class Pizza(
+  toppings: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Pizza, Pizza.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val toppings: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Pizza, Pizza.Builder>(ADAPTER, unknownFields) {
+  val toppings: List<String> = immutableCopyOf("toppings", toppings)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.toppings = toppings

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_3
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.immutableCopyOfStruct
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -42,13 +43,7 @@ class PizzaDelivery(
   )
   @JvmField
   val address: String = "",
-  @field:WireField(
-    tag = 3,
-    adapter = "squareup.proto3.Pizza#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val pizzas: List<Pizza> = emptyList(),
+  pizzas: List<Pizza> = emptyList(),
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
@@ -75,6 +70,14 @@ class PizzaDelivery(
   val ordered_at: Instant? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<PizzaDelivery, PizzaDelivery.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 3,
+    adapter = "squareup.proto3.Pizza#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val pizzas: List<Pizza> = immutableCopyOf("pizzas", pizzas)
+
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",

--- a/wire-library/wire-tests/src/jvmJsonTest/kotlin/com/squareup/wire/WireJsonTest.kt
+++ b/wire-library/wire-tests/src/jvmJsonTest/kotlin/com/squareup/wire/WireJsonTest.kt
@@ -145,8 +145,21 @@ class WireJsonTest {
         .IDitIt_my_wAy("frank")
         .map_int32_Int32(mapOf(1 to 2))
         .build()
-    assertThat(jsonLibrary.toJson(camel, CamelCase::class.java)).isEqualTo(
-        """{"nestedMessage":{"oneInt32":1},"RepInt32":[1,2],"iDitItMyWAy":"frank","mapInt32Int32":{"1":2}}""")
+    assertJsonEquals(jsonLibrary.toJson(camel, CamelCase::class.java), """
+        |{
+        |  "nestedMessage": {
+        |    "oneInt32": 1
+        |  },
+        |  "RepInt32": [
+        |    1,
+        |    2
+        |  ],
+        |  "iDitItMyWAy": "frank",
+        |  "mapInt32Int32": {
+        |    "1": 2
+        |  }
+        |}
+        |""".trimMargin())
 
     // Confirm protoc prints the same.
     assertJsonEquals(CAMEL_CASE_JSON, jsonLibrary.toJson(camel, CamelCase::class.java))

--- a/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -60,6 +61,10 @@ class Person(
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   val email: String? = null,
+  phone: List<PhoneNumber> = emptyList(),
+  aliases: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : AndroidMessage<Person, Nothing>(ADAPTER, unknownFields) {
   /**
    * A list of the customer's phone numbers.
    */
@@ -68,15 +73,15 @@ class Person(
     adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED
   )
-  val phone: List<PhoneNumber> = emptyList(),
+  val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
+
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
-  val aliases: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : AndroidMessage<Person, Nothing>(ADAPTER, unknownFields) {
+  val aliases: List<String> = immutableCopyOf("aliases", aliases)
+
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
@@ -7,6 +7,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -48,15 +49,17 @@ class ModelEvaluation(
   )
   @JvmField
   val score: Double? = null,
+  models: Map<String, ModelEvaluation> = emptyMap(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<ModelEvaluation, ModelEvaluation.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 3,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "ModelEvaluation#ADAPTER"
   )
   @JvmField
-  val models: Map<String, ModelEvaluation> = emptyMap(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<ModelEvaluation, ModelEvaluation.Builder>(ADAPTER, unknownFields) {
+  val models: Map<String, ModelEvaluation> = immutableCopyOf("models", models)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/DescriptorProto.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -32,61 +33,78 @@ class DescriptorProto(
   )
   @JvmField
   val name: String? = null,
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val field: List<FieldDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 6,
-    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val extension: List<FieldDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 3,
-    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val nested_type: List<DescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 4,
-    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val enum_type: List<EnumDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 5,
-    adapter = "com.google.protobuf.DescriptorProto${'$'}ExtensionRange#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val extension_range: List<ExtensionRange> = emptyList(),
-  @field:WireField(
-    tag = 8,
-    adapter = "com.google.protobuf.OneofDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val oneof_decl: List<OneofDescriptorProto> = emptyList(),
+  field: List<FieldDescriptorProto> = emptyList(),
+  extension: List<FieldDescriptorProto> = emptyList(),
+  nested_type: List<DescriptorProto> = emptyList(),
+  enum_type: List<EnumDescriptorProto> = emptyList(),
+  extension_range: List<ExtensionRange> = emptyList(),
+  oneof_decl: List<OneofDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 7,
     adapter = "com.google.protobuf.MessageOptions#ADAPTER"
   )
   @JvmField
   val options: MessageOptions? = null,
+  reserved_range: List<ReservedRange> = emptyList(),
+  reserved_name: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<DescriptorProto, DescriptorProto.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val field: List<FieldDescriptorProto> = immutableCopyOf("field", field)
+
+  @field:WireField(
+    tag = 6,
+    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val extension: List<FieldDescriptorProto> = immutableCopyOf("extension", extension)
+
+  @field:WireField(
+    tag = 3,
+    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val nested_type: List<DescriptorProto> = immutableCopyOf("nested_type", nested_type)
+
+  @field:WireField(
+    tag = 4,
+    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val enum_type: List<EnumDescriptorProto> = immutableCopyOf("enum_type", enum_type)
+
+  @field:WireField(
+    tag = 5,
+    adapter = "com.google.protobuf.DescriptorProto${'$'}ExtensionRange#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val extension_range: List<ExtensionRange> = immutableCopyOf("extension_range", extension_range)
+
+  @field:WireField(
+    tag = 8,
+    adapter = "com.google.protobuf.OneofDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val oneof_decl: List<OneofDescriptorProto> = immutableCopyOf("oneof_decl", oneof_decl)
+
   @field:WireField(
     tag = 9,
     adapter = "com.google.protobuf.DescriptorProto${'$'}ReservedRange#ADAPTER",
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val reserved_range: List<ReservedRange> = emptyList(),
+  val reserved_range: List<ReservedRange> = immutableCopyOf("reserved_range", reserved_range)
+
   /**
    * Reserved field names, which may not be used by fields in the same message.
    * A given name may only be reserved once.
@@ -97,9 +115,8 @@ class DescriptorProto(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val reserved_name: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<DescriptorProto, DescriptorProto.Builder>(ADAPTER, unknownFields) {
+  val reserved_name: List<String> = immutableCopyOf("reserved_name", reserved_name)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumDescriptorProto.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -32,19 +33,25 @@ class EnumDescriptorProto(
   )
   @JvmField
   val name: String? = null,
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.EnumValueDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val value: List<EnumValueDescriptorProto> = emptyList(),
+  value: List<EnumValueDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.google.protobuf.EnumOptions#ADAPTER"
   )
   @JvmField
   val options: EnumOptions? = null,
+  reserved_range: List<EnumReservedRange> = emptyList(),
+  reserved_name: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<EnumDescriptorProto, EnumDescriptorProto.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.EnumValueDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val value: List<EnumValueDescriptorProto> = immutableCopyOf("value", value)
+
   /**
    * Range of reserved numeric values. Reserved numeric values may not be used
    * by enum values in the same enum declaration. Reserved ranges may not
@@ -56,7 +63,8 @@ class EnumDescriptorProto(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val reserved_range: List<EnumReservedRange> = emptyList(),
+  val reserved_range: List<EnumReservedRange> = immutableCopyOf("reserved_range", reserved_range)
+
   /**
    * Reserved enum value names, which may not be reused. A given name may only
    * be reserved once.
@@ -67,9 +75,8 @@ class EnumDescriptorProto(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val reserved_name: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<EnumDescriptorProto, EnumDescriptorProto.Builder>(ADAPTER, unknownFields) {
+  val reserved_name: List<String> = immutableCopyOf("reserved_name", reserved_name)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumOptions.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -43,6 +44,9 @@ class EnumOptions(
   )
   @JvmField
   val deprecated: Boolean? = null,
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<EnumOptions, EnumOptions.Builder>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -52,9 +56,9 @@ class EnumOptions(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<EnumOptions, EnumOptions.Builder>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.allow_alias = allow_alias

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/EnumValueOptions.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -33,16 +34,7 @@ class EnumValueOptions(
   )
   @JvmField
   val deprecated: Boolean? = null,
-  /**
-   * The parser stores options it doesn't recognize here. See above.
-   */
-  @field:WireField(
-    tag = 999,
-    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
   /**
    * Extension source: foreign.proto
    */
@@ -54,6 +46,18 @@ class EnumValueOptions(
   val foreign_enum_value_option: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<EnumValueOptions, EnumValueOptions.Builder>(ADAPTER, unknownFields) {
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @field:WireField(
+    tag = 999,
+    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.deprecated = deprecated

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ExtensionRangeOptions.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -20,6 +21,9 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class ExtensionRangeOptions(
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<ExtensionRangeOptions, ExtensionRangeOptions.Builder>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -29,9 +33,9 @@ class ExtensionRangeOptions(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<ExtensionRangeOptions, ExtensionRangeOptions.Builder>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.uninterpreted_option = uninterpreted_option

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FieldOptions.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -126,16 +127,7 @@ class FieldOptions(
   )
   @JvmField
   val weak: Boolean? = null,
-  /**
-   * The parser stores options it doesn't recognize here. See above.
-   */
-  @field:WireField(
-    tag = 999,
-    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
   /**
    * Fields marked with redacted are not to be logged, generally for PCI or PII.
    * Extension source: option_redacted.proto
@@ -148,6 +140,18 @@ class FieldOptions(
   val redacted: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<FieldOptions, FieldOptions.Builder>(ADAPTER, unknownFields) {
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @field:WireField(
+    tag = 999,
+    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.ctype = ctype

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorProto.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -44,68 +45,13 @@ class FileDescriptorProto(
   )
   @JvmField
   val package_: String? = null,
-  /**
-   * Names of files imported by this file.
-   */
-  @field:WireField(
-    tag = 3,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val dependency: List<String> = emptyList(),
-  /**
-   * Indexes of the public imported files in the dependency list above.
-   */
-  @field:WireField(
-    tag = 10,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val public_dependency: List<Int> = emptyList(),
-  /**
-   * Indexes of the weak imported files in the dependency list.
-   * For Google-internal migration only. Do not use.
-   */
-  @field:WireField(
-    tag = 11,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val weak_dependency: List<Int> = emptyList(),
-  /**
-   * All top-level definitions in this file.
-   */
-  @field:WireField(
-    tag = 4,
-    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val message_type: List<DescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 5,
-    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val enum_type: List<EnumDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 6,
-    adapter = "com.google.protobuf.ServiceDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val service: List<ServiceDescriptorProto> = emptyList(),
-  @field:WireField(
-    tag = 7,
-    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val extension: List<FieldDescriptorProto> = emptyList(),
+  dependency: List<String> = emptyList(),
+  public_dependency: List<Int> = emptyList(),
+  weak_dependency: List<Int> = emptyList(),
+  message_type: List<DescriptorProto> = emptyList(),
+  enum_type: List<EnumDescriptorProto> = emptyList(),
+  service: List<ServiceDescriptorProto> = emptyList(),
+  extension: List<FieldDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 8,
     adapter = "com.google.protobuf.FileOptions#ADAPTER"
@@ -136,6 +82,75 @@ class FileDescriptorProto(
   val syntax: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<FileDescriptorProto, FileDescriptorProto.Builder>(ADAPTER, unknownFields) {
+  /**
+   * Names of files imported by this file.
+   */
+  @field:WireField(
+    tag = 3,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val dependency: List<String> = immutableCopyOf("dependency", dependency)
+
+  /**
+   * Indexes of the public imported files in the dependency list above.
+   */
+  @field:WireField(
+    tag = 10,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val public_dependency: List<Int> = immutableCopyOf("public_dependency", public_dependency)
+
+  /**
+   * Indexes of the weak imported files in the dependency list.
+   * For Google-internal migration only. Do not use.
+   */
+  @field:WireField(
+    tag = 11,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val weak_dependency: List<Int> = immutableCopyOf("weak_dependency", weak_dependency)
+
+  /**
+   * All top-level definitions in this file.
+   */
+  @field:WireField(
+    tag = 4,
+    adapter = "com.google.protobuf.DescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val message_type: List<DescriptorProto> = immutableCopyOf("message_type", message_type)
+
+  @field:WireField(
+    tag = 5,
+    adapter = "com.google.protobuf.EnumDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val enum_type: List<EnumDescriptorProto> = immutableCopyOf("enum_type", enum_type)
+
+  @field:WireField(
+    tag = 6,
+    adapter = "com.google.protobuf.ServiceDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val service: List<ServiceDescriptorProto> = immutableCopyOf("service", service)
+
+  @field:WireField(
+    tag = 7,
+    adapter = "com.google.protobuf.FieldDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val extension: List<FieldDescriptorProto> = immutableCopyOf("extension", extension)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileDescriptorSet.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -24,15 +25,17 @@ import okio.ByteString
  * files it parses.
  */
 class FileDescriptorSet(
+  file: List<FileDescriptorProto> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<FileDescriptorSet, FileDescriptorSet.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     adapter = "com.google.protobuf.FileDescriptorProto#ADAPTER",
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val file: List<FileDescriptorProto> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<FileDescriptorSet, FileDescriptorSet.Builder>(ADAPTER, unknownFields) {
+  val file: List<FileDescriptorProto> = immutableCopyOf("file", file)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.file = file

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/FileOptions.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -101,12 +102,12 @@ class FileOptions(
   /**
    * This option does nothing.
    */
+  @Deprecated(message = "java_generate_equals_and_hash is deprecated")
   @field:WireField(
     tag = 20,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   @JvmField
-  @Deprecated(message = "java_generate_equals_and_hash is deprecated")
   val java_generate_equals_and_hash: Boolean? = null,
   /**
    * If set true, then the Java2 code generator will generate code that
@@ -273,6 +274,9 @@ class FileOptions(
   )
   @JvmField
   val ruby_package: String? = null,
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<FileOptions, FileOptions.Builder>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here.
    * See the documentation for the "Options" section above.
@@ -283,9 +287,9 @@ class FileOptions(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<FileOptions, FileOptions.Builder>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.java_package = java_package

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/GeneratedCodeInfo.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -28,6 +29,9 @@ import okio.ByteString
  * source file, but may contain references to different source .proto files.
  */
 class GeneratedCodeInfo(
+  annotation: List<Annotation> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<GeneratedCodeInfo, GeneratedCodeInfo.Builder>(ADAPTER, unknownFields) {
   /**
    * An Annotation connects some span of text in generated code to an element
    * of its generating .proto file.
@@ -38,9 +42,8 @@ class GeneratedCodeInfo(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val annotation: List<Annotation> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<GeneratedCodeInfo, GeneratedCodeInfo.Builder>(ADAPTER, unknownFields) {
+  val annotation: List<Annotation> = immutableCopyOf("annotation", annotation)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.annotation = annotation
@@ -137,17 +140,7 @@ class GeneratedCodeInfo(
   }
 
   class Annotation(
-    /**
-     * Identifies the element in the original source .proto file. This field
-     * is formatted the same as SourceCodeInfo.Location.path.
-     */
-    @field:WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
-    )
-    @JvmField
-    val path: List<Int> = emptyList(),
+    path: List<Int> = emptyList(),
     /**
      * Identifies the filesystem path to the original source .proto.
      */
@@ -180,6 +173,18 @@ class GeneratedCodeInfo(
     val end: Int? = null,
     unknownFields: ByteString = ByteString.EMPTY
   ) : Message<Annotation, Annotation.Builder>(ADAPTER, unknownFields) {
+    /**
+     * Identifies the element in the original source .proto file. This field
+     * is formatted the same as SourceCodeInfo.Location.path.
+     */
+    @field:WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+    )
+    @JvmField
+    val path: List<Int> = immutableCopyOf("path", path)
+
     override fun newBuilder(): Builder {
       val builder = Builder()
       builder.path = path

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MessageOptions.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.protos.kotlin.foreign.ForeignMessage
 import kotlin.Any
@@ -100,16 +101,7 @@ class MessageOptions(
   )
   @JvmField
   val map_entry: Boolean? = null,
-  /**
-   * The parser stores options it doesn't recognize here. See above.
-   */
-  @field:WireField(
-    tag = 999,
-    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
   /**
    * Extension source: foreign.proto
    */
@@ -121,6 +113,18 @@ class MessageOptions(
   val foreign_message_option: ForeignMessage? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<MessageOptions, MessageOptions.Builder>(ADAPTER, unknownFields) {
+  /**
+   * The parser stores options it doesn't recognize here. See above.
+   */
+  @field:WireField(
+    tag = 999,
+    adapter = "com.google.protobuf.UninterpretedOption#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.message_set_wire_format = message_set_wire_format

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/MethodOptions.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -47,6 +48,9 @@ class MethodOptions(
   )
   @JvmField
   val idempotency_level: IdempotencyLevel? = null,
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<MethodOptions, MethodOptions.Builder>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -56,9 +60,9 @@ class MethodOptions(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<MethodOptions, MethodOptions.Builder>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.deprecated = deprecated

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/OneofOptions.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -20,6 +21,9 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class OneofOptions(
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<OneofOptions, OneofOptions.Builder>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -29,9 +33,9 @@ class OneofOptions(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<OneofOptions, OneofOptions.Builder>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.uninterpreted_option = uninterpreted_option

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceDescriptorProto.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -31,13 +32,7 @@ class ServiceDescriptorProto(
   )
   @JvmField
   val name: String? = null,
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.MethodDescriptorProto#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val method: List<MethodDescriptorProto> = emptyList(),
+  method: List<MethodDescriptorProto> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.google.protobuf.ServiceOptions#ADAPTER"
@@ -46,6 +41,14 @@ class ServiceDescriptorProto(
   val options: ServiceOptions? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<ServiceDescriptorProto, ServiceDescriptorProto.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.MethodDescriptorProto#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val method: List<MethodDescriptorProto> = immutableCopyOf("method", method)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/ServiceOptions.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -37,6 +38,9 @@ class ServiceOptions(
   )
   @JvmField
   val deprecated: Boolean? = null,
+  uninterpreted_option: List<UninterpretedOption> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<ServiceOptions, ServiceOptions.Builder>(ADAPTER, unknownFields) {
   /**
    * The parser stores options it doesn't recognize here. See above.
    */
@@ -46,9 +50,9 @@ class ServiceOptions(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val uninterpreted_option: List<UninterpretedOption> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<ServiceOptions, ServiceOptions.Builder>(ADAPTER, unknownFields) {
+  val uninterpreted_option: List<UninterpretedOption> = immutableCopyOf("uninterpreted_option",
+      uninterpreted_option)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.deprecated = deprecated

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/SourceCodeInfo.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
@@ -29,6 +30,9 @@ import okio.ByteString
  * FileDescriptorProto was generated.
  */
 class SourceCodeInfo(
+  location: List<Location> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<SourceCodeInfo, SourceCodeInfo.Builder>(ADAPTER, unknownFields) {
   /**
    * A Location identifies a piece of source code in a .proto file which
    * corresponds to a particular definition.  This information is intended
@@ -80,9 +84,8 @@ class SourceCodeInfo(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val location: List<Location> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<SourceCodeInfo, SourceCodeInfo.Builder>(ADAPTER, unknownFields) {
+  val location: List<Location> = immutableCopyOf("location", location)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.location = location
@@ -220,52 +223,8 @@ class SourceCodeInfo(
   }
 
   class Location(
-    /**
-     * Identifies which part of the FileDescriptorProto was defined at this
-     * location.
-     *
-     * Each element is a field number or an index.  They form a path from
-     * the root FileDescriptorProto to the place where the definition.  For
-     * example, this path:
-     *   [ 4, 3, 2, 7, 1 ]
-     * refers to:
-     *   file.message_type(3)  // 4, 3
-     *       .field(7)         // 2, 7
-     *       .name()           // 1
-     * This is because FileDescriptorProto.message_type has field number 4:
-     *   repeated DescriptorProto message_type = 4;
-     * and DescriptorProto.field has field number 2:
-     *   repeated FieldDescriptorProto field = 2;
-     * and FieldDescriptorProto.name has field number 1:
-     *   optional string name = 1;
-     *
-     * Thus, the above path gives the location of a field name.  If we removed
-     * the last element:
-     *   [ 4, 3, 2, 7 ]
-     * this path refers to the whole field declaration (from the beginning
-     * of the label to the terminating semicolon).
-     */
-    @field:WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
-    )
-    @JvmField
-    val path: List<Int> = emptyList(),
-    /**
-     * Always has exactly three or four elements: start line, start column,
-     * end line (optional, otherwise assumed same as start line), end column.
-     * These are packed into a single field for efficiency.  Note that line
-     * and column numbers are zero-based -- typically you will want to add
-     * 1 to each before displaying to a user.
-     */
-    @field:WireField(
-      tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
-    )
-    @JvmField
-    val span: List<Int> = emptyList(),
+    path: List<Int> = emptyList(),
+    span: List<Int> = emptyList(),
     /**
      * If this SourceCodeInfo represents a complete declaration, these are any
      * comments appearing before and after the declaration which appear to be
@@ -327,15 +286,66 @@ class SourceCodeInfo(
     )
     @JvmField
     val trailing_comments: String? = null,
+    leading_detached_comments: List<String> = emptyList(),
+    unknownFields: ByteString = ByteString.EMPTY
+  ) : Message<Location, Location.Builder>(ADAPTER, unknownFields) {
+    /**
+     * Identifies which part of the FileDescriptorProto was defined at this
+     * location.
+     *
+     * Each element is a field number or an index.  They form a path from
+     * the root FileDescriptorProto to the place where the definition.  For
+     * example, this path:
+     *   [ 4, 3, 2, 7, 1 ]
+     * refers to:
+     *   file.message_type(3)  // 4, 3
+     *       .field(7)         // 2, 7
+     *       .name()           // 1
+     * This is because FileDescriptorProto.message_type has field number 4:
+     *   repeated DescriptorProto message_type = 4;
+     * and DescriptorProto.field has field number 2:
+     *   repeated FieldDescriptorProto field = 2;
+     * and FieldDescriptorProto.name has field number 1:
+     *   optional string name = 1;
+     *
+     * Thus, the above path gives the location of a field name.  If we removed
+     * the last element:
+     *   [ 4, 3, 2, 7 ]
+     * this path refers to the whole field declaration (from the beginning
+     * of the label to the terminating semicolon).
+     */
+    @field:WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+    )
+    @JvmField
+    val path: List<Int> = immutableCopyOf("path", path)
+
+    /**
+     * Always has exactly three or four elements: start line, start column,
+     * end line (optional, otherwise assumed same as start line), end column.
+     * These are packed into a single field for efficiency.  Note that line
+     * and column numbers are zero-based -- typically you will want to add
+     * 1 to each before displaying to a user.
+     */
+    @field:WireField(
+      tag = 2,
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      label = WireField.Label.PACKED
+    )
+    @JvmField
+    val span: List<Int> = immutableCopyOf("span", span)
+
     @field:WireField(
       tag = 6,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REPEATED
     )
     @JvmField
-    val leading_detached_comments: List<String> = emptyList(),
-    unknownFields: ByteString = ByteString.EMPTY
-  ) : Message<Location, Location.Builder>(ADAPTER, unknownFields) {
+    val leading_detached_comments: List<String> = immutableCopyOf("leading_detached_comments",
+        leading_detached_comments)
+
     override fun newBuilder(): Builder {
       val builder = Builder()
       builder.path = path

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/google/protobuf/UninterpretedOption.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -34,13 +35,7 @@ import okio.ByteString
  * in them.
  */
 class UninterpretedOption(
-  @field:WireField(
-    tag = 2,
-    adapter = "com.google.protobuf.UninterpretedOption${'$'}NamePart#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val name: List<NamePart> = emptyList(),
+  name: List<NamePart> = emptyList(),
   /**
    * The value of the uninterpreted option, in whatever type the tokenizer
    * identified it as during parsing. Exactly one of these should be set.
@@ -83,6 +78,14 @@ class UninterpretedOption(
   val aggregate_value: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<UninterpretedOption, UninterpretedOption.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 2,
+    adapter = "com.google.protobuf.UninterpretedOption${'$'}NamePart#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val name: List<NamePart> = immutableCopyOf("name", name)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -20,12 +20,12 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class DeprecatedProto(
+  @Deprecated(message = "foo is deprecated")
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   @JvmField
-  @Deprecated(message = "foo is deprecated")
   val foo: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<DeprecatedProto, DeprecatedProto.Builder>(ADAPTER, unknownFields) {

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -254,223 +255,37 @@ class AllTypes(
   )
   @JvmField
   val req_nested_message: NestedMessage,
-  @field:WireField(
-    tag = 201,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 202,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 203,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 204,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 205,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 206,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 207,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 208,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 209,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 210,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 211,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 212,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 213,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 214,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_string: List<String> = emptyList(),
-  @field:WireField(
-    tag = 215,
-    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_bytes: List<ByteString> = emptyList(),
-  @field:WireField(
-    tag = 216,
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_nested_enum: List<NestedEnum> = emptyList(),
-  @field:WireField(
-    tag = 217,
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val rep_nested_message: List<NestedMessage> = emptyList(),
-  @field:WireField(
-    tag = 301,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_int32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 302,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_uint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 303,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sint32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 304,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_fixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 305,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sfixed32: List<Int> = emptyList(),
-  @field:WireField(
-    tag = 306,
-    adapter = "com.squareup.wire.ProtoAdapter#INT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_int64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 307,
-    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_uint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 308,
-    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sint64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 309,
-    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_fixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 310,
-    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_sfixed64: List<Long> = emptyList(),
-  @field:WireField(
-    tag = 311,
-    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_bool: List<Boolean> = emptyList(),
-  @field:WireField(
-    tag = 312,
-    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_float: List<Float> = emptyList(),
-  @field:WireField(
-    tag = 313,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_double: List<Double> = emptyList(),
-  @field:WireField(
-    tag = 316,
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val pack_nested_enum: List<NestedEnum> = emptyList(),
+  rep_int32: List<Int> = emptyList(),
+  rep_uint32: List<Int> = emptyList(),
+  rep_sint32: List<Int> = emptyList(),
+  rep_fixed32: List<Int> = emptyList(),
+  rep_sfixed32: List<Int> = emptyList(),
+  rep_int64: List<Long> = emptyList(),
+  rep_uint64: List<Long> = emptyList(),
+  rep_sint64: List<Long> = emptyList(),
+  rep_fixed64: List<Long> = emptyList(),
+  rep_sfixed64: List<Long> = emptyList(),
+  rep_bool: List<Boolean> = emptyList(),
+  rep_float: List<Float> = emptyList(),
+  rep_double: List<Double> = emptyList(),
+  rep_string: List<String> = emptyList(),
+  rep_bytes: List<ByteString> = emptyList(),
+  rep_nested_enum: List<NestedEnum> = emptyList(),
+  rep_nested_message: List<NestedMessage> = emptyList(),
+  pack_int32: List<Int> = emptyList(),
+  pack_uint32: List<Int> = emptyList(),
+  pack_sint32: List<Int> = emptyList(),
+  pack_fixed32: List<Int> = emptyList(),
+  pack_sfixed32: List<Int> = emptyList(),
+  pack_int64: List<Long> = emptyList(),
+  pack_uint64: List<Long> = emptyList(),
+  pack_sint64: List<Long> = emptyList(),
+  pack_fixed64: List<Long> = emptyList(),
+  pack_sfixed64: List<Long> = emptyList(),
+  pack_bool: List<Boolean> = emptyList(),
+  pack_float: List<Float> = emptyList(),
+  pack_double: List<Double> = emptyList(),
+  pack_nested_enum: List<NestedEnum> = emptyList(),
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT32"
@@ -567,34 +382,10 @@ class AllTypes(
   )
   @JvmField
   val default_nested_enum: NestedEnum? = null,
-  @field:WireField(
-    tag = 501,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-    adapter = "com.squareup.wire.ProtoAdapter#INT32"
-  )
-  @JvmField
-  val map_int32_int32: Map<Int, Int> = emptyMap(),
-  @field:WireField(
-    tag = 502,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.ProtoAdapter#STRING"
-  )
-  @JvmField
-  val map_string_string: Map<String, String> = emptyMap(),
-  @field:WireField(
-    tag = 503,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER"
-  )
-  @JvmField
-  val map_string_message: Map<String, NestedMessage> = emptyMap(),
-  @field:WireField(
-    tag = 504,
-    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER"
-  )
-  @JvmField
-  val map_string_enum: Map<String, NestedEnum> = emptyMap(),
+  map_int32_int32: Map<Int, Int> = emptyMap(),
+  map_string_string: Map<String, String> = emptyMap(),
+  map_string_message: Map<String, NestedMessage> = emptyMap(),
+  map_string_enum: Map<String, NestedEnum> = emptyMap(),
   /**
    * Extension source: all_types.proto
    */
@@ -748,6 +539,322 @@ class AllTypes(
   )
   @JvmField
   val ext_opt_nested_message: NestedMessage? = null,
+  ext_rep_int32: List<Int> = emptyList(),
+  ext_rep_uint32: List<Int> = emptyList(),
+  ext_rep_sint32: List<Int> = emptyList(),
+  ext_rep_fixed32: List<Int> = emptyList(),
+  ext_rep_sfixed32: List<Int> = emptyList(),
+  ext_rep_int64: List<Long> = emptyList(),
+  ext_rep_uint64: List<Long> = emptyList(),
+  ext_rep_sint64: List<Long> = emptyList(),
+  ext_rep_fixed64: List<Long> = emptyList(),
+  ext_rep_sfixed64: List<Long> = emptyList(),
+  ext_rep_bool: List<Boolean> = emptyList(),
+  ext_rep_float: List<Float> = emptyList(),
+  ext_rep_double: List<Double> = emptyList(),
+  ext_rep_string: List<String> = emptyList(),
+  ext_rep_bytes: List<ByteString> = emptyList(),
+  ext_rep_nested_enum: List<NestedEnum> = emptyList(),
+  ext_rep_nested_message: List<NestedMessage> = emptyList(),
+  ext_pack_int32: List<Int> = emptyList(),
+  ext_pack_uint32: List<Int> = emptyList(),
+  ext_pack_sint32: List<Int> = emptyList(),
+  ext_pack_fixed32: List<Int> = emptyList(),
+  ext_pack_sfixed32: List<Int> = emptyList(),
+  ext_pack_int64: List<Long> = emptyList(),
+  ext_pack_uint64: List<Long> = emptyList(),
+  ext_pack_sint64: List<Long> = emptyList(),
+  ext_pack_fixed64: List<Long> = emptyList(),
+  ext_pack_sfixed64: List<Long> = emptyList(),
+  ext_pack_bool: List<Boolean> = emptyList(),
+  ext_pack_float: List<Float> = emptyList(),
+  ext_pack_double: List<Double> = emptyList(),
+  ext_pack_nested_enum: List<NestedEnum> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<AllTypes, AllTypes.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 201,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
+
+  @field:WireField(
+    tag = 202,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
+
+  @field:WireField(
+    tag = 203,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
+
+  @field:WireField(
+    tag = 204,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
+
+  @field:WireField(
+    tag = 205,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
+
+  @field:WireField(
+    tag = 206,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
+
+  @field:WireField(
+    tag = 207,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
+
+  @field:WireField(
+    tag = 208,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
+
+  @field:WireField(
+    tag = 209,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
+
+  @field:WireField(
+    tag = 210,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
+
+  @field:WireField(
+    tag = 211,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
+
+  @field:WireField(
+    tag = 212,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
+
+  @field:WireField(
+    tag = 213,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
+
+  @field:WireField(
+    tag = 214,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
+
+  @field:WireField(
+    tag = 215,
+    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
+
+  @field:WireField(
+    tag = 216,
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
+
+  @field:WireField(
+    tag = 217,
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
+      rep_nested_message)
+
+  @field:WireField(
+    tag = 301,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
+
+  @field:WireField(
+    tag = 302,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
+
+  @field:WireField(
+    tag = 303,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
+
+  @field:WireField(
+    tag = 304,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
+
+  @field:WireField(
+    tag = 305,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
+
+  @field:WireField(
+    tag = 306,
+    adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
+
+  @field:WireField(
+    tag = 307,
+    adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
+
+  @field:WireField(
+    tag = 308,
+    adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
+
+  @field:WireField(
+    tag = 309,
+    adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
+
+  @field:WireField(
+    tag = 310,
+    adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
+
+  @field:WireField(
+    tag = 311,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
+
+  @field:WireField(
+    tag = 312,
+    adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
+
+  @field:WireField(
+    tag = 313,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
+
+  @field:WireField(
+    tag = 316,
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum", pack_nested_enum)
+
+  @field:WireField(
+    tag = 501,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
+    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+  )
+  @JvmField
+  val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
+
+  @field:WireField(
+    tag = 502,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+  )
+  @JvmField
+  val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
+      map_string_string)
+
+  @field:WireField(
+    tag = 503,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER"
+  )
+  @JvmField
+  val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
+      map_string_message)
+
+  @field:WireField(
+    tag = 504,
+    keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
+    adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER"
+  )
+  @JvmField
+  val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum", map_string_enum)
+
   /**
    * Extension source: all_types.proto
    */
@@ -757,7 +864,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_int32: List<Int> = emptyList(),
+  val ext_rep_int32: List<Int> = immutableCopyOf("ext_rep_int32", ext_rep_int32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -767,7 +875,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_uint32: List<Int> = emptyList(),
+  val ext_rep_uint32: List<Int> = immutableCopyOf("ext_rep_uint32", ext_rep_uint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -777,7 +886,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_sint32: List<Int> = emptyList(),
+  val ext_rep_sint32: List<Int> = immutableCopyOf("ext_rep_sint32", ext_rep_sint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -787,7 +897,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_fixed32: List<Int> = emptyList(),
+  val ext_rep_fixed32: List<Int> = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -797,7 +908,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_sfixed32: List<Int> = emptyList(),
+  val ext_rep_sfixed32: List<Int> = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -807,7 +919,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_int64: List<Long> = emptyList(),
+  val ext_rep_int64: List<Long> = immutableCopyOf("ext_rep_int64", ext_rep_int64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -817,7 +930,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_uint64: List<Long> = emptyList(),
+  val ext_rep_uint64: List<Long> = immutableCopyOf("ext_rep_uint64", ext_rep_uint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -827,7 +941,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_sint64: List<Long> = emptyList(),
+  val ext_rep_sint64: List<Long> = immutableCopyOf("ext_rep_sint64", ext_rep_sint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -837,7 +952,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_fixed64: List<Long> = emptyList(),
+  val ext_rep_fixed64: List<Long> = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -847,7 +963,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_sfixed64: List<Long> = emptyList(),
+  val ext_rep_sfixed64: List<Long> = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -857,7 +974,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_bool: List<Boolean> = emptyList(),
+  val ext_rep_bool: List<Boolean> = immutableCopyOf("ext_rep_bool", ext_rep_bool)
+
   /**
    * Extension source: all_types.proto
    */
@@ -867,7 +985,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_float: List<Float> = emptyList(),
+  val ext_rep_float: List<Float> = immutableCopyOf("ext_rep_float", ext_rep_float)
+
   /**
    * Extension source: all_types.proto
    */
@@ -877,7 +996,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_double: List<Double> = emptyList(),
+  val ext_rep_double: List<Double> = immutableCopyOf("ext_rep_double", ext_rep_double)
+
   /**
    * Extension source: all_types.proto
    */
@@ -887,7 +1007,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_string: List<String> = emptyList(),
+  val ext_rep_string: List<String> = immutableCopyOf("ext_rep_string", ext_rep_string)
+
   /**
    * Extension source: all_types.proto
    */
@@ -897,7 +1018,8 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_bytes: List<ByteString> = emptyList(),
+  val ext_rep_bytes: List<ByteString> = immutableCopyOf("ext_rep_bytes", ext_rep_bytes)
+
   /**
    * Extension source: all_types.proto
    */
@@ -907,7 +1029,9 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_nested_enum: List<NestedEnum> = emptyList(),
+  val ext_rep_nested_enum: List<NestedEnum> = immutableCopyOf("ext_rep_nested_enum",
+      ext_rep_nested_enum)
+
   /**
    * Extension source: all_types.proto
    */
@@ -917,7 +1041,9 @@ class AllTypes(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val ext_rep_nested_message: List<NestedMessage> = emptyList(),
+  val ext_rep_nested_message: List<NestedMessage> = immutableCopyOf("ext_rep_nested_message",
+      ext_rep_nested_message)
+
   /**
    * Extension source: all_types.proto
    */
@@ -927,7 +1053,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_int32: List<Int> = emptyList(),
+  val ext_pack_int32: List<Int> = immutableCopyOf("ext_pack_int32", ext_pack_int32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -937,7 +1064,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_uint32: List<Int> = emptyList(),
+  val ext_pack_uint32: List<Int> = immutableCopyOf("ext_pack_uint32", ext_pack_uint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -947,7 +1075,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_sint32: List<Int> = emptyList(),
+  val ext_pack_sint32: List<Int> = immutableCopyOf("ext_pack_sint32", ext_pack_sint32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -957,7 +1086,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_fixed32: List<Int> = emptyList(),
+  val ext_pack_fixed32: List<Int> = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -967,7 +1097,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_sfixed32: List<Int> = emptyList(),
+  val ext_pack_sfixed32: List<Int> = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32)
+
   /**
    * Extension source: all_types.proto
    */
@@ -977,7 +1108,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_int64: List<Long> = emptyList(),
+  val ext_pack_int64: List<Long> = immutableCopyOf("ext_pack_int64", ext_pack_int64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -987,7 +1119,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_uint64: List<Long> = emptyList(),
+  val ext_pack_uint64: List<Long> = immutableCopyOf("ext_pack_uint64", ext_pack_uint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -997,7 +1130,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_sint64: List<Long> = emptyList(),
+  val ext_pack_sint64: List<Long> = immutableCopyOf("ext_pack_sint64", ext_pack_sint64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -1007,7 +1141,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_fixed64: List<Long> = emptyList(),
+  val ext_pack_fixed64: List<Long> = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -1017,7 +1152,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_sfixed64: List<Long> = emptyList(),
+  val ext_pack_sfixed64: List<Long> = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64)
+
   /**
    * Extension source: all_types.proto
    */
@@ -1027,7 +1163,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_bool: List<Boolean> = emptyList(),
+  val ext_pack_bool: List<Boolean> = immutableCopyOf("ext_pack_bool", ext_pack_bool)
+
   /**
    * Extension source: all_types.proto
    */
@@ -1037,7 +1174,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_float: List<Float> = emptyList(),
+  val ext_pack_float: List<Float> = immutableCopyOf("ext_pack_float", ext_pack_float)
+
   /**
    * Extension source: all_types.proto
    */
@@ -1047,7 +1185,8 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_double: List<Double> = emptyList(),
+  val ext_pack_double: List<Double> = immutableCopyOf("ext_pack_double", ext_pack_double)
+
   /**
    * Extension source: all_types.proto
    */
@@ -1057,9 +1196,9 @@ class AllTypes(
     label = WireField.Label.PACKED
   )
   @JvmField
-  val ext_pack_nested_enum: List<NestedEnum> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<AllTypes, AllTypes.Builder>(ADAPTER, unknownFields) {
+  val ext_pack_nested_enum: List<NestedEnum> = immutableCopyOf("ext_pack_nested_enum",
+      ext_pack_nested_enum)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.opt_int32 = opt_int32

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -9,6 +9,7 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -20,15 +21,17 @@ import kotlin.lazy
 import okio.ByteString
 
 class Mappy(
+  things: Map<String, Thing> = emptyMap(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Mappy, Mappy.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER"
   )
   @JvmField
-  val things: Map<String, Thing> = emptyMap(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Mappy, Mappy.Builder>(ADAPTER, unknownFields) {
+  val things: Map<String, Thing> = immutableCopyOf("things", things)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.things = things

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.redactElements
 import com.squareup.wire.internal.sanitize
@@ -59,6 +60,10 @@ class Person(
   )
   @JvmField
   val email: String? = null,
+  phone: List<PhoneNumber> = emptyList(),
+  aliases: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Person, Person.Builder>(ADAPTER, unknownFields) {
   /**
    * A list of the customer's phone numbers.
    */
@@ -68,16 +73,16 @@ class Person(
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val phone: List<PhoneNumber> = emptyList(),
+  val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
+
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val aliases: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Person, Person.Builder>(ADAPTER, unknownFields) {
+  val aliases: List<String> = immutableCopyOf("aliases", aliases)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.name = name

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -20,15 +21,17 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class Repeated(
+  things: List<Thing> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<Repeated, Repeated.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.protos.kotlin.repeated.Thing#ADAPTER",
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val things: List<Thing> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<Repeated, Repeated.Builder>(ADAPTER, unknownFields) {
+  val things: List<Thing> = immutableCopyOf("things", things)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.things = things

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Float
@@ -27,16 +28,7 @@ class ExternalMessage(
   )
   @JvmField
   val f: Float? = null,
-  /**
-   * Extension source: simple_message.proto
-   */
-  @field:WireField(
-    tag = 125,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val fooext: List<Int> = emptyList(),
+  fooext: List<Int> = emptyList(),
   /**
    * Extension source: simple_message.proto
    */
@@ -75,6 +67,17 @@ class ExternalMessage(
   val nested_enum_ext: SimpleMessage.NestedEnum? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<ExternalMessage, ExternalMessage.Builder>(ADAPTER, unknownFields) {
+  /**
+   * Extension source: simple_message.proto
+   */
+  @field:WireField(
+    tag = 125,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val fooext: List<Int> = immutableCopyOf("fooext", fooext)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.f = f

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -13,6 +13,7 @@ import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.missingRequiredFields
 import com.squareup.wire.internal.sanitize
 import com.squareup.wire.protos.kotlin.foreign.ForeignEnum
@@ -44,12 +45,12 @@ class SimpleMessage(
   /**
    * An optional NestedMessage, *deprecated&#42;//
    */
+  @Deprecated(message = "optional_nested_msg is deprecated")
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedMessage#ADAPTER"
   )
   @JvmField
-  @Deprecated(message = "optional_nested_msg is deprecated")
   val optional_nested_msg: NestedMessage? = null,
   /**
    * An optional ExternalMessage
@@ -76,17 +77,7 @@ class SimpleMessage(
   )
   @JvmField
   val required_int32: Int,
-  /**
-   * A repeated double, deprecated
-   */
-  @field:WireField(
-    tag = 6,
-    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  @Deprecated(message = "repeated_double is deprecated")
-  val repeated_double: List<Double> = emptyList(),
+  repeated_double: List<Double> = emptyList(),
   /**
    * enum from another package with an explicit default
    */
@@ -144,6 +135,18 @@ class SimpleMessage(
   val o: String? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<SimpleMessage, SimpleMessage.Builder>(ADAPTER, unknownFields) {
+  /**
+   * A repeated double, deprecated
+   */
+  @Deprecated(message = "repeated_double is deprecated")
+  @field:WireField(
+    tag = 6,
+    adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val repeated_double: List<Double> = immutableCopyOf("repeated_double", repeated_double)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.optional_int32 = optional_int32

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.Boolean
@@ -52,15 +53,17 @@ class NestedVersionTwo(
   )
   @JvmField
   val v2_f64: Long? = null,
+  v2_rs: List<String> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<NestedVersionTwo, NestedVersionTwo.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val v2_rs: List<String> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<NestedVersionTwo, NestedVersionTwo.Builder>(ADAPTER, unknownFields) {
+  val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.i = i

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.sanitize
 import kotlin.Any
 import kotlin.Boolean
@@ -52,13 +53,7 @@ class VersionTwo(
   )
   @JvmField
   val v2_f64: Long? = null,
-  @field:WireField(
-    tag = 6,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REPEATED
-  )
-  @JvmField
-  val v2_rs: List<String> = emptyList(),
+  v2_rs: List<String> = emptyList(),
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.NestedVersionTwo#ADAPTER"
@@ -73,6 +68,14 @@ class VersionTwo(
   val en: EnumVersionTwo? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<VersionTwo, VersionTwo.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 6,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REPEATED
+  )
+  @JvmField
+  val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.i = i

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -11,6 +11,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import com.squareup.wire.internal.redactElements
 import kotlin.Any
 import kotlin.Boolean
@@ -28,15 +29,17 @@ class UsesAny(
   )
   @JvmField
   val just_one: AnyMessage? = null,
+  many_anys: List<AnyMessage> = emptyList(),
+  unknownFields: ByteString = ByteString.EMPTY
+) : Message<UsesAny, UsesAny.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.REPEATED
   )
   @JvmField
-  val many_anys: List<AnyMessage> = emptyList(),
-  unknownFields: ByteString = ByteString.EMPTY
-) : Message<UsesAny, UsesAny.Builder>(ADAPTER, unknownFields) {
+  val many_anys: List<AnyMessage> = immutableCopyOf("many_anys", many_anys)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.just_one = just_one

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -10,6 +10,7 @@ import com.squareup.wire.ProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.internal.checkElementsNotNull
+import com.squareup.wire.internal.immutableCopyOf
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Int
@@ -20,13 +21,7 @@ import kotlin.jvm.JvmField
 import okio.ByteString
 
 class EmbeddedMessage(
-  @field:WireField(
-    tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    label = WireField.Label.PACKED
-  )
-  @JvmField
-  val inner_repeated_number: List<Int> = emptyList(),
+  inner_repeated_number: List<Int> = emptyList(),
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32"
@@ -35,6 +30,15 @@ class EmbeddedMessage(
   val inner_number_after: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<EmbeddedMessage, EmbeddedMessage.Builder>(ADAPTER, unknownFields) {
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    label = WireField.Label.PACKED
+  )
+  @JvmField
+  val inner_repeated_number: List<Int> = immutableCopyOf("inner_repeated_number",
+      inner_repeated_number)
+
   override fun newBuilder(): Builder {
     val builder = Builder()
     builder.inner_repeated_number = inner_repeated_number

--- a/wire-library/wire-tests/src/jvmTest/kotlin/com/squareup/wire/IgnoreNative.kt
+++ b/wire-library/wire-tests/src/jvmTest/kotlin/com/squareup/wire/IgnoreNative.kt
@@ -1,0 +1,3 @@
+package com.squareup.wire
+
+actual annotation class IgnoreNative

--- a/wire-library/wire-tests/src/nativeTest/kotlin/com/squareup/wire/IgnoreNative.kt
+++ b/wire-library/wire-tests/src/nativeTest/kotlin/com/squareup/wire/IgnoreNative.kt
@@ -1,0 +1,3 @@
+package com.squareup.wire
+
+actual typealias IgnoreNative = kotlin.test.Ignore

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/StructTest.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/StructTest.kt
@@ -451,11 +451,68 @@ class StructTest {
     }
   }
 
+  @Test fun javaStructsInMapValuesAreDeeplyImmutable() {
+    val map = mutableMapOf("a" to "b")
+
+    val allStructs = AllStructsJ.Builder()
+        .map_int32_struct(mapOf(5 to map))
+        .build()
+    assertThat(allStructs.map_int32_struct.isDeeplyUnmodifiable()).isTrue()
+
+    // Mutate the values used to create the map. Wire should have defensive copies.
+    map.clear()
+
+    assertThat(allStructs.map_int32_struct).containsExactly(entry(5, mapOf("a" to "b")))
+  }
+
+  @Test fun kotlinStructsInMapValuesAreDeeplyImmutable() {
+    val map = mutableMapOf("a" to "b")
+
+    val allStructs = AllStructsK.Builder()
+        .map_int32_struct(mapOf(5 to map))
+        .build()
+    assertThat(allStructs.map_int32_struct.isDeeplyUnmodifiable()).isTrue()
+
+    // Mutate the values used to create the map. Wire should have defensive copies.
+    map.clear()
+
+    assertThat(allStructs.map_int32_struct).containsExactly(entry(5, mapOf("a" to "b")))
+  }
+
+  @Test fun javaStructsInListValuesAreDeeplyImmutable() {
+    val map = mutableMapOf("a" to "b")
+
+    val allStructs = AllStructsJ.Builder()
+        .rep_struct(listOf(map))
+        .build()
+    assertThat(allStructs.rep_struct.isDeeplyUnmodifiable()).isTrue()
+
+    // Mutate the values used to create the map. Wire should have defensive copies.
+    map.clear()
+
+    assertThat(allStructs.rep_struct).containsExactly(mapOf("a" to "b"))
+  }
+
+  @Test fun kotlinStructsInListValuesAreDeeplyImmutable() {
+    val map = mutableMapOf("a" to "b")
+
+    val allStructs = AllStructsK.Builder()
+        .rep_struct(listOf(map))
+        .build()
+    assertThat(allStructs.rep_struct.isDeeplyUnmodifiable()).isTrue()
+
+    // Mutate the values used to create the map. Wire should have defensive copies.
+    map.clear()
+
+    assertThat(allStructs.rep_struct).containsExactly(mapOf("a" to "b"))
+  }
+
   private fun Any?.isDeeplyUnmodifiable(): Boolean {
     return when (this) {
       null -> true
       is String -> true
       is Double -> true
+      is Int -> true
       is Boolean -> true
       is List<*> -> {
         this.all { it.isDeeplyUnmodifiable() } && this.isUnmodifiable()


### PR DESCRIPTION
This has a big problem - it causes fields to be reordered, which impacts
on-the-wire encoding of both .proto messages and JSON.

I'm tempted to force all of our properties to have separate parameter and
property declarations to prevent this shuffling.