### PR TITLE
Defer enforcement of source existence to execution time

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
@@ -44,7 +44,7 @@ internal class WireInput(var configuration: Provider<Configuration>) {
     get() = configuration.get().dependencies
 
   // Deferred dependency evaluation
-  val suspectFiles = mutableListOf<File>()
+  val inputFiles = mutableListOf<File>()
 
   fun addPaths(project: Project, paths: Set<String>) {
     for (path in paths) {
@@ -66,9 +66,7 @@ internal class WireInput(var configuration: Provider<Configuration>) {
   fun addTrees(project: Project, trees: Set<SourceDirectorySet>) {
     for (tree in trees) {
       tree.srcDirs.forEach {
-        if (!it.exists()) {
-          suspectFiles.add(it)
-        }
+        inputFiles.add(it)
       }
       val dependency = project.dependencies.create(tree)
       configuration.get().dependencies.add(dependency)
@@ -82,10 +80,7 @@ internal class WireInput(var configuration: Provider<Configuration>) {
 
     if (converted is File) {
       val file = if (!converted.isAbsolute) File(project.projectDir, converted.path) else converted
-
-      if (!file.exists()) {
-        suspectFiles.add(file)
-      }
+      inputFiles.add(file)
 
       return when {
         file.isDirectory -> project.dependencies.create(project.files(path))

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -148,6 +148,11 @@ class WirePlugin : Plugin<Project> {
     protoInput.addJars(project, extension.protoJars)
     protoInput.addPaths(project, extension.protoPaths)
 
+
+    val suspectFiles = mutableListOf<File>()
+    suspectFiles.addAll(sourceInput.suspectFiles)
+    suspectFiles.addAll(protoInput.suspectFiles)
+
     val targets = outputs.map { it.toTarget() }
 
     val projectDependencies = (sourceInput.dependencies + protoInput.dependencies)
@@ -188,6 +193,8 @@ class WirePlugin : Plugin<Project> {
         task.rules = extension.rules
         task.targets = targets
         task.permitPackageCycles = extension.permitPackageCycles
+
+        task.suspectFiles = suspectFiles
 
         for (projectDependency in projectDependencies) {
           task.dependsOn(projectDependency)

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -149,9 +149,9 @@ class WirePlugin : Plugin<Project> {
     protoInput.addPaths(project, extension.protoPaths)
 
 
-    val suspectFiles = mutableListOf<File>()
-    suspectFiles.addAll(sourceInput.suspectFiles)
-    suspectFiles.addAll(protoInput.suspectFiles)
+    val inputFiles = mutableListOf<File>()
+    inputFiles.addAll(sourceInput.inputFiles)
+    inputFiles.addAll(protoInput.inputFiles)
 
     val targets = outputs.map { it.toTarget() }
 
@@ -194,7 +194,7 @@ class WirePlugin : Plugin<Project> {
         task.targets = targets
         task.permitPackageCycles = extension.permitPackageCycles
 
-        task.suspectFiles = suspectFiles
+        task.inputFiles = inputFiles
 
         for (projectDependency in projectDependencies) {
           task.dependsOn(projectDependency)

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -80,7 +80,7 @@ open class WireTask : SourceTask() {
   var permitPackageCycles: Boolean = false
 
   @Input
-  lateinit var suspectFiles: List<File>
+  lateinit var inputFiles: List<File>
 
 
   @TaskAction
@@ -114,9 +114,7 @@ open class WireTask : SourceTask() {
       logger.debug("targets: $targets")
     }
 
-    // Second pass validate that input sources that did not exist at configuration time
-    // still do not exist after Gradle dependencies have been resolved.
-    suspectFiles.forEach {
+    inputFiles.forEach {
       check(it.exists()) {
         "Invalid path string: \"${it.path}\". Path does not exist."
       }

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -35,6 +35,7 @@ import java.io.File
 
 @CacheableTask
 open class WireTask : SourceTask() {
+
   @get:OutputDirectories
   var outputDirectories: List<File>? = null
 
@@ -78,6 +79,10 @@ open class WireTask : SourceTask() {
   @Input
   var permitPackageCycles: Boolean = false
 
+  @Input
+  lateinit var suspectFiles: List<File>
+
+
   @TaskAction
   fun generateWireFiles() {
     val includes = mutableListOf<String>()
@@ -107,6 +112,14 @@ open class WireTask : SourceTask() {
       logger.debug("prunes: $prunes")
       logger.debug("rules: $rules")
       logger.debug("targets: $targets")
+    }
+
+    // Second pass validate that input sources that did not exist at configuration time
+    // still do not exist after Gradle dependencies have been resolved.
+    suspectFiles.forEach {
+      check(it.exists()) {
+        "Invalid path string: \"${it.path}\". Path does not exist."
+      }
     }
 
     val wireRun = WireRun(

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -48,20 +48,38 @@ class WirePluginTest {
 
     assertThat(result.task(":generateProtos")).isNull()
     assertThat(result.output).contains(
-        """Invalid path string: "src/main/proto". Path does not exist."""
-    )
+            """
+            |Invalid path string: "src/main/proto".
+            |For individual files, use the following syntax:
+            |wire {
+            |  sourcePath {
+            |    srcDir 'dirPath'
+            |    include 'relativePath'
+            |  }
+            |}
+            """.trimMargin())
   }
 
   @Test
   fun sourcePathSrcDirDoesNotExist() {
     val fixtureRoot = File("src/test/projects/sourcepath-nonexistent-srcdir")
 
-    val result = gradleRunner.runFixture(fixtureRoot) { buildAndFail() }
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
 
-    assertThat(result.task(":generateProtos")).isNull()
-    assertThat(result.output).contains(
-        """Invalid path string: "src/main/proto". Path does not exist."""
-    )
+    assertThat(result.task(":generateMainProtos")).isNotNull
+    assertThat(result.output).contains("NO-SOURCE")
+  }
+
+  @Test
+  fun sourcePathBuildDir() {
+    val fixtureRoot = File("src/test/projects/sourcepath-build-dir")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+    assertThat(result.task(":copyProtos")).isNotNull
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+            .contains("Writing com.squareup.geology.Period")
+            .contains("src/test/projects/sourcepath-build-dir/build/generated/source/wire")
   }
 
   @Test

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-build-dir/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-build-dir/build.gradle
@@ -1,0 +1,26 @@
+plugins {
+  id 'application'
+  id 'com.squareup.wire'
+}
+
+final String OUTPUT_REPO_DIR = "$buildDir/src/main/proto/squareup"
+
+task copyProtos(type: Copy) {
+  from 'src/main/copydir/squareup'
+  include 'dinosaurs/*.proto'
+  include 'geology/*.proto'
+
+  into OUTPUT_REPO_DIR
+  fileMode = 0644
+  includeEmptyDirs false
+}
+
+afterEvaluate {
+  tasks.getByName('generateProtos').dependsOn copyProtos
+}
+
+wire {
+  sourcePath {
+    srcDir OUTPUT_REPO_DIR
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-build-dir/src/main/copydir/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-build-dir/src/main/copydir/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
The configuration state of the WireInput does a sanity check for whether or not specified source exists.

Unfortunately, this strictly enforces dependency checks rather than the expected lazy configuration.  Because the Wire plugin is using Gradle's tree filtering, by the time the WireTask executes, `WireTask.{sourceInput, protoInput}` have been filtered to only the ones that exist.

This PR passes the state of inputs that the strict enforcement would have asserted on to the task execution time, which is effectively is a lazy enforcement.

Note: this still does not resolve the case where the source directory exists and the `include` does not, but I am not sure this is handled before anyways.
