### PR TITLE
wire-compiler: support rpcRole and rpcCallStyle arguments

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -300,8 +300,8 @@ data class KotlinTarget(
         javaInterop = javaInterop,
         emitDeclaredOptions = emitDeclaredOptions,
         emitAppliedOptions = emitAppliedOptions,
+        rpcRole = rpcRole,
         rpcCallStyle = rpcCallStyle,
-        rpcRole = rpcRole
     )
 
     return object : SchemaHandler {

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.kt
@@ -15,6 +15,8 @@
  */
 package com.squareup.wire
 
+import com.squareup.wire.kotlin.RpcCallStyle
+import com.squareup.wire.kotlin.RpcRole
 import com.squareup.wire.schema.WireRun
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
@@ -120,6 +122,26 @@ class CommandLineOptionsTest {
 
     assertThat(compiler.modules).isEqualTo(
         mapOf("a" to WireRun.Module(), "b" to WireRun.Module(dependencies = setOf("a"))))
+  }
+  
+  @Test
+  fun rpcDefaultValues() {
+    val compiler = parseArgs("--kotlin_out=.")
+    assertThat(compiler.rpcRole).isEqualTo(RpcRole.CLIENT)
+    assertThat(compiler.rpcCallStyle).isEqualTo(RpcCallStyle.SUSPENDING)
+  }
+  
+  @Test
+  fun rpcRole() {
+    val compiler = parseArgs("--kotlin_out=.", "--rpcRole=server")
+    assertThat(compiler.rpcRole).isEqualTo(RpcRole.SERVER)
+  }
+  
+  @Test
+  fun rpcCallStyle() {
+    val compiler = parseArgs("--kotlin_out=.", "--rpcRole=client", "--rpcCallStyle=blocking")
+    assertThat(compiler.rpcRole).isEqualTo(RpcRole.CLIENT)
+    assertThat(compiler.rpcCallStyle).isEqualTo(RpcCallStyle.BLOCKING)
   }
 
   private fun parseArgs(vararg args: String) = WireCompiler.forArgs(args = *args)


### PR DESCRIPTION
The wire-compiler now accepts --rpcRole and --rpcCallStyle arguments.