### PR TITLE
Use the version from README.md in podspecs

### DIFF
--- a/Wire.podspec
+++ b/Wire.podspec
@@ -1,11 +1,15 @@
+require_relative 'wire-library/wire-runtime-swift/pod_helpers.rb'
+
 Pod::Spec.new do |s|
+  version = get_version
+
   s.name          = 'Wire'
-  s.version       = "#{ENV['POD_VERSION']}"
+  s.version       = version
   s.license       = { :type => 'apache2', :file => 'LICENSE.txt' }
   s.homepage      = 'https://github.com/square/wire'
   s.authors       = { 'Eric Firestone' => '@firetweet' }
   s.summary       = 'Protocol buffers runtime for Swift.'
-  s.source        = { :git => 'https://github.com/square/wire.git', :tag => "#{ENV['POD_VERSION']}" }
+  s.source        = { :git => 'https://github.com/square/wire.git', :tag => version }
   s.module_name   = 'Wire'
   s.swift_version = '5.0'
 

--- a/WireCompiler.podspec
+++ b/WireCompiler.podspec
@@ -1,11 +1,15 @@
+require_relative 'wire-library/wire-runtime-swift/pod_helpers.rb'
+
 Pod::Spec.new do |s|
+  version = get_version
+
   s.name          = 'WireCompiler'
-  s.version       = "#{ENV['POD_VERSION']}"
+  s.version       = version
   s.license       = { :type => 'apache2', :file => 'LICENSE.txt' }
   s.homepage      = 'https://github.com/square/wire'
   s.authors       = { 'Eric Firestone' => '@firetweet' }
   s.summary       = 'gRPC and protocol buffer compiler for Android, Kotlin, Java, and Swift.'
-  s.source        = { :git => 'https://github.com/square/wire.git', :tag => "#{ENV['POD_VERSION']}" }
+  s.source        = { :git => 'https://github.com/square/wire.git', :tag => version }
   s.module_name   = 'WireCompiler'
 
   s.prepare_command = <<-CMD

--- a/wire-library/wire-runtime-swift/pod_helpers.rb
+++ b/wire-library/wire-runtime-swift/pod_helpers.rb
@@ -1,0 +1,38 @@
+# Gets the version of the library to use
+def get_version
+  # If there's a manually specified version, then use that
+  return ENV['POD_VERSION'] unless ENV['POD_VERSION'].nil?
+
+  version_from_gradle = version_from_gradle()
+
+  # For development purposes (like with `pod gen`) we can use the version from Gradle directly.
+  return version_from_gradle unless is_publishing?
+
+  # When publishing, if this is a release version (not a snapshot), then we can use the Gradle version as well.
+  return version_from_gradle if is_release_version?(version_from_gradle)
+
+  error_message = "Must specify the POD_VERSION environment variable when publishing alpha builds. The alpha version should be based on #{version_from_gradle}."
+
+  # CocoaPods won't surface the exception string, so print it separately here.
+  puts error_message
+
+  raise error_message
+end
+
+
+private def git_root
+  `git rev-parse --show-toplevel`.strip
+end
+
+private def is_publishing?
+  ARGV.include?('trunk') && ARGV.include?('push')
+end
+
+private def is_release_version?(version)
+  version =~ /^[0-9.]+$/
+end
+
+private def version_from_gradle
+  properties_file = File.join(git_root, 'wire-library', 'gradle.properties')
+  File.read(properties_file).match(/^VERSION_NAME=([0-9.]+.*)$/).captures[0]
+end


### PR DESCRIPTION
Rather than having to specify this manually, we can read it from the README.