### PR TITLE
Support options in SchemaEncoder

### DIFF
--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/interop/interop_service.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/interop/interop_service.proto
@@ -26,7 +26,7 @@ service InteropService {
     option (method_option_one) = 789;
   }
 
-  rpc StreamingHello(stream HelloRequest) returns (stream HelloResponse) {}
+  rpc StreamingHello(stream HelloRequest) returns (stream HelloResponse);
 }
 
 message HelloRequest {


### PR DESCRIPTION
Currently it's fast and loose on supported option types. I'll follow
up with exhaustive tests for different options types and the corresponding
encodings they support. For now this is sufficient to get our tests
passing with options.