### PR TITLE
Add CLI flag for creating modules from a manifest

### DIFF
--- a/wire-library/build.gradle
+++ b/wire-library/build.gradle
@@ -9,6 +9,7 @@ buildscript {
 
   dependencies {
     classpath deps.plugins.kotlin
+    classpath deps.plugins.kotlinSerialization
     classpath deps.plugins.shadow
     classpath deps.plugins.japicmp
     classpath deps.plugins.mavenPublish

--- a/wire-library/dependencies.gradle
+++ b/wire-library/dependencies.gradle
@@ -26,6 +26,7 @@ ext.versions = [
 ext.deps = [
   plugins: [
     kotlin: "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}",
+    kotlinSerialization: "org.jetbrains.kotlin:kotlin-serialization:${versions.kotlin}",
     shadow: 'com.github.jengelman.gradle.plugins:shadow:4.0.1',
     japicmp: 'me.champeau.gradle:japicmp-gradle-plugin:0.2.8',
     mavenPublish: "com.vanniktech:gradle-maven-publish-plugin:${versions.mavenPublish}"
@@ -75,7 +76,9 @@ ext.deps = [
       ],
       'android': "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.coroutines}",
     ],
+    'serialization': 'org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0',
   ],
+  'kaml': 'com.charleskorn.kaml:kaml:0.18.1',
   'misk': "com.squareup.misk:misk:0.11.0",
   'moshi': "com.squareup.moshi:moshi:${versions.moshi}",
   'moshiKotlin': "com.squareup.moshi:moshi-kotlin:${versions.moshi}",

--- a/wire-library/wire-compiler/build.gradle
+++ b/wire-library/wire-compiler/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'application'
 apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'org.jetbrains.kotlin.plugin.serialization'
 apply plugin: 'com.github.johnrengelman.shadow'
 
 mainClassName = 'com.squareup.wire.WireCompiler'
@@ -17,6 +18,8 @@ dependencies {
   implementation project(':wire-java-generator')
   implementation deps.okio.jvm
   implementation deps.guava
+  implementation deps.kotlin.serialization
+  implementation deps.kaml
   testImplementation deps.junit
   testImplementation deps.assertj
   testImplementation deps.jimfs

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/Manifest.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/Manifest.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.charleskorn.kaml.Yaml
+import com.squareup.wire.schema.PruningRules
+import com.squareup.wire.schema.WireRun
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.builtins.MapSerializer
+import kotlinx.serialization.builtins.serializer
+
+private val defaultRoots = setOf("*")
+private val defaultPrunes = emptySet<String>()
+
+@Serializable
+private data class ManifestModule(
+  val dependencies: Set<String> = emptySet(),
+  val roots: Set<String> = defaultRoots,
+  val prunes: Set<String> = defaultPrunes
+)
+
+private val serializer = MapSerializer(String.serializer(), ManifestModule.serializer())
+
+internal fun parseManifestModules(yaml: String): Map<String, WireRun.Module> {
+  val modules = Yaml.default.parse(serializer, yaml)
+  return modules.mapValues { (_, module) ->
+    WireRun.Module(
+        dependencies = module.dependencies,
+        pruningRules = if (module.roots != defaultRoots || module.prunes != defaultPrunes) {
+          PruningRules.Builder()
+              .addRoot(module.roots)
+              .prune(module.prunes)
+              .build()
+        } else {
+          null
+        }
+    )
+  }
+}

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -91,6 +91,7 @@ class WireCompiler internal constructor(
   val sourceFileNames: List<String>,
   val treeShakingRoots: List<String>,
   val treeShakingRubbish: List<String>,
+  val modules: Map<String, WireRun.Module>,
   val dryRun: Boolean,
   val namedFilesOnly: Boolean,
   val emitAndroid: Boolean,
@@ -142,6 +143,7 @@ class WireCompiler internal constructor(
           treeShakingRoots = treeShakingRoots,
           treeShakingRubbish = treeShakingRubbish,
           targets = targets,
+          modules = modules,
           proto3Preview = proto3Preview == "UNSUPPORTED"
       )
 
@@ -191,6 +193,7 @@ class WireCompiler internal constructor(
     private const val FILES_FLAG = "--files="
     private const val INCLUDES_FLAG = "--includes="
     private const val EXCLUDES_FLAG = "--excludes="
+    private const val MANIFEST_FLAG = "--experimental-module-manifest="
     private const val QUIET_FLAG = "--quiet"
     private const val DRY_RUN_FLAG = "--dry_run"
     private const val NAMED_FILES_ONLY = "--named_files_only"
@@ -224,6 +227,7 @@ class WireCompiler internal constructor(
       val treeShakingRoots = mutableListOf<String>()
       val treeShakingRubbish = mutableListOf<String>()
       val protoPaths = mutableListOf<String>()
+      var modules = mapOf<String, WireRun.Module>()
       var javaOut: String? = null
       var kotlinOut: String? = null
       var quiet = false
@@ -273,6 +277,11 @@ class WireCompiler internal constructor(
             treeShakingRubbish += arg.substring(EXCLUDES_FLAG.length).split(Regex(","))
           }
 
+          arg.startsWith(MANIFEST_FLAG) -> {
+            val yaml = File(arg.substring(MANIFEST_FLAG.length)).readText()
+            modules = parseManifestModules(yaml)
+          }
+
           arg.startsWith(PROTO3_PREVIEW) -> {
             proto3Preview = arg.substring(PROTO3_PREVIEW.length)
           }
@@ -300,7 +309,7 @@ class WireCompiler internal constructor(
       }
 
       return WireCompiler(fileSystem, logger, protoPaths, javaOut, kotlinOut, sourceFileNames,
-          treeShakingRoots, treeShakingRubbish, dryRun, namedFilesOnly, emitAndroid,
+          treeShakingRoots, treeShakingRubbish, modules, dryRun, namedFilesOnly, emitAndroid,
           emitAndroidAnnotations, emitCompact, javaInterop, proto3Preview)
     }
   }

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire
 
+import com.squareup.wire.schema.WireRun
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.File
@@ -102,6 +103,23 @@ class CommandLineOptionsTest {
 
     compiler = parseArgs("--java_out=.", "--includes=com.example.Foo,com.example.Bar")
     assertThat(compiler.treeShakingRoots).containsExactly("com.example.Foo", "com.example.Bar")
+  }
+
+  @Test
+  fun manifestModules() {
+    val tmpFile = File.createTempFile("proto", ".yaml")
+    tmpFile.writeText("""
+      |a: {}
+      |b:
+      |  dependencies:
+      |   - a
+      |""".trimMargin())
+
+    val compiler =
+      parseArgs("--java_out=.", "--experimental-module-manifest=${tmpFile.absolutePath}")
+
+    assertThat(compiler.modules).isEqualTo(
+        mapOf("a" to WireRun.Module(), "b" to WireRun.Module(dependencies = setOf("a"))))
   }
 
   private fun parseArgs(vararg args: String) = WireCompiler.forArgs(args = *args)

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/ManifestParseTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/ManifestParseTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Assert.fail
+import org.junit.Test
+
+class ManifestParseTest {
+  @Test fun parseFormat() {
+    val yaml = """
+      |one:
+      |  dependencies:
+      |    - two
+      |    - three
+      |  roots:
+      |    - example.A
+      |    - example.B
+      |  prunes:
+      |    - example.C
+      |    - example.D
+      |two: {}
+      |three: {}
+    """.trimMargin()
+
+    val modules = parseManifestModules(yaml)
+    assertThat(modules.keys).containsExactlyInAnyOrder("one", "two", "three")
+
+    val one = modules.getValue("one")
+    assertThat(one.dependencies).containsExactlyInAnyOrder("two", "three")
+    assertThat(one.pruningRules!!.roots).containsExactlyInAnyOrder("example.A", "example.B")
+    assertThat(one.pruningRules!!.prunes).containsExactlyInAnyOrder("example.C", "example.D")
+  }
+
+  @Test fun parseFormatFailsOnUnknownKey() {
+    val yaml = """
+      |one:
+      |  includes:
+      |    - example.A
+    """.trimMargin()
+
+    try {
+      parseManifestModules(yaml)
+      fail()
+    } catch (e: Exception) {
+      assertThat(e).hasMessageContaining("Unknown property 'includes'")
+    }
+  }
+
+  @Test fun outOfOrderDependency() {
+    val yaml = """
+      |one:
+      |  dependencies:
+      |    - two
+      |two: {}
+    """.trimMargin()
+
+    val modules = parseManifestModules(yaml)
+    assertThat(modules.keys).containsExactly("one", "two")
+    assertThat(modules.getValue("one").dependencies).containsExactly("two")
+  }
+}


### PR DESCRIPTION
The manifest is a YAML file whose format is as follows:

```yaml
ModuleName:
  dependencies:
    - OtherModule
  roots:
    - example.feature.Message
  prunes:
    - example.logging.Settings

OtherModule:
  roots:
    - example.other.Type
```

All of the keys under the module name are optional.

The flag is prefixed with 'experimental' since we have yet to agree on its scope or format but want to allow its use for now.