### PR TITLE
Make schema models data classes

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/PartitionedSchema.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/PartitionedSchema.kt
@@ -60,10 +60,30 @@ internal fun Schema.partition(modules: Map<String, Module>): PartitionedSchema {
       }
     } as Map<ProtoType, String> // TODO use buildMap
 
-    val prunedSchema = if (module.pruningRules != null) {
-      prune(module.pruningRules)
-    } else {
+    val stubbedSchema = if (upstreamTypes.isEmpty()) {
       this
+    } else {
+      // Replace types which have already been generated with stub types that have no external
+      // references. This ensures our types can still link. More critically, it ensures that
+      // transitive types which were pruned upstream will only be generated in this module if they
+      // are reachable from this module's types.
+      val stubbedFiles = protoFiles.map { protoFile ->
+        protoFile.copy(
+            types = protoFile.types.map { type ->
+              if (type.type in upstreamTypes) type.asStub() else type
+            },
+            services = protoFile.services.map { service ->
+              if (service.type() in upstreamTypes) service.asStub() else service
+            }
+        )
+      }
+      Schema.fromFiles(stubbedFiles)
+    }
+
+    val prunedSchema = if (module.pruningRules != null) {
+      stubbedSchema.prune(module.pruningRules)
+    } else {
+      stubbedSchema
     }
 
     val ownedTypes = prunedSchema.protoFiles
@@ -110,3 +130,33 @@ internal fun Schema.partition(modules: Map<String, Module>): PartitionedSchema {
 
   return PartitionedSchema(partitions, warnings, errors)
 }
+
+/** Return a copy of this type with all possible type references removed. */
+private fun Type.asStub(): Type = when {
+  // Don't stub the built-in protobuf types which model concepts like options.
+  type.toString().startsWith("google.protobuf.") -> this
+
+  this is MessageType -> copy(
+      declaredFields = emptyList(),
+      extensionFields = mutableListOf(),
+      nestedTypes = nestedTypes.map { it.asStub() },
+      options = Options(Options.MESSAGE_OPTIONS, emptyList())
+  )
+
+  this is EnumType -> copy(
+      constants = emptyList(),
+      options = Options(Options.ENUM_OPTIONS, emptyList())
+  )
+
+  this is EnclosingType -> copy(
+      nestedTypes = nestedTypes.map { it.asStub() }
+  )
+
+  else -> throw AssertionError("Unknown type $type")
+}
+
+/** Return a copy of this service with all possible type references removed. */
+private fun Service.asStub() = copy(
+    rpcs = emptyList(),
+    options = Options(Options.SERVICE_OPTIONS, emptyList())
+)

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/PartitionedSchemaTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/PartitionedSchemaTest.kt
@@ -22,7 +22,6 @@ import org.junit.Ignore
 import org.junit.Test
 
 class ManifestPartitionTest {
-  @Ignore("We currently have no way of filtering this out in a Schema")
   @Test fun upstreamPruneIsNotGeneratedDownstream() {
     val schema = RepoBuilder()
         .add("example.proto", """

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnclosingType.kt
@@ -19,7 +19,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.schema.internal.parser.MessageElement
 
 /** An empty type which only holds nested types.  */
-class EnclosingType internal constructor(
+data class EnclosingType(
   override val location: Location,
   override val type: ProtoType,
   override val documentation: String,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
@@ -17,7 +17,7 @@ package com.squareup.wire.schema
 
 import com.squareup.wire.schema.internal.parser.EnumConstantElement
 
-class EnumConstant private constructor(
+data class EnumConstant(
   val location: Location,
   val name: String,
   val tag: Int,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -20,7 +20,7 @@ import com.squareup.wire.schema.Options.Companion.ENUM_OPTIONS
 import com.squareup.wire.schema.internal.parser.EnumElement
 import kotlin.jvm.JvmStatic
 
-class EnumType private constructor(
+data class EnumType(
   override val type: ProtoType,
   override val location: Location,
   override val documentation: String,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
@@ -19,7 +19,7 @@ import com.squareup.wire.schema.Field.Companion.retainAll
 import com.squareup.wire.schema.internal.parser.ExtendElement
 import kotlin.jvm.JvmStatic
 
-class Extend private constructor(
+data class Extend(
   val location: Location,
   val documentation: String,
   val name: String,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extensions.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extensions.kt
@@ -19,7 +19,7 @@ import com.squareup.wire.schema.internal.isValidTag
 import com.squareup.wire.schema.internal.parser.ExtensionsElement
 import kotlin.jvm.JvmStatic
 
-class Extensions private constructor(
+data class Extensions(
   val location: Location,
   val documentation: String,
   val values: List<Any>

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -21,7 +21,7 @@ import com.squareup.wire.schema.internal.parser.FieldElement
 import com.squareup.wire.schema.internal.parser.OptionElement.Companion.PACKED_OPTION_ELEMENT
 import kotlin.jvm.JvmStatic
 
-class Field private constructor(
+data class Field(
   val packageName: String?,
 
   val location: Location,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -30,7 +30,7 @@ import com.squareup.wire.schema.internal.parser.MessageElement
 import kotlin.jvm.JvmName
 import kotlin.jvm.JvmStatic
 
-class MessageType private constructor(
+data class MessageType(
   override val type: ProtoType,
   override val location: Location,
   override val documentation: String,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/OneOf.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/OneOf.kt
@@ -18,7 +18,7 @@ package com.squareup.wire.schema
 import com.squareup.wire.schema.internal.parser.OneOfElement
 import kotlin.jvm.JvmStatic
 
-class OneOf private constructor(
+data class OneOf(
   val name: String,
   val documentation: String,
   val fields: List<Field>

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -21,7 +21,7 @@ import com.squareup.wire.schema.Service.Companion.fromElements
 import com.squareup.wire.schema.Type.Companion.fromElements
 import com.squareup.wire.schema.internal.parser.ProtoFileElement
 
-class ProtoFile private constructor(
+data class ProtoFile(
   val location: Location,
   val imports: List<String>,
   val publicImports: List<String>,
@@ -33,30 +33,6 @@ class ProtoFile private constructor(
   val syntax: Syntax?
 ) {
   private var javaPackage: Any? = null
-
-  internal fun copy(
-    location: Location = this.location,
-    imports: List<String> = this.imports,
-    publicImports: List<String> = this.publicImports,
-    packageName: String? = this.packageName,
-    types: List<Type> = this.types,
-    services: List<Service> = this.services,
-    extendList: List<Extend> = this.extendList,
-    options: Options = this.options,
-    syntax: Syntax? = this.syntax
-  ): ProtoFile {
-    return ProtoFile(
-        location = location,
-        imports = imports,
-        publicImports = publicImports,
-        packageName = packageName,
-        types = types,
-        services = services,
-        extendList = extendList,
-        options = options,
-        syntax = syntax
-    )
-  }
 
   fun toElement(): ProtoFileElement {
     return ProtoFileElement(

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Reserved.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Reserved.kt
@@ -18,7 +18,7 @@ package com.squareup.wire.schema
 import com.squareup.wire.schema.internal.parser.ReservedElement
 import kotlin.jvm.JvmStatic
 
-class Reserved(
+data class Reserved(
   val location: Location,
   val documentation: String,
   val values: List<Any>

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Rpc.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Rpc.kt
@@ -18,7 +18,7 @@ package com.squareup.wire.schema
 import com.squareup.wire.schema.internal.parser.RpcElement
 import kotlin.jvm.JvmStatic
 
-class Rpc private constructor(
+data class Rpc(
   val location: Location,
   val name: String,
   val documentation: String,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Service.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Service.kt
@@ -23,7 +23,7 @@ import com.squareup.wire.schema.Rpc.Companion.fromElements
 import com.squareup.wire.schema.internal.parser.ServiceElement
 import kotlin.jvm.JvmStatic
 
-class Service private constructor(
+data class Service(
   private val protoType: ProtoType,
   private val location: Location,
   private val documentation: String,


### PR DESCRIPTION
This allows users to create and copy them on their own. This shouldn't be a problem since they will be linked in Schema.fromFiles() to ensure their validity before being used anywhere. But if you have public API that takes one of these classes you could now receive an unlinked/invalidly-linked instance.