### PR TITLE
Enum Decoding Strategy bug fix

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
@@ -125,7 +125,7 @@ public final class ProtoDecoder {
                 storage: baseAddress.bindMemory(to: UInt8.self, capacity: buffer.count),
                 count: buffer.count
             )
-            let reader = ProtoReader(buffer: readBuffer)
+            let reader = ProtoReader(buffer: readBuffer, enumDecodingStrategy: enumDecodingStrategy)
             value = try reader.decode(type)
         }
 


### PR DESCRIPTION
Passing the ProtoDecoder's enum decoding strategy to the ProtoReade to handle unknown enums.