### PR TITLE
Fix location filtering for windows

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
@@ -135,7 +135,7 @@ internal class WireInput(var configuration: Provider<Configuration>) {
   private fun File.toLocations(dependency: Dependency): List<Location> {
     if (dependency is FileCollectionDependency && dependency.files is SourceDirectorySet) {
       val srcDir = (dependency.files as SourceDirectorySet).srcDirs.first {
-        path.startsWith(it.path + "/")
+        path.startsWith(it.path + File.separator)
       }
       return listOf(Location.get(
           base = srcDir.path,


### PR DESCRIPTION
This should fix the `Collection contains no element matching the predicate.` error on windows described in https://github.com/square/wire/issues/1325#issuecomment-570569691

I believe imports across directories on windows will still not work because they also work based on file paths. Fixing that would require bigger changes in `wire-schema`.