### PR TITLE
Generate storage structs as file-private

### DIFF
--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -242,7 +242,7 @@ class SwiftGenerator private constructor(
 
     if (type.isHeapAllocated) {
       typeSpecs += TypeSpec.structBuilder(storageType)
-          .addModifiers(PRIVATE)
+          .addModifiers(FILEPRIVATE)
           .apply {
             generateMessageProperties(type, oneOfEnumNames, forStorageType = true)
             generateMessageConstructor(type, oneOfEnumNames, includeDefaults = false)

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1436,7 +1436,7 @@ public struct AllTypes {
 
 }
 
-private struct _AllTypes {
+fileprivate struct _AllTypes {
 
     public var opt_int32: Int32?
     public var opt_uint32: UInt32?


### PR DESCRIPTION
This ensures extensions (which are defined on the top-level) can always access the storage type, even when it's nested in another struct.

Closes #1750