### PR TITLE
Stop emitting enum constant options as fields

### DIFF
--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -14,7 +14,6 @@ import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.io.IOException;
-import java.lang.Boolean;
 import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Integer;
@@ -526,24 +525,21 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
   }
 
   public enum NestedEnum implements WireEnum {
-    FOO(1, null),
+    FOO(1),
 
-    BAR(2, null),
+    BAR(2),
 
-    BAZ(3, null),
+    BAZ(3),
 
     @Deprecated
-    BUZ(3, true);
+    BUZ(3);
 
     public static final ProtoAdapter<NestedEnum> ADAPTER = new ProtoAdapter_NestedEnum();
 
     private final int value;
 
-    public final Boolean deprecated;
-
-    NestedEnum(int value, Boolean deprecated) {
+    NestedEnum(int value) {
       this.value = value;
-      this.deprecated = deprecated;
     }
 
     /**

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -14,7 +14,6 @@ import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import com.squareup.wire.protos.foreign.ForeignEnumValueOption;
 import java.io.IOException;
-import java.lang.Boolean;
 import java.lang.Double;
 import java.lang.Float;
 import java.lang.Integer;
@@ -23,7 +22,6 @@ import java.lang.Object;
 import java.lang.Override;
 import java.lang.String;
 import java.lang.StringBuilder;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import okio.ByteString;
@@ -525,35 +523,21 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
   @EnumOption(true)
   public enum FooBarBazEnum implements WireEnum {
     @EnumValueOption(17)
-    FOO(1, 17, new More.Builder()
-        .serial(Arrays.asList(
-            99,
-            199))
-        .build(), null),
+    FOO(1),
 
     @ForeignEnumValueOption(true)
-    BAR(2, null, null, true),
+    BAR(2),
 
     @EnumValueOption(18)
     @ForeignEnumValueOption(false)
-    BAZ(3, 18, null, false);
+    BAZ(3);
 
     public static final ProtoAdapter<FooBarBazEnum> ADAPTER = new ProtoAdapter_FooBarBazEnum();
 
     private final int value;
 
-    public final Integer enum_value_option;
-
-    public final More complex_enum_value_option;
-
-    public final Boolean foreign_enum_value_option;
-
-    FooBarBazEnum(int value, Integer enum_value_option, More complex_enum_value_option,
-        Boolean foreign_enum_value_option) {
+    FooBarBazEnum(int value) {
       this.value = value;
-      this.enum_value_option = enum_value_option;
-      this.complex_enum_value_option = complex_enum_value_option;
-      this.foreign_enum_value_option = foreign_enum_value_option;
     }
 
     /**

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -14,7 +14,6 @@ import com.squareup.wire.WireField;
 import com.squareup.wire.internal.Internal;
 import com.squareup.wire.protos.foreign.ForeignEnum;
 import java.io.IOException;
-import java.lang.Boolean;
 import java.lang.Deprecated;
 import java.lang.Double;
 import java.lang.Integer;
@@ -526,24 +525,21 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
   }
 
   public enum NestedEnum implements WireEnum {
-    FOO(1, null),
+    FOO(1),
 
-    BAR(2, null),
+    BAR(2),
 
-    BAZ(3, null),
+    BAZ(3),
 
     @Deprecated
-    BUZ(3, true);
+    BUZ(3);
 
     public static final ProtoAdapter<NestedEnum> ADAPTER = new ProtoAdapter_NestedEnum();
 
     private final int value;
 
-    public final Boolean deprecated;
-
-    NestedEnum(int value, Boolean deprecated) {
+    NestedEnum(int value) {
       this.value = value;
-      this.deprecated = deprecated;
     }
 
     /**


### PR DESCRIPTION
We're using annotations now.