### PR TITLE
Configuration to turn on and off option annotations

### DIFF
--- a/gen-tests.gradle
+++ b/gen-tests.gradle
@@ -48,6 +48,7 @@ task generateJavaTests(type: JavaExec) {
   args = [
       '--proto_path=wire-library/wire-tests/src/commonTest/proto/java',
       '--java_out=wire-library/wire-tests/src/jvmJavaTest/proto-java',
+      '--emit_applied_options',
       'google/protobuf/any.proto',
       'google/protobuf/descriptor.proto',
       '--excludes=squareup.options.*',

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -103,6 +103,8 @@ class WireCompiler internal constructor(
   val emitAndroid: Boolean,
   val emitAndroidAnnotations: Boolean,
   val emitCompact: Boolean,
+  val emitDeclaredOptions: Boolean,
+  val emitAppliedOptions: Boolean,
   val javaInterop: Boolean,
   val proto3Preview: String?
 ) {
@@ -117,7 +119,9 @@ class WireCompiler internal constructor(
           outDirectory = javaOut,
           android = emitAndroid,
           androidAnnotations = emitAndroidAnnotations,
-          compact = emitCompact
+          compact = emitCompact,
+          emitDeclaredOptions = emitDeclaredOptions,
+          emitAppliedOptions = emitAppliedOptions
       )
     } else if (kotlinOut != null) {
       targets += KotlinTarget(
@@ -211,6 +215,8 @@ class WireCompiler internal constructor(
     private const val ANDROID = "--android"
     private const val ANDROID_ANNOTATIONS = "--android-annotations"
     private const val COMPACT = "--compact"
+    private const val SKIP_DECLARED_OPTIONS = "--skip_declared_options"
+    private const val EMIT_APPLIED_OPTIONS = "--emit_applied_options"
     private const val JAVA_INTEROP = "--java_interop"
     private const val PROTO3_PREVIEW = "--proto3-preview="
 
@@ -248,6 +254,8 @@ class WireCompiler internal constructor(
       var emitAndroid = false
       var emitAndroidAnnotations = false
       var emitCompact = false
+      var emitDeclaredOptions = true
+      var emitAppliedOptions = false
       var javaInterop = false
       var proto3Preview: String? = null
 
@@ -308,6 +316,8 @@ class WireCompiler internal constructor(
           arg == ANDROID -> emitAndroid = true
           arg == ANDROID_ANNOTATIONS -> emitAndroidAnnotations = true
           arg == COMPACT -> emitCompact = true
+          arg == SKIP_DECLARED_OPTIONS -> emitDeclaredOptions = false
+          arg == EMIT_APPLIED_OPTIONS -> emitAppliedOptions = true
           arg == JAVA_INTEROP -> javaInterop = true
           arg.startsWith("--") -> throw IllegalArgumentException("Unknown argument '$arg'.")
           else -> sourceFileNames.add(arg)
@@ -327,7 +337,8 @@ class WireCompiler internal constructor(
 
       return WireCompiler(fileSystem, logger, protoPaths, javaOut, kotlinOut, swiftOut,
           sourceFileNames, treeShakingRoots, treeShakingRubbish, modules, dryRun, namedFilesOnly,
-          emitAndroid, emitAndroidAnnotations, emitCompact, javaInterop, proto3Preview)
+          emitAndroid, emitAndroidAnnotations, emitCompact, emitDeclaredOptions, emitAppliedOptions,
+          javaInterop, proto3Preview)
     }
   }
 }

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -167,7 +167,13 @@ data class JavaTarget(
    * True to emit code that uses reflection for reading, writing, and toString methods which are
    * normally implemented with generated code.
    */
-  val compact: Boolean = false
+  val compact: Boolean = false,
+
+  /** True to emit types for options declared on messages, fields, etc. */
+  val emitDeclaredOptions: Boolean = true,
+
+  /** True to emit annotations for options applied on messages, fields, etc. */
+  val emitAppliedOptions: Boolean = false
 ) : Target() {
   override fun newHandler(
     schema: Schema,
@@ -194,6 +200,7 @@ data class JavaTarget(
         .withAndroid(android)
         .withAndroidAnnotations(androidAnnotations)
         .withCompact(compact)
+        .withOptions(emitDeclaredOptions, emitAppliedOptions)
 
     return object : SchemaHandler {
       override fun handle(type: Type): Path? {
@@ -208,7 +215,7 @@ data class JavaTarget(
       }
 
       override fun handle(extend: Extend, field: Field): Path? {
-        val typeSpec = javaGenerator.generateExtendField(extend, field) ?: return null
+        val typeSpec = javaGenerator.generateOptionType(extend, field) ?: return null
         val javaTypeName = javaGenerator.generatedTypeName(field)
         return write(javaTypeName, typeSpec, field.qualifiedName, field.location)
       }

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.kt
@@ -191,7 +191,7 @@ class WireCompilerTest {
   @Test
   fun testCustomOptions() {
     val sources = arrayOf("custom_options.proto", "option_redacted.proto")
-    compileToJava(sources, "--named_files_only")
+    compileToJava(sources, "--named_files_only", "--emit_applied_options")
 
     val outputs = arrayOf(
         "com/squareup/wire/protos/custom_options/FooBar.java",

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -57,6 +57,8 @@ open class JavaOutput @Inject constructor() : WireOutput() {
   var android: Boolean = false
   var androidAnnotations: Boolean = false
   var compact: Boolean = false
+  var emitDeclaredOptions: Boolean = true
+  var emitAppliedOptions: Boolean = false
 
   override fun toTarget(): JavaTarget {
     return JavaTarget(
@@ -66,7 +68,9 @@ open class JavaOutput @Inject constructor() : WireOutput() {
         outDirectory = out!!,
         android = android,
         androidAnnotations = androidAnnotations,
-        compact = compact
+        compact = compact,
+        emitDeclaredOptions = emitDeclaredOptions,
+        emitAppliedOptions = emitAppliedOptions
     )
   }
 

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -833,6 +833,21 @@ class WirePluginTest {
     assertThat(geologyProto).contains("enum Period {")
   }
 
+  @Test
+  fun emitJavaOptions() {
+    val fixtureRoot = File("src/test/projects/emit-java-options")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output).contains("Writing squareup.options.DocumentationUrl")
+
+    val generatedProto = File(
+        fixtureRoot, "build/generated/source/wire/squareup/polygons/Octagon.java")
+    val octagon = generatedProto.readText()
+    assertThat(octagon).contains("""@DocumentationUrl("https://en.wikipedia.org/wiki/Octagon")""")
+  }
+
   private fun GradleRunner.runFixture(
     root: File,
     action: GradleRunner.() -> BuildResult

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-java-options/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-java-options/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  java {
+    emitDeclaredOptions = true
+    emitAppliedOptions = true
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-java-options/src/main/proto/squareup/options/documentation.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-java-options/src/main/proto/squareup/options/documentation.proto
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package squareup.options;
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MessageOptions {
+  optional string documentation_url = 22200;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-java-options/src/main/proto/squareup/polygons/octagon.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-java-options/src/main/proto/squareup/polygons/octagon.proto
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package squareup.polygons;
+import "squareup/options/documentation.proto";
+
+message Octagon {
+  option (documentation_url) = "https://en.wikipedia.org/wiki/Octagon";
+  optional bool stop = 1;
+}

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
@@ -17,7 +17,6 @@ package com.squareup.wire.schema
 
 import com.squareup.wire.schema.Field.Companion.retainAll
 import com.squareup.wire.schema.internal.parser.ExtendElement
-import com.squareup.wire.schema.internal.parser.OptionElement
 import kotlin.jvm.JvmStatic
 
 data class Extend(
@@ -60,6 +59,14 @@ data class Extend(
 
   fun retainAll(schema: Schema, markSet: MarkSet): Extend? {
     val retainedFields = retainAll(schema, markSet, type!!, fields)
+    if (retainedFields.isEmpty()) return null
+    val result = Extend(location, documentation, name, retainedFields)
+    result.type = type
+    return result
+  }
+
+  fun retainLinked(linkedFields: Set<Field>): Extend? {
+    val retainedFields = fields.filter { it in linkedFields }
     if (retainedFields.isEmpty()) return null
     val result = Extend(location, documentation, name, retainedFields)
     result.type = type

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -126,6 +126,7 @@ class Options(
       }
       field = extensionsForType[path[0]]
     }
+    linker.request(field!!)
 
     val result = mutableMapOf<ProtoMember, Any>()
     var last = result
@@ -142,6 +143,7 @@ class Options(
 
       last = nested
       field = linker.dereference(field, path[i]) ?: return null // Unable to dereference segment.
+      linker.request(field)
     }
 
     last[get(lastProtoType!!, field!!)] = canonicalizeValue(linker, field, option.value)

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -107,14 +107,12 @@ data class ProtoFile(
   }
 
   /** Return a copy of this file with only the marked types. */
-  fun retainLinked(linkedTypes: Set<ProtoType>): ProtoFile {
+  fun retainLinked(linkedTypes: Set<ProtoType>, linkedFields: Set<Field>): ProtoFile {
     val retainedTypes = types.mapNotNull { it.retainLinked(linkedTypes) }
+    val retainedExtends = extendList.mapNotNull { it.retainLinked(linkedFields) }
 
     // Other .proto files can't link to our services so strip them unconditionally.
     val retainedServices = emptyList<Service>()
-
-    // Strip the extends. They've already been applied to their target types.
-    val retainedExtends = emptyList<Extend>()
 
     val retainedOptions = options.retainLinked()
 

--- a/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/internal/JvmLanguages.kt
+++ b/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/internal/JvmLanguages.kt
@@ -66,8 +66,8 @@ fun eligibleAsAnnotationMember(schema: Schema, field: Field): Boolean {
     return false
   }
 
-  if (field.packageName == "google.protobuf") {
-    return false // Don't emit annotations for packed, etc.
+  if (field.packageName == "google.protobuf" || field.packageName == "wire") {
+    return false // Don't emit annotations for packed, since, etc.
   }
 
   if (field.name == "redacted") {


### PR DESCRIPTION
Currently declared options are emitted by default, and applied options
are not. In a follow-up release I'll turn everything on by default.
I've chosen this mode because it's easiest to upgrade. Otherwise you
can't upgrade downstream things without upgrading upstream things
first.

This required some changes to linking because we now need to recover
the package name of the file the option is declared in. Previously this
was not necessary.