### PR TITLE
New protoLibrary option for the Gradle plugin

### DIFF
--- a/wire-library/docs/wire_compiler.md
+++ b/wire-library/docs/wire_compiler.md
@@ -292,6 +292,21 @@ wire {
 }
 ```
 
+### Proto Libraries
+
+By default, `.proto` input files are not included in the generated `.jar` artifact. Use the
+`protoLibrary` option to include them:
+
+```groovy
+wire {
+  protoLibrary = true
+}
+```
+
+This is most useful when building `.jar` files for other `wire` tasks to use as dependencies. Note
+that only the true sources are included – proto messages that are pruned or not used are not
+included in the output artifact.
+
 Customizing Output
 ------------------
 
@@ -415,6 +430,47 @@ wire {
 }
 ```
 
+### Custom Handlers
+
+Wire has an unstable API to generate code or other artifacts from a proto schema.
+
+You'll need to implement the [CustomHandlerBeta] interface. See our [MarkdownHandler] for a sample
+implementation. Note that this interface is subject to change.
+
+Build that into an `jar` artifact and add that as a buildscript dependency to your Gradle project.
+
+```groovy
+buildscript {
+  dependencies {
+    classpath "com.example.my-custom-handler:my-custom-handler:1.0.0"
+  }
+}
+```
+
+Next configure the Wire plugin to call your custom handler. Here's an exhaustive custom
+configuration. Booleans and enums are shown with their non-default behavior.
+
+```groovy
+wire {
+  custom {
+   // The name of a Java class to generate code with. This class must:
+   //  * be in the buildscript dependencies for this Gradle project
+   //  * be a public class
+   //  * have a public no-arguments constructor
+   //  * implement the com.squareup.wire.schema.CustomHandlerBeta interface
+   customHandlerClass = "com.example.MyCustomHandler"
+
+   // These options work the same as the java and kotlin targets above.
+   includes = ['com.example.pizza.*']
+   excludes = ['com.example.sales.*']
+   exclusive = false
+   out "${buildDir}/custom"
+  }
+}
+```
+
+ [CustomHandlerBeta]: https://github.com/square/wire/blob/5fac94f86879fdd7e412cddbeb51e09a708b2b64/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt#L583-L596
+ [MarkdownHandler]: https://github.com/square/wire/blob/ebacb88b1c487a7e7d97ff3729c67907e1f95616/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/MarkdownHandler.kt
  [gradle]: https://gradle.org/
  [kotlinpoet]: https://github.com/square/kotlinpoet
  [maven_coordinates]: https://maven.apache.org/pom.html#Maven_Coordinates

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
@@ -115,6 +115,17 @@ open class WireExtension(project: Project) {
   @get:Input
   val outputs = mutableListOf<WireOutput>()
 
+  /**
+   * True to emit `.proto` files into the output resources. Use this when your `.jar` file can be
+   * used as a library for other proto or Wire projects.
+   *
+   * Note that only the `.proto` files used in the library will be included, and these files will
+   * have tree-shaking applied.
+   */
+  @get:Input
+  @get:Optional
+  var protoLibrary = false
+
   @InputFiles
   @Optional
   fun getSourcePaths() = sourcePaths.toSet()

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
@@ -17,16 +17,17 @@ package com.squareup.wire.gradle
 
 import com.squareup.wire.gradle.WireExtension.ProtoRootSet
 import com.squareup.wire.schema.Location
+import java.io.File
+import java.net.URI
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.artifacts.Dependency
+import org.gradle.api.artifacts.DependencySet
 import org.gradle.api.artifacts.FileCollectionDependency
 import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.internal.file.FileOrUriNotationConverter
 import org.gradle.api.logging.Logger
 import org.gradle.api.provider.Provider
-import java.io.File
-import java.net.URI
 
 /**
  * Builds Wire's inputs (expressed as [Location] lists) from Gradle's objects (expressed as
@@ -38,6 +39,9 @@ internal class WireInput(var configuration: Provider<Configuration>) {
     get() = configuration.get().name
 
   private val dependencyToIncludes = mutableMapOf<Dependency, List<String>>()
+
+  val dependencies: DependencySet
+    get() = configuration.get().dependencies
 
   fun addPaths(project: Project, paths: Set<String>) {
     for (path in paths) {

--- a/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/build.gradle
@@ -1,0 +1,8 @@
+allprojects {
+  repositories {
+    maven {
+      url "file://${project.rootProject.projectDir}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/dinosaurs/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/dinosaurs/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+  id 'com.squareup.wire'
+  id 'org.jetbrains.kotlin.jvm'
+}
+
+dependencies {
+  protoPath project(":geology")
+}
+
+wire {
+  kotlin {
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/dinosaurs/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/dinosaurs/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/geology/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/geology/build.gradle
@@ -1,0 +1,11 @@
+plugins {
+  id 'com.squareup.wire'
+  id 'org.jetbrains.kotlin.jvm'
+}
+
+wire {
+  protoLibrary = true
+
+  kotlin {
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/geology/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/geology/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/settings.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/project-dependencies/settings.gradle
@@ -1,0 +1,2 @@
+include ':dinosaurs'
+include ':geology'

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
@@ -32,14 +32,15 @@ data class ProtoFileElement(
   val options: List<OptionElement> = emptyList()
 ) {
   fun toSchema() = buildString {
-    append("// ")
-    append(location.withPathOnly())
-    append('\n')
+    append("// Proto schema formatted by Wire, do not edit.\n")
+    append("// Source: ${location.withPathOnly()}\n")
 
     if (syntax != null) {
+      append('\n')
       append("syntax = \"$syntax\";\n")
     }
     if (packageName != null) {
+      append('\n')
       append("package $packageName;\n")
     }
     if (imports.isNotEmpty() || publicImports.isNotEmpty()) {

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/ProtoFileTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/ProtoFileTest.kt
@@ -90,7 +90,9 @@ class ProtoFileTest {
     val file = ProtoFile.get(fileElement)
 
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |
         |package example.simple;
         |
         |import "example.thing";

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/TypeMoverTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/TypeMoverTest.kt
@@ -69,8 +69,11 @@ class TypeMoverTest {
     ).move()
 
     assertThat(newSchema.protoFile("cafe/cafe.proto")!!.toSchema()).isEqualTo("""
-        |// cafe/cafe.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: cafe/cafe.proto
+        |
         |syntax = "proto2";
+        |
         |package cafe;
         |
         |import "cafe/espresso.proto";
@@ -83,8 +86,11 @@ class TypeMoverTest {
         |""".trimMargin()
     )
     assertThat(newSchema.protoFile("cafe/espresso.proto")!!.toSchema()).isEqualTo("""
-        |// cafe/espresso.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: cafe/espresso.proto
+        |
         |syntax = "proto2";
+        |
         |package cafe;
         |
         |import "cafe/roast.proto";
@@ -136,8 +142,11 @@ class TypeMoverTest {
     ).move()
 
     assertThat(newSchema.protoFile("cafe/cafe.proto")!!.toSchema()).isEqualTo("""
-        |// cafe/cafe.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: cafe/cafe.proto
+        |
         |syntax = "proto2";
+        |
         |package cafe;
         |
         |import "cafe/roast.proto";
@@ -150,8 +159,11 @@ class TypeMoverTest {
         |""".trimMargin()
     )
     assertThat(newSchema.protoFile("cafe/roast.proto")!!.toSchema()).isEqualTo("""
-        |// cafe/roast.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: cafe/roast.proto
+        |
         |syntax = "proto2";
+        |
         |package cafe;
         |
         |enum Roast {
@@ -198,13 +210,17 @@ class TypeMoverTest {
     ).move()
 
     assertThat(newSchema.protoFile("abc.proto")!!.toSchema()).isEqualTo("""
-        |// abc.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: abc.proto
+        |
         |syntax = "proto2";
         |""".trimMargin()
     )
 
     assertThat(newSchema.protoFile("a.proto")!!.toSchema()).isEqualTo("""
-        |// a.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: a.proto
+        |
         |syntax = "proto2";
         |
         |import "b.proto";
@@ -219,7 +235,9 @@ class TypeMoverTest {
     )
 
     assertThat(newSchema.protoFile("b.proto")!!.toSchema()).isEqualTo("""
-        |// b.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: b.proto
+        |
         |syntax = "proto2";
         |
         |import "c.proto";
@@ -231,7 +249,9 @@ class TypeMoverTest {
     )
 
     assertThat(newSchema.protoFile("c.proto")!!.toSchema()).isEqualTo("""
-        |// c.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: c.proto
+        |
         |syntax = "proto2";
         |
         |message C {}
@@ -266,7 +286,9 @@ class TypeMoverTest {
     ).move()
 
     assertThat(newSchema.protoFile("abc.proto")!!.toSchema()).isEqualTo("""
-        |// abc.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: abc.proto
+        |
         |syntax = "proto2";
         |
         |import "a.proto";
@@ -309,7 +331,9 @@ class TypeMoverTest {
     ).move()
 
     assertThat(newSchema.protoFile("b.proto")!!.toSchema()).isEqualTo("""
-        |// b.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: b.proto
+        |
         |syntax = "proto2";
         |
         |import "a.proto";
@@ -320,7 +344,9 @@ class TypeMoverTest {
         |""".trimMargin()
     )
     assertThat(newSchema.protoFile("a.proto")!!.toSchema()).isEqualTo("""
-        |// a.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: a.proto
+        |
         |syntax = "proto2";
         |
         |message B {}
@@ -353,7 +379,9 @@ class TypeMoverTest {
     ).move()
 
     assertThat(newSchema.protoFile("a.proto")!!.toSchema()).isEqualTo("""
-        |// a.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: a.proto
+        |
         |syntax = "proto2";
         |
         |import "b.proto";

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElementTest.kt
@@ -30,7 +30,10 @@ class ProtoFileElementTest {
   @Test
   fun emptyToSchema() {
     val file = ProtoFileElement(location = location)
-    val expected = "// file.proto\n"
+    val expected = """
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |""".trimMargin()
     assertThat(file.toSchema()).isEqualTo(expected)
   }
 
@@ -41,7 +44,9 @@ class ProtoFileElementTest {
         packageName = "example.simple"
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |
         |package example.simple;
         |""".trimMargin()
     assertThat(file.toSchema()).isEqualTo(expected)
@@ -58,7 +63,8 @@ class ProtoFileElementTest {
         types = listOf(element)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
         |
         |message Message {}
         |""".trimMargin()
@@ -77,7 +83,8 @@ class ProtoFileElementTest {
         types = listOf(element)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
         |
         |import "example.other";
         |
@@ -112,7 +119,8 @@ class ProtoFileElementTest {
         types = listOf(element)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
         |
         |import public "example.other";
         |
@@ -146,7 +154,8 @@ class ProtoFileElementTest {
         types = listOf(element)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
         |
         |import "example.thing";
         |import public "example.other";
@@ -172,7 +181,8 @@ class ProtoFileElementTest {
         services = listOf(service)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
         |
         |message Message {}
         |
@@ -211,7 +221,8 @@ class ProtoFileElementTest {
         types = listOf(element)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
         |
         |option kit = "kat";
         |
@@ -244,7 +255,8 @@ class ProtoFileElementTest {
         types = listOf(MessageElement(location = location, name = "Message"))
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
         |
         |message Message {}
         |
@@ -266,18 +278,18 @@ class ProtoFileElementTest {
 
   @Test
   fun multipleEverythingToSchema() {
-    val element1 = MessageElement(location = location.at(10, 1), name = "Message1")
-    val element2 = MessageElement(location = location.at(12, 1), name = "Message2")
-    val extend1 = ExtendElement(location = location.at(14, 1), name = "Extend1")
-    val extend2 = ExtendElement(location = location.at(16, 1), name = "Extend2")
+    val element1 = MessageElement(location = location.at(12, 1), name = "Message1")
+    val element2 = MessageElement(location = location.at(14, 1), name = "Message2")
+    val extend1 = ExtendElement(location = location.at(16, 1), name = "Extend1")
+    val extend2 = ExtendElement(location = location.at(18, 1), name = "Extend2")
     val option1 = OptionElement.create("kit", Kind.STRING, "kat")
     val option2 = OptionElement.create("foo", Kind.STRING, "bar")
     val service1 = ServiceElement(
-        location = location.at(18, 1),
+        location = location.at(20, 1),
         name = "Service1"
     )
     val service2 = ServiceElement(
-        location = location.at(20, 1),
+        location = location.at(22, 1),
         name = "Service2"
     )
     val file = ProtoFileElement(
@@ -291,7 +303,9 @@ class ProtoFileElementTest {
         options = listOf(option1, option2)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |
         |package example.simple;
         |
         |import "example.thing";
@@ -328,7 +342,9 @@ class ProtoFileElementTest {
         types = listOf(element)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |
         |syntax = "proto2";
         |
         |message Message {}
@@ -339,7 +355,7 @@ class ProtoFileElementTest {
   @Test
   fun defaultIsSetInProto2() {
     val field = FieldElement(
-        location = location.at(9, 3),
+        location = location.at(12, 3),
         label = Field.Label.REQUIRED,
         type = "string",
         name = "name",
@@ -347,7 +363,7 @@ class ProtoFileElementTest {
         defaultValue = "defaultValue"
     )
     val message =
-        MessageElement(location = location.at(8, 1), name = "Message", fields = listOf(field))
+        MessageElement(location = location.at(11, 1), name = "Message", fields = listOf(field))
     val file = ProtoFileElement(
         syntax = PROTO_2,
         location = location,
@@ -357,8 +373,11 @@ class ProtoFileElementTest {
         types = listOf(message)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |
         |syntax = "proto2";
+        |
         |package example.simple;
         |
         |import "example.thing";
@@ -378,14 +397,14 @@ class ProtoFileElementTest {
   @Test
   fun convertPackedOptionFromWireSchemaInProto2() {
     val fieldNumeric = FieldElement(
-        location = location.at(6, 3),
+        location = location.at(9, 3),
         label = Field.Label.REPEATED,
         type = "int32",
         name = "numeric_without_packed_option",
         tag = 1
     )
     val fieldNumericPackedTrue = FieldElement(
-        location = location.at(8, 3),
+        location = location.at(11, 3),
         label = Field.Label.REPEATED,
         type = "int32",
         name = "numeric_packed_true",
@@ -393,7 +412,7 @@ class ProtoFileElementTest {
         options = listOf(PACKED_OPTION_ELEMENT)
     )
     val fieldNumericPackedFalse = FieldElement(
-        location = location.at(10, 3),
+        location = location.at(13, 3),
         label = Field.Label.REPEATED,
         type = "int32",
         name = "numeric_packed_false",
@@ -401,14 +420,14 @@ class ProtoFileElementTest {
         options = listOf(PACKED_OPTION_ELEMENT.copy(value = "false"))
     )
     val fieldString = FieldElement(
-        location = location.at(12, 3),
+        location = location.at(15, 3),
         label = Field.Label.REPEATED,
         type = "string",
         name = "string_without_packed_option",
         tag = 4
     )
     val fieldStringPackedTrue = FieldElement(
-        location = location.at(14, 3),
+        location = location.at(17, 3),
         label = Field.Label.REPEATED,
         type = "string",
         name = "string_packed_true",
@@ -416,7 +435,7 @@ class ProtoFileElementTest {
         options = listOf(PACKED_OPTION_ELEMENT)
     )
     val fieldStringPackedFalse = FieldElement(
-        location = location.at(16, 3),
+        location = location.at(19, 3),
         label = Field.Label.REPEATED,
         type = "string",
         name = "string_packed_false",
@@ -425,7 +444,7 @@ class ProtoFileElementTest {
     )
 
     val message = MessageElement(
-        location = location.at(5, 1),
+        location = location.at(8, 1),
         name = "Message",
         fields = listOf(fieldNumeric, fieldNumericPackedTrue, fieldNumericPackedFalse, fieldString,
             fieldStringPackedTrue, fieldStringPackedFalse))
@@ -438,8 +457,11 @@ class ProtoFileElementTest {
         types = listOf(message)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |
         |syntax = "proto2";
+        |
         |package example.simple;
         |
         |message Message {
@@ -466,14 +488,14 @@ class ProtoFileElementTest {
   @Test
   fun convertPackedOptionFromWireSchemaInProto3() {
     val fieldNumeric = FieldElement(
-        location = location.at(6, 3),
+        location = location.at(9, 3),
         label = Field.Label.REPEATED,
         type = "int32",
         name = "numeric_without_packed_option",
         tag = 1
     )
     val fieldNumericPackedTrue = FieldElement(
-        location = location.at(8, 3),
+        location = location.at(11, 3),
         label = Field.Label.REPEATED,
         type = "int32",
         name = "numeric_packed_true",
@@ -481,7 +503,7 @@ class ProtoFileElementTest {
         options = listOf(PACKED_OPTION_ELEMENT)
     )
     val fieldNumericPackedFalse = FieldElement(
-        location = location.at(10, 3),
+        location = location.at(13, 3),
         label = Field.Label.REPEATED,
         type = "int32",
         name = "numeric_packed_false",
@@ -489,14 +511,14 @@ class ProtoFileElementTest {
         options = listOf(PACKED_OPTION_ELEMENT.copy(value = "false"))
     )
     val fieldString = FieldElement(
-        location = location.at(12, 3),
+        location = location.at(15, 3),
         label = Field.Label.REPEATED,
         type = "string",
         name = "string_without_packed_option",
         tag = 4
     )
     val fieldStringPackedTrue = FieldElement(
-        location = location.at(14, 3),
+        location = location.at(17, 3),
         label = Field.Label.REPEATED,
         type = "string",
         name = "string_packed_true",
@@ -504,7 +526,7 @@ class ProtoFileElementTest {
         options = listOf(PACKED_OPTION_ELEMENT)
     )
     val fieldStringPackedFalse = FieldElement(
-        location = location.at(16, 3),
+        location = location.at(19, 3),
         label = Field.Label.REPEATED,
         type = "string",
         name = "string_packed_false",
@@ -513,7 +535,7 @@ class ProtoFileElementTest {
     )
 
     val message = MessageElement(
-        location = location.at(5, 1),
+        location = location.at(8, 1),
         name = "Message",
         fields = listOf(fieldNumeric, fieldNumericPackedTrue, fieldNumericPackedFalse, fieldString,
             fieldStringPackedTrue, fieldStringPackedFalse)
@@ -527,8 +549,11 @@ class ProtoFileElementTest {
         types = listOf(message)
     )
     val expected = """
-        |// file.proto
+        |// Proto schema formatted by Wire, do not edit.
+        |// Source: file.proto
+        |
         |syntax = "proto3";
+        |
         |package example.simple;
         |
         |message Message {


### PR DESCRIPTION
Configuring a project as a protoLibrary will cause the generated
.jar file to include .proto sources.

Also automatically add a dependency when a protoPath or protoSource
depends on a project.

Also make protoPath and protoSource dependencies transitive by default.