### PR TITLE
Emit compiler flags around Codable, Equatable, Hashable, and Redactable

### DIFF
--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/FileMemberSpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/FileMemberSpec.kt
@@ -1,0 +1,72 @@
+package io.outfoxx.swiftpoet
+
+class FileMemberSpec internal constructor(builder: Builder) {
+  val kdoc = builder.kdoc.build()
+  val member = builder.member
+  val guardTest = builder.guardTest.build()
+
+  internal fun emit(out: CodeWriter): CodeWriter {
+
+    out.emitKdoc(kdoc)
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("#if ")
+      out.emitCode(guardTest)
+      out.emit("\n")
+    }
+
+    when (member) {
+      is TypeSpec -> member.emit(out)
+      is FunctionSpec -> member.emit(out, null, setOf(Modifier.PUBLIC))
+      is PropertySpec -> member.emit(out, setOf(Modifier.PUBLIC))
+      is TypeAliasSpec -> member.emit(out)
+      is ExtensionSpec -> member.emit(out)
+      else -> throw AssertionError()
+    }
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("#endif")
+      out.emit("\n")
+    }
+
+    return out
+  }
+
+  class Builder internal constructor(internal val member: Any) {
+    internal val kdoc = CodeBlock.builder()
+    internal val guardTest = CodeBlock.builder()
+
+    fun addKdoc(format: String, vararg args: Any) = apply {
+      kdoc.add(format, *args)
+    }
+
+    fun addKdoc(block: CodeBlock) = apply {
+      kdoc.add(block)
+    }
+
+    fun addGuard(test: CodeBlock) = apply {
+      guardTest.add(test)
+    }
+
+    fun addGuard(format: String, vararg args: Any) = apply {
+      addGuard(CodeBlock.of(format, args))
+    }
+
+    fun build(): FileMemberSpec {
+      return FileMemberSpec(this)
+    }
+  }
+
+  companion object {
+    @JvmStatic fun builder(member: TypeSpec) = Builder(member)
+
+    @JvmStatic fun builder(member: FunctionSpec) = Builder(member)
+
+    @JvmStatic fun builder(member: PropertySpec) = Builder(member)
+
+    @JvmStatic fun builder(member: TypeAliasSpec) = Builder(member)
+
+    @JvmStatic fun builder(member: ExtensionSpec) = Builder(member)
+  }
+
+}

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/FunctionSpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/FunctionSpec.kt
@@ -41,8 +41,14 @@ class FunctionSpec private constructor(
   internal fun emit(
     codeWriter: CodeWriter,
     enclosingName: String?,
-    implicitModifiers: Set<Modifier>
+    implicitModifiers: Set<Modifier>,
+    conciseGetter: Boolean = false
   ) {
+    if (name == GETTER && conciseGetter && kdoc.isEmpty() && attributes.isEmpty() && modifiers.isEmpty()) {
+      codeWriter.emitCode(body)
+      return
+    }
+
     codeWriter.emitKdoc(kdoc)
     codeWriter.emitAttributes(attributes)
     codeWriter.emitModifiers(modifiers, implicitModifiers)

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/ImportSpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/ImportSpec.kt
@@ -17,22 +17,77 @@
 package io.outfoxx.swiftpoet
 
 class ImportSpec internal constructor(
-   internal val name: String,
-   attributes: List<AttributeSpec> = listOf()
-) : AttributedSpec(attributes), Comparable<ImportSpec> {
+  builder: ImportSpec.Builder
+) : AttributedSpec(builder.attributes.toImmutableList()), Comparable<ImportSpec> {
+  val name = builder.name
+  val kdoc = builder.kdoc.build()
+  val guardTest = builder.guardTest.build()
 
   private val importString = buildString {
     append(name)
   }
 
   internal fun emit(out: CodeWriter): CodeWriter {
+
+    out.emitKdoc(kdoc)
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("#if ")
+      out.emitCode(guardTest)
+      out.emit("\n")
+    }
+
     out.emitAttributes(attributes, suffix = "")
     out.emit("import $name")
+
+    if (guardTest.isNotEmpty()) {
+      out.emit("\n")
+      out.emit("#endif")
+    }
+
     return out
   }
 
   override fun toString() = importString
 
   override fun compareTo(other: ImportSpec) = importString.compareTo(other.importString)
+
+  class Builder internal constructor(internal val name: String) {
+    internal val kdoc = CodeBlock.builder()
+    internal val attributes = mutableListOf<AttributeSpec>()
+    internal val guardTest = CodeBlock.builder()
+
+    fun addKdoc(format: String, vararg args: Any) = apply {
+      kdoc.add(format, *args)
+    }
+
+    fun addKdoc(block: CodeBlock) = apply {
+      kdoc.add(block)
+    }
+
+    fun addAttribute(attribute: AttributeSpec) = apply {
+      this.attributes += attribute
+    }
+
+    fun addAttribute(name: String, vararg arguments: String) = apply {
+      this.attributes += AttributeSpec.builder(name).addArguments(arguments.toList()).build()
+    }
+
+    fun addGuard(test: CodeBlock) = apply {
+      guardTest.add(test)
+    }
+
+    fun addGuard(format: String, vararg args: Any) = apply {
+      addGuard(CodeBlock.of(format, args))
+    }
+
+    fun build(): ImportSpec {
+      return ImportSpec(this)
+    }
+  }
+
+  companion object {
+    @JvmStatic fun builder(name: String) = Builder(name)
+  }
 
 }

--- a/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/PropertySpec.kt
+++ b/wire-library/wire-swift-generator/src/main/swiftpoet/io/outfoxx/swiftpoet/PropertySpec.kt
@@ -62,7 +62,7 @@ class PropertySpec private constructor(
       codeWriter.emit(" {\n")
       if (getter != null) {
         codeWriter.emitCode("%>")
-        getter.emit(codeWriter, null, implicitModifiers)
+        getter.emit(codeWriter, null, implicitModifiers, setter == null)
         codeWriter.emitCode("%<")
       }
       if (setter != null) {

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1885,11 +1885,15 @@ private struct _AllTypes {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension AllTypes.NestedMessage : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension AllTypes.NestedMessage : Hashable {
 }
+#endif
 
 extension AllTypes.NestedMessage : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -1913,6 +1917,7 @@ extension AllTypes.NestedMessage : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension AllTypes.NestedMessage : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -1920,12 +1925,17 @@ extension AllTypes.NestedMessage : Codable {
 
     }
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension AllTypes : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension AllTypes : Hashable {
 }
+#endif
 
 extension AllTypes : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -2487,9 +2497,12 @@ extension _AllTypes : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension AllTypes : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_CODABLE
 extension _AllTypes : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -2629,9 +2642,14 @@ extension _AllTypes : Codable {
 
     }
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension _AllTypes : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension _AllTypes : Hashable {
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
@@ -10,9 +10,7 @@ public enum DeprecatedEnum : UInt32, CaseIterable, Codable {
     case OFF = 4
 
     public static var allCases: [DeprecatedEnum] {
-        get {
-            return [.DISABLED, .ENABLED, .ON, .OFF]
-        }
+        return [.DISABLED, .ENABLED, .ON, .OFF]
     }
 
 }

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
@@ -15,11 +15,15 @@ public struct DeprecatedProto {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension DeprecatedProto : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension DeprecatedProto : Hashable {
 }
+#endif
 
 extension DeprecatedProto : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -43,6 +47,7 @@ extension DeprecatedProto : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension DeprecatedProto : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -50,3 +55,4 @@ extension DeprecatedProto : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -16,11 +16,15 @@ public struct EmbeddedMessage {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension EmbeddedMessage : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension EmbeddedMessage : Hashable {
 }
+#endif
 
 extension EmbeddedMessage : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -48,6 +52,7 @@ extension EmbeddedMessage : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension EmbeddedMessage : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -56,3 +61,4 @@ extension EmbeddedMessage : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
@@ -14,11 +14,15 @@ public struct ExternalMessage {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension ExternalMessage : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension ExternalMessage : Hashable {
 }
+#endif
 
 extension ExternalMessage : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -42,6 +46,7 @@ extension ExternalMessage : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension ExternalMessage : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -49,3 +54,4 @@ extension ExternalMessage : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
@@ -71,11 +71,15 @@ public struct FooBar {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension FooBar.Nested : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension FooBar.Nested : Hashable {
 }
+#endif
 
 extension FooBar.Nested : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -99,6 +103,7 @@ extension FooBar.Nested : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension FooBar.Nested : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -106,12 +111,17 @@ extension FooBar.Nested : Codable {
 
     }
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension FooBar.More : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension FooBar.More : Hashable {
 }
+#endif
 
 extension FooBar.More : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -135,6 +145,7 @@ extension FooBar.More : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension FooBar.More : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -142,12 +153,17 @@ extension FooBar.More : Codable {
 
     }
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension FooBar : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension FooBar : Hashable {
 }
+#endif
 
 extension FooBar : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -203,6 +219,7 @@ extension FooBar : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension FooBar : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -218,7 +235,9 @@ extension FooBar : Codable {
 
     }
 }
+#endif
 
+#if !WIRE_REMOVE_REDACTABLE
 extension FooBar : Redactable {
     public enum RedactedKeys : String, RedactedKey {
 
@@ -226,3 +245,4 @@ extension FooBar : Redactable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
@@ -14,11 +14,15 @@ public struct ForeignMessage {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension ForeignMessage : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension ForeignMessage : Hashable {
 }
+#endif
 
 extension ForeignMessage : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -42,6 +46,7 @@ extension ForeignMessage : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension ForeignMessage : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -49,3 +54,4 @@ extension ForeignMessage : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Form.swift
@@ -156,17 +156,25 @@ public struct Form {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.Choice : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.Choice : Hashable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.ButtonElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.ButtonElement : Hashable {
 }
+#endif
 
 extension Form.ButtonElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -185,14 +193,20 @@ extension Form.ButtonElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.ButtonElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.LocalImageElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.LocalImageElement : Hashable {
 }
+#endif
 
 extension Form.LocalImageElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -211,14 +225,20 @@ extension Form.LocalImageElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.LocalImageElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.RemoteImageElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.RemoteImageElement : Hashable {
 }
+#endif
 
 extension Form.RemoteImageElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -237,14 +257,20 @@ extension Form.RemoteImageElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.RemoteImageElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.MoneyElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.MoneyElement : Hashable {
 }
+#endif
 
 extension Form.MoneyElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -263,14 +289,20 @@ extension Form.MoneyElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.MoneyElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.SpacerElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.SpacerElement : Hashable {
 }
+#endif
 
 extension Form.SpacerElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -289,14 +321,20 @@ extension Form.SpacerElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.SpacerElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.TextElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.TextElement : Hashable {
 }
+#endif
 
 extension Form.TextElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -315,14 +353,20 @@ extension Form.TextElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.TextElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.CustomizedCardElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.CustomizedCardElement : Hashable {
 }
+#endif
 
 extension Form.CustomizedCardElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -341,14 +385,20 @@ extension Form.CustomizedCardElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.CustomizedCardElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.AddressElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.AddressElement : Hashable {
 }
+#endif
 
 extension Form.AddressElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -367,14 +417,20 @@ extension Form.AddressElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.AddressElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.TextInputElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.TextInputElement : Hashable {
 }
+#endif
 
 extension Form.TextInputElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -393,14 +449,20 @@ extension Form.TextInputElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.TextInputElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.OptionPickerElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.OptionPickerElement : Hashable {
 }
+#endif
 
 extension Form.OptionPickerElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -419,14 +481,20 @@ extension Form.OptionPickerElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.OptionPickerElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.DetailRowElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.DetailRowElement : Hashable {
 }
+#endif
 
 extension Form.DetailRowElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -445,14 +513,20 @@ extension Form.DetailRowElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.DetailRowElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form.CurrencyConversionFlagsElement : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form.CurrencyConversionFlagsElement : Hashable {
 }
+#endif
 
 extension Form.CurrencyConversionFlagsElement : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -471,14 +545,20 @@ extension Form.CurrencyConversionFlagsElement : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form.CurrencyConversionFlagsElement : Codable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Form : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Form : Hashable {
 }
+#endif
 
 extension Form : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -515,6 +595,7 @@ extension Form : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Form : Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: Form.CodingKeys.self)
@@ -595,3 +676,4 @@ extension Form : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
@@ -14,11 +14,15 @@ public struct Mappy {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Mappy : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Mappy : Hashable {
 }
+#endif
 
 extension Mappy : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -42,6 +46,7 @@ extension Mappy : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Mappy : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -49,3 +54,4 @@ extension Mappy : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
@@ -19,11 +19,15 @@ public struct MessageUsingMultipleEnums {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension MessageUsingMultipleEnums : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension MessageUsingMultipleEnums : Hashable {
 }
+#endif
 
 extension MessageUsingMultipleEnums : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -51,6 +55,7 @@ extension MessageUsingMultipleEnums : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension MessageUsingMultipleEnums : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -59,3 +64,4 @@ extension MessageUsingMultipleEnums : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
@@ -12,11 +12,15 @@ public struct MessageWithOptions {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension MessageWithOptions : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension MessageWithOptions : Hashable {
 }
+#endif
 
 extension MessageWithOptions : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -35,5 +39,7 @@ extension MessageWithOptions : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension MessageWithOptions : Codable {
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -18,11 +18,15 @@ public struct MessageWithStatus {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension MessageWithStatus : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension MessageWithStatus : Hashable {
 }
+#endif
 
 extension MessageWithStatus : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -41,5 +45,7 @@ extension MessageWithStatus : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension MessageWithStatus : Codable {
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -37,11 +37,15 @@ public struct ModelEvaluation {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension ModelEvaluation : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension ModelEvaluation : Hashable {
 }
+#endif
 
 extension ModelEvaluation : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -73,6 +77,7 @@ extension ModelEvaluation : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension ModelEvaluation : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -82,3 +87,4 @@ extension ModelEvaluation : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
@@ -14,11 +14,15 @@ public struct NestedVersionOne {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension NestedVersionOne : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension NestedVersionOne : Hashable {
 }
+#endif
 
 extension NestedVersionOne : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -42,6 +46,7 @@ extension NestedVersionOne : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension NestedVersionOne : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -49,3 +54,4 @@ extension NestedVersionOne : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -32,11 +32,15 @@ public struct NestedVersionTwo {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension NestedVersionTwo : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension NestedVersionTwo : Hashable {
 }
+#endif
 
 extension NestedVersionTwo : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -80,6 +84,7 @@ extension NestedVersionTwo : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension NestedVersionTwo : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -92,3 +97,4 @@ extension NestedVersionTwo : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
@@ -12,11 +12,15 @@ public struct NoFields {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension NoFields : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension NoFields : Hashable {
 }
+#endif
 
 extension NoFields : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -35,5 +39,7 @@ extension NoFields : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension NoFields : Codable {
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -45,17 +45,25 @@ public struct OneOfMessage {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension OneOfMessage.Choice : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension OneOfMessage.Choice : Hashable {
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension OneOfMessage : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension OneOfMessage : Hashable {
 }
+#endif
 
 extension OneOfMessage : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -83,6 +91,7 @@ extension OneOfMessage : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension OneOfMessage : Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: OneOfMessage.CodingKeys.self)
@@ -118,3 +127,4 @@ extension OneOfMessage : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -21,11 +21,15 @@ public struct OptionalEnumUser {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension OptionalEnumUser : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension OptionalEnumUser : Hashable {
 }
+#endif
 
 extension OptionalEnumUser : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -49,6 +53,7 @@ extension OptionalEnumUser : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension OptionalEnumUser : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -56,3 +61,4 @@ extension OptionalEnumUser : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -18,11 +18,15 @@ public struct OtherMessageWithStatus {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension OtherMessageWithStatus : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension OtherMessageWithStatus : Hashable {
 }
+#endif
 
 extension OtherMessageWithStatus : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -41,5 +45,7 @@ extension OtherMessageWithStatus : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension OtherMessageWithStatus : Codable {
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
@@ -16,11 +16,15 @@ public struct OuterMessage {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension OuterMessage : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension OuterMessage : Hashable {
 }
+#endif
 
 extension OuterMessage : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -48,6 +52,7 @@ extension OuterMessage : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension OuterMessage : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -56,3 +61,4 @@ extension OuterMessage : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/Percents.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Percents.swift
@@ -17,11 +17,15 @@ public struct Percents {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Percents : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Percents : Hashable {
 }
+#endif
 
 extension Percents : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -45,6 +49,7 @@ extension Percents : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Percents : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -52,3 +57,4 @@ extension Percents : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Person.swift
@@ -76,11 +76,15 @@ public struct Person {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Person.PhoneNumber : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Person.PhoneNumber : Hashable {
 }
+#endif
 
 extension Person.PhoneNumber : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -108,6 +112,7 @@ extension Person.PhoneNumber : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Person.PhoneNumber : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -116,12 +121,17 @@ extension Person.PhoneNumber : Codable {
 
     }
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Person : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Person : Hashable {
 }
+#endif
 
 extension Person : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -161,6 +171,7 @@ extension Person : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Person : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -172,3 +183,4 @@ extension Person : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -28,12 +28,17 @@ public struct RedactedOneOf {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension RedactedOneOf.A : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension RedactedOneOf.A : Hashable {
 }
+#endif
 
+#if !WIRE_REMOVE_REDACTABLE
 extension RedactedOneOf.A : Redactable {
     public enum RedactedKeys : String, RedactedKey {
 
@@ -41,12 +46,17 @@ extension RedactedOneOf.A : Redactable {
 
     }
 }
+#endif
 
+#if !WIRE_REMOVE_EQUATABLE
 extension RedactedOneOf : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension RedactedOneOf : Hashable {
 }
+#endif
 
 extension RedactedOneOf : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -73,6 +83,7 @@ extension RedactedOneOf : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension RedactedOneOf : Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: RedactedOneOf.CodingKeys.self)
@@ -103,3 +114,4 @@ extension RedactedOneOf : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/Thing.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Thing.swift
@@ -14,11 +14,15 @@ public struct Thing {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension Thing : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension Thing : Hashable {
 }
+#endif
 
 extension Thing : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -42,6 +46,7 @@ extension Thing : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension Thing : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -49,3 +54,4 @@ extension Thing : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
@@ -22,11 +22,15 @@ public struct VersionOne {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension VersionOne : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension VersionOne : Hashable {
 }
+#endif
 
 extension VersionOne : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -58,6 +62,7 @@ extension VersionOne : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension VersionOne : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -67,3 +72,4 @@ extension VersionOne : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -38,11 +38,15 @@ public struct VersionTwo {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension VersionTwo : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension VersionTwo : Hashable {
 }
+#endif
 
 extension VersionTwo : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -94,6 +98,7 @@ extension VersionTwo : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension VersionTwo : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -108,3 +113,4 @@ extension VersionTwo : Codable {
 
     }
 }
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -17,11 +17,15 @@ public struct VeryLongProtoNameCausingBrokenLineBreaks {
 
 }
 
+#if !WIRE_REMOVE_EQUATABLE
 extension VeryLongProtoNameCausingBrokenLineBreaks : Equatable {
 }
+#endif
 
+#if !WIRE_REMOVE_HASHABLE
 extension VeryLongProtoNameCausingBrokenLineBreaks : Hashable {
 }
+#endif
 
 extension VeryLongProtoNameCausingBrokenLineBreaks : Proto2Codable {
     public init(from reader: ProtoReader) throws {
@@ -45,6 +49,7 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Proto2Codable {
     }
 }
 
+#if !WIRE_REMOVE_CODABLE
 extension VeryLongProtoNameCausingBrokenLineBreaks : Codable {
     public enum CodingKeys : String, CodingKey {
 
@@ -52,3 +57,4 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Codable {
 
     }
 }
+#endif


### PR DESCRIPTION
This allows you to turn off features for a module which are not needed to save binary size.