### PR TITLE
Throw if one sets a null to a omit-identity enum in Java

### DIFF
--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1408,7 +1408,7 @@ public final class JavaGenerator {
         // Other scalars use not-boxed types to guarantee a value.
         if (field.getType().isScalar()
             && (field.getType() == ProtoType.STRING || field.getType() == ProtoType.BYTES)
-            || isEnum(field.getType())) {
+            || (isEnum(field.getType()) && !field.getType().equals(ProtoType.STRUCT_NULL))) {
           result.beginControlFlow("if ($L == null)", fieldAccessName);
           result.addStatement("throw new IllegalArgumentException($S)",
               fieldAccessName + " == null");

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1404,9 +1404,11 @@ public final class JavaGenerator {
         result.addParameter(param.build());
       }
 
-      if (field.getEncodeMode() == Field.EncodeMode.OMIT_IDENTITY && field.getType().isScalar()) {
+      if (field.getEncodeMode() == Field.EncodeMode.OMIT_IDENTITY) {
         // Other scalars use not-boxed types to guarantee a value.
-        if (field.getType() == ProtoType.STRING || field.getType() == ProtoType.BYTES) {
+        if (field.getType().isScalar()
+            && (field.getType() == ProtoType.STRING || field.getType() == ProtoType.BYTES)
+            || isEnum(field.getType())) {
           result.beginControlFlow("if ($L == null)", fieldAccessName);
           result.addStatement("throw new IllegalArgumentException($S)",
               fieldAccessName + " == null");

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/all_types/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/all_types/AllTypes.java
@@ -731,6 +731,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       throw new IllegalArgumentException("builder.bytes == null");
     }
     this.bytes = builder.bytes;
+    if (builder.nested_enum == null) {
+      throw new IllegalArgumentException("builder.nested_enum == null");
+    }
     this.nested_enum = builder.nested_enum;
     this.nested_message = builder.nested_message;
     this.any = builder.any;

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/person/Person.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/person/Person.java
@@ -343,6 +343,9 @@ public final class Person extends Message<Person, Person.Builder> {
         throw new IllegalArgumentException("number == null");
       }
       this.number = number;
+      if (type == null) {
+        throw new IllegalArgumentException("type == null");
+      }
       this.type = type;
     }
 

--- a/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/com/squareup/wire/proto3/alltypes/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/com/squareup/wire/proto3/alltypes/AllTypes.java
@@ -492,6 +492,9 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
       throw new IllegalArgumentException("builder.my_bytes == null");
     }
     this.my_bytes = builder.my_bytes;
+    if (builder.nested_enum == null) {
+      throw new IllegalArgumentException("builder.nested_enum == null");
+    }
     this.nested_enum = builder.nested_enum;
     this.nested_message = builder.nested_message;
     this.rep_int32 = Internal.immutableCopyOf("rep_int32", builder.rep_int32);

--- a/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/FreeDrinkPromotion.java
+++ b/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/FreeDrinkPromotion.java
@@ -30,6 +30,9 @@ public final class FreeDrinkPromotion extends Message<FreeDrinkPromotion, FreeDr
 
   public FreeDrinkPromotion(Drink drink, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
+    if (drink == null) {
+      throw new IllegalArgumentException("drink == null");
+    }
     this.drink = drink;
   }
 

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -346,6 +346,15 @@ class Proto3WireProtocCompatibilityTests {
     }
   }
 
+  @Test fun cannotPassNullToIdentityEnum(){
+    try {
+      AllTypesJ.Builder().nested_enum(null).build()
+      fail()
+    } catch (exception: IllegalArgumentException) {
+      assertThat(exception).hasMessage("builder.nested_enum == null")
+    }
+  }
+
   companion object {
     private val defaultAllTypesProtoc = AllTypesOuterClass.AllTypes.newBuilder()
         .setMyInt32(111)


### PR DESCRIPTION
But we let `STRUCT_NULL` be free as the wind.