### PR TITLE
Use WireOutput for task property

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -22,6 +22,9 @@ import com.squareup.wire.schema.JavaTarget
 import com.squareup.wire.schema.KotlinTarget
 import com.squareup.wire.schema.ProtoTarget
 import com.squareup.wire.schema.Target
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity.RELATIVE
+import java.io.Serializable
 import javax.inject.Inject
 
 /**
@@ -29,8 +32,9 @@ import javax.inject.Inject
  * as destination directories and configuration options). This includes registering output
  * directories with the project so they can be compiled after they are generated.
  */
-abstract class WireOutput {
+abstract class WireOutput : Serializable {
   /** This will be set to a non-null value before [toTarget] is invoked. */
+  @get:PathSensitive(RELATIVE)
   var out: String? = null
 
   /** Create a target for the WireCompiler to use when emitting sources. */

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -152,7 +152,6 @@ class WirePlugin : Plugin<Project> {
         protoInput.addPaths(project, extension.protoPaths)
       }
 
-      val targets = outputs.map { it.toTarget() }
       val task =
           project.tasks.register("generate${source.name.capitalize()}Protos",
               WireTask::class.java) { task: WireTask ->
@@ -174,7 +173,7 @@ class WirePlugin : Plugin<Project> {
             task.untilVersion = extension.untilVersion
             task.onlyVersion = extension.onlyVersion
             task.rules = extension.rules
-            task.targets = targets
+            task.outputs.set(outputs)
             task.permitPackageCycles = extension.permitPackageCycles
           }
 


### PR DESCRIPTION
Resolves #1859 by using WireOutput for the `WireTask` property and normalizing its path. I need to double check if `String` is valid for path normalizing though