### PR TITLE
Filter ProtoFile before SchemaHandler

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -167,6 +167,7 @@ data class JavaTarget(
         outPath
       }
     }
+    Files.createDirectories(modulePath)
 
     val javaGenerator = JavaGenerator.get(schema)
         .withProfile(profile)
@@ -242,6 +243,8 @@ data class KotlinTarget(
         outPath
       }
     }
+    Files.createDirectories(modulePath)
+
     val kotlinGenerator = KotlinGenerator(
         schema = schema,
         emitAndroid = android,
@@ -338,6 +341,8 @@ data class ProtoTarget(
         outPath
       }
     }
+    Files.createDirectories(modulePath)
+
     return object : SchemaHandler {
       override fun handle(type: Type): Path? = null
       override fun handle(service: Service): List<Path> = emptyList()

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -259,13 +259,19 @@ data class WireRun(
           continue
         }
 
+        // Remove types from the file which are not owned by this partition.
+        val filteredProtoFile = protoFile.copy(
+            types = protoFile.types.filter { it.type in partition.types },
+            services = protoFile.services.filter { it.type in partition.types }
+        )
+
         val claimedDefinitions = ClaimedDefinitions()
         claimedDefinitions.claim(ProtoType.ANY)
 
         for (target in targetsExclusiveLast) {
           val schemaHandler = targetToSchemaHandler.getValue(target)
           schemaHandler.handle(
-              protoFile,
+              filteredProtoFile,
               targetToEmittingRules.getValue(target),
               claimedDefinitions,
               claimedPaths,


### PR DESCRIPTION
When a file is split across partitions, only expose the types to be generated when handing the file to the schema handler.