### PR TITLE
Don't include all protos if we have a custom include

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
@@ -206,8 +206,11 @@ open class WireExtension(project: Project) {
       // map to SourceDirectorySet which does the work for us!
       val protoTree = objectFactory.sourceDirectorySet(name, "Wire proto sources for $name.")
       protoTree.srcDirs(protoRootSet.srcDirs)
-      protoTree.filter.include("**/*.proto")
-      protoTree.filter.include(protoRootSet.includes)
+      if (protoRootSet.includes.isEmpty()) {
+        protoTree.filter.include("**/*.proto")
+      } else {
+        protoTree.filter.include(protoRootSet.includes)
+      }
       sourceTrees.add(protoTree)
     }
 

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+mainClassName = 'com.squareup.dinosaurs.Sample'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+dependencies {
+  implementation "com.squareup.wire:wire-runtime-multiplatform:$VERSION_NAME"
+}
+
+wire {
+  sourcePath {
+    srcDir 'src/main/proto'
+    include 'squareup/**'
+  }
+  kotlin {}
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/java/com/squareup/dinosaurs/Sample.kt
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/java/com/squareup/dinosaurs/Sample.kt
@@ -1,0 +1,30 @@
+package com.squareup.dinosaurs
+
+import com.squareup.geology.Period
+import java.io.IOException
+import okio.ByteString.Companion.toByteString
+
+class Sample {
+  @Throws(IOException::class)
+  fun run() {
+    // Create an immutable value object with the Builder API.
+    val stegosaurus = Dinosaur(
+        name = "Stegosaurus",
+        period = Period.JURASSIC,
+        length_meters = 9.0,
+        mass_kilograms = 5_000.0,
+        picture_urls = listOf("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67")
+    )
+    // Encode that value to bytes, and print that as base64.
+    val stegosaurusEncoded = Dinosaur.ADAPTER.encode(stegosaurus)
+    println(stegosaurusEncoded.toByteString().base64())
+  }
+
+  companion object {
+    @Throws(IOException::class)
+    @JvmStatic
+    fun main(args: Array<String>) {
+      Sample().run()
+    }
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/proto/excluded/martian.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/proto/excluded/martian.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package excluded;
+
+option java_package = "com.excluded";
+
+message Martian {
+  optional string name = 1;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-include/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
I'm really surprised it hasn't been a problem since we released the plugin so my confidence level isn't that high.
But _tests don't lie_.

![image](https://user-images.githubusercontent.com/1767669/109831665-a9caee80-7c0d-11eb-89b2-0a96658767ef.png)
