### PR TITLE
Add support for special float literals

### DIFF
--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1943,6 +1943,8 @@ public final class JavaGenerator {
         return CodeBlock.of("Float.POSITIVE_INFINITY");
       } else if ("-inf".equals(value)) {
         return CodeBlock.of("Float.NEGATIVE_INFINITY");
+      } else if ("nan".equals(value) || "-nan".equals(value)) {
+        return CodeBlock.of("Float.NaN");
       } else {
         return CodeBlock.of("$Lf", String.valueOf(value));
       }
@@ -1954,6 +1956,8 @@ public final class JavaGenerator {
         return CodeBlock.of("Double.POSITIVE_INFINITY");
       } else if ("-inf".equals(value)) {
         return CodeBlock.of("Double.NEGATIVE_INFINITY");
+      } else if ("nan".equals(value) || "-nan".equals(value)) {
+        return CodeBlock.of("Double.NaN");
       } else {
         return CodeBlock.of("$Ld", String.valueOf(value));
       }

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1937,10 +1937,26 @@ public final class JavaGenerator {
       return CodeBlock.of("$LL", optionValueToLong(value));
 
     } else if (javaType.equals(TypeName.FLOAT)) {
-      return CodeBlock.of("$Lf", value != null ? String.valueOf(value) : 0f);
+      if (value == null) {
+        return CodeBlock.of("0.0f");
+      } else if ("inf".equals(value)) {
+        return CodeBlock.of("Float.POSITIVE_INFINITY");
+      } else if ("-inf".equals(value)) {
+        return CodeBlock.of("Float.NEGATIVE_INFINITY");
+      } else {
+        return CodeBlock.of("$Lf", String.valueOf(value));
+      }
 
     } else if (javaType.equals(TypeName.DOUBLE)) {
-      return CodeBlock.of("$Ld", value != null ? String.valueOf(value) : 0d);
+      if (value == null) {
+        return CodeBlock.of("0.0d");
+      } else if ("inf".equals(value)) {
+        return CodeBlock.of("Double.POSITIVE_INFINITY");
+      } else if ("-inf".equals(value)) {
+        return CodeBlock.of("Double.NEGATIVE_INFINITY");
+      } else {
+        return CodeBlock.of("$Ld", String.valueOf(value));
+      }
 
     } else if (javaType.equals(STRING)) {
       return CodeBlock.of("$S", value != null ? value : "");

--- a/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -364,6 +364,8 @@ public final class JavaGeneratorTest {
             + "  optional int64 d = 4 [default = 0x21 ];\n"
             + "  optional float e = 5 [default = inf ];\n"
             + "  optional double f = 6 [default = -inf ];\n"
+            + "  optional double g = 7 [default = nan ];\n"
+            + "  optional double h = 8 [default = -nan ];\n"
             + "}\n");
     String code = repoBuilder.generateCode("Message");
     assertThat(code).contains("  public static final Integer DEFAULT_A = 10;");
@@ -372,6 +374,8 @@ public final class JavaGeneratorTest {
     assertThat(code).contains("  public static final Long DEFAULT_D = 33L;");
     assertThat(code).contains("  public static final Float DEFAULT_E = Float.POSITIVE_INFINITY;");
     assertThat(code).contains("  public static final Double DEFAULT_F = Double.NEGATIVE_INFINITY;");
+    assertThat(code).contains("  public static final Double DEFAULT_G = Double.NaN;");
+    assertThat(code).contains("  public static final Double DEFAULT_H = Double.NaN;");
   }
 
   @Test public void defaultValuesMustNotBeOctal() throws IOException {

--- a/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -353,7 +353,6 @@ public final class JavaGeneratorTest {
     assertThat(repoBuilder.generateCode("A", "android")).contains(""
         + "  public abstract static class AbstractBAdapter extends ProtoAdapter<String> {\n");
   }
-
   /** https://github.com/square/wire/issues/655 */
   @Test public void defaultValues() throws IOException {
     RepoBuilder repoBuilder = new RepoBuilder()
@@ -363,12 +362,16 @@ public final class JavaGeneratorTest {
             + "  optional int32 b = 2 [default = 0x20 ];\n"
             + "  optional int64 c = 3 [default = 11 ];\n"
             + "  optional int64 d = 4 [default = 0x21 ];\n"
+            + "  optional float e = 5 [default = inf ];\n"
+            + "  optional double f = 6 [default = -inf ];\n"
             + "}\n");
     String code = repoBuilder.generateCode("Message");
     assertThat(code).contains("  public static final Integer DEFAULT_A = 10;");
     assertThat(code).contains("  public static final Integer DEFAULT_B = 32;");
     assertThat(code).contains("  public static final Long DEFAULT_C = 11L;");
     assertThat(code).contains("  public static final Long DEFAULT_D = 33L;");
+    assertThat(code).contains("  public static final Float DEFAULT_E = Float.POSITIVE_INFINITY;");
+    assertThat(code).contains("  public static final Double DEFAULT_F = Double.NEGATIVE_INFINITY;");
   }
 
   @Test public void defaultValuesMustNotBeOctal() throws IOException {

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1165,8 +1165,8 @@ class KotlinGenerator private constructor(
       typeName == BOOLEAN -> CodeBlock.of("%L", defaultValue)
       typeName == INT -> defaultValue.toIntFieldInitializer()
       typeName == LONG -> defaultValue.toLongFieldInitializer()
-      typeName == FLOAT -> CodeBlock.of("%Lf", defaultValue.toString())
-      typeName == DOUBLE -> CodeBlock.of("%L", defaultValue.toString().toDouble())
+      typeName == FLOAT -> defaultValue.toFloatFieldInitializer()
+      typeName == DOUBLE -> defaultValue.toDoubleFieldInitializer()
       typeName == STRING -> CodeBlock.of("%S", defaultValue)
       typeName == ByteString::class.asTypeName() -> CodeBlock.of("%S.%M()!!",
           defaultValue.toString().encode(charset = Charsets.ISO_8859_1).base64(),
@@ -1211,6 +1211,18 @@ class KotlinGenerator private constructor(
     Long.MIN_VALUE -> CodeBlock.of("%T.MIN_VALUE", LONG)
     Long.MAX_VALUE -> CodeBlock.of("%T.MAX_VALUE", LONG)
     else -> CodeBlock.of("%LL", long)
+  }
+
+  private fun Any.toFloatFieldInitializer(): CodeBlock = when(this) {
+    "inf" -> CodeBlock.of("Float.POSITIVE_INFINITY")
+    "-inf" -> CodeBlock.of("Float.NEGATIVE_INFINITY")
+    else -> CodeBlock.of("%Lf", this.toString())
+  }
+
+  private fun Any.toDoubleFieldInitializer(): CodeBlock = when(this) {
+    "inf" -> CodeBlock.of("Double.POSITIVE_INFINITY")
+    "-inf" -> CodeBlock.of("Double.NEGATIVE_INFINITY")
+    else -> CodeBlock.of("%L", this.toString().toDouble())
   }
 
   /**

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1216,12 +1216,16 @@ class KotlinGenerator private constructor(
   private fun Any.toFloatFieldInitializer(): CodeBlock = when(this) {
     "inf" -> CodeBlock.of("Float.POSITIVE_INFINITY")
     "-inf" -> CodeBlock.of("Float.NEGATIVE_INFINITY")
+    "nan" -> CodeBlock.of("Float.NaN")
+    "-nan" -> CodeBlock.of("Float.NaN")
     else -> CodeBlock.of("%Lf", this.toString())
   }
 
   private fun Any.toDoubleFieldInitializer(): CodeBlock = when(this) {
     "inf" -> CodeBlock.of("Double.POSITIVE_INFINITY")
     "-inf" -> CodeBlock.of("Double.NEGATIVE_INFINITY")
+    "nan" -> CodeBlock.of("Double.NaN")
+    "-nan" -> CodeBlock.of("Double.NaN")
     else -> CodeBlock.of("%L", this.toString().toDouble())
   }
 

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -71,6 +71,8 @@ class KotlinGeneratorTest {
         |  optional double j = 10 [default = -1e-2];
         |  optional double k = 11 [default = -1.23e45];
         |  optional double l = 12 [default = 255];
+        |  optional double m = 13 [default = inf];
+        |  optional double n = 14 [default = -inf];
         |}""".trimMargin())
     val code = repoBuilder.generateKotlin("Message")
     assertTrue(code.contains("const val DEFAULT_A: Int = 10"))
@@ -85,6 +87,8 @@ class KotlinGeneratorTest {
     assertTrue(code.contains("const val DEFAULT_J: Double = -0.01"))
     assertTrue(code.contains("const val DEFAULT_K: Double = -1.23E45"))
     assertTrue(code.contains("const val DEFAULT_L: Double = 255.0"))
+    assertTrue(code.contains("const val DEFAULT_M: Double = Double.POSITIVE_INFINITY"))
+    assertTrue(code.contains("const val DEFAULT_N: Double = Double.NEGATIVE_INFINITY"))
   }
 
   @Test fun nameAllocatorIsUsed() {

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -73,6 +73,8 @@ class KotlinGeneratorTest {
         |  optional double l = 12 [default = 255];
         |  optional double m = 13 [default = inf];
         |  optional double n = 14 [default = -inf];
+        |  optional double o = 15 [default = nan];
+        |  optional double p = 16 [default = -nan];
         |}""".trimMargin())
     val code = repoBuilder.generateKotlin("Message")
     assertTrue(code.contains("const val DEFAULT_A: Int = 10"))
@@ -89,6 +91,8 @@ class KotlinGeneratorTest {
     assertTrue(code.contains("const val DEFAULT_L: Double = 255.0"))
     assertTrue(code.contains("const val DEFAULT_M: Double = Double.POSITIVE_INFINITY"))
     assertTrue(code.contains("const val DEFAULT_N: Double = Double.NEGATIVE_INFINITY"))
+    assertTrue(code.contains("const val DEFAULT_O: Double = Double.NaN"))
+    assertTrue(code.contains("const val DEFAULT_P: Double = Double.NaN"))
   }
 
   @Test fun nameAllocatorIsUsed() {


### PR DESCRIPTION
Both the [proto2 spec] and [proto3 spec] define floating-point literal values "inf", "-inf", and "nan" that may be used as default values for both float and double fields. This change adds support for such literal values in both the Java and Kotlin generators.

[proto2 spec]: https://developers.google.com/protocol-buffers/docs/reference/proto2-spec#floating-point-literals
[proto3 spec]: https://developers.google.com/protocol-buffers/docs/reference/proto3-spec#floating-point-literals