### PR TITLE
[WIP] redacted string member that is not optional

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1507,6 +1507,7 @@ class KotlinGenerator private constructor(
       return when {
         isRepeated -> CodeBlock.of("emptyList()")
         isMap -> CodeBlock.of("emptyMap()")
+        ProtoType.STRING == type -> CodeBlock.of("")
         else -> CodeBlock.of("null")
       }
     } else if (!type!!.isScalar && !type!!.isEnum) {

--- a/wire-library/wire-tests/src/commonTest/proto/kotlin/redacted_test.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/kotlin/redacted_test.proto
@@ -29,6 +29,8 @@ message RedactedFields {
   optional string a = 1 [(squareup.protos.kotlin.redacted_option.redacted) = true];
   optional string b = 2 [(squareup.protos.kotlin.redacted_option.redacted) = false];
   optional string c = 3;
+  string d = 4 [(squareup.protos.kotlin.redacted_option.redacted) = true];
+  string e = 5 [(squareup.protos.kotlin.redacted_option.redacted) = false];
   extensions 10 to 20;
 }
 


### PR DESCRIPTION
`string` members that are not optional with a FieldOption of `*.redacted = true` will cause a build error

Default the value to an empty string instead of null