### PR TITLE
Expose deprecation directly on an enum constant

### DIFF
--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -84,7 +84,6 @@ import okio.ByteString;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.squareup.wire.internal._PlatformKt.camelCase;
 import static com.squareup.wire.schema.Options.ENUM_OPTIONS;
-import static com.squareup.wire.schema.Options.ENUM_VALUE_OPTIONS;
 import static com.squareup.wire.schema.Options.FIELD_OPTIONS;
 import static com.squareup.wire.schema.Options.MESSAGE_OPTIONS;
 import static javax.lang.model.element.Modifier.ABSTRACT;
@@ -102,10 +101,6 @@ import static javax.lang.model.element.Modifier.STATIC;
  * java.lang.String}, or {@code com.squareup.protos.person.Person}).
  */
 public final class JavaGenerator {
-  static final ProtoMember FIELD_DEPRECATED = ProtoMember.get(FIELD_OPTIONS, "deprecated");
-  static final ProtoMember ENUM_DEPRECATED = ProtoMember.get(ENUM_VALUE_OPTIONS, "deprecated");
-  static final ProtoMember PACKED = ProtoMember.get(FIELD_OPTIONS, "packed");
-
   static final ClassName BYTE_STRING = ClassName.get(ByteString.class);
   static final ClassName STRING = ClassName.get(String.class);
   static final ClassName LIST = ClassName.get(List.class);
@@ -581,7 +576,7 @@ public final class JavaGenerator {
         constantBuilder.addJavadoc("$L\n", sanitizeJavadoc(constant.getDocumentation()));
       }
 
-      if ("true".equals(constant.getOptions().get(ENUM_DEPRECATED))) {
+      if (constant.isDeprecated()) {
         constantBuilder.addAnnotation(Deprecated.class);
       }
 
@@ -857,7 +852,7 @@ public final class JavaGenerator {
       if (!constant.getDocumentation().isEmpty()) {
         fieldBuilder.addJavadoc("$L\n", sanitizeJavadoc(constant.getDocumentation()));
       }
-      if ("true".equals(constant.getOptions().get(ENUM_DEPRECATED))) {
+      if (constant.isDeprecated()) {
         fieldBuilder.addAnnotation(Deprecated.class);
       }
       builder.addField(fieldBuilder.build());

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1445,7 +1445,7 @@ class KotlinGenerator private constructor(
             if (constant.documentation.isNotBlank()) {
               addKdoc("%L\n", constant.documentation.sanitizeKdoc())
             }
-            if (constant.options.get(ENUM_DEPRECATED) == "true") {
+            if (constant.isDeprecated) {
               addAnnotation(AnnotationSpec.builder(Deprecated::class)
                   .addMember("message = %S", "${constant.name} is deprecated")
                   .build())
@@ -1756,8 +1756,6 @@ class KotlinGenerator private constructor(
     )
     private val MESSAGE = Message::class.asClassName()
     private val ANDROID_MESSAGE = MESSAGE.peerClass("AndroidMessage")
-
-    private val ENUM_DEPRECATED = ProtoMember.get(ENUM_VALUE_OPTIONS, "deprecated")
 
     @JvmStatic @JvmName("get")
     operator fun invoke(

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumConstant.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.schema
 
+import com.squareup.wire.schema.Options.Companion.ENUM_VALUE_OPTIONS
 import com.squareup.wire.schema.internal.parser.EnumConstantElement
 
 data class EnumConstant(
@@ -24,6 +25,9 @@ data class EnumConstant(
   val documentation: String,
   val options: Options
 ) {
+  val isDeprecated: Boolean
+    get() = "true" == options.get(DEPRECATED)
+
   internal fun toElement() =
     EnumConstantElement(location, name, tag, documentation, options.elements)
 
@@ -41,11 +45,13 @@ data class EnumConstant(
       EnumConstant(location, name, tag, documentation, options.retainLinked())
 
   companion object {
+    private val DEPRECATED = ProtoMember.get(ENUM_VALUE_OPTIONS, "deprecated")
+
     internal fun fromElements(elements: List<EnumConstantElement>) =
       elements.map {
         EnumConstant(
             it.location, it.name, it.tag, it.documentation,
-            Options(Options.ENUM_VALUE_OPTIONS, it.options)
+            Options(ENUM_VALUE_OPTIONS, it.options)
         )
       }
 

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/DeclaredTypeName.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/DeclaredTypeName.kt
@@ -43,12 +43,6 @@ class DeclaredTypeName internal constructor(
 
   val compoundName get() = simpleNames.joinToString("") { it.capitalize() }
 
-  init {
-    for (i in 1 until names.size) {
-      require(names[i].isName) { "part ${names[i]} is keyword" }
-    }
-  }
-
   /**
    * Returns the enclosing type, like [Map] for `Map.Entry`. Returns null if this type
    * is not nested in another type.

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/EnumerationCaseSpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/EnumerationCaseSpec.kt
@@ -1,0 +1,74 @@
+package io.outfoxx.swiftpoet
+
+class EnumerationCaseSpec private constructor(
+  builder: Builder
+) : AttributedSpec(builder.attributes) {
+
+  val name = builder.name
+  val typeOrConstant = builder.typeOrConstant
+  val kdoc = builder.kdoc.build()
+
+  fun toBuilder(): Builder {
+    val builder = Builder(name, typeOrConstant)
+    builder.kdoc.add(kdoc)
+    builder.attributes += attributes
+    return builder
+  }
+
+  internal fun emit(codeWriter: CodeWriter) {
+
+    codeWriter.emitKdoc(kdoc)
+    codeWriter.emitAttributes(attributes)
+    codeWriter.emitCode("case %L", escapeIfKeyword(name))
+    when (typeOrConstant) {
+      null -> {}
+      is CodeBlock -> codeWriter.emitCode(" = %L", typeOrConstant)
+      is TupleTypeName -> typeOrConstant.emit(codeWriter)
+      else -> throw IllegalStateException("Invalid enum type of constant")
+    }
+  }
+
+  class Builder internal constructor(
+    internal var name: String,
+    internal var typeOrConstant: Any?
+  ) {
+
+    internal val attributes = mutableListOf<AttributeSpec>()
+    internal val kdoc = CodeBlock.builder()
+
+    fun addKdoc(format: String, vararg args: Any) = apply {
+      kdoc.add(format, *args)
+    }
+
+    fun addKdoc(block: CodeBlock) = apply {
+      kdoc.add(block)
+    }
+
+    fun addAttribute(attribute: AttributeSpec) = apply {
+      this.attributes += attribute
+    }
+
+    fun addAttribute(name: String, vararg arguments: String) = apply {
+      this.attributes += AttributeSpec.builder(name).addArguments(arguments.toList()).build()
+    }
+
+    fun build(): EnumerationCaseSpec {
+      return EnumerationCaseSpec(this)
+    }
+  }
+
+  companion object {
+    @JvmStatic fun builder(name: String) = Builder(name, null)
+
+    @JvmStatic fun builder(name: String, type: TypeName) = Builder(name, TupleTypeName.of("" to type))
+
+    @JvmStatic fun builder(name: String, type: TupleTypeName) = Builder(name, type)
+
+    @JvmStatic fun builder(name: String, constant: CodeBlock) = Builder(name, constant)
+
+    @JvmStatic fun builder(name: String, constant: String) = Builder(name, CodeBlock.of("%S", constant))
+
+    @JvmStatic fun builder(name: String, constant: Int) = Builder(name, CodeBlock.of("%L", constant.toString()))
+  }
+
+}

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/FileSpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/FileSpec.kt
@@ -60,6 +60,7 @@ class FileSpec private constructor(builder: FileSpec.Builder) {
     require(Files.notExists(directory) || Files.isDirectory(directory)) {
       "path $directory exists but is not a directory."
     }
+    Files.createDirectories(directory)
     val outputPath = directory.resolve("$name.swift")
     OutputStreamWriter(Files.newOutputStream(outputPath), UTF_8).use { writer -> writeTo(writer) }
   }

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/PropertySpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/PropertySpec.kt
@@ -164,20 +164,17 @@ class PropertySpec private constructor(
 
   companion object {
     @JvmStatic fun builder(name: String, type: TypeName, vararg modifiers: Modifier): Builder {
-      require(name.isName) { "not a valid name: $name" }
       return Builder(name, type)
           .addModifiers(*modifiers)
     }
 
     @JvmStatic fun varBuilder(name: String, type: TypeName, vararg modifiers: Modifier): Builder {
-      require(name.isName) { "not a valid name: $name" }
       return Builder(name, type)
           .mutable(true)
           .addModifiers(*modifiers)
     }
 
     @JvmStatic fun abstractBuilder(name: String, type: TypeName, vararg modifiers: Modifier): Builder {
-      require(name.isName) { "not a valid name: $name" }
       return Builder(name, type)
          .mutable(true)
          .addModifiers(*modifiers)

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/TypeSpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/TypeSpec.kt
@@ -22,6 +22,7 @@ import io.outfoxx.swiftpoet.Modifier.INTERNAL
 class TypeSpec private constructor(
    builder: TypeSpec.Builder
 ) : AttributedSpec(builder.attributes.toImmutableList()) {
+
   val kind = builder.kind
   val name = builder.name
   val kdoc = builder.kdoc.build()
@@ -32,7 +33,7 @@ class TypeSpec private constructor(
   val isEnum = builder.isEnum
 
   val superTypes = builder.superTypes.toImmutableSet()
-  val enumCases = builder.enumCases.toImmutableMap()
+  val enumCases = builder.enumCases.toImmutableList()
   val propertySpecs = builder.propertySpecs.toImmutableList()
   val funSpecs = builder.functionSpecs.toImmutableList()
   val typeSpecs = builder.typeSpecs.toImmutableList()
@@ -100,15 +101,9 @@ class TypeSpec private constructor(
       if (enumCases.isNotEmpty()) {
         codeWriter.emit("\n")
         firstMember = false
-        val i = enumCases.entries.iterator()
+        val i = enumCases.iterator()
         while (i.hasNext()) {
-          val enumCase = i.next()
-          val enumCaseValue = enumCase.value
-          codeWriter.emitCode("case %L", enumCase.key)
-          when (enumCaseValue) {
-            is String -> codeWriter.emitCode(" = %L", enumCaseValue)
-            is TupleTypeName -> enumCaseValue.emit(codeWriter)
-          }
+          i.next().emit(codeWriter)
           codeWriter.emit("\n")
         }
       }
@@ -252,7 +247,7 @@ class TypeSpec private constructor(
     internal val attributes = mutableListOf<AttributeSpec>()
     internal val typeVariables = mutableListOf<TypeVariableName>()
     internal val superTypes = mutableSetOf<TypeName>()
-    internal val enumCases = mutableMapOf<String, Any?>()
+    internal val enumCases = mutableListOf<EnumerationCaseSpec>()
     internal val propertySpecs = mutableListOf<PropertySpec>()
     internal val functionSpecs = mutableListOf<FunctionSpec>()
     internal val typeSpecs = mutableListOf<TypeSpec>()
@@ -262,10 +257,6 @@ class TypeSpec private constructor(
     internal val isClass = kind is Kind.Class
     internal val isStruct = kind is Kind.Struct
     internal val isProtocol = kind is Kind.Protocol
-
-    init {
-      require(name.isName) { "not a valid name: $name" }
-    }
 
     fun addKdoc(format: String, vararg args: Any) = apply {
       kdoc.add(format, *args)
@@ -305,33 +296,37 @@ class TypeSpec private constructor(
     }
 
     fun addSuperType(superType: TypeName) = apply {
-        this.superTypes += superType
+      this.superTypes += superType
+    }
+
+    fun addEnumCase(enumerationCaseSpec: EnumerationCaseSpec) = apply {
+      check(isEnum) { "${this.name} is not an enum" }
+      require(enumCases.none { it.name == enumerationCaseSpec.name }) { "case already exists: ${enumerationCaseSpec.name}" }
+      enumCases.add(enumerationCaseSpec)
     }
 
     fun addEnumCase(name: String, type: TupleTypeName) = apply {
-      check(isEnum) { "${this.name} is not an enum" }
-      require(name.isName) { "not a valid enum case: $name" }
-      enumCases[name] = type
+      addEnumCase(EnumerationCaseSpec.builder(name, type).build())
     }
 
     fun addEnumCase(name: String, type: TypeName) = apply {
-      check(isEnum) { "${this.name} is not an enum" }
-      require(name.isName) { "not a valid enum case: $name" }
-      enumCases[name] = TupleTypeName.of("" to type)
+      addEnumCase(EnumerationCaseSpec.builder(name, type).build())
     }
 
     fun addEnumCase(name: String, constant: String) = apply {
-      check(isEnum) { "${this.name} is not enum" }
-      require(name.isName) { "not a valid enum constant: $name" }
-      enumCases[name] = constant
+      addEnumCase(EnumerationCaseSpec.builder(name, constant).build())
     }
 
-    fun addEnumCase(
-       name: String
-    ) = apply {
-      check(isEnum) { "${this.name} is not enum" }
-      require(name.isName) { "not a valid enum constant: $name" }
-      enumCases[name] = null
+    fun addEnumCase(name: String, constant: Int) = apply {
+      addEnumCase(EnumerationCaseSpec.builder(name, constant).build())
+    }
+
+    fun addEnumCase(name: String, constant: CodeBlock) = apply {
+      addEnumCase(EnumerationCaseSpec.builder(name, constant).build())
+    }
+
+    fun addEnumCase(name: String) = apply {
+      addEnumCase(EnumerationCaseSpec.builder(name).build())
     }
 
     fun addProperties(propertySpecs: Iterable<PropertySpec>) = apply {
@@ -384,10 +379,6 @@ class TypeSpec private constructor(
     }
 
     fun build(): TypeSpec {
-      require(!isEnum || enumCases.isNotEmpty()) {
-        "at least one enum constant is required for $name"
-      }
-
       return TypeSpec(this)
     }
   }
@@ -417,4 +408,3 @@ private object CLASS : TypeName() {
     return out.emit("class")
   }
 }
-

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/Util.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/Util.kt
@@ -209,6 +209,8 @@ private val KEYWORDS = setOf(
    "throw",
    "throws",
    "true",
-   "try"
+   "try",
 
+   "Type",
+   "Self"
 )

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
@@ -2,9 +2,17 @@
 // Source: squareup.protos.kotlin.DeprecatedEnum in deprecated_enum.proto
 public enum DeprecatedEnum : UInt32, CaseIterable, Codable {
 
+    @available(*, deprecated)
     case DISABLED = 1
+    @available(*, deprecated)
     case ENABLED = 2
     case ON = 3
     case OFF = 4
+
+    public static var allCases: [DeprecatedEnum] {
+        get {
+            return [.DISABLED, .ENABLED, .ON, .OFF]
+        }
+    }
 
 }

--- a/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -20,8 +20,17 @@ public struct OneOfMessage {
 
     public enum Choice {
 
+        /**
+         * What foo.
+         */
         case foo(Int32)
+        /**
+         * Such bar.
+         */
         case bar(String)
+        /**
+         * Nice baz.
+         */
         case baz(String)
 
         fileprivate func encode(to writer: ProtoWriter) throws {

--- a/wire-library/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Person.swift
@@ -48,6 +48,9 @@ public struct Person {
 
         case MOBILE = 0
         case HOME = 1
+        /**
+         * Could be phone or fax.
+         */
         case WORK = 2
 
     }


### PR DESCRIPTION
For symmetry with Field.

Update SwiftPoet and Swift codegen to emit enum constant deprecation along with documentation using its newly-added API.