### PR TITLE
Add 'nameSuffix' parameter for configuring generated service-class names

### DIFF
--- a/wire-library/docs/wire_compiler.md
+++ b/wire-library/docs/wire_compiler.md
@@ -450,6 +450,12 @@ wire {
     // `none` to not generate services.
     rpcRole = 'server'
 
+    // When null, generated service types will have a suffix appended to
+    // their names, inferred from rpcRole - 'Server' for 'server',
+    // 'Client' for 'client', etc. When non-null, generated service types
+    //  will have the given value for a suffix.
+    nameSuffix = null
+
     // True for emitted services to implement one interface per RPC.
     singleMethodServices = true
   }

--- a/wire-library/docs/wire_compiler.md
+++ b/wire-library/docs/wire_compiler.md
@@ -450,11 +450,9 @@ wire {
     // `none` to not generate services.
     rpcRole = 'server'
 
-    // When null, generated service types will have a suffix appended to
-    // their names, inferred from rpcRole - 'Server' for 'server',
-    // 'Client' for 'client', etc. When non-null, generated service types
-    //  will have the given value for a suffix.
-    nameSuffix = null
+    // If set, the value will be appended to generated service type names. If null, their rpcRole
+    // will be used as a suffix instead.
+    nameSuffix = "Suffix"
 
     // True for emitted services to implement one interface per RPC.
     singleMethodServices = true

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -294,6 +294,12 @@ data class KotlinTarget(
 
   /** True to also generate gRPC server-compatible classes. */
   val grpcServerCompatible: Boolean = false,
+
+  /**
+   * If present, generated services classes will use this as a suffix instead of inferring one
+   * from the [rpcRole].
+   */
+  val nameSuffix: String? = null,
 ) : Target() {
   override fun newHandler(
     schema: Schema,
@@ -327,7 +333,8 @@ data class KotlinTarget(
         rpcCallStyle = rpcCallStyle,
         rpcRole = rpcRole,
         boxOneOfsMinSize = boxOneOfsMinSize,
-        grpcServerCompatible = grpcServerCompatible
+        grpcServerCompatible = grpcServerCompatible,
+        nameSuffix = nameSuffix,
     )
 
     return object : SchemaHandler {

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -76,6 +76,7 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
   var singleMethodServices: Boolean = false
   var boxOneOfsMinSize: Int = 5_000
   var grpcServerCompatible: Boolean = false
+  var nameSuffix: String? = null
 
   override fun toTarget(): KotlinTarget {
     val rpcCallStyle = RpcCallStyle.values()
@@ -102,6 +103,7 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
         singleMethodServices = singleMethodServices,
         boxOneOfsMinSize = boxOneOfsMinSize,
         grpcServerCompatible = grpcServerCompatible,
+        nameSuffix = nameSuffix,
     )
   }
 }

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -689,6 +689,20 @@ class WirePluginTest {
         File(outputRoot, "com/squareup/dinosaurs/BattleServiceBrawlBlockingServer.kt")).exists()
   }
 
+  @Test
+  fun emitServiceWithSpecificSuffix() {
+    val fixtureRoot = File("src/test/projects/emit-service-name-suffix")
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+    val task = result.task(":generateProtos")
+
+    assertThat(task).isNotNull
+    assertThat(result.output)
+        .contains("Writing com.squareup.dinosaurs.BattleServiceClient")
+
+    val outputRoot = File(fixtureRoot, "build/generated/source/wire")
+    assertThat(File(outputRoot, "com/squareup/dinosaurs/BattleServiceClient.kt")).exists()
+  }
+
   /**
    * This test is symmetric with [protoPathMavenCoordinates] but it manipulates the configuration
    * directly. We expect this to be useful in cases where users want to make dependency resolution

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/build.gradle
@@ -1,0 +1,12 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  kotlin {
+    rpcRole = 'server'
+    nameSuffix = 'Client'
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/src/main/proto/squareup/dinosaurs/battle.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/src/main/proto/squareup/dinosaurs/battle.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/dinosaurs/dinosaur.proto";
+
+service BattleService {
+  rpc Fight(Dinosaur) returns (Dinosaur) {}
+  rpc Brawl(stream Dinosaur) returns (stream Dinosaur) {}
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/emit-service-name-suffix/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -172,12 +172,6 @@ class KotlinGenerator private constructor(
       if (rpc != null) {
         append(rpc.name)
       }
-      when (rpcCallStyle) {
-        RpcCallStyle.SUSPENDING -> Unit // Suspending is implicit.
-        RpcCallStyle.BLOCKING -> {
-          if (rpcRole == RpcRole.SERVER) append("Blocking")
-        }
-      }
       append(serviceNameSuffix)
     }
     return typeName.peerClass(simpleName)
@@ -185,14 +179,24 @@ class KotlinGenerator private constructor(
 
   private val serviceNameSuffix: String
     get() {
+      // nameSuffix, if given, overrides both call-style and rpc-role suffixes.
       if (nameSuffix != null) {
         return nameSuffix
       }
 
-      return when (rpcRole) {
-        RpcRole.CLIENT -> "Client"
-        RpcRole.SERVER -> "Server"
-        RpcRole.NONE   -> ""
+      return buildString {
+        when (rpcCallStyle) {
+          RpcCallStyle.SUSPENDING -> Unit // Suspending is implicit.
+          RpcCallStyle.BLOCKING -> {
+            if (rpcRole == RpcRole.SERVER) append("Blocking")
+          }
+        }
+
+        when (rpcRole) {
+          RpcRole.CLIENT -> append("Client")
+          RpcRole.SERVER -> append("Server")
+          RpcRole.NONE   -> Unit
+        }
       }
     }
 

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -122,6 +122,7 @@ class KotlinGenerator private constructor(
   private val rpcRole: RpcRole,
   private val boxOneOfsMinSize: Int,
   private val grpcServerCompatible: Boolean,
+  private val nameSuffix: String?,
 ) {
   private val nameAllocatorStore = mutableMapOf<Type, NameAllocator>()
 
@@ -177,13 +178,23 @@ class KotlinGenerator private constructor(
           if (rpcRole == RpcRole.SERVER) append("Blocking")
         }
       }
-      when (rpcRole) {
-        RpcRole.CLIENT -> append("Client")
-        RpcRole.SERVER -> append("Server")
-      }
+      append(serviceNameSuffix)
     }
     return typeName.peerClass(simpleName)
   }
+
+  private val serviceNameSuffix: String
+    get() {
+      if (nameSuffix != null) {
+        return nameSuffix
+      }
+
+      return when (rpcRole) {
+        RpcRole.CLIENT -> "Client"
+        RpcRole.SERVER -> "Server"
+        RpcRole.NONE   -> ""
+      }
+    }
 
   fun generateType(type: Type): TypeSpec {
     check(type.type != ProtoType.ANY)
@@ -2238,6 +2249,7 @@ class KotlinGenerator private constructor(
       rpcRole: RpcRole = RpcRole.CLIENT,
       boxOneOfsMinSize: Int = 5_000,
       grpcServerCompatible: Boolean = false,
+      nameSuffix: String? = null,
     ): KotlinGenerator {
       val typeToKotlinName = mutableMapOf<ProtoType, TypeName>()
       val memberToKotlinName = mutableMapOf<ProtoMember, TypeName>()
@@ -2287,7 +2299,8 @@ class KotlinGenerator private constructor(
           rpcCallStyle = rpcCallStyle,
           rpcRole = rpcRole,
           boxOneOfsMinSize = boxOneOfsMinSize,
-          grpcServerCompatible = grpcServerCompatible
+          grpcServerCompatible = grpcServerCompatible,
+          nameSuffix = nameSuffix,
       )
     }
 

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1006,7 +1006,7 @@ class KotlinGeneratorTest {
           |/**
           | * RouteGuide service interface.
           | */
-          |public interface RouteGuideBlockingThing : Service {
+          |public interface RouteGuideThing : Service {
           |  /**
           |   * Returns the \[Feature\] for a \[Point\].
           |   */

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -971,6 +971,87 @@ class KotlinGeneratorTest {
         repoBuilder.generateGrpcKotlin("routeguide.RouteGuide", "RouteChat"))
   }
 
+  @Test fun nameSuffixes() {
+    //language=kotlin
+    val suspendingInterface = """
+          |package routeguide
+          |
+          |import com.squareup.wire.Service
+          |import com.squareup.wire.WireRpc
+          |
+          |/**
+          | * RouteGuide service interface.
+          | */
+          |public interface RouteGuide : Service {
+          |  /**
+          |   * Returns the \[Feature\] for a \[Point\].
+          |   */
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER",
+          |    sourceFile = "routeguide.proto"
+          |  )
+          |  public suspend fun GetFeature(request: Point): Feature
+          |}
+          |""".trimMargin()
+
+    //language=kotlin
+    val blockingInterface = """
+          |package routeguide
+          |
+          |import com.squareup.wire.Service
+          |import com.squareup.wire.WireRpc
+          |
+          |/**
+          | * RouteGuide service interface.
+          | */
+          |public interface RouteGuideBlockingThing : Service {
+          |  /**
+          |   * Returns the \[Feature\] for a \[Point\].
+          |   */
+          |  @WireRpc(
+          |    path = "/routeguide.RouteGuide/GetFeature",
+          |    requestAdapter = "routeguide.Point#ADAPTER",
+          |    responseAdapter = "routeguide.Feature#ADAPTER",
+          |    sourceFile = "routeguide.proto"
+          |  )
+          |  public fun GetFeature(request: Point): Feature
+          |}
+          |""".trimMargin()
+
+    val repoBuilder = RepoBuilder()
+        .add("routeguide.proto", """
+          |package routeguide;
+          |
+          |/**
+          | * RouteGuide service interface.
+          | */
+          |service RouteGuide {
+          |  // Returns the [Feature] for a [Point].
+          |  rpc GetFeature(Point) returns (Feature);
+          |}
+          |$pointMessage
+          |$featureMessage
+          |""".trimMargin())
+
+    assertEquals(listOf(suspendingInterface),
+        repoBuilder.generateGrpcKotlin(
+            serviceName = "routeguide.RouteGuide",
+            rpcRole = RpcRole.SERVER,
+            rpcCallStyle = RpcCallStyle.SUSPENDING,
+            nameSuffix = "",
+        ))
+
+    assertEquals(listOf(blockingInterface),
+        repoBuilder.generateGrpcKotlin(
+            serviceName = "routeguide.RouteGuide",
+            rpcRole = RpcRole.SERVER,
+            rpcCallStyle = RpcCallStyle.BLOCKING,
+            nameSuffix = "Thing",
+        ))
+  }
+
   @Test fun nameAllocatorIsUsedInDecodeForReaderTag() {
     val repoBuilder = RepoBuilder()
         .add("message.proto", """

--- a/wire-library/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.kt
+++ b/wire-library/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.kt
@@ -141,7 +141,8 @@ class RepoBuilder {
     rpcName: String? = null,
     rpcCallStyle: RpcCallStyle = RpcCallStyle.SUSPENDING,
     rpcRole: RpcRole = RpcRole.CLIENT,
-    profileName: String? = null
+    profileName: String? = null,
+    nameSuffix: String? = null,
   ): List<String> {
     if (rpcRole === RpcRole.NONE) return emptyList()
 
@@ -152,7 +153,8 @@ class RepoBuilder {
         emitAndroid = false,
         javaInterop = false,
         rpcCallStyle = rpcCallStyle,
-        rpcRole = rpcRole
+        rpcRole = rpcRole,
+        nameSuffix = nameSuffix,
     )
     val service = schema.getService(serviceName)!!
     val rpc = rpcName?.let { service.rpc(rpcName)!! }


### PR DESCRIPTION
This PR introduces a `nameSuffix` option to `KotlinGenerator`.  If specified, it will override the suffix that is currently computed from `rpcRole`.  It also adds an eponymous option to `KotlinOutput` in the Gradle plugin, along with the plumbing to get it from point A to point B.

Fixes #1962 