### PR TITLE
emitDeclaredOptions / emitAppliedOptions default values

### DIFF
--- a/wire-library/docs/wire_compiler.md
+++ b/wire-library/docs/wire_compiler.md
@@ -390,10 +390,10 @@ wire {
     compact = true
 
     // True to emit types for options declared on messages, fields, etc.
-    emitDeclaredOptions = false,
+    emitDeclaredOptions = true,
 
     // True to emit annotations for options applied on messages, fields, etc.
-    emitAppliedOptions = true
+    emitAppliedOptions = false
   }
 }
 ```


### PR DESCRIPTION
According to [wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt:2192](https://github.com/square/wire/blob/6cc58cda6285a1d6fb48259d6ecb234b176c5803/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt#L2192):
```kotlin
emitDeclaredOptions: Boolean = true,
emitAppliedOptions: Boolean = false,
```