### PR TITLE
Include the importing file when an import fails

### DIFF
--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/SchemaLoaderTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/SchemaLoaderTest.kt
@@ -330,12 +330,14 @@ class SchemaLoaderTest {
       }
     }
     assertThat(exception).hasMessage("""
-        |unable to resolve 2 imports:
-        |  squareup/curves/circle.proto
-        |  squareup/polygons/rectangle.proto
-        |searching 2 proto paths:
-        |  polygons/src/main/proto
-        |  lib/curves.zip
+        |unable to find squareup/curves/circle.proto
+        |  searching 2 proto paths:
+        |    polygons/src/main/proto
+        |    lib/curves.zip
+        |unable to find squareup/polygons/rectangle.proto
+        |  searching 2 proto paths:
+        |    polygons/src/main/proto
+        |    lib/curves.zip
         """.trimMargin())
   }
 

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -890,6 +890,33 @@ class WireRunTest {
         .doesNotContain("@DocumentationUrl")
   }
 
+  @Test
+  fun importNotFoundIncludesReferencingFile() {
+    writeBlueProto()
+    writeSquareProto()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(Location.get("colors/src/main/proto")),
+        protoPath = listOf(Location.get("polygons/src/main/proto")),
+        targets = listOf(NullTarget())
+    )
+
+    try {
+      wireRun.execute(fs, logger)
+      fail()
+    } catch (expected: SchemaException) {
+      assertThat(expected).hasMessage("""
+          |unable to find squareup/polygons/triangle.proto
+          |  searching 1 proto paths:
+          |    polygons/src/main/proto
+          |  for file colors/src/main/proto/squareup/colors/blue.proto
+          |unable to resolve squareup.polygons.Triangle
+          |  for field triangle (colors/src/main/proto/squareup/colors/blue.proto:7:3)
+          |  in message squareup.colors.Blue (colors/src/main/proto/squareup/colors/blue.proto:5:1)
+          """.trimMargin())
+    }
+  }
+
   private fun writeOrangeProto() {
     fs.add("colors/src/main/proto/squareup/colors/orange.proto", """
           |syntax = "proto2";

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -60,7 +60,7 @@ class Linker {
     val existing = fileLinkers[path]
     if (existing != null) return existing
 
-    val protoFile = loader.load(path)
+    val protoFile = loader.withErrors(errors).load(path)
     val result = FileLinker(protoFile, withContext(protoFile))
     fileLinkers[path] = result
     fileOptionsQueue += result

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Loader.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Loader.kt
@@ -18,4 +18,7 @@ package com.squareup.wire.schema
 /** Loads other files as needed by their import path. */
 interface Loader {
   fun load(path: String): ProtoFile
+
+  /** Returns a new loader that reports failures to [errors]. */
+  fun withErrors(errors: ErrorCollector): Loader
 }

--- a/wire-library/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
+++ b/wire-library/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
@@ -19,4 +19,6 @@ actual object CoreLoader : Loader {
   override fun load(path: String): ProtoFile {
     TODO("Not yet implemented in JS")
   }
+
+  override fun withErrors(errors: ErrorCollector) = this
 }

--- a/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
+++ b/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/CoreLoader.kt
@@ -71,4 +71,6 @@ actual object CoreLoader : Loader {
         path == WRAPPERS_PROTO ||
         path == WIRE_EXTENSIONS_PROTO
   }
+
+  override fun withErrors(errors: ErrorCollector) = this
 }


### PR DESCRIPTION
This presents significantly larger errors because we include both
the failed imports and the failed resolution of the imported types.
Overall I think it's an improvement.