### PR TITLE
Redacted Kotlin scalars respect nullability

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/FieldExtensions.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/FieldExtensions.kt
@@ -30,3 +30,9 @@ internal val Field.keyType: ProtoType
 
 internal val Field.valueType: ProtoType
   get() = type!!.valueType!!
+
+internal val Field.isOptional: Boolean
+  get() = Field.Label.OPTIONAL == label
+
+internal val Field.isScalar: Boolean
+  get() = type!!.isScalar

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/FieldExtensions.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/FieldExtensions.kt
@@ -31,8 +31,5 @@ internal val Field.keyType: ProtoType
 internal val Field.valueType: ProtoType
   get() = type!!.valueType!!
 
-internal val Field.isOptional: Boolean
-  get() = Field.Label.OPTIONAL == label
-
 internal val Field.isScalar: Boolean
   get() = type!!.isScalar

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1476,10 +1476,9 @@ class KotlinGenerator private constructor(
     }
 
     val redactedFields = mutableListOf<CodeBlock>()
-    val flattenedOneOfFields = message.flatOneOfs().flatMap { it.fields }
     for (field in message.fieldsAndFlatOneOfFields()) {
       val fieldName = nameAllocator[field]
-      val redactedField = field.redact(fieldName, flattenedOneOfFields.contains(field))
+      val redactedField = field.redact(fieldName)
       if (redactedField != null) {
         redactedFields += CodeBlock.of("%N = %L", fieldName, redactedField)
       }
@@ -1494,12 +1493,12 @@ class KotlinGenerator private constructor(
         .build()
   }
 
-  private fun Field.redact(fieldName: String, isOneOf: Boolean): CodeBlock? {
+  private fun Field.redact(fieldName: String): CodeBlock? {
     if (isRedacted) {
       return when {
         isRepeated -> CodeBlock.of("emptyList()")
         isMap -> CodeBlock.of("emptyMap()")
-        isOptional || isOneOf -> CodeBlock.of("null")
+        Field.EncodeMode.NULL_IF_ABSENT == encodeMode  -> CodeBlock.of("null")
         isScalar -> PROTOTYPE_TO_IDENTITY_VALUES[type!!]
         else -> CodeBlock.of("null")
       }

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1498,7 +1498,7 @@ class KotlinGenerator private constructor(
       return when {
         isRepeated -> CodeBlock.of("emptyList()")
         isMap -> CodeBlock.of("emptyMap()")
-        Field.EncodeMode.NULL_IF_ABSENT == encodeMode  -> CodeBlock.of("null")
+        encodeMode!! == EncodeMode.NULL_IF_ABSENT -> CodeBlock.of("null")
         isScalar -> PROTOTYPE_TO_IDENTITY_VALUES[type!!]
         else -> CodeBlock.of("null")
       }

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1503,6 +1503,27 @@ class KotlinGeneratorTest {
     )
   }
 
+  @Test
+  fun redactedNonNullableFieldsForProto3() {
+    val repoBuilder = RepoBuilder()
+      .add("message.proto", """
+        |syntax = "proto3";
+        |import "option_redacted.proto";
+        |message RedactedFields {
+        |  string a = 1 [(squareup.protos.redacted_option.redacted) = true];
+        |  int32  b = 2 [(squareup.protos.redacted_option.redacted) = true];
+        |}
+        |""".trimMargin()
+      )
+      .add("option_redacted.proto")
+    val code = repoBuilder.generateKotlin("RedactedFields")
+    assertThat(code).contains("""val a: String = "",""")
+    assertThat(code).contains("""val b: Int = 0,""")
+    assertThat(code).contains("public override fun redact(value: RedactedFields): RedactedFields = value.copy(")
+    assertThat(code).contains("""a = "",""")
+    assertThat(code).contains("""b = 0,""")
+  }
+
   companion object {
     private val pointMessage = """
           |message Point {

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1516,20 +1516,30 @@ class KotlinGeneratorTest {
         |    string c = 3 [(squareup.protos.redacted_option.redacted) = true];
         |    int32  d = 4 [(squareup.protos.redacted_option.redacted) = true];
         |  }
+        |  SecretData secret_data = 5 [(squareup.protos.redacted_option.redacted) = true];
         |}
+        |
+        |message SecretData {}
         |""".trimMargin()
       )
       .add("option_redacted.proto")
     val code = repoBuilder.generateKotlin("RedactedFields")
-    assertThat(code).contains("""val a: String = "",""")
-    assertThat(code).contains("""val b: Int = 0,""")
-    assertThat(code).contains("""val c: String? = null,""")
-    assertThat(code).contains("""val d: Int? = null,""")
-    assertThat(code).contains("public override fun redact(value: RedactedFields): RedactedFields = value.copy(")
-    assertThat(code).contains("""a = "",""")
-    assertThat(code).contains("""b = 0,""")
-    assertThat(code).contains("""c = null,""")
-    assertThat(code).contains("""d = null,""")
+    println(code)
+    assertThat(code).contains("""public val a: String = "",""")
+    assertThat(code).contains("""public val b: Int = 0,""")
+    assertThat(code).contains("""public val c: String? = null,""")
+    assertThat(code).contains("""public val d: Int? = null,""")
+    assertThat(code).contains("""public val secret_data: SecretData? = null,""")
+    assertThat(code).contains("""
+      |      public override fun redact(`value`: RedactedFields): RedactedFields = value.copy(
+      |        a = "",
+      |        b = 0,
+      |        secret_data = null,
+      |        c = null,
+      |        d = null,
+      |        unknownFields = ByteString.EMPTY
+      |      )
+    """.trimMargin())
   }
 
   companion object {

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1512,6 +1512,10 @@ class KotlinGeneratorTest {
         |message RedactedFields {
         |  string a = 1 [(squareup.protos.redacted_option.redacted) = true];
         |  int32  b = 2 [(squareup.protos.redacted_option.redacted) = true];
+        |  oneof choice {
+        |    string c = 3 [(squareup.protos.redacted_option.redacted) = true];
+        |    int32  d = 4 [(squareup.protos.redacted_option.redacted) = true];
+        |  }
         |}
         |""".trimMargin()
       )
@@ -1519,9 +1523,13 @@ class KotlinGeneratorTest {
     val code = repoBuilder.generateKotlin("RedactedFields")
     assertThat(code).contains("""val a: String = "",""")
     assertThat(code).contains("""val b: Int = 0,""")
+    assertThat(code).contains("""val c: String? = null,""")
+    assertThat(code).contains("""val d: Int? = null,""")
     assertThat(code).contains("public override fun redact(value: RedactedFields): RedactedFields = value.copy(")
     assertThat(code).contains("""a = "",""")
     assertThat(code).contains("""b = 0,""")
+    assertThat(code).contains("""c = null,""")
+    assertThat(code).contains("""d = null,""")
   }
 
   companion object {


### PR DESCRIPTION
Prior to this PR  `KotlinGenerator` was generating invalid code for redacted proto3 scalars. For example:

```
public override fun redact(value: MyExample): MyExample = value.copy(
    my_string = null, // build fails because type is String not String?
    my_int32 = null, // build fails because type is Int and not Int?
    unknownFields = ByteString.EMPTY
)
```

With this change, non-nullable Kotlin scalar values are redacted as the identity value for the given type.