### PR TITLE
Updating workflows for brew cask is dead

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Chrome
         run: |
           brew update
-          brew cask install google-chrome
+          brew install google-chrome
 
       - name: Test
         run: |


### PR DESCRIPTION
```
Error: Calling brew cask install is disabled! Use brew install [--cask] instead.
Error: Process completed with exit code 1.
```