### PR TITLE
Example of test for pruning with service declarations

### DIFF
--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-proto-with-grpc-prune/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-proto-with-grpc-prune/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  prune 'squareup.geology.Period'
+
+  // Non-service can be pruned
+  prune 'squareup.dinosaurs.MoreDinosaur'
+
+  // One of these pairs should work, neither of them does
+  prune 'squareup.dinosaurs.MyGuideClient'
+  prune 'squareup.dinosaurs.GrpcMyGuideClient'
+
+  prune 'com.squareup.dinosaurs.MyGuideClient'
+  prune 'com.squareup.dinosaurs.GrpcMyGuideClient'
+  proto {}
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-proto-with-grpc-prune/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-proto-with-grpc-prune/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,28 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}
+
+message MoreDinosaur {
+  string name = 1;
+}
+
+service MyGuide {
+  // A simple RPC.
+  rpc GetDinosaur(Dinosaur) returns (Dinosaur) {}
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-proto-with-grpc-prune/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-proto-with-grpc-prune/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
Service declarations auto-magically generate gRPC interfaces and clients by default (https://square.github.io/wire/wire_grpc/), but these do not appear to be easily pruned.  

Add case of adding a dumb service to the existing `dinosaur.proto` but the build.gradle config does not appear to be able to handle filtering 

```
prune 'squareup.dinosaurs.MyGuideClient'
prune 'squareup.dinosaurs.GrpcMyGuideClient'
```
Seems like it should be able to filter the output, but the below also does not do the filtering.
```
prune 'com.squareup.dinosaurs.MyGuideClient'
prune 'com.squareup.dinosaurs.GrpcMyGuideClient'
```
In another project (ignoreproto) I have copied and executed and it shows in the output

```
Unused element in treeShakingRubbish: squareup.dinosaurs.MyGuideClient
Unused element in treeShakingRubbish: squareup.dinosaurs.GrpcMyGuideClient
Unused element in treeShakingRubbish: com.squareup.dinosaurs.MyGuideClient
Unused element in treeShakingRubbish: com.squareup.dinosaurs.GrpcMyGuideClient
Writing com.squareup.dinosaurs.Dinosaur to /Users/sgaw/AndroidStudioProjects/ignoreproto/proto/build/generated/source/wire
Writing com.squareup.dinosaurs.MyGuideClient to /Users/sgaw/AndroidStudioProjects/ignoreproto/proto/build/generated/source/wire
Writing com.squareup.dinosaurs.GrpcMyGuideClient to /Users/sgaw/AndroidStudioProjects/ignoreproto/proto/build/generated/source/wire
```

`./gradle clean check` does not appear to execute the existing test cases in `:wire-library:wire-gradle-plugin`
I'm unclear how to test otherwise.

https://gradle.com/s/bosxusebdd6mk