### PR TITLE
Add option for how Swift ProtoDecoder handles unknown enum values

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
@@ -32,25 +32,23 @@ public final class ProtoDecoder {
 
     /// Determines the way in which Wire's Swift runtime library handles unknown enum values when decoding.
     public enum UnknownEnumValueDecodingStrategy {
-        /// Throws an error when encountering unknown enum values in single-value fields or arrays.
+        /// Throws an error when encountering unknown enum values in single-value fields or collections.
         case throwError
-        /// Defaults the unknown enum value to nil for single-value fields. With this option, unknown values in arrays are removed
-        /// from the array in which they originated in and added to an array for the same tag in unknown fields.
+        /// Defaults the unknown enum value to nil for single-value fields. With this option, unknown values in collections are removed
+        /// from the collection in which they originated and added to a collection for the same tag in unknown fields.
         case returnNil
     }
 
     public enum Error: Swift.Error, LocalizedError {
 
         case boxedValueMissingField(type: Any.Type)
-        case currentTagExpectedButNotFound
         case fieldKeyValueZero
         case invalidFieldWireType(_: UInt32)
-        case invalidPastBufferRead(requested: Int, actual: Int)
         case invalidStructure(message: String)
         case invalidUTF8StringData(_: Data)
         case malformedVarint
         case mapEntryWithoutKey(value: Any?)
-        case mapEntryWithoutValue(key: Any?)
+        case mapEntryWithoutValue(key: Any)
         case missingRequiredField(typeName: String, fieldName: String)
         case recursionLimitExceeded
         case unexpectedEndOfData
@@ -62,14 +60,10 @@ public final class ProtoDecoder {
 
         var localizedDescription: String {
             switch self {
-            case .currentTagExpectedButNotFound:
-                return "Performed an operation that expected an active tag, but none was found."
             case .fieldKeyValueZero:
                 return "Message field has a field number of zero, which is invalid."
             case let .invalidFieldWireType(value):
                 return "Field has an invalid wire type of \(value)."
-            case .invalidPastBufferRead(let requested, let actual):
-                return "A request (\(requested)) was made to the ReadBuffer that either exceeded the number of past reads (\(actual)) or returned no data."
             case let .invalidStructure(message):
                 return "Message structure is invalid: \(message)."
             case let .invalidUTF8StringData(data):
@@ -79,7 +73,7 @@ public final class ProtoDecoder {
             case let .mapEntryWithoutKey(value):
                 return "Map entry with value \(value ?? "") did not include a key."
             case let .mapEntryWithoutValue(key):
-                return "Map entry with \(key ?? "") did not include a value."
+                return "Map entry with \(key) did not include a value."
             case let .missingRequiredField(typeName, fieldName):
                 return "Required field \(fieldName) for type \(typeName) is not included in the message data."
             case let .boxedValueMissingField(type):
@@ -108,7 +102,7 @@ public final class ProtoDecoder {
 
     // MARK: - Private constants
 
-    private let enumDecodingStrategy: UnknownEnumValueDecodingStrategy
+    public private(set) var enumDecodingStrategy: UnknownEnumValueDecodingStrategy
 
     // MARK: - Initialization
 

--- a/wire-library/wire-runtime-swift/src/main/swift/ReadBuffer.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ReadBuffer.swift
@@ -43,7 +43,10 @@ final class ReadBuffer {
 
     // MARK: - Private Properties
 
-    fileprivate(set) var pointer: UnsafePointer<UInt8>
+    private(set) var pointer: UnsafePointer<UInt8>
+
+    // track the distances we've advanced the pointer for each read
+    private(set) var previousPointerOffsets: [Int] = []
 
     // MARK: - Initialization
 
@@ -73,16 +76,46 @@ final class ReadBuffer {
         }
     }
 
+    /// Advances the current pointer by the given byte offset. All internal mutation of the pointer should
+    /// use this method through this method so our reads can be tracked.
+    /// - Parameter by:The number of bytes to advance the pointer
+    /// - Returns: A pointer to new position.
+    func advancePointer(by: Int) {
+        previousPointerOffsets.append(by)
+        pointer = pointer.advanced(by: by)
+    }
+
+    /// Returns a Data instance representative of the last n reads that we've done. This is useful when
+    /// we've gone past one or more fields that did not validate, and need to retrieve associated data
+    /// for further processing. Example: When a dictionary has an unknown enum for a value, we must retrieve
+    /// the key to place in unknown fields.
+    /// - Parameter numPastReads:The number of previous reads to include in the historical data.
+    /// - Returns: All of the data that was read in the past given number of reads. NB: we do not store
+    ///            the data with each read, just the offsets. Therefore the data returned is the data present
+    ///            in the buffer at the time of the request.
+    func getDataFromPastReads(numPastReads: Int) throws -> Data {
+        let lastOffsets = previousPointerOffsets.suffix(numPastReads)
+        let totalBytes = lastOffsets.reduce(0) { $0 + $1 }
+        guard totalBytes > 0 && totalBytes <= pointer - start  else {
+            throw ProtoDecoder.Error.invalidPastBufferRead(
+                requested: numPastReads,
+                actual: previousPointerOffsets.count
+            )
+        }
+
+        let backwardsPointer = pointer.advanced(by: -totalBytes)
+        return Data(bytes: backwardsPointer, count: totalBytes)
+    }
 }
 
 extension ReadBuffer {
 
-    // MARK: - Reading
+    // MARK: - Readings
 
     func readBuffer(count: Int) throws -> UnsafeRawBufferPointer {
         try verifyAdditional(count: count)
         let buffer = UnsafeRawBufferPointer(start: pointer, count: count)
-        pointer = pointer.advanced(by: count)
+        advancePointer(by: count)
 
         return buffer
     }
@@ -90,7 +123,7 @@ extension ReadBuffer {
     func readData(count: Int) throws -> Data {
         try verifyAdditional(count: count)
         let data = Data(bytes: pointer, count: count)
-        pointer = pointer.advanced(by: count)
+        advancePointer(by: count)
 
         return data
     }
@@ -101,7 +134,7 @@ extension ReadBuffer {
         withUnsafeMutableBytes(of: &value) { dest -> Void in
             dest.copyMemory(from: UnsafeRawBufferPointer(start: pointer, count: 4))
         }
-        pointer = pointer.advanced(by: 4)
+        advancePointer(by: 4)
 
         return UInt32(littleEndian: value)
     }
@@ -125,7 +158,7 @@ extension ReadBuffer {
         var result: UInt32 = 0
         while shift < 32 {
             let byte = pointer.pointee
-            pointer = pointer.advanced(by: 1)
+            advancePointer(by: 1)
 
             result |= UInt32(byte & 0x7f) << shift
             if byte < 0x80 {


### PR DESCRIPTION
Currently, the Swift runtime library for Wire throws an error any time it encounters an unknown value in an enum field. While this was a purposeful design choice, early design discussions suggested offering a second approach as a configuration option: convert unknown enum values to nil.

This PR adds that option, but still uses `throw` as the default behavior. Here's how enums are handled in various scenarios when using the new `returnNil` decoding strategy:

* For single-value enum fields, the field is set to nil and the value is added to unknown fields.
* For collections such as arrays/maps -- the value (or the key/value pair in the case of maps) are removed and added to unknown fields.