### PR TITLE
Don't generate @Nullable for .

### DIFF
--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -257,7 +257,7 @@ public final class JavaGenerator {
     this.memberToJavaName = ImmutableMap.copyOf(memberToJavaName);
     this.profile = profile;
     this.emitAndroid = emitAndroid;
-    this.emitAndroidAnnotations = emitAndroidAnnotations || emitAndroid;
+    this.emitAndroidAnnotations = emitAndroidAnnotations;
     this.emitCompact = emitCompact;
     this.emitDeclaredOptions = emitDeclaredOptions;
     this.emitAppliedOptions = emitAppliedOptions;

--- a/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -424,7 +424,6 @@ public final class JavaGeneratorTest {
         + "        tag = 1,\n"
         + "        adapter = \"com.squareup.wire.ProtoAdapter#STRING\"\n"
         + "    )\n"
-        + "    @Nullable\n"
         + "    public final String c;")
         .contains(""
         + "public static final Parcelable.Creator<B> CREATOR = AndroidMessage.newCreator(ADAPTER)");

--- a/wire-library/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-library/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -3,7 +3,6 @@
 package com.squareup.wire.protos.person;
 
 import android.os.Parcelable;
-import androidx.annotation.Nullable;
 import com.squareup.wire.AndroidMessage;
 import com.squareup.wire.Message;
 import com.squareup.wire.ProtoAdapter;
@@ -58,7 +57,6 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
-  @Nullable
   public final String email;
 
   /**
@@ -78,12 +76,12 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   )
   public final List<String> aliases;
 
-  public Person(String name, Integer id, @Nullable String email, List<PhoneNumber> phone,
+  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
       List<String> aliases) {
     this(name, id, email, phone, aliases, ByteString.EMPTY);
   }
 
-  public Person(String name, Integer id, @Nullable String email, List<PhoneNumber> phone,
+  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
       List<String> aliases, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
     this.name = name;
@@ -263,14 +261,13 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
         tag = 2,
         adapter = "com.squareup.wire.protos.person.Person$PhoneType#ADAPTER"
     )
-    @Nullable
     public final PhoneType type;
 
-    public PhoneNumber(String number, @Nullable PhoneType type) {
+    public PhoneNumber(String number, PhoneType type) {
       this(number, type, ByteString.EMPTY);
     }
 
-    public PhoneNumber(String number, @Nullable PhoneType type, ByteString unknownFields) {
+    public PhoneNumber(String number, PhoneType type, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.number = number;
       this.type = type;

--- a/wire-library/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-library/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -3,7 +3,6 @@
 package com.squareup.wire.protos.person;
 
 import android.os.Parcelable;
-import androidx.annotation.Nullable;
 import com.squareup.wire.AndroidMessage;
 import com.squareup.wire.EnumAdapter;
 import com.squareup.wire.FieldEncoding;
@@ -64,7 +63,6 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
-  @Nullable
   public final String email;
 
   /**
@@ -84,12 +82,12 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   )
   public final List<String> aliases;
 
-  public Person(String name, Integer id, @Nullable String email, List<PhoneNumber> phone,
+  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
       List<String> aliases) {
     this(name, id, email, phone, aliases, ByteString.EMPTY);
   }
 
-  public Person(String name, Integer id, @Nullable String email, List<PhoneNumber> phone,
+  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
       List<String> aliases, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
     this.name = name;
@@ -291,14 +289,13 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
         tag = 2,
         adapter = "com.squareup.wire.protos.person.Person$PhoneType#ADAPTER"
     )
-    @Nullable
     public final PhoneType type;
 
-    public PhoneNumber(String number, @Nullable PhoneType type) {
+    public PhoneNumber(String number, PhoneType type) {
       this(number, type, ByteString.EMPTY);
     }
 
-    public PhoneNumber(String number, @Nullable PhoneType type, ByteString unknownFields) {
+    public PhoneNumber(String number, PhoneType type, ByteString unknownFields) {
       super(ADAPTER, unknownFields);
       this.number = number;
       this.type = type;


### PR DESCRIPTION
For some reason, `emitAndroid` could override `emitAndroidAnnotations` when true.

Our API says
```kotlin
  /** True for emitted types to implement `android.os.Parcelable`. */
  val android: Boolean = false,

  /** True to enable the `androidx.annotation.Nullable` annotation where applicable. */
  val androidAnnotations: Boolean = false,
```