### PR TITLE
Avoid partitioning when no modules specified

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/PartitionedSchema.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/PartitionedSchema.kt
@@ -20,16 +20,16 @@ import com.squareup.wire.schema.WireRun.Module
 
 internal class PartitionedSchema(
   /** Module name to partition info. The iteration order of this map is the generation order. */
-  val modules: Map<String, Partition>,
+  val partitions: Map<String, Partition>,
   val warnings: List<String>,
   val errors: List<String>
 ) {
   class Partition(
     val schema: Schema,
     /** The types that this partition will generate. */
-    val types: Set<ProtoType>,
+    val types: Set<ProtoType> = schema.types,
     /** These are the types depended upon by [types] associated with their module name. */
-    val transitiveUpstreamTypes: Map<ProtoType, String>
+    val transitiveUpstreamTypes: Map<ProtoType, String> = emptyMap()
   )
 }
 

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/PartitionedSchemaTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/PartitionedSchemaTest.kt
@@ -18,7 +18,6 @@ package com.squareup.wire.schema
 import com.squareup.wire.schema.WireRun.Module
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.Test
 
 class ManifestPartitionTest {
@@ -55,14 +54,14 @@ class ManifestPartitionTest {
 
     val partitionedSchema = schema.partition(modules)
 
-    val commonPartition = partitionedSchema.modules.getValue("common")
+    val commonPartition = partitionedSchema.partitions.getValue("common")
     // B has no field of type C because of its inclusion in common's prune list.
     assertThat(commonPartition.schema.getMessage("B").field("c")).isNull()
     // C is not generated in common because of its inclusion in the prune list.
     assertThat(commonPartition.types).doesNotContain(ProtoType.get("C"))
 
     // C is not in feature because its only dependant is B which is from common.
-    val featurePartition = partitionedSchema.modules.getValue("feature")
+    val featurePartition = partitionedSchema.partitions.getValue("feature")
     assertThat(featurePartition.types).doesNotContain(ProtoType.get("C"))
   }
 
@@ -100,13 +99,13 @@ class ManifestPartitionTest {
 
     val partitionedSchema = schema.partition(modules)
 
-    val commonPartition = partitionedSchema.modules.getValue("common")
+    val commonPartition = partitionedSchema.partitions.getValue("common")
     // B has no field of type C because of its inclusion in common's prune list.
     assertThat(commonPartition.schema.getMessage("B").field("c")).isNull()
     // C is not generated in common because of its inclusion in the prune list.
     assertThat(commonPartition.types).doesNotContain(ProtoType.get("C"))
 
-    val featurePartition = partitionedSchema.modules.getValue("feature")
+    val featurePartition = partitionedSchema.partitions.getValue("feature")
     // A has a field of type C because common's prunes do not apply to feature.
     assertThat(featurePartition.schema.getMessage("A").field("c")).isNotNull()
     // C is generated in feature because common's prunes do not apply and A depends on it.

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Schema.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Schema.kt
@@ -28,15 +28,17 @@ import kotlin.jvm.JvmOverloads
 class Schema internal constructor(protoFiles: Iterable<ProtoFile>) {
   val protoFiles: List<ProtoFile> = protoFiles.sortedBy { it.location.path }
 
-  private val protoFilesIndex: Map<ProtoType?, ProtoFile?>
+  private val protoFilesIndex: Map<ProtoType, ProtoFile>
   private val typesIndex: Map<String, Type>
   private val servicesIndex: Map<String, Service>
   init {
-    val index = mutableMapOf<ProtoType?, ProtoFile?>()
+    val index = mutableMapOf<ProtoType, ProtoFile>()
     typesIndex = buildTypesIndex(protoFiles, index)
     servicesIndex = buildServicesIndex(protoFiles, index)
     protoFilesIndex = index
   }
+
+  val types: Set<ProtoType> get() = protoFilesIndex.keys
 
   /** Returns the proto file at [path], or null if this schema has no such file.  */
   fun protoFile(path: String): ProtoFile? = protoFiles.firstOrNull { it.location.path == path }
@@ -129,7 +131,7 @@ class Schema internal constructor(protoFiles: Iterable<ProtoFile>) {
 
     private fun buildTypesIndex(
       protoFiles: Iterable<ProtoFile>,
-      protoFilesIndex: MutableMap<ProtoType?, ProtoFile?>
+      protoFilesIndex: MutableMap<ProtoType, ProtoFile>
     ): Map<String, Type> {
       val typesByName = mutableMapOf<String, Type>()
 
@@ -154,7 +156,7 @@ class Schema internal constructor(protoFiles: Iterable<ProtoFile>) {
 
     private fun buildServicesIndex(
       protoFiles: Iterable<ProtoFile>,
-      protoFilesIndex: MutableMap<ProtoType?, ProtoFile?>
+      protoFilesIndex: MutableMap<ProtoType, ProtoFile>
     ): Map<String, Service> {
       val result = mutableMapOf<String, Service>()
       for (protoFile in protoFiles) {


### PR DESCRIPTION
Bypasses needing a special default module name and keeps the `null` module name logic contained inside `WireRun` rather than leaking it into the partitioning code.