### PR TITLE
Support FieldOptions with a `.` qualified prefix

### DIFF
--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
@@ -149,6 +149,12 @@ class OptionsTest {
   }
 
   @Test
+  fun resolveFieldPathMatchesLeadingDotFirstSegment() {
+    assertThat(Options.resolveFieldPath(".a.b.c.d", setOf("a", "z", "y")))
+            .containsExactly("a", "b", "c", "d")
+  }
+
+  @Test
   fun resolveFieldPathMatchesFirstSegment() {
     assertThat(Options.resolveFieldPath("a.b.c.d", setOf("a", "z", "y")))
         .containsExactly("a", "b", "c", "d")


### PR DESCRIPTION
https://developers.google.com/protocol-buffers/docs/overview?hl=en#packages_and_name_resolution

The `.foo.bar.Baz` resolution described was not handled for FieldOptions.  Fields were able to resolve.