### PR TITLE
Fixes a bad access crash that can occur in ProtoReader

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/ProtoReader.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ProtoReader.swift
@@ -127,10 +127,11 @@ public final class ProtoReader {
 
         state = .tag
 
-        messageStackIndex += 1
-        if messageStackIndex >= messageStackCapacity {
+        if messageStackIndex + 1 >= messageStackCapacity {
             expandMessageStack()
         }
+        
+        messageStackIndex += 1
 
         let frame = MessageFrame(
             isProto3: isProto3Message,


### PR DESCRIPTION
When using the ProtoReader to parse proto Data, if we need to expand the message stack from within `beginMessage`, we first increment the `messageStackIndex`. However, `expandMessageStack` expects that the `messageStackIndex` is the pre-expansion value. Therefore, it winds up moving too many instances of `MessageFrame` over to the expanded buffer, resulting in a EXC_BAD_ACCESS in some scenarios.

The change in this PR is to wait until after we call `messageStackIndex` to increment the `messageStackIndex`.