### PR TITLE
Fix up some quality of life things in the Wire Gradle Plugin

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireLogger.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireLogger.kt
@@ -28,5 +28,5 @@ interface WireLogger {
   fun artifact(outputPath: Path, kotlinFile: FileSpec)
   fun artifact(outputPath: Path, type: ProtoType, swiftFile: SwiftFileSpec)
   fun artifactSkipped(type: ProtoType)
-  fun info(message: String)
+  fun warn(message: String)
 }

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -282,20 +282,20 @@ data class WireRun(
 
     for (emittingRules in targetToEmittingRules.values) {
       if (emittingRules.unusedIncludes().isNotEmpty()) {
-        logger.info("""Unused includes in targets:
+        logger.warn("""Unused includes in targets:
             |  ${emittingRules.unusedIncludes().joinToString(separator = "\n  ")}
             """.trimMargin())
       }
 
       if (emittingRules.unusedExcludes().isNotEmpty()) {
-        logger.info("""Unused excludes in targets:
+        logger.warn("""Unused excludes in targets:
             |  ${emittingRules.unusedExcludes().joinToString(separator = "\n  ")}
             """.trimMargin())
       }
     }
 
     if (skippedForSyntax.isNotEmpty()) {
-      logger.info("""Skipped .proto files with unsupported syntax. Add this line to fix:
+      logger.warn("""Skipped .proto files with unsupported syntax. Add this line to fix:
           |  syntax = "proto2";
           |  ${skippedForSyntax.joinToString(separator = "\n  ") { it.toString() }}
           """.trimMargin())
@@ -323,11 +323,11 @@ data class WireRun(
     val prunedSchema = schema.prune(pruningRules)
 
     for (rule in pruningRules.unusedRoots()) {
-      logger.info("Unused element in treeShakingRoots: $rule")
+      logger.warn("Unused element in treeShakingRoots: $rule")
     }
 
     for (rule in pruningRules.unusedPrunes()) {
-      logger.info("Unused element in treeShakingRubbish: $rule")
+      logger.warn("Unused element in treeShakingRubbish: $rule")
     }
 
     return TypeMover(prunedSchema, moves).move()

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/StringWireLogger.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/StringWireLogger.kt
@@ -54,7 +54,7 @@ internal class StringWireLogger : WireLogger {
     buffer.append("skipped $type\n")
   }
 
-  @Synchronized override fun info(message: String) {
+  @Synchronized override fun warn(message: String) {
     if (!quiet) {
       buffer.append("$message\n")
     }

--- a/wire-library/wire-gradle-plugin/build.gradle.kts
+++ b/wire-library/wire-gradle-plugin/build.gradle.kts
@@ -16,6 +16,7 @@ gradlePlugin {
 dependencies {
   implementation(project(":wire-compiler"))
   implementation(project(":wire-kotlin-generator"))
+  implementation(deps.swiftpoet)
 
   compileOnly(gradleApi())
   implementation(deps.plugins.kotlin)

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -21,19 +21,19 @@ import com.squareup.wire.gradle.internal.targetDefaultOutputPath
 import com.squareup.wire.gradle.kotlin.sourceRoots
 import com.squareup.wire.schema.JavaTarget
 import com.squareup.wire.schema.KotlinTarget
-import java.io.File
-import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.artifacts.UnknownConfigurationException
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.SourceSetContainer
-import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.compile.JavaCompile
 import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
 import org.jetbrains.kotlin.gradle.plugin.KotlinPlatformType
 import org.jetbrains.kotlin.gradle.plugin.sources.DefaultKotlinSourceSet
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 
 class WirePlugin : Plugin<Project> {
   private val android = AtomicBoolean(false)
@@ -157,11 +157,28 @@ class WirePlugin : Plugin<Project> {
       .filterIsInstance<ProjectDependency>()
 
     val generatedSourcesDirectories = outputs.map { output -> File(output.out!!) }.toSet()
+
+    // Both the JavaCompile and KotlinCompile tasks might already have been configured by now. Even
+    // though we add the Wire output directories into the corresponding sourceSets, the compilation
+    // tasks won't know about them so we fix that here.
+    if (targets.any { it is JavaTarget }) {
+      project.tasks.matching { it.name == "compileJava" }.configureEach {
+        (it as JavaCompile).source(generatedSourcesDirectories)
+      }
+    }
+    if (targets.any { it is KotlinTarget || it is JavaTarget }) {
+      project.tasks.matching { it.name == "compileKotlin" }.configureEach {
+        // Note that [KotlinCompile.source] will process files but will ignore strings.
+        (it as KotlinCompile).source(generatedSourcesDirectories)
+      }
+    }
+
     val common = sources.singleOrNull { it.type == KotlinPlatformType.common }
     for (generatedSourcesDirectory in generatedSourcesDirectories) {
       common?.kotlinSourceDirectorySet
         ?.srcDir(generatedSourcesDirectory.toRelativeString(project.projectDir))
     }
+
     sources.forEach { source ->
       if (common == null) {
         // TODO: pair up generatedSourceDirectories with their targets so we can be precise.
@@ -216,14 +233,6 @@ class WirePlugin : Plugin<Project> {
       }
 
       source.registerTaskDependency(task)
-      for (output in outputs) {
-        // TODO(Benoit) Why do I need this?
-        if (output is JavaOutput && !android.get()) {
-          (project.tasks.named("compileJava") as TaskProvider<JavaCompile>).configure {
-            it.source(output.out!!)
-          }
-        }
-      }
     }
   }
 
@@ -236,10 +245,10 @@ class WirePlugin : Plugin<Project> {
     if (hasJavaOutput || hasKotlinOutput) {
       if (isMultiplatform) {
         val sourceSets =
-            project.extensions.getByType(KotlinMultiplatformExtension::class.java).sourceSets
+          project.extensions.getByType(KotlinMultiplatformExtension::class.java).sourceSets
         val sourceSet = (sourceSets.getByName("commonMain") as DefaultKotlinSourceSet)
         project.configurations.getByName(sourceSet.apiConfigurationName).dependencies.add(
-            project.dependencies.create("com.squareup.wire:wire-runtime-multiplatform:$VERSION")
+          project.dependencies.create("com.squareup.wire:wire-runtime-multiplatform:$VERSION")
         )
       } else {
         try {

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -16,9 +16,11 @@
 package com.squareup.wire.gradle
 
 import com.squareup.wire.VERSION
+import com.squareup.wire.gradle.internal.GradleWireLogger
 import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.Target
 import com.squareup.wire.schema.WireRun
+import java.io.File
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -31,7 +33,6 @@ import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
-import java.io.File
 
 @CacheableTask
 open class WireTask : SourceTask() {
@@ -137,7 +138,7 @@ open class WireTask : SourceTask() {
         File(target.outDirectory).deleteRecursively()
       }
     }
-    wireRun.execute()
+    wireRun.execute(logger = GradleWireLogger)
   }
 
   @InputFiles

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/internal/GradleWireLogger.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/internal/GradleWireLogger.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013 Square Inc.
+ * Copyright 2021 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,51 +13,39 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.squareup.wire
+package com.squareup.wire.gradle.internal
 
 import com.squareup.javapoet.JavaFile
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.wire.WireLogger
+import com.squareup.wire.gradle.WirePlugin
 import com.squareup.wire.schema.ProtoType
 import okio.Path
+import org.slf4j.LoggerFactory
 import io.outfoxx.swiftpoet.FileSpec as SwiftFileSpec
 
-internal class ConsoleWireLogger : WireLogger {
-  private var quiet: Boolean = false
+internal object GradleWireLogger : WireLogger {
+  private val slf4jLogger = LoggerFactory.getLogger(WirePlugin::class.java)
 
   override fun setQuiet(quiet: Boolean) {
-    this.quiet = quiet
   }
 
   override fun warn(message: String) {
-    if (!quiet) {
-      println(message)
-    }
+    slf4jLogger.warn(message)
   }
 
   override fun artifact(outputPath: Path, filePath: String) {
-    if (quiet) {
-      println(filePath)
-    } else {
-      println("Writing $filePath to $outputPath")
-    }
+    slf4jLogger.info("Writing $filePath to $outputPath")
   }
 
   override fun artifact(outputPath: Path, javaFile: JavaFile) {
-    if (quiet) {
-      println("${javaFile.packageName}.${javaFile.typeSpec.name}")
-    } else {
-      println("Writing ${javaFile.packageName}.${javaFile.typeSpec.name} to $outputPath")
-    }
+    slf4jLogger.info("Writing ${javaFile.packageName}.${javaFile.typeSpec.name} to $outputPath")
   }
 
   override fun artifact(outputPath: Path, kotlinFile: FileSpec) {
     val typeSpec = kotlinFile.members.first() as TypeSpec
-    if (quiet) {
-      println("${kotlinFile.packageName}.${typeSpec.name}")
-    } else {
-      println("Writing ${kotlinFile.packageName}.${typeSpec.name} to $outputPath")
-    }
+    slf4jLogger.info("Writing ${kotlinFile.packageName}.${typeSpec.name} to $outputPath")
   }
 
   override fun artifact(
@@ -65,14 +53,10 @@ internal class ConsoleWireLogger : WireLogger {
     type: ProtoType,
     swiftFile: SwiftFileSpec
   ) {
-    if (quiet) {
-      println(swiftFile.name)
-    } else {
-      println("Writing $type to $outputPath")
-    }
+    slf4jLogger.info("Writing $type to $outputPath")
   }
 
   override fun artifactSkipped(type: ProtoType) {
-    println("Skipping $type")
+    slf4jLogger.info("Skipping $type")
   }
 }

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -62,7 +62,8 @@ internal fun WirePlugin.sourceRoots(kotlin: Boolean, java: Boolean): List<Source
       type = KotlinPlatformType.jvm,
       name = "main",
       sourceSets = listOf("main"),
-      sourceDirectorySet = WireSourceDirectorySet.of(sourceSets.getByName("main").java),
+      kotlinSourceDirectorySet = null,
+      javaSourceDirectorySet = WireSourceDirectorySet.of(sourceSets.getByName("main").java),
       registerTaskDependency = { task ->
         project.tasks.named("compileJava").configure { it.dependsOn(task) }
       }
@@ -76,11 +77,13 @@ internal fun WirePlugin.sourceRoots(kotlin: Boolean, java: Boolean): List<Source
 
   // Kotlin project.
   val sourceSets = project.property("sourceSets") as SourceSetContainer
+  val main = sourceSets.getByName("main")
   return listOf(Source(
     type = KotlinPlatformType.jvm,
     name = "main",
     sourceSets = listOf("main"),
-    sourceDirectorySet = WireSourceDirectorySet.of(sourceSets.getByName("main").kotlin!!),
+    javaSourceDirectorySet = WireSourceDirectorySet.of(main.java),
+    kotlinSourceDirectorySet = WireSourceDirectorySet.of(main.kotlin!!),
     registerTaskDependency = { task ->
       project.tasks.named("compileKotlin").configure { it.dependsOn(task) }
     }
@@ -116,7 +119,8 @@ private fun KotlinMultiplatformExtension.sourceRoots(project: Project): List<Sou
           type = target.platformType,
           name = "${target.name}${compilation.name.capitalize()}",
           variantName = (compilation as? KotlinJvmAndroidCompilation)?.name,
-          sourceDirectorySet = WireSourceDirectorySet.of(compilation.defaultSourceSet.kotlin),
+          javaSourceDirectorySet = null,
+          kotlinSourceDirectorySet = WireSourceDirectorySet.of(compilation.defaultSourceSet.kotlin),
           sourceSets = compilation.allKotlinSourceSets.map { it.name },
           registerTaskDependency = { task ->
             (target as? KotlinNativeTarget)?.binaries?.forEach {
@@ -151,23 +155,26 @@ private fun BaseExtension.sourceRoots(project: Project, kotlin: Boolean): List<S
     } else null
 
   return variants.map { variant ->
-    val sourceDirectSet = if (kotlin) {
-      WireSourceDirectorySet.of(
-        sourceSets!![variant.name]
+    val kotlinSourceDirectSet = when {
+      kotlin -> {
+        val sourceDirectorySet = sourceSets!![variant.name]
           ?: throw IllegalStateException("Couldn't find ${variant.name} in $sourceSets")
-      )
-    } else {
-      WireSourceDirectorySet.of(
-        androidSourceSets!![variant.name]
-          ?: throw IllegalStateException("Couldn't find ${variant.name} in $sourceSets")
-      )
+        WireSourceDirectorySet.of(sourceDirectorySet)
+      }
+      else -> null
+    }
+    val androidSourceDirectorySet = androidSourceSets!![variant.name]
+    val javaSourceDirectorySet = when {
+      androidSourceDirectorySet != null -> WireSourceDirectorySet.of(androidSourceDirectorySet)
+      else -> null
     }
 
     Source(
       type = KotlinPlatformType.androidJvm,
       name = variant.name,
       variantName = variant.name,
-      sourceDirectorySet = sourceDirectSet,
+      javaSourceDirectorySet = javaSourceDirectorySet,
+      kotlinSourceDirectorySet = kotlinSourceDirectSet,
       sourceSets = variant.sourceSets.map { it.name },
       registerTaskDependency = { task ->
         // TODO: Lazy task configuration!!!
@@ -183,7 +190,8 @@ private fun BaseExtension.sourceRoots(project: Project, kotlin: Boolean): List<S
 
 internal data class Source(
   val type: KotlinPlatformType,
-  val sourceDirectorySet: WireSourceDirectorySet,
+  val kotlinSourceDirectorySet: WireSourceDirectorySet?,
+  val javaSourceDirectorySet: WireSourceDirectorySet?,
   val name: String,
   val variantName: String? = null,
   val sourceSets: List<String>,

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -58,16 +58,17 @@ internal fun WirePlugin.sourceRoots(kotlin: Boolean, java: Boolean): List<Source
   // Java project.
   if (!kotlin && java) {
     val sourceSets = project.property("sourceSets") as SourceSetContainer
-    return listOf(Source(
-      type = KotlinPlatformType.jvm,
-      name = "main",
-      sourceSets = listOf("main"),
-      kotlinSourceDirectorySet = null,
-      javaSourceDirectorySet = WireSourceDirectorySet.of(sourceSets.getByName("main").java),
-      registerTaskDependency = { task ->
-        project.tasks.named("compileJava").configure { it.dependsOn(task) }
-      }
-    ))
+    return listOf(
+      Source(
+        type = KotlinPlatformType.jvm,
+        kotlinSourceDirectorySet = null,
+        javaSourceDirectorySet = WireSourceDirectorySet.of(sourceSets.getByName("main").java),
+        name = "main",
+        registerTaskDependency = { task ->
+          project.tasks.named("compileJava").configure { it.dependsOn(task) }
+        }
+      )
+    )
   }
 
   // Android project.
@@ -78,16 +79,20 @@ internal fun WirePlugin.sourceRoots(kotlin: Boolean, java: Boolean): List<Source
   // Kotlin project.
   val sourceSets = project.property("sourceSets") as SourceSetContainer
   val main = sourceSets.getByName("main")
-  return listOf(Source(
-    type = KotlinPlatformType.jvm,
-    name = "main",
-    sourceSets = listOf("main"),
-    javaSourceDirectorySet = WireSourceDirectorySet.of(main.java),
-    kotlinSourceDirectorySet = WireSourceDirectorySet.of(main.kotlin!!),
-    registerTaskDependency = { task ->
-      project.tasks.named("compileKotlin").configure { it.dependsOn(task) }
-    }
-  ))
+  return listOf(
+    Source(
+      type = KotlinPlatformType.jvm,
+      kotlinSourceDirectorySet = WireSourceDirectorySet.of(main.kotlin!!),
+      javaSourceDirectorySet = WireSourceDirectorySet.of(main.java),
+      name = "main",
+      registerTaskDependency = { task ->
+        if (java) {
+          project.tasks.named("compileJava").configure { it.dependsOn(task) }
+        }
+        project.tasks.named("compileKotlin").configure { it.dependsOn(task) }
+      }
+    )
+  )
 }
 
 private fun KotlinMultiplatformExtension.sourceRoots(project: Project): List<Source> {
@@ -104,7 +109,6 @@ private fun KotlinMultiplatformExtension.sourceRoots(project: Project): List<Sou
             val compilation = target.compilations.single { it.name == source.name }
             return@map source.copy(
               name = "${target.name}${source.name.capitalize()}",
-              sourceSets = source.sourceSets.map { "${target.name}${it.capitalize()}" } + "commonMain",
               registerTaskDependency = { task ->
                 compilation.compileKotlinTask.dependsOn(task)
               }
@@ -117,11 +121,10 @@ private fun KotlinMultiplatformExtension.sourceRoots(project: Project): List<Sou
         }
         Source(
           type = target.platformType,
+          kotlinSourceDirectorySet = WireSourceDirectorySet.of(compilation.defaultSourceSet.kotlin),
+          javaSourceDirectorySet = null,
           name = "${target.name}${compilation.name.capitalize()}",
           variantName = (compilation as? KotlinJvmAndroidCompilation)?.name,
-          javaSourceDirectorySet = null,
-          kotlinSourceDirectorySet = WireSourceDirectorySet.of(compilation.defaultSourceSet.kotlin),
-          sourceSets = compilation.allKotlinSourceSets.map { it.name },
           registerTaskDependency = { task ->
             (target as? KotlinNativeTarget)?.binaries?.forEach {
               it.linkTask.dependsOn(task)
@@ -171,11 +174,10 @@ private fun BaseExtension.sourceRoots(project: Project, kotlin: Boolean): List<S
 
     Source(
       type = KotlinPlatformType.androidJvm,
+      kotlinSourceDirectorySet = kotlinSourceDirectSet,
+      javaSourceDirectorySet = javaSourceDirectorySet,
       name = variant.name,
       variantName = variant.name,
-      javaSourceDirectorySet = javaSourceDirectorySet,
-      kotlinSourceDirectorySet = kotlinSourceDirectSet,
-      sourceSets = variant.sourceSets.map { it.name },
       registerTaskDependency = { task ->
         // TODO: Lazy task configuration!!!
         variant.registerJavaGeneratingTask(task.get(), task.get().outputDirectories)
@@ -194,7 +196,6 @@ internal data class Source(
   val javaSourceDirectorySet: WireSourceDirectorySet?,
   val name: String,
   val variantName: String? = null,
-  val sourceSets: List<String>,
   val registerTaskDependency: (TaskProvider<WireTask>) -> Unit
 )
 
@@ -212,7 +213,7 @@ internal class WireSourceDirectorySet private constructor(
   }
 
   /** Adds the path to this set. */
-  fun srcDir(path: String): WireSourceDirectorySet {
+  fun srcDir(path: Any): WireSourceDirectorySet {
     sourceDirectorySet?.srcDir(path)
     androidSourceDirectorySet?.srcDir(path)
 

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -23,7 +23,7 @@ class WirePluginTest {
   fun setUp() {
     gradleRunner = GradleRunner.create()
         .withPluginClasspath()
-        .withArguments("generateProtos", "--stacktrace")
+        .withArguments("generateProtos", "--stacktrace", "--info")
   }
 
   @After
@@ -458,7 +458,7 @@ class WirePluginTest {
     val fixtureRoot = File("src/test/projects/java-project-java-protos")
 
     val result = gradleRunner.runFixture(fixtureRoot) {
-      withArguments("run", "--stacktrace").build()
+      withArguments("run", "--stacktrace", "--info").build()
     }
 
     assertThat(result.task(":generateMainProtos")).isNotNull
@@ -480,7 +480,7 @@ class WirePluginTest {
     val fixtureRoot = File("src/test/projects/java-project-kotlin-protos")
 
     val result = gradleRunner.runFixture(fixtureRoot) {
-      withArguments("run", "--stacktrace").build()
+      withArguments("run", "--stacktrace", "--info").build()
     }
 
     assertThat(result.task(":generateMainProtos")).isNotNull
@@ -502,7 +502,7 @@ class WirePluginTest {
     val fixtureRoot = File("src/test/projects/kotlin-project-java-protos")
 
     val result = gradleRunner.runFixture(fixtureRoot) {
-      withArguments("run", "--stacktrace").build()
+      withArguments("run", "--stacktrace", "--info").build()
     }
 
     assertThat(result.task(":generateMainProtos")).isNotNull
@@ -524,7 +524,7 @@ class WirePluginTest {
     val fixtureRoot = File("src/test/projects/kotlin-project-kotlin-protos")
 
     val result = gradleRunner.runFixture(fixtureRoot) {
-      withArguments("run", "--stacktrace").build()
+      withArguments("run", "--stacktrace", "--info").build()
     }
 
     assertThat(result.task(":generateMainProtos")).isNotNull
@@ -546,7 +546,7 @@ class WirePluginTest {
     val fixtureRoot = File("src/test/projects/sourcedir-include")
 
     val result = gradleRunner.runFixture(fixtureRoot) {
-      withArguments("run", "--stacktrace").build()
+      withArguments("run", "--stacktrace", "--info").build()
     }
 
     assertThat(result.task(":generateMainProtos")).isNotNull
@@ -781,7 +781,7 @@ class WirePluginTest {
 
     val result = gradleRunner.runFixture(fixtureRoot) {
       withArguments(
-          "assemble", "--stacktrace", "-Dkjs=$kmpJsEnabled", "-Dknative=$kmpNativeEnabled"
+          "assemble", "--stacktrace", "-Dkjs=$kmpJsEnabled", "-Dknative=$kmpNativeEnabled", "--info"
       ).build()
     }
 
@@ -952,7 +952,7 @@ class WirePluginTest {
     val fixtureRoot = File("src/test/projects/project-dependencies")
 
     val result = gradleRunner.runFixture(fixtureRoot) {
-      withArguments("generateMainProtos", "--stacktrace").build()
+      withArguments("generateMainProtos", "--stacktrace", "--info").build()
     }
 
     assertThat(result.task(":dinosaurs:generateMainProtos")?.outcome)


### PR DESCRIPTION
We weren't doing the right thing with generated .java files when the
Kotlin plugin was installed.

We were using println() for logging instead of hooking in standard
Gradle logging stuff.