### PR TITLE
Prefix EnumValue's wire.since/until with constant_

### DIFF
--- a/wire-library/docs/wire_compiler.md
+++ b/wire-library/docs/wire_compiler.md
@@ -241,8 +241,9 @@ wire {
 Another way to prune obsolete fields is to assign them a version, then to generate your code
 against a version range or a unique version. The fields out of the version range will get pruned.
 
-Members, or enum constants, may be declared with `wire.since` and `wire.until` options. For example,
-these options declare a field `age` that was replaced with `birth_date` in version "5.0":
+Members may be declared with `wire.since` and `wire.until` options; enum constant can use
+`wire.constant_since` and `wire.constant_until`. For example, these options declare a field `age`
+that was replaced with `birth_date` in version "5.0":
 
 ```proto
 import "wire/extensions.proto";

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/PruningRules.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/PruningRules.kt
@@ -266,8 +266,8 @@ class PruningRules private constructor(builder: Builder) {
   companion object {
     internal val FIELD_SINCE = ProtoMember.get(Options.FIELD_OPTIONS, "wire.since")
     internal val FIELD_UNTIL = ProtoMember.get(Options.FIELD_OPTIONS, "wire.until")
-    internal val ENUM_CONSTANT_SINCE = ProtoMember.get(Options.ENUM_VALUE_OPTIONS, "wire.since")
-    internal val ENUM_CONSTANT_UNTIL = ProtoMember.get(Options.ENUM_VALUE_OPTIONS, "wire.until")
+    internal val ENUM_CONSTANT_SINCE = ProtoMember.get(Options.ENUM_VALUE_OPTIONS, "wire.constant_since")
+    internal val ENUM_CONSTANT_UNTIL = ProtoMember.get(Options.ENUM_VALUE_OPTIONS, "wire.constant_until")
 
     /**
      * Returns the identifier or wildcard that encloses [identifier], or null if it is not enclosed.

--- a/wire-library/wire-schema/src/jvmMain/resources/wire/extensions.proto
+++ b/wire-library/wire-schema/src/jvmMain/resources/wire/extensions.proto
@@ -44,7 +44,7 @@ extend google.protobuf.EnumValueOptions {
    * The value is the earliest version in which the annotated constant is retained. It is pruned
    * from all preceding versions.
    */
-  optional string since = 1076;
+  optional string constant_since = 1076;
 
   /**
    * Annotates an enum constant that ceases to be available with a specified version.
@@ -52,7 +52,7 @@ extend google.protobuf.EnumValueOptions {
    * The value is the version that drops the annotated constant. It is not available in that version
    * or any subsequent version.
    */
-  optional string until = 1077;
+  optional string constant_until = 1077;
 }
 
 extend google.protobuf.FileOptions {

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1592,9 +1592,9 @@ class PrunerTest {
             |import "wire/extensions.proto";
             |
             |enum Roshambo {
-            |  ROCK = 1 [(wire.until) = "29"];
-            |  SCISSORS = 2 [(wire.since) = "30"];
-            |  PAPER = 3 [(wire.since) = "29"];
+            |  ROCK = 1 [(wire.constant_until) = "29"];
+            |  SCISSORS = 2 [(wire.constant_since) = "30"];
+            |  PAPER = 3 [(wire.constant_since) = "29"];
             |}
             """.trimMargin())
         .schema()
@@ -1615,9 +1615,9 @@ class PrunerTest {
             |import "wire/extensions.proto";
             |
             |enum Roshambo {
-            |  ROCK = 1 [(wire.until) = "29"];
-            |  SCISSORS = 2 [(wire.since) = "30"];
-            |  PAPER = 3 [(wire.since) = "29"];
+            |  ROCK = 1 [(wire.constant_until) = "29"];
+            |  SCISSORS = 2 [(wire.constant_since) = "30"];
+            |  PAPER = 3 [(wire.constant_since) = "29"];
             |}
             """.trimMargin())
         .schema()

--- a/wire-protoc-compatibility-tests/build.gradle
+++ b/wire-protoc-compatibility-tests/build.gradle
@@ -49,6 +49,7 @@ sourceSets {
 }
 
 dependencies {
+  protobuf deps.wire.schema
   implementation deps.kotlin.stdlib.jdk8
   implementation deps.okio.jvm
   implementation deps.protobuf.java
@@ -63,5 +64,14 @@ test {
   testLogging {
     events "passed", "skipped", "failed"
     exceptionFormat "full"
+  }
+}
+
+// Workaround the Gradle bug resolving multiplatform dependencies.
+// https://youtrack.jetbrains.com/issue/KT-32239
+configurations.all { configuration ->
+  if (name.contains('kapt') || name.contains("wire") || name.contains("proto")) {
+    attributes.attribute(Usage.USAGE_ATTRIBUTE,
+            project.objects.named(Usage.class, Usage.JAVA_RUNTIME))
   }
 }

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/extensions/wire_message.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/extensions/wire_message.proto
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package squareup.proto2.kotlin.extensions;
+
+import "wire/extensions.proto";
+
+option (wire.wire_package) = "squareup.proto2.wire.extensions";
+
+message WireMessage {
+  enum WireEnum {
+    UNKNOWN = 0 [(wire.constant_until) = "3.2.0"];
+    A = 1 [(wire.constant_since) = "3.2.0"];
+  }
+
+  optional int32 opt_int32 = 1 [(wire.until) = "3.2.0"];
+  optional string opt_string = 2 [(wire.since) = "3.2.0"];
+}

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/extensions/wire_message.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/extensions/wire_message.proto
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+
+package squareup.proto3.kotlin.extensions;
+
+import "wire/extensions.proto";
+
+option (wire.wire_package) = "squareup.proto3.wire.extensions";
+
+message WireMessage {
+  enum WireEnum {
+    UNKNOWN = 0 [(wire.constant_until) = "3.2.0"];
+    A = 1 [(wire.constant_since) = "3.2.0"];
+  }
+
+  int32 opt_int32 = 1 [(wire.until) = "3.2.0"];
+  string opt_string = 2 [(wire.since) = "3.2.0"];
+}

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
@@ -24,6 +24,8 @@ import squareup.proto2.kotlin.alltypes.AllTypesOuterClass
 import squareup.proto2.kotlin.alltypes.AllTypesOuterClass.extOptBool
 import squareup.proto2.kotlin.alltypes.AllTypesOuterClass.extPackBool
 import squareup.proto2.kotlin.alltypes.AllTypesOuterClass.extRepBool
+import squareup.proto2.kotlin.extensions.WireMessageOuterClass
+import squareup.proto2.wire.extensions.WireMessage
 import com.squareup.wire.proto2.kotlin.simple.SimpleMessage as SimpleMessageK
 import squareup.proto2.kotlin.alltypes.AllTypes as AllTypesK
 
@@ -78,6 +80,11 @@ class Proto2WireProtocCompatibilityTests {
 
     assertThat(AllTypesOuterClass.AllTypes.parseFrom(byteArrayWire, allTypesRegistry))
         .isEqualTo(identityAllTypesProtoc)
+  }
+
+  @Test fun protocDontThrowUpOnWireExtensions() {
+    assertThat(WireMessageOuterClass.WireMessage.newBuilder().build()).isNotNull()
+    assertThat(WireMessage()).isNotNull()
   }
 
   companion object {

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -33,10 +33,12 @@ import okio.source
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
+import squareup.proto3.kotlin.extensions.WireMessageOuterClass
 import squareup.proto3.kotlin.alltypes.All64OuterClass
 import squareup.proto3.kotlin.alltypes.AllTypesOuterClass
 import squareup.proto3.kotlin.alltypes.CamelCaseOuterClass
 import squareup.proto3.kotlin.pizza.PizzaOuterClass
+import squareup.proto3.wire.extensions.WireMessage
 import java.io.File
 import java.lang.IllegalArgumentException
 import com.squareup.wire.proto3.kotlin.requiredextension.RequiredExtension as RequiredExtensionK
@@ -353,6 +355,11 @@ class Proto3WireProtocCompatibilityTests {
     } catch (exception: IllegalArgumentException) {
       assertThat(exception).hasMessage("builder.nested_enum == null")
     }
+  }
+
+  @Test fun protocDontThrowUpOnWireExtensions() {
+    assertThat(WireMessageOuterClass.WireMessage.newBuilder().build()).isNotNull()
+    assertThat(WireMessage()).isNotNull()
   }
 
   companion object {


### PR DESCRIPTION
Protoc doesn't allow same named extensions on the same package even if they are extensions of different types.