### PR TITLE
Fully support Optional Int64 and UInt64 for JSONString

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
@@ -25,13 +25,15 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
     public init(from decoder: Decoder) throws {
         switch T.self {
         case is Int64.Type:
-            self.wrappedValue = try decoder.decodeStringTo(Int64.self)
+            let container = try decoder.singleValueContainer()
+            self.wrappedValue = Int64(try container.decode(String.self))! as! T
         case is Optional<Int64>.Type:
-            self.wrappedValue = try decoder.decodeStringIfPresentTo(Int64.self)
+            self.wrappedValue = try decoder.decodeStringIfPresentToInt64()
         case is UInt64.Type:
-            self.wrappedValue = try decoder.decodeStringTo(UInt64.self)
+            let container = try decoder.singleValueContainer()
+            self.wrappedValue = UInt64(try container.decode(String.self))! as! T
         case is Optional<UInt64>.Type:
-            self.wrappedValue = try decoder.decodeStringIfPresentTo(UInt64.self)
+            self.wrappedValue = try decoder.decodeStringIfPresentToUInt64()
         case is [Int64].Type:
             var container = try decoder.unkeyedContainer()
             var array: [Int64] = []
@@ -80,19 +82,23 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
 }
 
 private extension Decoder {
-    func decodeStringTo<T, Integer: FixedWidthInteger>(_ type: Integer.Type) throws -> T {
-        let container = try singleValueContainer()
-        let value = try container.decode(String.self)
-        return Integer(value)! as! T
-    }
-
-    func decodeStringIfPresentTo<T, Integer: FixedWidthInteger>(_ type: Integer.Type) throws -> T {
+    func decodeStringIfPresentToInt64<T>() throws -> T {
         let container = try singleValueContainer()
         if container.decodeNil() {
-            return Optional<Integer>.none as! T
+            return Optional<Int64>.none as! T
         } else {
             let value = try container.decode(String.self)
-            return Integer(value)! as! T
+            return Int64(value)! as! T
+        }
+    }
+
+    func decodeStringIfPresentToUInt64<T>() throws -> T {
+        let container = try singleValueContainer()
+        if container.decodeNil() {
+            return Optional<UInt64>.none as! T
+        } else {
+            let value = try container.decode(String.self)
+            return UInt64(value)! as! T
         }
     }
 }

--- a/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
@@ -28,12 +28,12 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
             let container = try decoder.singleValueContainer()
             self.wrappedValue = Int64(try container.decode(String.self))! as! T
         case is Optional<Int64>.Type:
-            self.wrappedValue = try decoder.decodeStringIfPresentToInt64()
+            self.wrappedValue = try decoder.decodeStringIfPresentToInt64() as! T
         case is UInt64.Type:
             let container = try decoder.singleValueContainer()
             self.wrappedValue = UInt64(try container.decode(String.self))! as! T
         case is Optional<UInt64>.Type:
-            self.wrappedValue = try decoder.decodeStringIfPresentToUInt64()
+            self.wrappedValue = try decoder.decodeStringIfPresentToUInt64() as! T
         case is [Int64].Type:
             var container = try decoder.unkeyedContainer()
             var array: [Int64] = []
@@ -83,23 +83,23 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
 }
 
 private extension Decoder {
-    func decodeStringIfPresentToInt64<T>() throws -> T {
+    func decodeStringIfPresentToInt64() throws -> Int64? {
         let container = try singleValueContainer()
         if container.decodeNil() {
-            return Optional<Int64>.none as! T
+            return Optional<Int64>.none
         } else {
             let value = try container.decode(String.self)
-            return Int64(value)! as! T
+            return Int64(value)!
         }
     }
 
-    func decodeStringIfPresentToUInt64<T>() throws -> T {
+    func decodeStringIfPresentToUInt64() throws -> UInt64? {
         let container = try singleValueContainer()
         if container.decodeNil() {
-            return Optional<UInt64>.none as! T
+            return Optional<UInt64>.none
         } else {
             let value = try container.decode(String.self)
-            return UInt64(value)! as! T
+            return UInt64(value)!
         }
     }
 }

--- a/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
@@ -26,10 +26,18 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
         switch T.self {
         case is Int64.Type, is Optional<Int64>.Type:
             let container = try decoder.singleValueContainer()
-            self.wrappedValue = Int64(try container.decode(String.self))! as! T
+            if let value = try? container.decode(String.self) {
+                self.wrappedValue = Int64(value)! as! T
+            } else {
+                self.wrappedValue = Optional<Int64>.none as! T
+            }
         case is UInt64.Type, is Optional<UInt64>.Type:
             let container = try decoder.singleValueContainer()
-            self.wrappedValue = UInt64(try container.decode(String.self))! as! T
+            if let value = try? container.decode(String.self) {
+                self.wrappedValue = UInt64(value)! as! T
+            } else {
+                self.wrappedValue = Optional<UInt64>.none as! T
+            }
         case is [Int64].Type:
             var container = try decoder.unkeyedContainer()
             var array: [Int64] = []
@@ -66,7 +74,12 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
                 try container.encode(String(value))
             }
         default:
-            fatalError("Unsupported type \(T.self)")
+            if T.self is Optional<Int64>.Type || T.self is Optional<UInt64>.Type {
+                var container = encoder.singleValueContainer()
+                try container.encodeNil()
+            } else {
+                fatalError("Unsupported type \(T.self)")
+            }
         }
     }
 

--- a/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
@@ -54,6 +54,7 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
     }
 
     public func encode(to encoder: Encoder) throws {
+        /// First check to see if there is a non-nil value of the accepted types. Otherwise, allow only optionals of Int64 and UInt64.
         switch wrappedValue {
         case let value as Int64:
             try String(value).encode(to: encoder)

--- a/wire-library/wire-runtime-swift/src/test/swift/JSONStringTests.swift
+++ b/wire-library/wire-runtime-swift/src/test/swift/JSONStringTests.swift
@@ -28,6 +28,14 @@ final class JsonStringTests: XCTestCase {
         var c: [Int64]
         @JSONString
         var d: [UInt64]
+        @JSONString
+        var e: Int64?
+        @JSONString
+        var f: Int64?
+        @JSONString
+        var g: UInt64?
+        @JSONString
+        var h: UInt64?
     }
 
     func testSupportedTypes() throws {
@@ -35,25 +43,33 @@ final class JsonStringTests: XCTestCase {
             a: -12,
             b: 13,
             c: [-14],
-            d: [15]
+            d: [15],
+            e: -16,
+            f: nil,
+            g: 17,
+            h: nil
         )
         let expectedJson = """
         {\
         "a":"-12",\
         "b":"13",\
         "c":["-14"],\
-        "d":["15"]\
+        "d":["15"],\
+        "e":"-16",\
+        "f":null,\
+        "g":"17",\
+        "h":null\
         }
         """
 
         let encoder = JSONEncoder()
         encoder.outputFormatting = .sortedKeys // For deterministic output.
 
-        let jsonData = try! encoder.encode(expectedStruct)
+        let jsonData = try encoder.encode(expectedStruct)
         let actualJson = String(data: jsonData, encoding: .utf8)!
         XCTAssertEqual(expectedJson, actualJson)
 
-        let actualStruct = try! JSONDecoder().decode(SupportedTypes.self, from: jsonData)
+        let actualStruct = try JSONDecoder().decode(SupportedTypes.self, from: jsonData)
         XCTAssertEqual(expectedStruct, actualStruct)
     }
 }


### PR DESCRIPTION
> Test Case '-[Wire_iOS_Unit_Tests.PerformanceTests testLargeMessages]' measured [Time, seconds] average: 187.346, relative standard deviation: 2.415%, values: [195.824060, 190.312459, 181.115462, 189.611396, 185.115898, 184.345728, 193.289135, 186.988711, 183.481014, 183.372329], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "Local Baseline", baselineAverage: 184.580, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100

> Test Case '-[Wire_iOS_Unit_Tests.PerformanceTests testSmallMessages]' measured [Time, seconds] average: 0.908, relative standard deviation: 4.467%, values: [0.995099, 0.866084, 0.883802, 0.887528, 0.880648, 0.910776, 0.855597, 0.925192, 0.954589, 0.919320], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "Local Baseline", baselineAverage: 0.948, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100

> Test Case '-[Wire_iOS_Unit_Tests.PerformanceTests testVaryingMessageSizes]' measured [Time, seconds] average: 1.593, relative standard deviation: 3.746%, values: [1.578649, 1.531343, 1.544598, 1.598733, 1.565962, 1.726319, 1.557558, 1.684333, 1.580753, 1.561848], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "Local Baseline", baselineAverage: 1.685, maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100