### PR TITLE
New ErrorsCollector abstraction

### DIFF
--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/ProfileLoaderTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/ProfileLoaderTest.kt
@@ -142,7 +142,7 @@ class ProfileLoaderTest {
     try {
       loadAndLinkProfile("android")
       fail()
-    } catch (expected: IllegalArgumentException) {
+    } catch (expected: SchemaException) {
       assertThat(expected).hasMessage("a/b/android.wire needs to import a/b/message.proto" +
           " (source-path/a/b/android.wire:2:1)")
     }

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/SchemaLoaderTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/SchemaLoaderTest.kt
@@ -30,7 +30,7 @@ import kotlin.text.Charsets.UTF_32BE
 import kotlin.text.Charsets.UTF_32LE
 import kotlin.text.Charsets.UTF_8
 
-class NewSchemaLoaderTest {
+class SchemaLoaderTest {
   private val fs = Jimfs.newFileSystem(Configuration.unix())
 
   @Test
@@ -114,7 +114,7 @@ class NewSchemaLoaderTest {
 
   @Test
   fun noSourcesFound() {
-    val exception = assertFailsWith<IllegalArgumentException> {
+    val exception = assertFailsWith<SchemaException> {
       SchemaLoader(fs).use { loader ->
         loader.initRoots(sourcePath = listOf())
         loader.loadSourcePathFiles()
@@ -151,7 +151,7 @@ class NewSchemaLoaderTest {
         |}
         """.trimMargin())
 
-    val exception = assertFailsWith<IllegalArgumentException> {
+    val exception = assertFailsWith<SchemaException> {
       SchemaLoader(fs).use { loader ->
         loader.initRoots(
             sourcePath = listOf(Location.get("colors/src/main/proto/squareup/shapes/blue.proto"))
@@ -312,7 +312,7 @@ class NewSchemaLoaderTest {
         |}
         """.trimMargin())
 
-    val exception = assertFailsWith<IllegalArgumentException> {
+    val exception = assertFailsWith<SchemaException> {
       SchemaLoader(fs).use { loader ->
         loader.initRoots(
             sourcePath = listOf(
@@ -362,7 +362,7 @@ class NewSchemaLoaderTest {
         |}
         """.trimMargin())
 
-    val exception = assertFailsWith<IllegalArgumentException> {
+    val exception = assertFailsWith<SchemaException> {
       SchemaLoader(fs).use { loader ->
         loader.initRoots(
             sourcePath = listOf(

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/CycleChecker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/CycleChecker.kt
@@ -29,7 +29,7 @@ import com.squareup.wire.schema.internal.DagChecker
  */
 internal class CycleChecker(
   private val fileLinkers: Map<String, FileLinker>,
-  private val linker: Linker
+  private val errors: ErrorCollector
 ) {
   private val goPackageOption = ProtoMember.get("google.protobuf.FileOptions#go_package")
 
@@ -52,7 +52,7 @@ internal class CycleChecker(
     val cycles = dagChecker.check()
 
     for (cycle in cycles) {
-      linker.addError(importCycleMessageError(cycle))
+      errors += importCycleMessageError(cycle)
     }
   }
 
@@ -105,7 +105,7 @@ internal class CycleChecker(
     val cycles = dagChecker.check()
 
     for (cycle in cycles) {
-      linker.addError(packagesCycleMessageError(cycle))
+      errors += packagesCycleMessageError(cycle)
     }
   }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -66,7 +66,7 @@ data class EnumType(
 
   private fun validateZeroValueAtFirstPosition(linker: Linker) {
     if (constants.isEmpty() || constants.first().tag != 0) {
-      linker.addError("missing a zero value at the first element [proto3]")
+      linker.errors += "missing a zero value at the first element [proto3]"
     }
   }
 
@@ -86,7 +86,7 @@ data class EnumType(
             append("\n  ${index + 1}. ${it.name} (${it.location})")
           }
         }
-        linker.addError(error)
+        linker.errors += error
       }
     }
   }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ErrorCollector.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ErrorCollector.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+/**
+ * Collects errors to be reported as a batch. Errors include both a detail message plus context of
+ * where they occurred within the schema.
+ */
+class ErrorCollector {
+  private val errors: MutableList<String>
+  private val contextStack: List<Any>
+
+  constructor() {
+    this.errors = mutableListOf()
+    this.contextStack = listOf()
+  }
+
+  private constructor(enclosing: ErrorCollector, contextStack: List<Any>) {
+    this.errors = enclosing.errors
+    this.contextStack = contextStack
+  }
+
+  /**
+   * Returns a copy of this error collector that includes [additionalContext] in error messages
+   * reported to it. The current and returned instance both contribute errors to the same list.
+   */
+  fun at(additionalContext: Any) = ErrorCollector(this, contextStack + additionalContext)
+
+  /** Add [message] as an error to this collector. */
+  operator fun plusAssign(message: String) {
+    val error = StringBuilder()
+    error.append(message)
+
+    val contextStack = contextStack.toMutableList()
+    if (contextStack.any { it !is ProtoFile }) {
+      contextStack.removeAll { it is ProtoFile }
+    }
+    for (i in contextStack.indices.reversed()) {
+      val context = contextStack[i]
+      val prefix = if (i == contextStack.size - 1) "\n  for" else "\n  in"
+
+      when (context) {
+        is Rpc -> error.append("$prefix rpc ${context.name} (${context.location})")
+        is Field -> error.append("$prefix field ${context.name} (${context.location})")
+        is MessageType -> error.append("$prefix message ${context.type} (${context.location})")
+        is EnumConstant -> error.append("$prefix constant ${context.name} (${context.location})")
+        is EnumType -> error.append("$prefix enum ${context.type} (${context.location})")
+        is Service -> error.append("$prefix service ${context.type} (${context.location})")
+        is Extensions -> error.append("$prefix extensions (${context.location})")
+        is ProtoFile -> error.append("$prefix file ${context.location}")
+        is Extend -> {
+          if (context.type != null) {
+            error.append("$prefix extend ${context.type} (${context.location})")
+          } else {
+            error.append("$prefix extend (${context.location})")
+          }
+        }
+      }
+    }
+    errors += error.toString()
+  }
+
+  fun throwIfNonEmpty() {
+    if (errors.isNotEmpty()) {
+      throw SchemaException(errors)
+    }
+  }
+}

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
@@ -53,7 +53,7 @@ data class Extend(
     linker.validateImport(location, type!!)
 
     if (!syntaxRules.canExtend(ProtoType.get(name))) {
-      linker.addError("extensions are not allowed [proto3]")
+      linker.errors += "extensions are not allowed [proto3]"
     }
   }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extensions.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extensions.kt
@@ -43,7 +43,7 @@ data class Extensions(
       }
     }
     if (outOfRangeTags.isNotEmpty()) {
-      linker.addError("tags are out of range: ${outOfRangeTags.joinToString(separator = ", ")}")
+      linker.errors += "tags are out of range: ${outOfRangeTags.joinToString(separator = ", ")}"
     }
   }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -118,23 +118,23 @@ data class Field(
   fun validate(linker: Linker, syntaxRules: SyntaxRules) {
     val linker = linker.withContext(this)
     if (isPacked && !isPackable(linker, type!!)) {
-      linker.addError("packed=true not permitted on $type")
+      linker.errors += "packed=true not permitted on $type"
     }
     if (isExtension) {
       if (isRequired) {
-        linker.addError("extension fields cannot be required")
+        linker.errors += "extension fields cannot be required"
       }
       if (type!!.isMap) {
-        linker.addError("extension fields cannot be a map")
+        linker.errors += "extension fields cannot be a map"
       }
     }
     if (default != null && !syntaxRules.allowUserDefinedDefaultValue()) {
-      linker.addError("user-defined default values are not permitted [proto3]")
+      linker.errors += "user-defined default values are not permitted [proto3]"
     }
     if (type!!.isMap) {
       val valueType = linker.get(type!!.valueType!!)
       if (valueType is EnumType && valueType.constants[0].tag != 0) {
-        linker.addError("enum value in map must define 0 as the first value")
+        linker.errors += "enum value in map must define 0 as the first value"
       }
     }
     linker.validateImport(location, type!!)

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -106,10 +106,10 @@ class Options(
             val extensionFields = type.extensionFields.filter { it.name == option.name }
             if (extensionFields.size > 1) {
               if (validate){
-                linker.addError("""
+                linker.errors += """
                    |ambiguous options ${option.name} defined in
                    |  ${extensionFields.map { "- ${it.location}" }.joinToString("\n  ")}
-                   """.trimMargin())
+                   """.trimMargin()
                 return null
               }
             } else {
@@ -120,7 +120,7 @@ class Options(
       }
       if (path == null) {
         if (validate) {
-          linker.addError("unable to resolve option ${option.name}")
+          linker.errors += "unable to resolve option ${option.name}"
         }
         return null // Unable to find the root of this field path.
       }
@@ -163,7 +163,7 @@ class Options(
         val result = mutableMapOf<ProtoMember, Any>()
         val field = linker.dereference(context, value.name)
         if (field == null) {
-          linker.addError("unable to resolve option ${value.name} on ${context.type}")
+          linker.errors += "unable to resolve option ${value.name} on ${context.type}"
         } else {
           val protoMember = get(context.type!!, field)
           result[protoMember] = canonicalizeValue(linker, field, value.value)
@@ -177,7 +177,7 @@ class Options(
           val name = entry.key as String
           val field = linker.dereference(context, name)
           if (field == null) {
-            linker.addError("unable to resolve option $name on ${context.type}")
+            linker.errors += "unable to resolve option $name on ${context.type}"
           } else {
             val protoMember = get(context.type!!, field)
             result[protoMember] = canonicalizeValue(linker, field, entry.value!!)
@@ -223,7 +223,7 @@ class Options(
       }
 
       else -> {
-        linker.addError("conflicting options: $a, $b")
+        linker.errors += "conflicting options: $a, $b"
         a // Just return any placeholder.
       }
     }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Schema.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Schema.kt
@@ -121,13 +121,6 @@ class Schema internal constructor(protoFiles: Iterable<ProtoFile>) {
   }
 
   companion object {
-    @JvmOverloads
-    fun fromFiles(
-      sourceProtoFiles: Iterable<ProtoFile>,
-      pathFilesLoader: Loader = CoreLoader
-    ): Schema {
-      return Linker(pathFilesLoader).link(sourceProtoFiles)
-    }
 
     private fun buildTypesIndex(
       protoFiles: Iterable<ProtoFile>,

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Service.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Service.kt
@@ -84,7 +84,7 @@ data class Service(
             append("\n  ${index + 1}. ${rpc.name} (${rpc.location})")
           }
         }
-        linker.addError(error)
+        linker.errors += error
       }
     }
   }


### PR DESCRIPTION
Stop linker from needing to do errors collection work.

One small drawback here is the context stack is now duplicated between
errors reporting and linking. This is likely an opportunity to simplify
as the two purposes actually use the context stack for different things.