### PR TITLE
Make WireTask cacheable

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -19,6 +19,7 @@ import com.squareup.wire.VERSION
 import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.Target
 import com.squareup.wire.schema.WireRun
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -27,6 +28,7 @@ import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
+@CacheableTask
 open class WireTask : SourceTask() {
   @get:OutputDirectories
   var outputDirectories: List<File>? = null


### PR DESCRIPTION
https://docs.gradle.org/current/userguide/build_cache.html#enable_caching_of_non_cacheable_tasks

fixes #1784 

Tested on our test module.
![image](https://user-images.githubusercontent.com/1767669/93907870-eb08bb00-fccb-11ea-86c9-59e214ebbc6b.png)
