### PR TITLE
Add a ProtoAdapter extension to decode NSData

### DIFF
--- a/wire-library/wire-runtime/build.gradle
+++ b/wire-library/wire-runtime/build.gradle
@@ -63,12 +63,18 @@ kotlin {
     nativeTest {
       dependsOn commonTest
     }
+    darwinMain {
+      dependsOn commonMain
+    }
 
     configure([iosX64Main, iosArm64Main, linuxX64Main, macosX64Main]) {
       dependsOn nativeMain
     }
     configure([iosX64Test, iosArm64Test, linuxX64Test, macosX64Test]) {
       dependsOn nativeTest
+    }
+    configure([iosX64Main, iosArm64Main, macosX64Main]) {
+      dependsOn darwinMain
     }
   }
 }

--- a/wire-library/wire-runtime/src/darwinMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/darwinMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.posix.memcpy
+
+/**
+ * Read an encoded message from `data`.
+ *
+ * Note: this method is marked with [ExperimentalUnsignedTypes] annotation and requires an opt-in
+ * (e.g. through `@OptIn(ExperimentalUnsignedTypes::class)` to be used.
+ *
+ * @throws IllegalArgumentException if `data.length` is larger than [Int.MAX_VALUE].
+ */
+@ExperimentalUnsignedTypes
+fun <E> ProtoAdapter<E>.decode(data: NSData): E {
+  require(data.length <= Int.MAX_VALUE.toULong()) {
+    "Can't decode data with length ${data.length}, maximum length is ${Int.MAX_VALUE}."
+  }
+  val bytes = ByteArray(data.length.toInt()).apply {
+    usePinned { pinned ->
+      memcpy(pinned.addressOf(0), data.bytes, data.length)
+    }
+  }
+  return decode(bytes)
+}

--- a/wire-library/wire-tests/build.gradle
+++ b/wire-library/wire-tests/build.gradle
@@ -91,12 +91,18 @@ kotlin {
     nativeTest {
       dependsOn commonTest
     }
+    darwinTest {
+      dependsOn commonTest
+    }
 
     configure([iosX64Main, iosArm64Main, linuxX64Main, macosX64Main]) {
       dependsOn nativeMain
     }
     configure([iosX64Test, iosArm64Test, linuxX64Test, macosX64Test]) {
       dependsOn nativeTest
+    }
+    configure([iosX64Test, iosArm64Test, macosX64Test]) {
+      dependsOn darwinTest
     }
     all {
       languageSettings {

--- a/wire-library/wire-tests/src/darwinTest/kotlin/com/squareup/wire/DarwinProtoAdapterTest.kt
+++ b/wire-library/wire-tests/src/darwinTest/kotlin/com/squareup/wire/DarwinProtoAdapterTest.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.wire.protos.kotlin.person.Person
+import com.squareup.wire.protos.kotlin.person.Person.PhoneNumber
+import com.squareup.wire.protos.kotlin.person.Person.PhoneType.WORK
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import platform.Foundation.NSData
+import platform.Foundation.create
+
+class DarwinProtoAdapterTest {
+  @Test fun decodeNSData() {
+    val expected = Person(
+        name = "Alice",
+        id = 1,
+        phone = listOf(PhoneNumber(number = "+15551234567", type = WORK)),
+        email = "alice@squareup.com"
+    )
+    val data = NSData.create(
+        base64Encoding = "CgVBbGljZRABGhJhbGljZUBzcXVhcmV1cC5jb20iEAoMKzE1NTUxMjM0NTY3EAI="
+    )!!
+    assertEquals(expected, Person.ADAPTER.decode(data))
+  }
+}


### PR DESCRIPTION
Upstreaming from [wire-multiplatform-demo](https://github.com/Egorand/wire-multiplatform-sample/blob/master/protos/src/iosMain/kotlin/com/squareup/util/Okio.kt).

Example usage:

https://github.com/Egorand/wire-multiplatform-sample/blob/d4485faf3156c75d8bce2541a03470ad59ba01d2/ios/Dinosaurs/Dinosaurs/Resource.swift#L47-L49

Implementation borrowed from https://github.com/JetBrains/kotlin-native/issues/3172.