### PR TITLE
Fix enum values in geology period sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,13 +58,13 @@ option java_package = "com.squareup.geology";
 
 enum Period {
   // 145.5 million years ago — 66.0 million years ago.
-  CRETACEOUS = 1;
+  CRETACEOUS = 0;
 
   // 201.3 million years ago — 145.0 million years ago.
-  JURASSIC = 2;
+  JURASSIC = 1;
 
   // 252.17 million years ago — 201.3 million years ago.
-  TRIASSIC = 3;
+  TRIASSIC = 2;
 }
 ```
 


### PR DESCRIPTION
Relates to #1394.

Using the current sample produces the following error:

```
* What went wrong:
Execution failed for task ':module:generateProtos'.
> missing a zero value at the first element [proto3]
    for enum squareup.geology.Period (module/src/main/proto/squareup/geology/period.proto:7:1)
```

The `wire/sample` module uses PB 2 producing no error on builds. You might want to change it to PB 3 or have two samples.