### PR TITLE
Add base64 encoded ReflectionResponse interop tests

### DIFF
--- a/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
@@ -18,7 +18,7 @@ object versions {
   val okio = "3.0.0-alpha.3"
   val okhttp = "4.2.2"
   val moshi = "1.11.0"
-  val protobuf = "3.13.0"
+  val protobuf = "3.14.0"
   val protobufGradlePlugin = "0.8.13"
   val junit = "4.12"
   val assertj = "3.11.0"

--- a/wire-library/wire-reflector/build.gradle.kts
+++ b/wire-library/wire-reflector/build.gradle.kts
@@ -11,8 +11,9 @@ kotlin {
     val jvmMain by getting {
       kotlin.srcDir("$buildDir/wire")
       dependencies {
-        api(project(":wire-runtime"))
+        api(project(":wire-compiler"))
         api(project(":wire-grpc-client"))
+        api(project(":wire-runtime"))
         api(project(":wire-schema"))
         implementation(deps.okio.jvm)
         api(deps.guava)

--- a/wire-library/wire-reflector/src/jvmTest/kotlin/com/squareup/wire/reflector/GrpcurlProto2InteropTest.kt
+++ b/wire-library/wire-reflector/src/jvmTest/kotlin/com/squareup/wire/reflector/GrpcurlProto2InteropTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.reflector
+
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.Schema
+import com.squareup.wire.schema.SchemaLoader
+import grpc.reflection.v1alpha.ServerReflectionRequest
+import grpc.reflection.v1alpha.ServerReflectionResponse
+import okio.ByteString.Companion.decodeBase64
+import okio.FileSystem
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
+import org.junit.Test
+
+// Reference golang reflection tests https://github.com/juliaogris/reflect
+internal class GrpcurlProto2InteropTest {
+  @Test
+  fun `list services`() {
+    val schema = loadSchema()
+    // See golden test file https://github.com/juliaogris/reflect/blob/v0.0.7/testdata/proto2-base64/TestServicesCmd.base64
+    val respBase64 = "Cgtsb2NhbGhvc3Q6MBIPCgtsb2NhbGhvc3Q6MDoAMjoKDAoKZWNobzIuRWNobwoqCihncnBjLnJlZmxlY3Rpb24udjFhbHBoYS5TZXJ2ZXJSZWZsZWN0aW9u=="
+    val expectedResponse = ServerReflectionResponse.ADAPTER.decode(respBase64.decodeBase64()!!)
+    assertThat(
+      SchemaReflector(schema).process(
+        ServerReflectionRequest(
+          list_services = "",
+          host = "localhost:0"
+        )
+      )
+    ).isEqualTo(expectedResponse)
+  }
+  @Test
+  @Ignore("disagreements over snake_case vs. camelCase for json_name")
+  fun `file_containing_symbol`() {
+    val schema = loadSchema()
+    val respBase64 = "EhciFXJvdXRlZ3VpZGUuUm91dGVHdWlkZSLfBgrcBgoXcmd1aWRlL3JvdXRlZ3VpZGUucHJvdG8SCnJvdXRlZ3VpZGUiQQoFUG9pbnQSGgoIbGF0aXR1ZGUYASABKAVSCGxhdGl0dWRlEhwKCWxvbmdpdHVkZRgCIAEoBVIJbG9uZ2l0dWRlIlEKCVJlY3RhbmdsZRIhCgJsbxgBIAEoCzIRLnJvdXRlZ3VpZGUuUG9pbnRSAmxvEiEKAmhpGAIgASgLMhEucm91dGVndWlkZS5Qb2ludFICaGkiTAoHRmVhdHVyZRISCgRuYW1lGAEgASgJUgRuYW1lEi0KCGxvY2F0aW9uGAIgASgLMhEucm91dGVndWlkZS5Qb2ludFIIbG9jYXRpb24iVAoJUm91dGVOb3RlEi0KCGxvY2F0aW9uGAEgASgLMhEucm91dGVndWlkZS5Qb2ludFIIbG9jYXRpb24SGAoHbWVzc2FnZRgCIAEoCVIHbWVzc2FnZSKTAQoMUm91dGVTdW1tYXJ5Eh8KC3BvaW50X2NvdW50GAEgASgFUgpwb2ludENvdW50EiMKDWZlYXR1cmVfY291bnQYAiABKAVSDGZlYXR1cmVDb3VudBIaCghkaXN0YW5jZRgDIAEoBVIIZGlzdGFuY2USIQoMZWxhcHNlZF90aW1lGAQgASgFUgtlbGFwc2VkVGltZTK6AgoKUm91dGVHdWlkZRI0CgpHZXRGZWF0dXJlEhEucm91dGVndWlkZS5Qb2ludBoTLnJvdXRlZ3VpZGUuRmVhdHVyZRI7ChFHZXREZWZhdWx0RmVhdHVyZRIRLnJvdXRlZ3VpZGUuUG9pbnQaEy5yb3V0ZWd1aWRlLkZlYXR1cmUSPAoMTGlzdEZlYXR1cmVzEhUucm91dGVndWlkZS5SZWN0YW5nbGUaEy5yb3V0ZWd1aWRlLkZlYXR1cmUwARI8CgtSZWNvcmRSb3V0ZRIRLnJvdXRlZ3VpZGUuUG9pbnQaGC5yb3V0ZWd1aWRlLlJvdXRlU3VtbWFyeSgBEj0KCVJvdXRlQ2hhdBIVLnJvdXRlZ3VpZGUuUm91dGVOb3RlGhUucm91dGVndWlkZS5Sb3V0ZU5vdGUoATABQihaJmdpdGh1Yi5jb20vanVsaWFvZ3Jpcy9ndXBweS9wa2cvcmd1aWRl"
+    val expectedResponse = ServerReflectionResponse.ADAPTER.decode(respBase64.decodeBase64()!!)
+    val response = SchemaReflector(schema).process(
+      ServerReflectionRequest(
+        file_containing_symbol = "routeguide.RouteGuide"
+      )
+    )
+    assertThat(response.fileDescriptors).isEqualTo(expectedResponse.fileDescriptors)
+  }
+
+  private val ServerReflectionResponse.fileDescriptors
+    get() = file_descriptor_response!!.file_descriptor_proto.map {
+      FileDescriptorProto.parseFrom(
+        it.toByteArray()
+      )
+    }
+
+  private fun loadSchema(): Schema {
+    return SchemaLoader(FileSystem.SYSTEM)
+      .apply {
+        initRoots(
+          // TODO(juliaogris): Can we derive dependencies transitively?
+          sourcePath = listOf(
+            Location.get("src/jvmMain/resources", "grpc/reflection/v1alpha/reflection.proto"),
+            Location.get("src/jvmTest/proto", "echo2/echo2.proto"),
+            Location.get("src/jvmTest/proto", "google/api/annotations.proto"),
+            Location.get("src/jvmTest/proto", "google/api/http.proto"),
+            Location.get("src/jvmTest/proto", "google/protobuf/any.proto"),
+          ),
+          protoPath = listOf()
+        )
+      }
+      .loadSchema()
+    }
+  }
+

--- a/wire-library/wire-reflector/src/jvmTest/kotlin/com/squareup/wire/reflector/GrpcurlProto3InteropTest.kt
+++ b/wire-library/wire-reflector/src/jvmTest/kotlin/com/squareup/wire/reflector/GrpcurlProto3InteropTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.reflector
+
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.Schema
+import com.squareup.wire.schema.SchemaLoader
+import grpc.reflection.v1alpha.ServerReflectionRequest
+import grpc.reflection.v1alpha.ServerReflectionResponse
+import okio.ByteString.Companion.decodeBase64
+import okio.FileSystem
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
+import org.junit.Test
+
+// Reference golang reflection tests https://github.com/juliaogris/reflect
+internal class GrpcurlProto3InteropTest {
+  @Test
+  fun `list services`() {
+    val schema = loadSchema()
+    // See golden test file https://github.com/juliaogris/reflect/blob/v0.0.7/testdata/proto3-base64/TestServicesCmd.base64
+    val listRespBase64 = "Cgtsb2NhbGhvc3Q6MBIPCgtsb2NhbGhvc3Q6MDoAMjoKDAoKZWNobzMuRWNobwoqCihncnBjLnJlZmxlY3Rpb24udjFhbHBoYS5TZXJ2ZXJSZWZsZWN0aW9u"
+    val expectedListResponse = ServerReflectionResponse.ADAPTER.decode(listRespBase64.decodeBase64()!!)
+    assertThat(
+      SchemaReflector(schema).process(
+        ServerReflectionRequest(
+          list_services = "",
+          host = "localhost:0"
+        )
+      )
+    ).isEqualTo(expectedListResponse)
+  }
+
+  val ECHO3_FILEDESCRIPTOR_RESPONSE = "Cgtsb2NhbGhvc3Q6MBIaCgtsb2NhbGhvc3Q6MCILZWNobzMuRWNobzM6HwgFEht1bmtub3duIHN5bWJvbDogZWNobzMuRWNobzM="
+  @Test
+  @Ignore("Fails with java.lang.IllegalStateException: field type not implemented: http at com.squareup.wire.schema.internal.SchemaEncoder.toJson(SchemaEncoder.kt:412)")
+  fun `file_containing_symbol`() {
+    val schema = loadSchema()
+    val expectedResponse = ServerReflectionResponse.ADAPTER.decode(ECHO3_FILEDESCRIPTOR_RESPONSE.decodeBase64()!!)
+    val response = SchemaReflector(schema).process(
+      ServerReflectionRequest(
+        file_containing_symbol = "echo3.Echo",
+        host = "localhost:0"
+      )
+    )
+    assertThat(response).isEqualTo(expectedResponse)
+  }
+
+  private val ServerReflectionResponse.fileDescriptors
+    get() = file_descriptor_response!!.file_descriptor_proto.map {
+      FileDescriptorProto.parseFrom(
+        it.toByteArray()
+      )
+    }
+
+}
+private fun loadSchema(): Schema {
+  return SchemaLoader(FileSystem.SYSTEM)
+    .apply {
+      initRoots(
+        sourcePath = listOf(
+          Location.get("src/jvmMain/resources", "grpc/reflection/v1alpha/reflection.proto"),
+          Location.get("src/jvmTest/proto", "echo3/echo3.proto"),
+          Location.get("src/jvmTest/proto", "google/api/annotations.proto"),
+          Location.get("src/jvmTest/proto", "google/api/http.proto"),
+          Location.get("src/jvmTest/proto", "google/protobuf/any.proto"),
+        ),
+        protoPath = listOf()
+      )
+    }
+    .loadSchema()
+}

--- a/wire-library/wire-reflector/src/jvmTest/kotlin/com/squareup/wire/reflector/SchemaReflectorTest.kt
+++ b/wire-library/wire-reflector/src/jvmTest/kotlin/com/squareup/wire/reflector/SchemaReflectorTest.kt
@@ -15,11 +15,14 @@
  */
 package com.squareup.wire.reflector
 
+import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.RepoBuilder
+import com.squareup.wire.schema.SchemaLoader
 import grpc.reflection.v1alpha.ListServiceResponse
 import grpc.reflection.v1alpha.ServerReflectionRequest
 import grpc.reflection.v1alpha.ServerReflectionResponse
 import grpc.reflection.v1alpha.ServiceResponse
+import okio.FileSystem
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
@@ -28,15 +31,12 @@ internal class SchemaReflectorTest {
   fun `outputs a list of services`() {
     val repoBuilder = RepoBuilder().addLocal("src/jvmTest/proto/RouteGuideProto.proto")
     val schema = repoBuilder.schema()
-
+    val request =  ServerReflectionRequest(list_services = "*")
     assertThat(
-      SchemaReflector(schema).process(
-        ServerReflectionRequest(
-          list_services = "*"
-        )
-      )
+      SchemaReflector(schema).process(request)
     ).isEqualTo(
       ServerReflectionResponse(
+        original_request = request,
         list_services_response = ListServiceResponse(
           service = listOf(ServiceResponse(name = "routeguide.RouteGuide"))
         )

--- a/wire-library/wire-reflector/src/jvmTest/proto/echo2/echo2.proto
+++ b/wire-library/wire-reflector/src/jvmTest/proto/echo2/echo2.proto
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copied from https://github.com/juliaogris/reflect/blob/v0.0.7/protos/echo2/echo2.proto
+ */
+
+syntax = "proto2";
+
+package echo2;
+option go_package = "github.com/juliaogris/guppy/pkg/echo2";
+import "google/api/annotations.proto";
+import "google/protobuf/any.proto";
+
+// Echo service.
+service Echo {
+  // Hello greets.
+  rpc Hello (HelloRequest) returns (HelloResponse) {
+    option (google.api.http) = { post:"/api/echo/hello" body:"*" };
+  };
+  // HelloStream greets repeatedly.
+  rpc HelloStream (HelloRequest) returns (stream HelloResponse) {
+    option (google.api.http) = { post:"/api/echo/stream" body:"*" };
+  };
+}
+
+message HelloRequest {
+  required string message = 1;
+  optional Details more_details = 2;
+}
+
+message HelloResponse {
+  required string robot_response = 1;
+}
+
+message Details {
+  map<string, int64> label_count = 1;
+  required ColorType color_type = 2;
+  required google.protobuf.Any any = 3;
+  repeated Notification notifications = 4;
+  optional int32 a_int32 = 5;
+  optional uint32 a_uint32 = 6;
+  optional int64 a_int64 = 7;
+  optional uint64 a_uint64 = 8;
+  optional bool a_bool = 9;
+  optional sint32 a_sint32 = 10;
+  optional sint64 a_sint64 = 11;
+  optional string a_string = 12;
+  optional bytes a_bytes = 13;
+  optional fixed32 a_fixed32 = 14;
+  optional sfixed32 a_sfixed32 = 15;
+  optional fixed64 a_fixed64 = 16;
+  optional sfixed64 a_sfixed64 = 17;
+}
+
+enum ColorType {
+  RED = 0;
+  BLUE = 1;
+  GREEN = 2;
+}
+
+message Notification {
+  required int32 id = 1;
+  oneof instrument {
+    PrivateNotification private = 2;
+    PublicNotification public = 3;
+  }
+}
+
+message PrivateNotification {
+  required string secret_content = 1;
+}
+
+message PublicNotification {
+  required string content = 1;
+}

--- a/wire-library/wire-reflector/src/jvmTest/proto/echo3/echo3.proto
+++ b/wire-library/wire-reflector/src/jvmTest/proto/echo3/echo3.proto
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2021 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copied from https://github.com/juliaogris/reflect/blob/v0.0.7/protos/echo3/echo3.proto
+ */
+
+syntax = "proto3";
+
+package echo3;
+option go_package = "github.com/juliaogris/guppy/pkg/echo3";
+import "google/api/annotations.proto";
+import "google/protobuf/any.proto";
+
+// Echo service.
+service Echo {
+  // Hello greets.
+  rpc Hello (HelloRequest) returns (HelloResponse) {
+    option (google.api.http) = { post:"/api/echo/hello" body:"*" };
+  };
+  // HelloStream greets repeatedly.
+  rpc HelloStream (HelloRequest) returns (stream HelloResponse) {
+    option (google.api.http) = { post:"/api/echo/stream" body:"*" };
+  };
+}
+
+message HelloRequest {
+  string message = 1;
+  Details more_details = 2;
+}
+
+message HelloResponse {
+  string robot_response = 1;
+}
+
+message Details {
+  map<string, int64> label_count = 1;
+  ColorType color_type = 2;
+  optional google.protobuf.Any any = 3;
+  repeated Notification notifications = 4;
+  int32 a_int32 = 5;
+  uint32 a_uint32 = 6;
+  int64 a_int64 = 7;
+  uint64 a_uint64 = 8;
+  bool a_bool = 9;
+  sint32 a_sint32 = 10;
+  sint64 a_sint64 = 11;
+  string a_string = 12;
+  bytes a_bytes = 13;
+  fixed32 a_fixed32 = 14;
+  sfixed32 a_sfixed32 = 15;
+  fixed64 a_fixed64 = 16;
+  sfixed64 a_sfixed64 = 17;
+}
+
+enum ColorType {
+  RED = 0;
+  BLUE = 1;
+  GREEN = 2;
+}
+
+message Notification {
+  int32 id = 1;
+  oneof instrument {
+    PrivateNotification private = 2;
+    PublicNotification public = 3;
+  }
+}
+
+message PrivateNotification {
+  string secret_content = 1;
+}
+
+message PublicNotification {
+  string content = 1;
+}

--- a/wire-library/wire-reflector/src/jvmTest/proto/google/api/annotations.proto
+++ b/wire-library/wire-reflector/src/jvmTest/proto/google/api/annotations.proto
@@ -1,0 +1,31 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+import "google/api/http.proto";
+import "google/protobuf/descriptor.proto";
+
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "AnnotationsProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+extend google.protobuf.MethodOptions {
+  // See `HttpRule`.
+  HttpRule http = 72295728;
+}

--- a/wire-library/wire-reflector/src/jvmTest/proto/google/api/http.proto
+++ b/wire-library/wire-reflector/src/jvmTest/proto/google/api/http.proto
@@ -1,0 +1,375 @@
+// Copyright 2015 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+syntax = "proto3";
+
+package google.api;
+
+option cc_enable_arenas = true;
+option go_package = "google.golang.org/genproto/googleapis/api/annotations;annotations";
+option java_multiple_files = true;
+option java_outer_classname = "HttpProto";
+option java_package = "com.google.api";
+option objc_class_prefix = "GAPI";
+
+// Defines the HTTP configuration for an API service. It contains a list of
+// [HttpRule][google.api.HttpRule], each specifying the mapping of an RPC method
+// to one or more HTTP REST API methods.
+message Http {
+  // A list of HTTP configuration rules that apply to individual API methods.
+  //
+  // **NOTE:** All service configuration rules follow "last one wins" order.
+  repeated HttpRule rules = 1;
+
+  // When set to true, URL path parameters will be fully URI-decoded except in
+  // cases of single segment matches in reserved expansion, where "%2F" will be
+  // left encoded.
+  //
+  // The default behavior is to not decode RFC 6570 reserved characters in multi
+  // segment matches.
+  bool fully_decode_reserved_expansion = 2;
+}
+
+// # gRPC Transcoding
+//
+// gRPC Transcoding is a feature for mapping between a gRPC method and one or
+// more HTTP REST endpoints. It allows developers to build a single API service
+// that supports both gRPC APIs and REST APIs. Many systems, including [Google
+// APIs](https://github.com/googleapis/googleapis),
+// [Cloud Endpoints](https://cloud.google.com/endpoints), [gRPC
+// Gateway](https://github.com/grpc-ecosystem/grpc-gateway),
+// and [Envoy](https://github.com/envoyproxy/envoy) proxy support this feature
+// and use it for large scale production services.
+//
+// `HttpRule` defines the schema of the gRPC/REST mapping. The mapping specifies
+// how different portions of the gRPC request message are mapped to the URL
+// path, URL query parameters, and HTTP request body. It also controls how the
+// gRPC response message is mapped to the HTTP response body. `HttpRule` is
+// typically specified as an `google.api.http` annotation on the gRPC method.
+//
+// Each mapping specifies a URL path template and an HTTP method. The path
+// template may refer to one or more fields in the gRPC request message, as long
+// as each field is a non-repeated field with a primitive (non-message) type.
+// The path template controls how fields of the request message are mapped to
+// the URL path.
+//
+// Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get: "/v1/{name=messages/*}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string name = 1; // Mapped to URL path.
+//     }
+//     message Message {
+//       string text = 1; // The resource content.
+//     }
+//
+// This enables an HTTP REST to gRPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456`  | `GetMessage(name: "messages/123456")`
+//
+// Any fields in the request message which are not bound by the path template
+// automatically become HTTP query parameters if there is no HTTP request body.
+// For example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//             get:"/v1/messages/{message_id}"
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       message SubMessage {
+//         string subfield = 1;
+//       }
+//       string message_id = 1; // Mapped to URL path.
+//       int64 revision = 2;    // Mapped to URL query parameter `revision`.
+//       SubMessage sub = 3;    // Mapped to URL query parameter `sub.subfield`.
+//     }
+//
+// This enables a HTTP JSON to RPC mapping as below:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456?revision=2&sub.subfield=foo` |
+// `GetMessage(message_id: "123456" revision: 2 sub: SubMessage(subfield:
+// "foo"))`
+//
+// Note that fields which are mapped to URL query parameters must have a
+// primitive type or a repeated primitive type or a non-repeated message type.
+// In the case of a repeated type, the parameter can be repeated in the URL
+// as `...?param=A&param=B`. In the case of a message type, each field of the
+// message is mapped to a separate parameter, such as
+// `...?foo.a=A&foo.b=B&foo.c=C`.
+//
+// For HTTP methods that allow a request body, the `body` field
+// specifies the mapping. Consider a REST update method on the
+// message resource collection:
+//
+//     service Messaging {
+//       rpc UpdateMessage(UpdateMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "message"
+//         };
+//       }
+//     }
+//     message UpdateMessageRequest {
+//       string message_id = 1; // mapped to the URL
+//       Message message = 2;   // mapped to the body
+//     }
+//
+// The following HTTP JSON to RPC mapping is enabled, where the
+// representation of the JSON in the request body is determined by
+// protos JSON encoding:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" message { text: "Hi!" })`
+//
+// The special name `*` can be used in the body mapping to define that
+// every field not bound by the path template should be mapped to the
+// request body.  This enables the following alternative definition of
+// the update method:
+//
+//     service Messaging {
+//       rpc UpdateMessage(Message) returns (Message) {
+//         option (google.api.http) = {
+//           patch: "/v1/messages/{message_id}"
+//           body: "*"
+//         };
+//       }
+//     }
+//     message Message {
+//       string message_id = 1;
+//       string text = 2;
+//     }
+//
+//
+// The following HTTP JSON to RPC mapping is enabled:
+//
+// HTTP | gRPC
+// -----|-----
+// `PATCH /v1/messages/123456 { "text": "Hi!" }` | `UpdateMessage(message_id:
+// "123456" text: "Hi!")`
+//
+// Note that when using `*` in the body mapping, it is not possible to
+// have HTTP parameters, as all fields not bound by the path end in
+// the body. This makes this option more rarely used in practice when
+// defining REST APIs. The common usage of `*` is in custom methods
+// which don't use the URL at all for transferring data.
+//
+// It is possible to define multiple HTTP methods for one RPC by using
+// the `additional_bindings` option. Example:
+//
+//     service Messaging {
+//       rpc GetMessage(GetMessageRequest) returns (Message) {
+//         option (google.api.http) = {
+//           get: "/v1/messages/{message_id}"
+//           additional_bindings {
+//             get: "/v1/users/{user_id}/messages/{message_id}"
+//           }
+//         };
+//       }
+//     }
+//     message GetMessageRequest {
+//       string message_id = 1;
+//       string user_id = 2;
+//     }
+//
+// This enables the following two alternative HTTP JSON to RPC mappings:
+//
+// HTTP | gRPC
+// -----|-----
+// `GET /v1/messages/123456` | `GetMessage(message_id: "123456")`
+// `GET /v1/users/me/messages/123456` | `GetMessage(user_id: "me" message_id:
+// "123456")`
+//
+// ## Rules for HTTP mapping
+//
+// 1. Leaf request fields (recursive expansion nested messages in the request
+//    message) are classified into three categories:
+//    - Fields referred by the path template. They are passed via the URL path.
+//    - Fields referred by the [HttpRule.body][google.api.HttpRule.body]. They are passed via the HTTP
+//      request body.
+//    - All other fields are passed via the URL query parameters, and the
+//      parameter name is the field path in the request message. A repeated
+//      field can be represented as multiple query parameters under the same
+//      name.
+//  2. If [HttpRule.body][google.api.HttpRule.body] is "*", there is no URL query parameter, all fields
+//     are passed via URL path and HTTP request body.
+//  3. If [HttpRule.body][google.api.HttpRule.body] is omitted, there is no HTTP request body, all
+//     fields are passed via URL path and URL query parameters.
+//
+// ### Path template syntax
+//
+//     Template = "/" Segments [ Verb ] ;
+//     Segments = Segment { "/" Segment } ;
+//     Segment  = "*" | "**" | LITERAL | Variable ;
+//     Variable = "{" FieldPath [ "=" Segments ] "}" ;
+//     FieldPath = IDENT { "." IDENT } ;
+//     Verb     = ":" LITERAL ;
+//
+// The syntax `*` matches a single URL path segment. The syntax `**` matches
+// zero or more URL path segments, which must be the last part of the URL path
+// except the `Verb`.
+//
+// The syntax `Variable` matches part of the URL path as specified by its
+// template. A variable template must not contain other variables. If a variable
+// matches a single path segment, its template may be omitted, e.g. `{var}`
+// is equivalent to `{var=*}`.
+//
+// The syntax `LITERAL` matches literal text in the URL path. If the `LITERAL`
+// contains any reserved character, such characters should be percent-encoded
+// before the matching.
+//
+// If a variable contains exactly one path segment, such as `"{var}"` or
+// `"{var=*}"`, when such a variable is expanded into a URL path on the client
+// side, all characters except `[-_.~0-9a-zA-Z]` are percent-encoded. The
+// server side does the reverse decoding. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{var}`.
+//
+// If a variable contains multiple path segments, such as `"{var=foo/*}"`
+// or `"{var=**}"`, when such a variable is expanded into a URL path on the
+// client side, all characters except `[-_.~/0-9a-zA-Z]` are percent-encoded.
+// The server side does the reverse decoding, except "%2F" and "%2f" are left
+// unchanged. Such variables show up in the
+// [Discovery
+// Document](https://developers.google.com/discovery/v1/reference/apis) as
+// `{+var}`.
+//
+// ## Using gRPC API Service Configuration
+//
+// gRPC API Service Configuration (service config) is a configuration language
+// for configuring a gRPC service to become a user-facing product. The
+// service config is simply the YAML representation of the `google.api.Service`
+// proto message.
+//
+// As an alternative to annotating your proto file, you can configure gRPC
+// transcoding in your service config YAML files. You do this by specifying a
+// `HttpRule` that maps the gRPC method to a REST endpoint, achieving the same
+// effect as the proto annotation. This can be particularly useful if you
+// have a proto that is reused in multiple services. Note that any transcoding
+// specified in the service config will override any matching transcoding
+// configuration in the proto.
+//
+// Example:
+//
+//     http:
+//       rules:
+//         # Selects a gRPC method and applies HttpRule to it.
+//         - selector: example.v1.Messaging.GetMessage
+//           get: /v1/messages/{message_id}/{sub.subfield}
+//
+// ## Special notes
+//
+// When gRPC Transcoding is used to map a gRPC to JSON REST endpoints, the
+// proto to JSON conversion must follow the [proto3
+// specification](https://developers.google.com/protocol-buffers/docs/proto3#json).
+//
+// While the single segment variable follows the semantics of
+// [RFC 6570](https://tools.ietf.org/html/rfc6570) Section 3.2.2 Simple String
+// Expansion, the multi segment variable **does not** follow RFC 6570 Section
+// 3.2.3 Reserved Expansion. The reason is that the Reserved Expansion
+// does not expand special characters like `?` and `#`, which would lead
+// to invalid URLs. As the result, gRPC Transcoding uses a custom encoding
+// for multi segment variables.
+//
+// The path variables **must not** refer to any repeated or mapped field,
+// because client libraries are not capable of handling such variable expansion.
+//
+// The path variables **must not** capture the leading "/" character. The reason
+// is that the most common use case "{var}" does not capture the leading "/"
+// character. For consistency, all path variables must share the same behavior.
+//
+// Repeated message fields must not be mapped to URL query parameters, because
+// no client library can support such complicated mapping.
+//
+// If an API needs to use a JSON array for request or response body, it can map
+// the request or response body to a repeated field. However, some gRPC
+// Transcoding implementations may not support this feature.
+message HttpRule {
+  // Selects a method to which this rule applies.
+  //
+  // Refer to [selector][google.api.DocumentationRule.selector] for syntax details.
+  string selector = 1;
+
+  // Determines the URL pattern is matched by this rules. This pattern can be
+  // used with any of the {get|put|post|delete|patch} methods. A custom method
+  // can be defined using the 'custom' field.
+  oneof pattern {
+    // Maps to HTTP GET. Used for listing and getting information about
+    // resources.
+    string get = 2;
+
+    // Maps to HTTP PUT. Used for replacing a resource.
+    string put = 3;
+
+    // Maps to HTTP POST. Used for creating a resource or performing an action.
+    string post = 4;
+
+    // Maps to HTTP DELETE. Used for deleting a resource.
+    string delete = 5;
+
+    // Maps to HTTP PATCH. Used for updating a resource.
+    string patch = 6;
+
+    // The custom pattern is used for specifying an HTTP method that is not
+    // included in the `pattern` field, such as HEAD, or "*" to leave the
+    // HTTP method unspecified for this rule. The wild-card rule is useful
+    // for services that provide content to Web (HTML) clients.
+    CustomHttpPattern custom = 8;
+  }
+
+  // The name of the request field whose value is mapped to the HTTP request
+  // body, or `*` for mapping all request fields not captured by the path
+  // pattern to the HTTP body, or omitted for not having any HTTP request body.
+  //
+  // NOTE: the referred field must be present at the top-level of the request
+  // message type.
+  string body = 7;
+
+  // Optional. The name of the response field whose value is mapped to the HTTP
+  // response body. When omitted, the entire response message will be used
+  // as the HTTP response body.
+  //
+  // NOTE: The referred field must be present at the top-level of the response
+  // message type.
+  string response_body = 12;
+
+  // Additional HTTP bindings for the selector. Nested bindings must
+  // not contain an `additional_bindings` field themselves (that is,
+  // the nesting may only be one level deep).
+  repeated HttpRule additional_bindings = 11;
+}
+
+// A custom pattern is used for defining custom HTTP verb.
+message CustomHttpPattern {
+  // The name of this custom HTTP verb.
+  string kind = 1;
+
+  // The path matched by this custom verb.
+  string path = 2;
+}

--- a/wire-library/wire-reflector/src/jvmTest/proto/google/protobuf/any.proto
+++ b/wire-library/wire-reflector/src/jvmTest/proto/google/protobuf/any.proto
@@ -1,0 +1,158 @@
+// Protocol Buffers - Google's data interchange format
+// Copyright 2008 Google Inc.  All rights reserved.
+// https://developers.google.com/protocol-buffers/
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//     * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+syntax = "proto3";
+
+package google.protobuf;
+
+option csharp_namespace = "Google.Protobuf.WellKnownTypes";
+option go_package = "google.golang.org/protobuf/types/known/anypb";
+option java_package = "com.google.protobuf";
+option java_outer_classname = "AnyProto";
+option java_multiple_files = true;
+option objc_class_prefix = "GPB";
+
+// `Any` contains an arbitrary serialized protocol buffer message along with a
+// URL that describes the type of the serialized message.
+//
+// Protobuf library provides support to pack/unpack Any values in the form
+// of utility functions or additional generated methods of the Any type.
+//
+// Example 1: Pack and unpack a message in C++.
+//
+//     Foo foo = ...;
+//     Any any;
+//     any.PackFrom(foo);
+//     ...
+//     if (any.UnpackTo(&foo)) {
+//       ...
+//     }
+//
+// Example 2: Pack and unpack a message in Java.
+//
+//     Foo foo = ...;
+//     Any any = Any.pack(foo);
+//     ...
+//     if (any.is(Foo.class)) {
+//       foo = any.unpack(Foo.class);
+//     }
+//
+//  Example 3: Pack and unpack a message in Python.
+//
+//     foo = Foo(...)
+//     any = Any()
+//     any.Pack(foo)
+//     ...
+//     if any.Is(Foo.DESCRIPTOR):
+//       any.Unpack(foo)
+//       ...
+//
+//  Example 4: Pack and unpack a message in Go
+//
+//      foo := &pb.Foo{...}
+//      any, err := anypb.New(foo)
+//      if err != nil {
+//        ...
+//      }
+//      ...
+//      foo := &pb.Foo{}
+//      if err := any.UnmarshalTo(foo); err != nil {
+//        ...
+//      }
+//
+// The pack methods provided by protobuf library will by default use
+// 'type.googleapis.com/full.type.name' as the type URL and the unpack
+// methods only use the fully qualified type name after the last '/'
+// in the type URL, for example "foo.bar.com/x/y.z" will yield type
+// name "y.z".
+//
+//
+// JSON
+// ====
+// The JSON representation of an `Any` value uses the regular
+// representation of the deserialized, embedded message, with an
+// additional field `@type` which contains the type URL. Example:
+//
+//     package google.profile;
+//     message Person {
+//       string first_name = 1;
+//       string last_name = 2;
+//     }
+//
+//     {
+//       "@type": "type.googleapis.com/google.profile.Person",
+//       "firstName": <string>,
+//       "lastName": <string>
+//     }
+//
+// If the embedded message type is well-known and has a custom JSON
+// representation, that representation will be embedded adding a field
+// `value` which holds the custom JSON in addition to the `@type`
+// field. Example (for message [google.protobuf.Duration][]):
+//
+//     {
+//       "@type": "type.googleapis.com/google.protobuf.Duration",
+//       "value": "1.212s"
+//     }
+//
+message Any {
+  // A URL/resource name that uniquely identifies the type of the serialized
+  // protocol buffer message. This string must contain at least
+  // one "/" character. The last segment of the URL's path must represent
+  // the fully qualified name of the type (as in
+  // `path/google.protobuf.Duration`). The name should be in a canonical form
+  // (e.g., leading "." is not accepted).
+  //
+  // In practice, teams usually precompile into the binary all types that they
+  // expect it to use in the context of Any. However, for URLs which use the
+  // scheme `http`, `https`, or no scheme, one can optionally set up a type
+  // server that maps type URLs to message definitions as follows:
+  //
+  // * If no scheme is provided, `https` is assumed.
+  // * An HTTP GET on the URL must yield a [google.protobuf.Type][]
+  //   value in binary format, or produce an error.
+  // * Applications are allowed to cache lookup results based on the
+  //   URL, or have them precompiled into a binary to avoid any
+  //   lookup. Therefore, binary compatibility needs to be preserved
+  //   on changes to types. (Use versioned type names to manage
+  //   breaking changes.)
+  //
+  // Note: this functionality is not currently available in the official
+  // protobuf release, and it is not used for type URLs beginning with
+  // type.googleapis.com.
+  //
+  // Schemes other than `http`, `https` (or the empty scheme) might be
+  // used with implementation specific semantics.
+  //
+  string type_url = 1;
+
+  // Must be a valid serialized protocol buffer of the above specified type.
+  bytes value = 2;
+}

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
@@ -144,11 +144,10 @@ class SchemaEncoder(
       }
 
       STRING.encodeWithTag(writer, 1, value.type.simpleName)
-      fieldEncoder.asRepeated().encodeWithTag(writer, 2, encodedFields)
 
-      for (encodedOneOf in encodedOneOfs) {
-        fieldEncoder.asRepeated().encodeWithTag(writer, 2, encodedOneOf.fields)
-      }
+      val fieldsAndOneOfFields = (encodedFields + encodedOneOfs.flatMap { it.fields })
+        .sortedBy { it.field.tag }
+      fieldEncoder.asRepeated().encodeWithTag(writer, 2, fieldsAndOneOfFields)
 
       // FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 6, value.extension)
 


### PR DESCRIPTION
Add base64 encoded ReflectionResponse tests, running against golden set
retrieved from golang reflection API and gRPC services at [reflect](https://github.com/juliaogris/reflect).

