### PR TITLE
Explicitly set xcode version on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,6 +69,10 @@ jobs:
           brew update
           brew install google-chrome
 
+      # See https://github.com/square/wire/issues/1875
+      - name: Use Xcode 12.0 for swift tests
+        run: sudo xcode-select -switch "/Applications/Xcode_12.app"
+
       - name: Test
         run: |
           ./gradlew -p wire-library build


### PR DESCRIPTION
It seems that Xcode has been updated to 12.2 on github workflows which doesn't include 10.15 SDK so we explicitly go back to 12.2.

Fixes #1875 