### PR TITLE
Configure task lazily

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -198,7 +198,9 @@ class WirePlugin : Plugin<Project> {
         it.dependsOn(task)
       }
       if (extension.protoLibrary) {
-        tasks.getByName("processResources").dependsOn(task)
+        project.tasks.named("processResources").configure {
+          it.dependsOn(task)
+        }
       }
 
       source.registerTaskDependency(task)


### PR DESCRIPTION
Gradle's best practices recommend lazy task configuration to allow for configuration avoidance.  IIRC, the upcoming configuration caching feature depends on this practice.

https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:how_do_i_reference_a_task