### PR TITLE
GrpcClient.Builder().minMessageToCompress()

### DIFF
--- a/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/GrpcMessageSink.kt
+++ b/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/GrpcMessageSink.kt
@@ -28,8 +28,9 @@ import okio.BufferedSink
  * @param callForCancel the HTTP call that can be canceled to signal abnormal termination.
  * @param grpcEncoding the content coding for the stream body.
  */
-class GrpcMessageSink<T : Any> constructor(
+class GrpcMessageSink<T : Any>(
   private val sink: BufferedSink,
+  private val minMessageToCompress: Long,
   private val messageAdapter: ProtoAdapter<T>,
   private val callForCancel: Call?,
   private val grpcEncoding: String
@@ -39,15 +40,23 @@ class GrpcMessageSink<T : Any> constructor(
     check(!closed) { "closed" }
 
     val encodedMessage = Buffer()
-    grpcEncoding.toGrpcEncoder().encode(encodedMessage).use(BufferedSink::close) { encodingSink ->
-      messageAdapter.encode(encodingSink, message)
+    messageAdapter.encode(encodedMessage, message)
+
+    if (grpcEncoding == "identity" || encodedMessage.size < minMessageToCompress) {
+      sink.writeByte(0) // 0 = Not encoded.
+      sink.writeInt(encodedMessage.size.toInt())
+      sink.writeAll(encodedMessage)
+    } else {
+      val compressedMessage = Buffer()
+      grpcEncoding.toGrpcEncoder().encode(compressedMessage).use(BufferedSink::close) { sink ->
+        sink.writeAll(encodedMessage)
+      }
+      sink.writeByte(1) // 1 = Compressed.
+      sink.writeInt(compressedMessage.size.toInt())
+      sink.writeAll(compressedMessage)
     }
 
-    val compressedFlag = if (grpcEncoding == "identity") 0 else 1
-    sink.writeByte(compressedFlag)
     // TODO: fail if the message size is more than MAX_INT
-    sink.writeInt(encodedMessage.size.toInt())
-    sink.writeAll(encodedMessage)
     sink.flush()
   }
 

--- a/wire-library/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcCall.kt
+++ b/wire-library/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcCall.kt
@@ -125,7 +125,11 @@ internal class RealGrpcCall<S : Any, R : Any>(
   private fun initCall(request: S): Call {
     check(this.call == null) { "already executed" }
 
-    val requestBody = newRequestBody(method.requestAdapter, request)
+    val requestBody = newRequestBody(
+      minMessageToCompress = grpcClient.minMessageToCompress,
+      requestAdapter = method.requestAdapter,
+      onlyMessage = request
+    )
     val result = grpcClient.newCall(method, requestBody)
     this.call = result
     if (canceled) result.cancel()

--- a/wire-library/wire-grpc-mockwebserver/src/main/java/com/squareup/wire/mockwebserver/GrpcDispatcher.kt
+++ b/wire-library/wire-grpc-mockwebserver/src/main/java/com/squareup/wire/mockwebserver/GrpcDispatcher.kt
@@ -22,6 +22,7 @@ import com.squareup.wire.ProtoAdapter
 import com.squareup.wire.Service
 import com.squareup.wire.internal.GrpcMessageSink
 import com.squareup.wire.internal.GrpcMessageSource
+import java.lang.reflect.Method
 import okhttp3.Call
 import okhttp3.Callback
 import okhttp3.Headers.Companion.headersOf
@@ -31,7 +32,6 @@ import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.RecordedRequest
 import okio.Buffer
 import okio.Timeout
-import java.lang.reflect.Method
 
 /**
  * Serves gRPC calls using MockWebServer over HTTP/2.
@@ -166,10 +166,11 @@ class GrpcDispatcher(
   ): Buffer {
     val result = Buffer()
     GrpcMessageSink(
-        sink = result,
-        messageAdapter = protoAdapter,
-        callForCancel = null,
-        grpcEncoding = "identity"
+      sink = result,
+      minMessageToCompress = 0L,
+      messageAdapter = protoAdapter,
+      callForCancel = null,
+      grpcEncoding = "identity",
     ).use {
       it.write(response)
     }


### PR DESCRIPTION
This allows users to have more control over our compression settings.
It's currently compress-everything, but only compressing messages
of a certain size is more efficient.

For interop with some GRPC servers that don't have compression,
using Long.MAX_VALUE to disable compression is useful.

Closes: https://github.com/square/wire/issues/1948