### PR TITLE
Add support for json_name

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -43,7 +43,9 @@ data class Field(
 
   val isExtension: Boolean,
 
-  val isOneOf: Boolean
+  val isOneOf: Boolean,
+
+  val declaredJsonName: String?
 ) {
   // Null until this field is linked.
   var type: ProtoType? = null
@@ -112,7 +114,7 @@ data class Field(
 
     encodeMode =
         syntaxRules.getEncodeMode(type!!, label, isPacked = packed == "true", isOneOf = isOneOf)
-    jsonName = syntaxRules.jsonName(name)
+    jsonName = syntaxRules.jsonName(name, declaredJsonName)
   }
 
   fun validate(linker: Linker, syntaxRules: SyntaxRules) {
@@ -174,7 +176,8 @@ data class Field(
         elementType = elementType,
         options = options,
         isExtension = isExtension,
-        isOneOf = isOneOf
+        isOneOf = isOneOf,
+        declaredJsonName = declaredJsonName,
     )
     result.type = type
     result.deprecated = deprecated
@@ -280,7 +283,8 @@ data class Field(
           elementType = it.type,
           options = Options(FIELD_OPTIONS, it.options),
           isExtension = extension,
-          isOneOf = oneOf
+          isOneOf = oneOf,
+          declaredJsonName = it.jsonName,
       )
     }
 
@@ -292,6 +296,7 @@ data class Field(
           type = it.elementType,
           name = it.name,
           defaultValue = it.default,
+          jsonName = it.declaredJsonName,
           tag = it.tag,
           documentation = it.documentation,
           options = it.options.elements

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -372,7 +372,9 @@ class Linker {
       nameToField.getOrPut(field.qualifiedName, { mutableSetOf() }).add(field)
       // We allow JSON collisions for extensions.
       if (!field.isExtension) {
-        jsonNameToField.getOrPut(syntaxRules.jsonName(field.name), { mutableSetOf() }).add(field)
+        jsonNameToField
+            .getOrPut(syntaxRules.jsonName(field.name, field.declaredJsonName), { mutableSetOf() })
+            .add(field)
       }
 
       val type = get(field.type!!)
@@ -410,7 +412,7 @@ class Linker {
       for ((jsonName, fields) in jsonNameToField) {
         if (fields.size > 1) {
           val error = StringBuilder()
-          error.append("multiple fields share same JSON camel-case name '${jsonName}':")
+          error.append("multiple fields share same JSON name '${jsonName}':")
           fields.forEachIndexed { index, field ->
             error.append("\n  ${index + 1}. ${field.name} (${field.location})")
           }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SyntaxRules.kt
@@ -33,7 +33,7 @@ interface SyntaxRules {
     isOneOf: Boolean
   ): Field.EncodeMode
 
-  fun jsonName(name: String): String
+  fun jsonName(name: String, declaredJsonName: String?): String
   fun allowTypeReference(type: Type): Boolean
 
   companion object {
@@ -71,7 +71,9 @@ interface SyntaxRules {
         }
       }
 
-      override fun jsonName(name: String): String = name
+      override fun jsonName(name: String, declaredJsonName: String?): String {
+        return declaredJsonName ?: name
+      }
       override fun allowTypeReference(type: Type) = true
     }
 
@@ -108,7 +110,9 @@ interface SyntaxRules {
         return Field.EncodeMode.OMIT_IDENTITY
       }
 
-      override fun jsonName(name: String): String = camelCase(name, upperCamel = false)
+      override fun jsonName(name: String, declaredJsonName: String?): String {
+        return declaredJsonName ?: camelCase(name, upperCamel = false)
+      }
       override fun allowTypeReference(type: Type): Boolean {
         if (type is EnumType) {
           return type.syntax != PROTO_2

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
@@ -356,6 +356,7 @@ class ProtoParser internal constructor(
     val options: MutableList<OptionElement> = OptionReader(reader).readOptions().toMutableList()
 
     val defaultValue = stripDefault(options)
+    val jsonName = stripJsonName(options)
     reader.require(';')
 
     documentation = reader.tryAppendTrailingDocumentation(documentation)
@@ -366,24 +367,35 @@ class ProtoParser internal constructor(
         type = type,
         name = name,
         defaultValue = defaultValue,
+        jsonName = jsonName,
         tag = tag,
         documentation = documentation,
         options = options.toList()
     )
   }
 
-  /**
-   * Defaults aren't options. This finds an option named "default", removes, and returns it. Returns
-   * null if no default option is present.
-   */
+  /** Defaults aren't options. */
   private fun stripDefault(options: MutableList<OptionElement>): String? {
+    return stripValue("default", options)
+  }
+
+  /** `json_name` isn't an option. */
+  private fun stripJsonName(options: MutableList<OptionElement>): String? {
+    return stripValue("json_name", options)
+  }
+
+  /**
+   * This finds an option named [name], removes, and returns it.
+   * Returns null if no [name] option is present.
+   */
+  private fun stripValue(name: String, options: MutableList<OptionElement>): String? {
     var result: String? = null
     val i = options.iterator()
     while (i.hasNext()) {
       val element = i.next()
-      if (element.name == "default") {
+      if (element.name == name) {
         i.remove()
-        result = element.value.toString() // Defaults aren't options!
+        result = element.value.toString()
       }
     }
     return result

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ExtendElementTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ExtendElementTest.kt
@@ -108,6 +108,30 @@ class ExtendElementTest {
   }
 
   @Test
+  fun jsonNameToSchema() {
+    val extend = ExtendElement(
+        location = location,
+        name = "Name",
+        fields = listOf(
+            FieldElement(
+                location = location,
+                label = REQUIRED,
+                type = "string",
+                name = "name",
+                jsonName = "my_json",
+                tag = 1
+            )
+        )
+    )
+    val expected = """
+        |extend Name {
+        |  required string name = 1 [json_name = "my_json"];
+        |}
+        |""".trimMargin()
+    assertThat(extend.toSchema()).isEqualTo(expected)
+  }
+
+  @Test
   fun defaultIsSetInProto2File() {
     val extend = ExtendElement(
         location = location,

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/FieldElementTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/FieldElementTest.kt
@@ -18,7 +18,6 @@ package com.squareup.wire.schema.internal.parser
 import com.squareup.wire.schema.Field.Label.OPTIONAL
 import com.squareup.wire.schema.Field.Label.REQUIRED
 import com.squareup.wire.schema.Location
-import com.squareup.wire.schema.SyntaxRules
 import com.squareup.wire.schema.SyntaxRules.Companion.PROTO_2_SYNTAX_RULES
 import com.squareup.wire.schema.SyntaxRules.Companion.PROTO_3_SYNTAX_RULES
 import com.squareup.wire.schema.internal.parser.OptionElement.Kind
@@ -77,7 +76,47 @@ class FieldElementTest {
     )
 
     assertThat(field.toSchema(PROTO_2_SYNTAX_RULES))
-        .isEqualTo("required string name = 1 [default = \"defaultValue\"];\n")
+        .isEqualTo("""
+            |required string name = 1 [default = "defaultValue"];
+            |""".trimMargin())
+  }
+
+  @Test
+  fun jsonNameAndDefaultValue() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "string",
+        name = "name",
+        defaultValue = "defaultValue",
+        jsonName = "my_json",
+        tag = 1
+    )
+
+    assertThat(field.toSchema())
+        .isEqualTo("""
+            |required string name = 1 [
+            |  default = "defaultValue",
+            |  json_name = "my_json"
+            |];
+            |""".trimMargin())
+  }
+
+  @Test
+  fun jsonName() {
+    val field = FieldElement(
+        location = location,
+        label = REQUIRED,
+        type = "string",
+        name = "name",
+        jsonName = "my_json",
+        tag = 1
+    )
+
+    assertThat(field.toSchema(PROTO_2_SYNTAX_RULES))
+        .isEqualTo("""
+            |required string name = 1 [json_name = "my_json"];
+            |""".trimMargin())
   }
 
   @Test

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -241,7 +241,7 @@ class ProtoParserTest {
     }
   }
 
-  /** It looks like an option, but 'default' is special. It's missing from descriptor.proto!  */
+  /** It looks like an option, but 'default' is special. It's not defined as an option. */
   @Test
   fun defaultFieldOptionIsSpecial() {
     val proto = """
@@ -265,6 +265,38 @@ class ProtoParserTest {
                         defaultValue = "b",
                         options = listOf(OptionElement.create("faulted", Kind.STRING, "c")),
                         tag = 1
+                    )
+                )
+            )
+        )
+    )
+    assertThat(ProtoParser.parse(location, proto)).isEqualTo(expected)
+  }
+
+  /** It looks like an option, but 'json_name' is special. It's not defined as an option. */
+  @Test
+  fun jsonNameOptionIsSpecial() {
+    val proto = """
+        |message Message {
+        |  required string a = 1 [json_name = "b", faulted = "c"];
+        |}
+        |""".trimMargin()
+
+    val expected = ProtoFileElement(
+        location = location,
+        types = listOf(
+            MessageElement(
+                location = location.at(1, 1),
+                name = "Message",
+                fields = listOf(
+                    FieldElement(
+                        location = location.at(2, 3),
+                        label = REQUIRED,
+                        type = "string",
+                        name = "a",
+                        jsonName = "b",
+                        tag = 1,
+                        options = listOf(OptionElement.create("faulted", Kind.STRING, "c"))
                     )
                 )
             )

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/java/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/java/interop/interop_test.proto
@@ -33,3 +33,9 @@ message InteropCamelCase {
   optional string _Ccc_ddd = 3;
   optional string EEee_ff_gGg = 4;
 }
+
+message InteropJsonName {
+  optional string a = 1 [json_name = "one"];
+  optional string public = 2 [json_name = "two"];
+  optional string camel_case = 3 [json_name = "three"];
+}

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/interop/interop_test.proto
@@ -33,3 +33,9 @@ message InteropCamelCase {
   optional string _Ccc_ddd = 3;
   optional string EEee_ff_gGg = 4;
 }
+
+message InteropJsonName {
+  optional string a = 1 [json_name = "one"];
+  optional string public = 2 [json_name = "two"];
+  optional string camel_case = 3 [json_name = "three"];
+}

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/java/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/java/interop/interop_test.proto
@@ -33,3 +33,9 @@ message InteropCamelCase {
   string _Ccc_ddd = 3;
   string EEee_ff_gGg = 4;
 }
+
+message InteropJsonName {
+  string a = 1 [json_name = "one"];
+  string public = 2 [json_name = "two"];
+  string camel_case = 3 [json_name = "three"];
+}

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/interop/interop_test.proto
@@ -33,3 +33,9 @@ message InteropCamelCase {
   string _Ccc_ddd = 3;
   string EEee_ff_gGg = 4;
 }
+
+message InteropJsonName {
+  string a = 1 [json_name = "one"];
+  string public = 2 [json_name = "two"];
+  string camel_case = 3 [json_name = "three"];
+}

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropTest.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropTest.kt
@@ -19,20 +19,26 @@ import com.google.protobuf.Duration
 import org.junit.Test
 import squareup.proto2.java.interop.InteropCamelCase as InteropCamelCaseJ2
 import squareup.proto2.java.interop.InteropDuration as InteropDurationJ2
+import squareup.proto2.java.interop.InteropJsonName as InteropJsonNameJ2
 import squareup.proto2.java.interop.InteropTest.InteropCamelCase as InteropCamelCaseP2
+import squareup.proto2.java.interop.InteropTest.InteropJsonName as InteropJsonNameP2
 import squareup.proto2.java.interop.InteropTest.InteropUint64 as InteropUint64P2
 import squareup.proto2.java.interop.InteropUint64 as InteropUint64J2
 import squareup.proto2.kotlin.interop.InteropCamelCase as InteropCamelCaseK2
 import squareup.proto2.kotlin.interop.InteropDuration as InteropDurationK2
+import squareup.proto2.kotlin.interop.InteropJsonName as InteropJsonNameK2
 import squareup.proto2.kotlin.interop.InteropUint64 as InteropUint64K2
 import squareup.proto3.java.interop.InteropCamelCase as InteropCamelCaseJ3
 import squareup.proto3.java.interop.InteropDuration as InteropDurationJ3
+import squareup.proto3.java.interop.InteropJsonName as InteropJsonNameJ3
 import squareup.proto3.java.interop.InteropTest.InteropCamelCase as InteropCamelCaseP3
 import squareup.proto3.java.interop.InteropTest.InteropDuration as InteropDurationP3
+import squareup.proto3.java.interop.InteropTest.InteropJsonName as InteropJsonNameP3
 import squareup.proto3.java.interop.InteropTest.InteropUint64 as InteropUint64P3
 import squareup.proto3.java.interop.InteropUint64 as InteropUint64J3
 import squareup.proto3.kotlin.interop.InteropCamelCase as InteropCamelCaseK3
 import squareup.proto3.kotlin.interop.InteropDuration as InteropDurationK3
+import squareup.proto3.kotlin.interop.InteropJsonName as InteropJsonNameK3
 import squareup.proto3.kotlin.interop.InteropUint64 as InteropUint64K3
 
 class InteropTest {
@@ -154,6 +160,40 @@ class InteropTest {
 
     checker.check(InteropCamelCaseK2("1", "2", "3", "4"))
     checker.check(InteropCamelCaseJ2("1", "2", "3", "4"))
+  }
+
+  @Test fun `json names`() {
+    val checked = InteropChecker(
+        protocMessage = InteropJsonNameP3.newBuilder()
+            .setA("1")
+            .setPublic("2")
+            .setCamelCase("3")
+            .build(),
+        canonicalJson = """{"one":"1","two":"2","three":"3"}""",
+        alternateJsons = listOf(
+            """{"a":"1","public":"2","camel_case":"3"}""",
+        ),
+    )
+
+    checked.check(InteropJsonNameJ3("1", "2", "3"))
+    checked.check(InteropJsonNameK3("1", "2", "3"))
+  }
+
+  @Test fun `json names proto2`() {
+    val checked = InteropChecker(
+        protocMessage = InteropJsonNameP2.newBuilder()
+            .setA("1")
+            .setPublic("2")
+            .setCamelCase("3")
+            .build(),
+        canonicalJson = """{"one":"1","two":"2","three":"3"}""",
+        alternateJsons = listOf(
+            """{"a":"1","public":"2","camel_case":"3"}""",
+        ),
+    )
+
+    checked.check(InteropJsonNameJ2("1", "2", "3"))
+    checked.check(InteropJsonNameK2("1", "2", "3"))
   }
 }
 


### PR DESCRIPTION
fixes #1756 

from `descriptor.proto`

```protobuf
  // JSON name of this field. The value is set by protocol compiler. If the
  // user has set a "json_name" option on this field, that option's value
  // will be used. Otherwise, it's deduced from the field's name by converting
  // it to camelCase.
  optional string json_name = 10;
```

> it's deduced from the field's name by converting it to camelCase.

That's what happening for proto2 which Wire will want to support as well in follow up.