### PR TITLE
Handle double default in Kotlin

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -945,7 +945,7 @@ class KotlinGenerator private constructor(
       typeName == INT -> defaultValue.toIntFieldInitializer()
       typeName == LONG -> defaultValue.toLongFieldInitializer()
       typeName == FLOAT -> CodeBlock.of("%Lf", defaultValue.toString())
-      typeName == DOUBLE -> CodeBlock.of("%L", defaultValue.toString())
+      typeName == DOUBLE -> CodeBlock.of("%L", defaultValue.toString().toDouble())
       typeName == STRING -> CodeBlock.of("%S", defaultValue)
       typeName == ByteString::class.asTypeName() -> CodeBlock.of("%S.%M()!!",
           defaultValue.toString().encode(charset = Charsets.ISO_8859_1).base64(),

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -62,12 +62,28 @@ class KotlinGeneratorTest {
         |  optional int32 b = 2 [default = 0x20 ];
         |  optional int64 c = 3 [default = 11 ];
         |  optional int64 d = 4 [default = 0x21 ];
+        |  optional float e = 5 [default = 806 ];
+        |  optional double f = 6 [default = -0];
+        |  optional double g = 7 [default = 0.0];
+        |  optional double h = 8 [default = -1.0];
+        |  optional double i = 9 [default = 1e10];
+        |  optional double j = 10 [default = -1e-2];
+        |  optional double k = 11 [default = -1.23e45];
+        |  optional double l = 12 [default = 255];
         |}""".trimMargin())
     val code = repoBuilder.generateKotlin("Message")
     assertTrue(code.contains("const val DEFAULT_A: Int = 10"))
     assertTrue(code.contains("const val DEFAULT_B: Int = 32"))
     assertTrue(code.contains("const val DEFAULT_C: Long = 11L"))
     assertTrue(code.contains("const val DEFAULT_D: Long = 33L"))
+    assertTrue(code.contains("const val DEFAULT_E: Float = 806f"))
+    assertTrue(code.contains("const val DEFAULT_F: Double = -0.0"))
+    assertTrue(code.contains("const val DEFAULT_G: Double = 0.0"))
+    assertTrue(code.contains("const val DEFAULT_H: Double = -1.0"))
+    assertTrue(code.contains("const val DEFAULT_I: Double = 1.0E10"))
+    assertTrue(code.contains("const val DEFAULT_J: Double = -0.01"))
+    assertTrue(code.contains("const val DEFAULT_K: Double = -1.23E45"))
+    assertTrue(code.contains("const val DEFAULT_L: Double = 255.0"))
   }
 
   @Test fun nameAllocatorIsUsed() {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -1683,7 +1683,7 @@ class AllTypes(
 
     const val DEFAULT_DEFAULT_FLOAT: Float = 123.456e7f
 
-    const val DEFAULT_DEFAULT_DOUBLE: Double = 123.456e78
+    const val DEFAULT_DEFAULT_DOUBLE: Double = 1.23456E80
 
     const val DEFAULT_DEFAULT_STRING: String =
         "çok\u0007\b\u000c\n\r\t\u000b\u0001\u0001\u0001\u000f\u000f~\u0001\u0001\u0011\u0001\u0001\u0011güzel"

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -3286,7 +3286,7 @@ class AllTypes(
 
     const val DEFAULT_DEFAULT_FLOAT: Float = 123.456e7f
 
-    const val DEFAULT_DEFAULT_DOUBLE: Double = 123.456e78
+    const val DEFAULT_DEFAULT_DOUBLE: Double = 1.23456E80
 
     const val DEFAULT_DEFAULT_STRING: String =
         "çok\u0007\b\u000c\n\r\t\u000b\u0001\u0001\u0001\u000f\u000f~\u0001\u0001\u0011\u0001\u0001\u0011güzel"

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -3213,7 +3213,7 @@ class AllTypes(
 
     const val DEFAULT_DEFAULT_FLOAT: Float = 123.456e7f
 
-    const val DEFAULT_DEFAULT_DOUBLE: Double = 123.456e78
+    const val DEFAULT_DEFAULT_DOUBLE: Double = 1.23456E80
 
     const val DEFAULT_DEFAULT_STRING: String =
         "çok\u0007\b\u000c\n\r\t\u000b\u0001\u0001\u0001\u000f\u000f~\u0001\u0001\u0011\u0001\u0001\u0011güzel"


### PR DESCRIPTION
Fixes #1733

Is there no KotlinPoet method that would do that for me? Or should we parse the value to a double first before printing it?