### PR TITLE
Adds a redacting moshi json adapter

### DIFF
--- a/wire-library/dependencies.gradle
+++ b/wire-library/dependencies.gradle
@@ -11,7 +11,7 @@ ext.versions = [
   'kotlin': '1.4.10',
   'okio': '2.8.0',
   'okhttp': '4.2.2',
-  'moshi': '1.10.0',
+  'moshi': '1.11.0',
   'protobuf': '3.13.0',
   'protobufGradlePlugin': '0.8.13',
   'junit': '4.12',

--- a/wire-library/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.kt
+++ b/wire-library/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.kt
@@ -42,7 +42,11 @@ internal class MessageTypeAdapter<M : Message<M, B>, B : Message.Builder<M, B>>(
   @Throws(IOException::class)
   override fun write(out: JsonWriter, message: M?) {
     out.beginObject()
-    messageAdapter.writeAllFields(message, jsonAdapters) { name, value, jsonAdapter ->
+    messageAdapter.writeAllFields(
+        message = message,
+        jsonAdapters = jsonAdapters,
+        redactedFieldsAdapter = null
+    ) { name, value, jsonAdapter ->
       out.name(name)
       jsonAdapter.write(out, value)
     }

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/RedactingJsonAdapter.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/RedactingJsonAdapter.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.moshi.JsonAdapter
+import com.squareup.moshi.JsonReader
+import com.squareup.moshi.JsonWriter
+
+fun <T> JsonAdapter<T>.redacting(): JsonAdapter<T> {
+  val delegate = this
+  return object : JsonAdapter<T>() {
+    override fun fromJson(reader: JsonReader): T? {
+      return delegate.fromJson(reader)
+    }
+
+    override fun toJson(writer: JsonWriter, value: T?) {
+      var redactedTag = writer.tag(RedactedTag::class.java)
+      if (redactedTag == null) {
+        redactedTag = RedactedTag()
+        writer.setTag(RedactedTag::class.java, redactedTag)
+      }
+      val wasRedacted = redactedTag.enabled
+      redactedTag.enabled = true
+      try {
+        delegate.toJson(writer, value)
+      } finally {
+        redactedTag.enabled = wasRedacted
+      }
+    }
+  }
+}
+
+internal class RedactedTag {
+  var enabled = false
+}

--- a/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
+++ b/wire-library/wire-moshi-adapter/src/main/java/com/squareup/wire/WireJsonAdapterFactory.kt
@@ -77,7 +77,9 @@ class WireJsonAdapterFactory private constructor(
       Message::class.java.isAssignableFrom(rawType) -> {
         val messageAdapter = RuntimeMessageAdapter.create<Nothing, Nothing>(type as Class<Nothing>)
         val jsonAdapters = messageAdapter.jsonAdapters(MoshiJsonIntegration, moshi)
-        MessageJsonAdapter(messageAdapter, jsonAdapters).nullSafe()
+        val redactedFieldsAdapter = moshi.adapter<List<String>>(
+            Types.newParameterizedType(List::class.java, String::class.java))
+        MessageJsonAdapter(messageAdapter, jsonAdapters, redactedFieldsAdapter).nullSafe()
       }
       WireEnum::class.java.isAssignableFrom(rawType) -> {
         val enumAdapter = RuntimeEnumAdapter.create(type as Class<Nothing>)

--- a/wire-library/wire-tests/jvm.gradle
+++ b/wire-library/wire-tests/jvm.gradle
@@ -92,7 +92,10 @@ kotlin.targets.matching { it.platformType.name == 'jvm' }.all { target ->
       jsonKotlinTestImplementation deps.assertj
       jsonKotlinTestImplementation deps.jimfs
 
+      jvmJavaTestImplementation project(':wire-moshi-adapter')
       jvmJavaTestImplementation deps.kotlin.reflect
+      jvmJavaTestImplementation deps.moshi
+      jvmJavaTestImplementation deps.moshiKotlin
     }
   }
 

--- a/wire-library/wire-tests/src/jvmJavaTest/java/com/squareup/wire/MoshiRedactedTest.kt
+++ b/wire-library/wire-tests/src/jvmJavaTest/java/com/squareup/wire/MoshiRedactedTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import com.squareup.moshi.Moshi
+import com.squareup.wire.protos.redacted.NotRedacted
+import com.squareup.wire.protos.redacted.RedactedChild
+import com.squareup.wire.protos.redacted.RedactedFields
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class MoshiRedactedTest {
+  @Test fun nonRedacted() {
+    val redacted = RedactedFields.Builder().a("a").b("b").c("c").build()
+    val jsonAdapter = moshi.adapter(RedactedFields::class.java)
+    assertThat(jsonAdapter.toJson(redacted)).isEqualTo("""{"a":"a","b":"b","c":"c"}""")
+  }
+
+  @Test fun redacted() {
+    val redacted = RedactedFields.Builder().a("a").b("b").c("c").build()
+    val jsonAdapter = moshi.adapter(RedactedFields::class.java).redacting()
+    assertThat(jsonAdapter.toJson(redacted))
+        .isEqualTo("""{"b":"b","c":"c","__redacted_fields":["a"]}""")
+  }
+
+  @Test fun redactedButSkipped() {
+    val redacted = RedactedFields.Builder().b("b").c("c").build()
+    val jsonAdapter = moshi.adapter(RedactedFields::class.java).redacting()
+    assertThat(jsonAdapter.toJson(redacted)).isEqualTo("""{"b":"b","c":"c"}""")
+  }
+
+  @Test fun redactedChild() {
+    val redacted = RedactedChild.Builder()
+        .a("a")
+        .b(RedactedFields.Builder()
+            .a("a")
+            .b("b")
+            .c("c")
+            .build()
+        ).c(NotRedacted.Builder()
+            .a("a")
+            .b("b")
+            .build()
+        ).build()
+
+    val jsonAdapter = moshi.adapter(RedactedChild::class.java).redacting()
+    assertThat(jsonAdapter.toJson(redacted)).isEqualTo(
+        """{"a":"a","b":{"b":"b","c":"c","__redacted_fields":["a"]},"c":{"a":"a","b":"b"}}"""
+    )
+  }
+
+  companion object {
+    private val moshi = Moshi.Builder()
+        .add(WireJsonAdapterFactory())
+        .build()
+  }
+}
+


### PR DESCRIPTION
This commit introduces the ability to create a redacting moshi adapter
which will redact fields when converting to json and include each field
redacted in a `__redacted_fields` list of names in the outputted json for
consumers to use.