### PR TITLE
Throwing an error when encountering an unexpected `ProtoReader.beginMessage` instead of calling `fatalError`.

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
@@ -49,9 +49,9 @@ public final class ProtoDecoder {
         case malformedVarint
         case mapEntryWithoutKey(value: Any?)
         case mapEntryWithoutValue(key: Any)
+        case messageWithoutLength
         case missingRequiredField(typeName: String, fieldName: String)
         case recursionLimitExceeded
-        case unexpectedCallToBeginMessage
         case unexpectedEndOfData
         case unexpectedEndGroupFieldNumber(expected: UInt32?, found: UInt32)
         case unexpectedFieldNumberInMap(_: UInt32)
@@ -75,6 +75,8 @@ public final class ProtoDecoder {
                 return "Map entry with value \(value ?? "") did not include a key."
             case let .mapEntryWithoutValue(key):
                 return "Map entry with \(key) did not include a value."
+            case .messageWithoutLength:
+                return "Attempting to decode a message without first decoding the length of that message."
             case let .missingRequiredField(typeName, fieldName):
                 return "Required field \(fieldName) for type \(typeName) is not included in the message data."
             case let .boxedValueMissingField(type):
@@ -97,8 +99,6 @@ public final class ProtoDecoder {
                 return "Unknown case with value \(fieldNumber) found for enum of type \(String(describing: type))."
             case let .unterminatedGroup(fieldNumber):
                 return "The group with field number \(fieldNumber) has no matching end-group key."
-            case .unexpectedCallToBeginMessage:
-                return "Unexpected call to beginMessage()."
             }
         }
     }

--- a/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ProtoDecoder.swift
@@ -51,6 +51,7 @@ public final class ProtoDecoder {
         case mapEntryWithoutValue(key: Any)
         case missingRequiredField(typeName: String, fieldName: String)
         case recursionLimitExceeded
+        case unexpectedCallToBeginMessage
         case unexpectedEndOfData
         case unexpectedEndGroupFieldNumber(expected: UInt32?, found: UInt32)
         case unexpectedFieldNumberInMap(_: UInt32)
@@ -96,6 +97,8 @@ public final class ProtoDecoder {
                 return "Unknown case with value \(fieldNumber) found for enum of type \(String(describing: type))."
             case let .unterminatedGroup(fieldNumber):
                 return "The group with field number \(fieldNumber) has no matching end-group key."
+            case .unexpectedCallToBeginMessage:
+                return "Unexpected call to beginMessage()."
             }
         }
     }

--- a/wire-library/wire-runtime-swift/src/main/swift/ProtoReader.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ProtoReader.swift
@@ -121,7 +121,7 @@ public final class ProtoReader {
      */
     public func beginMessage() throws -> Int {
         guard case let .lengthDelimited(length) = state else {
-            fatalError("Unexpected call to beginMessage()")
+            throw ProtoDecoder.Error.unexpectedCallToBeginMessage
         }
         if length == 0 {
             // Indicate that this is an empty message.

--- a/wire-library/wire-runtime-swift/src/main/swift/ProtoReader.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/ProtoReader.swift
@@ -121,7 +121,7 @@ public final class ProtoReader {
      */
     public func beginMessage() throws -> Int {
         guard case let .lengthDelimited(length) = state else {
-            throw ProtoDecoder.Error.unexpectedCallToBeginMessage
+            throw ProtoDecoder.Error.messageWithoutLength
         }
         if length == 0 {
             // Indicate that this is an empty message.


### PR DESCRIPTION
When developers attempt to decode invalid proto data, it's possible they'll hit a `fatalError` inside Wire's `ProtoReader`. Instead, we want to to allow them to catch the error and recover from it. This PR enables this by throwing an error in `ProtoReader.beginMessage` if `beginMessage` is called unexpectedly.