### PR TITLE
Disable lint vital checks

### DIFF
--- a/wire-grpc-sample/client/build.gradle
+++ b/wire-grpc-sample/client/build.gradle
@@ -13,6 +13,9 @@ android {
     sourceCompatibility = JavaVersion.VERSION_1_8
     targetCompatibility = JavaVersion.VERSION_1_8
   }
+  lintOptions {
+    checkReleaseBuilds false // CI runs full lint.
+  }
 }
 
 wire {


### PR DESCRIPTION
On CI we run build which runs full lint.