### PR TITLE
Deduplicate check for common dependency

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/PartitionedSchema.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/PartitionedSchema.kt
@@ -87,11 +87,9 @@ internal fun Schema.partition(modules: Map<String, Module>): PartitionedSchema {
 
   val warnings = mutableListOf<String>()
   for (subgraph in moduleGraph.disjointGraphs()) {
-    for (currentName in subgraph) {
-      for (otherName in subgraph) {
-        if (otherName == currentName) {
-          break
-        }
+    val subgraphList = subgraph.toList()
+    for ((index, currentName) in subgraphList.withIndex()) {
+      for (otherName in subgraphList.drop(index + 1)) {
         val currentTypes = partitions.getValue(currentName).types
         val otherTypes = partitions.getValue(otherName).types
         val duplicates = currentTypes.intersect(otherTypes)


### PR DESCRIPTION
`Schema.partition` was running comparison twice for any given pair of modules `A` and `B`. As a result, any duplicate was reported twice (for `A, B` and `B, A` ordering), and computation was performed twice as well.

By using list with fixed ordering, we can skip half of comparisons, and avoid duplicated warnings.