### PR TITLE
Add compact flag to toSchema

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/EnumElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/EnumElement.kt
@@ -30,7 +30,7 @@ data class EnumElement(
   // Enums do not allow nested type declarations.
   override val nestedTypes: List<TypeElement> = emptyList()
 
-  override fun toSchema() = buildString {
+  override fun toSchema(compact: Boolean) = buildString {
     appendDocumentation(documentation)
     append("enum $name {")
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/MessageElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/MessageElement.kt
@@ -31,7 +31,7 @@ data class MessageElement(
   val extensions: List<ExtensionsElement> = emptyList(),
   val groups: List<GroupElement> = emptyList()
 ) : TypeElement {
-  override fun toSchema() = buildString {
+  override fun toSchema(compact: Boolean) = buildString {
     appendDocumentation(documentation)
     append("message $name {")
 
@@ -48,20 +48,35 @@ data class MessageElement(
       }
     }
     if (fields.isNotEmpty()) {
-      for (field in fields) {
+      if (compact) {
         append('\n')
+      }
+      for (field in fields) {
+        if (!compact) {
+          append('\n')
+        }
         appendIndented(field.toSchema())
       }
     }
     if (oneOfs.isNotEmpty()) {
-      for (oneOf in oneOfs) {
+      if (compact) {
         append('\n')
+      }
+      for (oneOf in oneOfs) {
+        if (!compact) {
+          append('\n')
+        }
         appendIndented(oneOf.toSchema())
       }
     }
     if (groups.isNotEmpty()) {
-      for (group in groups) {
+      if (compact) {
         append('\n')
+      }
+      for (group in groups) {
+        if (!compact) {
+          append('\n')
+        }
         appendIndented(group.toSchema())
       }
     }
@@ -72,8 +87,13 @@ data class MessageElement(
       }
     }
     if (nestedTypes.isNotEmpty()) {
-      for (type in nestedTypes) {
+      if (compact) {
         append('\n')
+      }
+      for (type in nestedTypes) {
+        if (!compact) {
+          append('\n')
+        }
         appendIndented(type.toSchema())
       }
     }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
@@ -31,7 +31,7 @@ data class ProtoFileElement(
   val extendDeclarations: List<ExtendElement> = emptyList(),
   val options: List<OptionElement> = emptyList()
 ) {
-  fun toSchema() = buildString {
+  fun toSchema(compact: Boolean = false) = buildString {
     append("// ")
     append(location.withPathOnly())
     append('\n')
@@ -58,20 +58,35 @@ data class ProtoFileElement(
       }
     }
     if (types.isNotEmpty()) {
-      for (typeElement in types) {
+      if (compact) {
         append('\n')
+      }
+      for (typeElement in types) {
+        if (!compact) {
+          append('\n')
+        }
         append(typeElement.toSchema())
       }
     }
     if (extendDeclarations.isNotEmpty()) {
-      for (extendDeclaration in extendDeclarations) {
+      if (compact) {
         append('\n')
+      }
+      for (extendDeclaration in extendDeclarations) {
+        if (!compact) {
+          append('\n')
+        }
         append(extendDeclaration.toSchema())
       }
     }
     if (services.isNotEmpty()) {
-      for (service in services) {
+      if (compact) {
         append('\n')
+      }
+      for (service in services) {
+        if (!compact) {
+          append('\n')
+        }
         append(service.toSchema())
       }
     }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/TypeElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/TypeElement.kt
@@ -24,5 +24,5 @@ interface TypeElement {
   val documentation: String
   val options: List<OptionElement>
   val nestedTypes: List<TypeElement>
-  fun toSchema(): String
+  fun toSchema(compact: Boolean = false): String
 }


### PR DESCRIPTION
A recent PR https://github.com/square/wire/pull/1615 changed the format of `toSchema`.  This is a breaking change for Confluent Schema Registry (https://github.com/confluentinc/schema-registry).   This PR allows a client to request the old format in a way that is backward compatible with the recent change.