### PR TITLE
Use a compiler option to prevent crashes executing in Gradle

### DIFF
--- a/wire-library/build.gradle
+++ b/wire-library/build.gradle
@@ -48,6 +48,8 @@ subprojects { project ->
   tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
     kotlinOptions {
       jvmTarget = "1.8"
+      // Disable optimized callable references. See https://youtrack.jetbrains.com/issue/KT-37435
+      freeCompilerArgs += "-Xno-optimized-callable-references"
     }
   }
 


### PR DESCRIPTION
It was crashing like this:

```
java.lang.NoSuchMethodError: 'void kotlin.jvm.internal.FunctionReferenceImpl.<init>(int, java.lang.Object, java.lang.Class, java.lang.String, java.lang.String, int)'
        at com.squareup.wire.kotlin.KotlinGenerator.<init>(KotlinGenerator.kt)
        at com.squareup.wire.kotlin.KotlinGenerator.redactFun(KotlinGenerator.kt:1244)
        at com.squareup.wire.kotlin.KotlinGenerator.addAdapter(KotlinGenerator.kt:1052)
```

See https://youtrack.jetbrains.com/issue/KT-37435