### PR TITLE
Update to KotlinPoet 1.8.0 and address few API changes

### DIFF
--- a/samples/android-app-kotlin-sample/src/main/java/com/squareup/wire/android/app/kotlin/MainActivity.kt
+++ b/samples/android-app-kotlin-sample/src/main/java/com/squareup/wire/android/app/kotlin/MainActivity.kt
@@ -24,6 +24,6 @@ class MainActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.activity_main)
     val someText = SomeText("Hi")
-    findViewById<TextView>(R.id.text_view).setText(someText.value)
+    findViewById<TextView>(R.id.text_view).setText(someText.value_)
   }
 }

--- a/samples/android-app-variants-sample/src/test/java/com/squareup/wire/android/app/variants/CommonUnitTest.kt
+++ b/samples/android-app-variants-sample/src/test/java/com/squareup/wire/android/app/variants/CommonUnitTest.kt
@@ -10,8 +10,8 @@ class CommonUnitTest {
     val commonText = CommonText("name")
     val commonType = CommonType(32, "name")
 
-    if (commonText.value != commonType.name) {
-      throw AssertionError("BOOM!: ${commonText.value} != ${commonType.name}")
+    if (commonText.value_ != commonType.name) {
+      throw AssertionError("BOOM!: ${commonText.value_} != ${commonType.name}")
     }
   }
 }

--- a/samples/android-app-variants-sample/src/testDebug/java/com/squareup/wire/android/app/variants/DebugUnitTest.kt
+++ b/samples/android-app-variants-sample/src/testDebug/java/com/squareup/wire/android/app/variants/DebugUnitTest.kt
@@ -10,8 +10,8 @@ class DebugUnitTest {
     val commonText = CommonText("name")
     val commonType = CommonType(32, "name")
 
-    if (commonText.value != commonType.name) {
-      throw AssertionError("BOOM!: ${commonText.value} != ${commonType.name}")
+    if (commonText.value_ != commonType.name) {
+      throw AssertionError("BOOM!: ${commonText.value_} != ${commonType.name}")
     }
   }
 

--- a/samples/android-app-variants-sample/src/testRelease/java/com/squareup/wire/android/app/variants/ReleaseUnitTest.kt
+++ b/samples/android-app-variants-sample/src/testRelease/java/com/squareup/wire/android/app/variants/ReleaseUnitTest.kt
@@ -10,8 +10,8 @@ class ReleaseUnitTest {
     val commonText = CommonText("name")
     val commonType = CommonType(32, "name")
 
-    if (commonText.value != commonType.name) {
-      throw AssertionError("BOOM!: ${commonText.value} != ${commonType.name}")
+    if (commonText.value_ != commonType.name) {
+      throw AssertionError("BOOM!: ${commonText.value_} != ${commonType.name}")
     }
   }
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -68,8 +67,8 @@ public class Feature(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
-      result = result * 37 + location.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
+      result = result * 37 + (location?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -97,14 +96,14 @@ public class Feature(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Feature): Int {
+      public override fun encodedSize(`value`: Feature): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += Point.ADAPTER.encodedSizeWithTag(2, value.location)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Feature): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Feature): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         Point.ADAPTER.encodeWithTag(writer, 2, value.location)
         writer.writeBytes(value.unknownFields)
@@ -127,7 +126,7 @@ public class Feature(
         )
       }
 
-      public override fun redact(value: Feature): Feature = value.copy(
+      public override fun redact(`value`: Feature): Feature = value.copy(
         location = value.location?.let(Point.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -82,13 +82,13 @@ public class FeatureDatabase(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: FeatureDatabase): Int {
+      public override fun encodedSize(`value`: FeatureDatabase): Int {
         var size = value.unknownFields.size
         size += Feature.ADAPTER.asRepeated().encodedSizeWithTag(1, value.feature)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: FeatureDatabase): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: FeatureDatabase): Unit {
         Feature.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.feature)
         writer.writeBytes(value.unknownFields)
       }
@@ -107,7 +107,7 @@ public class FeatureDatabase(
         )
       }
 
-      public override fun redact(value: FeatureDatabase): FeatureDatabase = value.copy(
+      public override fun redact(`value`: FeatureDatabase): FeatureDatabase = value.copy(
         feature = value.feature.redactElements(Feature.ADAPTER),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -62,8 +61,8 @@ public class Point(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + latitude.hashCode()
-      result = result * 37 + longitude.hashCode()
+      result = result * 37 + (latitude?.hashCode() ?: 0)
+      result = result * 37 + (longitude?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -91,14 +90,14 @@ public class Point(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Point): Int {
+      public override fun encodedSize(`value`: Point): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.latitude)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.longitude)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Point): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Point): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.latitude)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.longitude)
         writer.writeBytes(value.unknownFields)
@@ -121,7 +120,7 @@ public class Point(
         )
       }
 
-      public override fun redact(value: Point): Point = value.copy(
+      public override fun redact(`value`: Point): Point = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -66,8 +65,8 @@ public class Rectangle(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + lo.hashCode()
-      result = result * 37 + hi.hashCode()
+      result = result * 37 + (lo?.hashCode() ?: 0)
+      result = result * 37 + (hi?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -95,14 +94,14 @@ public class Rectangle(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Rectangle): Int {
+      public override fun encodedSize(`value`: Rectangle): Int {
         var size = value.unknownFields.size
         size += Point.ADAPTER.encodedSizeWithTag(1, value.lo)
         size += Point.ADAPTER.encodedSizeWithTag(2, value.hi)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Rectangle): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Rectangle): Unit {
         Point.ADAPTER.encodeWithTag(writer, 1, value.lo)
         Point.ADAPTER.encodeWithTag(writer, 2, value.hi)
         writer.writeBytes(value.unknownFields)
@@ -125,7 +124,7 @@ public class Rectangle(
         )
       }
 
-      public override fun redact(value: Rectangle): Rectangle = value.copy(
+      public override fun redact(`value`: Rectangle): Rectangle = value.copy(
         lo = value.lo?.let(Point.ADAPTER::redact),
         hi = value.hi?.let(Point.ADAPTER::redact),
         unknownFields = ByteString.EMPTY

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -66,8 +65,8 @@ public class RouteNote(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + location.hashCode()
-      result = result * 37 + message.hashCode()
+      result = result * 37 + (location?.hashCode() ?: 0)
+      result = result * 37 + (message?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -95,14 +94,14 @@ public class RouteNote(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RouteNote): Int {
+      public override fun encodedSize(`value`: RouteNote): Int {
         var size = value.unknownFields.size
         size += Point.ADAPTER.encodedSizeWithTag(1, value.location)
         size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.message)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RouteNote): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RouteNote): Unit {
         Point.ADAPTER.encodeWithTag(writer, 1, value.location)
         ProtoAdapter.STRING.encodeWithTag(writer, 2, value.message)
         writer.writeBytes(value.unknownFields)
@@ -125,7 +124,7 @@ public class RouteNote(
         )
       }
 
-      public override fun redact(value: RouteNote): RouteNote = value.copy(
+      public override fun redact(`value`: RouteNote): RouteNote = value.copy(
         location = value.location?.let(Point.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -87,10 +86,10 @@ public class RouteSummary(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + point_count.hashCode()
-      result = result * 37 + feature_count.hashCode()
-      result = result * 37 + distance.hashCode()
-      result = result * 37 + elapsed_time.hashCode()
+      result = result * 37 + (point_count?.hashCode() ?: 0)
+      result = result * 37 + (feature_count?.hashCode() ?: 0)
+      result = result * 37 + (distance?.hashCode() ?: 0)
+      result = result * 37 + (elapsed_time?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -122,7 +121,7 @@ public class RouteSummary(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RouteSummary): Int {
+      public override fun encodedSize(`value`: RouteSummary): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.point_count)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.feature_count)
@@ -131,7 +130,7 @@ public class RouteSummary(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RouteSummary): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RouteSummary): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.point_count)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.feature_count)
         ProtoAdapter.INT32.encodeWithTag(writer, 3, value.distance)
@@ -162,7 +161,7 @@ public class RouteSummary(
         )
       }
 
-      public override fun redact(value: RouteSummary): RouteSummary = value.copy(
+      public override fun redact(`value`: RouteSummary): RouteSummary = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,7 @@ object versions {
   val gson = "2.8.6"
   val guava = "20.0"
   val javapoet = "1.13.0"
-  val kotlinpoet = "1.7.2"
+  val kotlinpoet = "1.8.0"
   val jsr305 = "3.0.2"
   val kotlin = "1.4.10"
   val okio = "3.0.0-alpha.3"

--- a/wire-library/wire-grpc-server-generator/src/test/golden/ImplBase.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/ImplBase.kt
@@ -41,28 +41,28 @@ public class RouteGuideWireGrpc {
             ).build()
 
     public class PointMarshaller : MethodDescriptor.Marshaller<Point> {
-      public override fun stream(value: Point): InputStream =
+      public override fun stream(`value`: Point): InputStream =
           Point.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): Point = Point.ADAPTER.decode(stream)
     }
 
     public class FeatureMarshaller : MethodDescriptor.Marshaller<Feature> {
-      public override fun stream(value: Feature): InputStream =
+      public override fun stream(`value`: Feature): InputStream =
           Feature.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): Feature = Feature.ADAPTER.decode(stream)
     }
 
     public class RectangleMarshaller : MethodDescriptor.Marshaller<Rectangle> {
-      public override fun stream(value: Rectangle): InputStream =
+      public override fun stream(`value`: Rectangle): InputStream =
           Rectangle.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): Rectangle = Rectangle.ADAPTER.decode(stream)
     }
 
     public class RouteSummaryMarshaller : MethodDescriptor.Marshaller<RouteSummary> {
-      public override fun stream(value: RouteSummary): InputStream =
+      public override fun stream(`value`: RouteSummary): InputStream =
           RouteSummary.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): RouteSummary =
@@ -70,7 +70,7 @@ public class RouteGuideWireGrpc {
     }
 
     public class RouteNoteMarshaller : MethodDescriptor.Marshaller<RouteNote> {
-      public override fun stream(value: RouteNote): InputStream =
+      public override fun stream(`value`: RouteNote): InputStream =
           RouteNote.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): RouteNote = RouteNote.ADAPTER.decode(stream)

--- a/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -189,28 +189,28 @@ public object RouteGuideWireGrpc {
             ).build()
 
     public class PointMarshaller : MethodDescriptor.Marshaller<Point> {
-      public override fun stream(value: Point): InputStream =
+      public override fun stream(`value`: Point): InputStream =
           Point.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): Point = Point.ADAPTER.decode(stream)
     }
 
     public class FeatureMarshaller : MethodDescriptor.Marshaller<Feature> {
-      public override fun stream(value: Feature): InputStream =
+      public override fun stream(`value`: Feature): InputStream =
           Feature.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): Feature = Feature.ADAPTER.decode(stream)
     }
 
     public class RectangleMarshaller : MethodDescriptor.Marshaller<Rectangle> {
-      public override fun stream(value: Rectangle): InputStream =
+      public override fun stream(`value`: Rectangle): InputStream =
           Rectangle.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): Rectangle = Rectangle.ADAPTER.decode(stream)
     }
 
     public class RouteSummaryMarshaller : MethodDescriptor.Marshaller<RouteSummary> {
-      public override fun stream(value: RouteSummary): InputStream =
+      public override fun stream(`value`: RouteSummary): InputStream =
           RouteSummary.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): RouteSummary =
@@ -218,7 +218,7 @@ public object RouteGuideWireGrpc {
     }
 
     public class RouteNoteMarshaller : MethodDescriptor.Marshaller<RouteNote> {
-      public override fun stream(value: RouteNote): InputStream =
+      public override fun stream(`value`: RouteNote): InputStream =
           RouteNote.ADAPTER.encode(value).inputStream()
 
       public override fun parse(stream: InputStream): RouteNote = RouteNote.ADAPTER.decode(stream)

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -21,7 +21,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -94,11 +93,11 @@ public class Dinosaur(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
       result = result * 37 + picture_urls.hashCode()
-      result = result * 37 + length_meters.hashCode()
-      result = result * 37 + mass_kilograms.hashCode()
-      result = result * 37 + period.hashCode()
+      result = result * 37 + (length_meters?.hashCode() ?: 0)
+      result = result * 37 + (mass_kilograms?.hashCode() ?: 0)
+      result = result * 37 + (period?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -190,7 +189,7 @@ public class Dinosaur(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Dinosaur): Int {
+      public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls)
@@ -200,7 +199,7 @@ public class Dinosaur(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Dinosaur): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Dinosaur): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 2, value.picture_urls)
         ProtoAdapter.DOUBLE.encodeWithTag(writer, 3, value.length_meters)
@@ -239,7 +238,7 @@ public class Dinosaur(
         )
       }
 
-      public override fun redact(value: Dinosaur): Dinosaur = value.copy(
+      public override fun redact(`value`: Dinosaur): Dinosaur = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -24,7 +24,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -88,11 +87,11 @@ public class Dinosaur(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
       result = result * 37 + picture_urls.hashCode()
-      result = result * 37 + length_meters.hashCode()
-      result = result * 37 + mass_kilograms.hashCode()
-      result = result * 37 + period.hashCode()
+      result = result * 37 + (length_meters?.hashCode() ?: 0)
+      result = result * 37 + (mass_kilograms?.hashCode() ?: 0)
+      result = result * 37 + (period?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -126,7 +125,7 @@ public class Dinosaur(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Dinosaur): Int {
+      public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls)
@@ -136,7 +135,7 @@ public class Dinosaur(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Dinosaur): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Dinosaur): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 2, value.picture_urls)
         ProtoAdapter.DOUBLE.encodeWithTag(writer, 3, value.length_meters)
@@ -175,7 +174,7 @@ public class Dinosaur(
         )
       }
 
-      public override fun redact(value: Dinosaur): Dinosaur = value.copy(
+      public override fun redact(`value`: Dinosaur): Dinosaur = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/geology/javainteropkotlin/Period.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/geology/javainteropkotlin/Period.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class Period(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   /**
    * 145.5 million years ago — 66.0 million years ago.
@@ -34,11 +34,11 @@ public enum class Period(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): Period? = Period.fromValue(value)
+      public override fun fromValue(`value`: Int): Period? = Period.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): Period? = when (value) {
+    public fun fromValue(`value`: Int): Period? = when (value) {
       1 -> CRETACEOUS
       2 -> JURASSIC
       3 -> TRIASSIC

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/geology/kotlin/Period.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/geology/kotlin/Period.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class Period(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   /**
    * 145.5 million years ago — 66.0 million years ago.
@@ -34,11 +34,11 @@ public enum class Period(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): Period? = Period.fromValue(value)
+      public override fun fromValue(`value`: Int): Period? = Period.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): Period? = when (value) {
+    public fun fromValue(`value`: Int): Period? = when (value) {
       1 -> CRETACEOUS
       2 -> JURASSIC
       3 -> TRIASSIC

--- a/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -25,7 +25,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.lazy
@@ -105,7 +104,7 @@ public class KeywordKotlin(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + object_.hashCode()
+      result = result * 37 + (object_?.hashCode() ?: 0)
       result = result * 37 + when_.hashCode()
       result = result * 37 + fun_.hashCode()
       result = result * 37 + return_.hashCode()
@@ -199,7 +198,7 @@ public class KeywordKotlin(
       private val funAdapter: ProtoAdapter<Map<String, String>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING) }
 
-      public override fun encodedSize(value: KeywordKotlin): Int {
+      public override fun encodedSize(`value`: KeywordKotlin): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.object_)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.when_)
@@ -209,7 +208,7 @@ public class KeywordKotlin(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: KeywordKotlin): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: KeywordKotlin): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.object_)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.when_)
         funAdapter.encodeWithTag(writer, 3, value.fun_)
@@ -248,7 +247,7 @@ public class KeywordKotlin(
         )
       }
 
-      public override fun redact(value: KeywordKotlin): KeywordKotlin = value.copy(
+      public override fun redact(`value`: KeywordKotlin): KeywordKotlin = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -257,7 +256,7 @@ public class KeywordKotlin(
   }
 
   public enum class KeywordKotlinEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     @WireEnumConstant(declaredName = "object")
     object_(0),
@@ -278,12 +277,12 @@ public class KeywordKotlin(
         PROTO_2, 
         KeywordKotlinEnum.object_
       ) {
-        public override fun fromValue(value: Int): KeywordKotlinEnum? =
+        public override fun fromValue(`value`: Int): KeywordKotlinEnum? =
             KeywordKotlinEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): KeywordKotlinEnum? = when (value) {
+      public fun fromValue(`value`: Int): KeywordKotlinEnum? = when (value) {
         0 -> object_
         1 -> when_
         2 -> fun_

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -219,7 +219,6 @@ public final class JavaGenerator {
         }
 
       } else if (type instanceof EnumType) {
-        nameAllocator.newName("value", "value");
         nameAllocator.newName("i", "i");
         nameAllocator.newName("reader", "reader");
         nameAllocator.newName("writer", "writer");
@@ -513,7 +512,7 @@ public final class JavaGenerator {
 
   private TypeSpec generateEnum(EnumType type) {
     NameAllocator nameAllocator = nameAllocators.getUnchecked(type);
-    String value = nameAllocator.get("value");
+    String value = "value";
     ClassName javaType = (ClassName) typeName(type.getType());
 
     TypeSpec.Builder builder = TypeSpec.enumBuilder(javaType.simpleName())
@@ -823,7 +822,7 @@ public final class JavaGenerator {
    */
   private TypeSpec enumAdapter(NameAllocator nameAllocator, EnumType type, ClassName javaType,
       ClassName adapterJavaType) {
-    String value = nameAllocator.get("value");
+    String value = "value";
     String i = nameAllocator.get("i");
     String reader = nameAllocator.get("reader");
     String writer = nameAllocator.get("writer");

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -219,6 +219,7 @@ public final class JavaGenerator {
         }
 
       } else if (type instanceof EnumType) {
+        nameAllocator.newName("value", "value");
         nameAllocator.newName("i", "i");
         nameAllocator.newName("reader", "reader");
         nameAllocator.newName("writer", "writer");
@@ -512,7 +513,7 @@ public final class JavaGenerator {
 
   private TypeSpec generateEnum(EnumType type) {
     NameAllocator nameAllocator = nameAllocators.getUnchecked(type);
-    String value = "value";
+    String value = nameAllocator.get("value");
     ClassName javaType = (ClassName) typeName(type.getType());
 
     TypeSpec.Builder builder = TypeSpec.enumBuilder(javaType.simpleName())
@@ -822,7 +823,7 @@ public final class JavaGenerator {
    */
   private TypeSpec enumAdapter(NameAllocator nameAllocator, EnumType type, ClassName javaType,
       ClassName adapterJavaType) {
-    String value = "value";
+    String value = nameAllocator.get("value");
     String i = nameAllocator.get("i");
     String reader = nameAllocator.get("reader");
     String writer = nameAllocator.get("writer");

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1630,6 +1630,9 @@ class KotlinGenerator private constructor(
     val type = enum.type
     val nameAllocator = nameAllocator(enum)
 
+    // Note that we cannot use nameAllocator for `value` because if we rename it the generated code
+    // will not compile for the constructor parameter `override val value_: Int` won't be overriding
+    // anything anymore.
     val valueName = "value"
 
     val primaryConstructor = FunSpec.constructorBuilder()

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -397,7 +397,6 @@ class KotlinGenerator private constructor(
       NameAllocator().apply {
         when (message) {
           is EnumType -> {
-            newName("value", "value")
             newName("ADAPTER", "ADAPTER")
             newName("ENUM_OPTIONS", "ENUM_OPTIONS")
             message.constants.forEach { constant ->
@@ -640,7 +639,6 @@ class KotlinGenerator private constructor(
       addStatement("var %N = super.hashCode", resultName)
       beginControlFlow("if (%N == 0)", resultName)
 
-      val hashCode = MemberName("kotlin", "hashCode")
       addStatement("%N = unknownFields.hashCode()", resultName)
       for (field in type.fieldsAndFlatOneOfFields()) {
         val fieldName = localNameAllocator[field]
@@ -648,13 +646,13 @@ class KotlinGenerator private constructor(
         if (field.isRepeated || field.isRequired || field.isMap) {
           addStatement("%L.hashCode()", fieldName)
         } else {
-          addStatement("%L.%M()", fieldName, hashCode)
+          addStatement("(%L?.hashCode() ?: 0)", fieldName)
         }
       }
       for (oneOf in type.boxOneOfs()) {
         val fieldName = localNameAllocator[oneOf]
         add("%1N = %1N * 37 + ", resultName)
-        addStatement("%L.%M()", fieldName, hashCode)
+        addStatement("(%L?.hashCode() ?: 0)", fieldName)
       }
 
       addStatement("super.hashCode = %N", resultName)
@@ -1632,7 +1630,7 @@ class KotlinGenerator private constructor(
     val type = enum.type
     val nameAllocator = nameAllocator(enum)
 
-    val valueName = nameAllocator["value"]
+    val valueName = "value"
 
     val primaryConstructor = FunSpec.constructorBuilder()
         .addParameter(valueName, Int::class, OVERRIDE)
@@ -1690,7 +1688,7 @@ class KotlinGenerator private constructor(
     val nameAllocator = nameAllocator(message)
     val companionObjectBuilder = TypeSpec.companionObjectBuilder()
     val parentClassName = typeToKotlinName.getValue(message.type)
-    val valueName = nameAllocator["value"]
+    val valueName = "value"
     val fromValue = FunSpec.builder("fromValue")
         .jvmStatic()
         .addParameter(valueName, Int::class)
@@ -1724,7 +1722,7 @@ class KotlinGenerator private constructor(
     val nameAllocator = nameAllocator(message)
 
     val adapterName = nameAllocator["ADAPTER"]
-    val valueName = nameAllocator["value"]
+    val valueName = "value"
 
     val adapterType = ProtoAdapter::class.asClassName().parameterizedBy(parentClassName)
     val adapterObject = TypeSpec.anonymousClassBuilder()

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -49,9 +49,9 @@ class KotlinGeneratorTest {
     assertTrue(code.contains("object : ProtoAdapter<PhoneNumber>("))
     assertTrue(code.contains("FieldEncoding.LENGTH_DELIMITED"))
     assertTrue(code.contains("PhoneNumber::class"))
-    assertTrue(code.contains("override fun encode(writer: ProtoWriter, value: Person)"))
-    assertTrue(code.contains("enum class PhoneType(    public override val value: Int  ) : WireEnum"))
-    assertTrue(code.contains("fun fromValue(value: Int): PhoneType?"))
+    assertTrue(code.contains("override fun encode(writer: ProtoWriter, `value`: Person)"))
+    assertTrue(code.contains("enum class PhoneType(    public override val `value`: Int  ) : WireEnum"))
+    assertTrue(code.contains("fun fromValue(`value`: Int): PhoneType?"))
     assertTrue(code.contains("WORK(1),"))
   }
 
@@ -1156,9 +1156,9 @@ class KotlinGeneratorTest {
     assertTrue(code.contains("object : ProtoAdapter<PhoneNumber>("))
     assertTrue(code.contains("FieldEncoding.LENGTH_DELIMITED"))
     assertTrue(code.contains("PhoneNumber::class"))
-    assertTrue(code.contains("override fun encode(writer: ProtoWriter, value: Person)"))
-    assertTrue(code.contains("enum class PhoneType(    public override val value: Int  ) : WireEnum"))
-    assertTrue(code.contains("fun fromValue(value: Int): PhoneType?"))
+    assertTrue(code.contains("override fun encode(writer: ProtoWriter, `value`: Person)"))
+    assertTrue(code.contains("enum class PhoneType(    public override val `value`: Int  ) : WireEnum"))
+    assertTrue(code.contains("fun fromValue(`value`: Int): PhoneType?"))
     assertTrue(code.contains("WORK(1),"))
   }
 

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -21,7 +21,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -94,11 +93,11 @@ public class Dinosaur(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
       result = result * 37 + picture_urls.hashCode()
-      result = result * 37 + length_meters.hashCode()
-      result = result * 37 + mass_kilograms.hashCode()
-      result = result * 37 + period.hashCode()
+      result = result * 37 + (length_meters?.hashCode() ?: 0)
+      result = result * 37 + (mass_kilograms?.hashCode() ?: 0)
+      result = result * 37 + (period?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -190,7 +189,7 @@ public class Dinosaur(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Dinosaur): Int {
+      public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls)
@@ -200,7 +199,7 @@ public class Dinosaur(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Dinosaur): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Dinosaur): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 2, value.picture_urls)
         ProtoAdapter.DOUBLE.encodeWithTag(writer, 3, value.length_meters)
@@ -239,7 +238,7 @@ public class Dinosaur(
         )
       }
 
-      public override fun redact(value: Dinosaur): Dinosaur = value.copy(
+      public override fun redact(`value`: Dinosaur): Dinosaur = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -24,7 +24,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -88,11 +87,11 @@ public class Dinosaur(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
       result = result * 37 + picture_urls.hashCode()
-      result = result * 37 + length_meters.hashCode()
-      result = result * 37 + mass_kilograms.hashCode()
-      result = result * 37 + period.hashCode()
+      result = result * 37 + (length_meters?.hashCode() ?: 0)
+      result = result * 37 + (mass_kilograms?.hashCode() ?: 0)
+      result = result * 37 + (period?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -126,7 +125,7 @@ public class Dinosaur(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Dinosaur): Int {
+      public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(2, value.picture_urls)
@@ -136,7 +135,7 @@ public class Dinosaur(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Dinosaur): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Dinosaur): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 2, value.picture_urls)
         ProtoAdapter.DOUBLE.encodeWithTag(writer, 3, value.length_meters)
@@ -175,7 +174,7 @@ public class Dinosaur(
         )
       }
 
-      public override fun redact(value: Dinosaur): Dinosaur = value.copy(
+      public override fun redact(`value`: Dinosaur): Dinosaur = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/geology/javainteropkotlin/Period.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/geology/javainteropkotlin/Period.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class Period(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   /**
    * 145.5 million years ago — 66.0 million years ago.
@@ -34,11 +34,11 @@ public enum class Period(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): Period? = Period.fromValue(value)
+      public override fun fromValue(`value`: Int): Period? = Period.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): Period? = when (value) {
+    public fun fromValue(`value`: Int): Period? = when (value) {
       1 -> CRETACEOUS
       2 -> JURASSIC
       3 -> TRIASSIC

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/geology/kotlin/Period.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/geology/kotlin/Period.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class Period(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   /**
    * 145.5 million years ago — 66.0 million years ago.
@@ -34,11 +34,11 @@ public enum class Period(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): Period? = Period.fromValue(value)
+      public override fun fromValue(`value`: Int): Period? = Period.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): Period? = when (value) {
+    public fun fromValue(`value`: Int): Period? = when (value) {
       1 -> CRETACEOUS
       2 -> JURASSIC
       3 -> TRIASSIC

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
@@ -24,7 +24,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -103,7 +102,7 @@ public class Person(
       result = unknownFields.hashCode()
       result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
-      result = result * 37 + email.hashCode()
+      result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       super.hashCode = result
     }
@@ -191,7 +190,7 @@ public class Person(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Person): Int {
+      public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
@@ -200,7 +199,7 @@ public class Person(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Person): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
@@ -231,7 +230,7 @@ public class Person(
         )
       }
 
-      public override fun redact(value: Person): Person = value.copy(
+      public override fun redact(`value`: Person): Person = value.copy(
         phone = value.phone.redactElements(PhoneNumber.ADAPTER),
         unknownFields = ByteString.EMPTY
       )
@@ -244,7 +243,7 @@ public class Person(
    * Represents the type of the phone number: mobile, home or work.
    */
   public enum class PhoneType(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     MOBILE(0),
     HOME(1),
@@ -261,11 +260,11 @@ public class Person(
         PROTO_2, 
         PhoneType.MOBILE
       ) {
-        public override fun fromValue(value: Int): PhoneType? = PhoneType.fromValue(value)
+        public override fun fromValue(`value`: Int): PhoneType? = PhoneType.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): PhoneType? = when (value) {
+      public fun fromValue(`value`: Int): PhoneType? = when (value) {
         0 -> MOBILE
         1 -> HOME
         2 -> WORK
@@ -318,7 +317,7 @@ public class Person(
       if (result == 0) {
         result = unknownFields.hashCode()
         result = result * 37 + number.hashCode()
-        result = result * 37 + type.hashCode()
+        result = result * 37 + (type?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -379,14 +378,14 @@ public class Person(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: PhoneNumber): Int {
+        public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
           size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: PhoneNumber): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: PhoneNumber): Unit {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
           PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
           writer.writeBytes(value.unknownFields)
@@ -413,7 +412,7 @@ public class Person(
           )
         }
 
-        public override fun redact(value: PhoneNumber): PhoneNumber = value.copy(
+        public override fun redact(`value`: PhoneNumber): PhoneNumber = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
@@ -27,7 +27,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -99,7 +98,7 @@ public class Person(
       result = unknownFields.hashCode()
       result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
-      result = result * 37 + email.hashCode()
+      result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       super.hashCode = result
     }
@@ -132,7 +131,7 @@ public class Person(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Person): Int {
+      public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
@@ -141,7 +140,7 @@ public class Person(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Person): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
@@ -172,7 +171,7 @@ public class Person(
         )
       }
 
-      public override fun redact(value: Person): Person = value.copy(
+      public override fun redact(`value`: Person): Person = value.copy(
         phone = value.phone.redactElements(PhoneNumber.ADAPTER),
         unknownFields = ByteString.EMPTY
       )
@@ -185,7 +184,7 @@ public class Person(
    * Represents the type of the phone number: mobile, home or work.
    */
   public enum class PhoneType(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     MOBILE(0),
     HOME(1),
@@ -202,11 +201,11 @@ public class Person(
         PROTO_2, 
         PhoneType.MOBILE
       ) {
-        public override fun fromValue(value: Int): PhoneType? = PhoneType.fromValue(value)
+        public override fun fromValue(`value`: Int): PhoneType? = PhoneType.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): PhoneType? = when (value) {
+      public fun fromValue(`value`: Int): PhoneType? = when (value) {
         0 -> MOBILE
         1 -> HOME
         2 -> WORK
@@ -256,7 +255,7 @@ public class Person(
       if (result == 0) {
         result = unknownFields.hashCode()
         result = result * 37 + number.hashCode()
-        result = result * 37 + type.hashCode()
+        result = result * 37 + (type?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -287,14 +286,14 @@ public class Person(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: PhoneNumber): Int {
+        public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
           size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: PhoneNumber): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: PhoneNumber): Unit {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
           PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
           writer.writeBytes(value.unknownFields)
@@ -321,7 +320,7 @@ public class Person(
           )
         }
 
-        public override fun redact(value: PhoneNumber): PhoneNumber = value.copy(
+        public override fun redact(`value`: PhoneNumber): PhoneNumber = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -25,7 +25,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.lazy
@@ -105,7 +104,7 @@ public class KeywordKotlin(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + object_.hashCode()
+      result = result * 37 + (object_?.hashCode() ?: 0)
       result = result * 37 + when_.hashCode()
       result = result * 37 + fun_.hashCode()
       result = result * 37 + return_.hashCode()
@@ -199,7 +198,7 @@ public class KeywordKotlin(
       private val funAdapter: ProtoAdapter<Map<String, String>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING) }
 
-      public override fun encodedSize(value: KeywordKotlin): Int {
+      public override fun encodedSize(`value`: KeywordKotlin): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.object_)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.when_)
@@ -209,7 +208,7 @@ public class KeywordKotlin(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: KeywordKotlin): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: KeywordKotlin): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.object_)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.when_)
         funAdapter.encodeWithTag(writer, 3, value.fun_)
@@ -248,7 +247,7 @@ public class KeywordKotlin(
         )
       }
 
-      public override fun redact(value: KeywordKotlin): KeywordKotlin = value.copy(
+      public override fun redact(`value`: KeywordKotlin): KeywordKotlin = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -257,7 +256,7 @@ public class KeywordKotlin(
   }
 
   public enum class KeywordKotlinEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     @WireEnumConstant(declaredName = "object")
     object_(0),
@@ -278,12 +277,12 @@ public class KeywordKotlin(
         PROTO_2, 
         KeywordKotlinEnum.object_
       ) {
-        public override fun fromValue(value: Int): KeywordKotlinEnum? =
+        public override fun fromValue(`value`: Int): KeywordKotlinEnum? =
             KeywordKotlinEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): KeywordKotlinEnum? = when (value) {
+      public fun fromValue(`value`: Int): KeywordKotlinEnum? = when (value) {
         0 -> object_
         1 -> when_
         2 -> fun_

--- a/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/ParseTest.kt
+++ b/wire-library/wire-tests/src/commonTest/kotlin/com/squareup/wire/ParseTest.kt
@@ -82,7 +82,7 @@ class ParseTest {
         + "81236123412321230122e122c122a12281226122412221220121e121c121a12181216121412121210120e120"
         + "c120a1208120612041202120008c803").decodeHex()
     val recursive = Recursive.ADAPTER.decode(data.toByteArray())
-    assertEquals(456, recursive.value!!.toInt())
+    assertEquals(456, recursive.value_!!.toInt())
   }
 
   @Test

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
@@ -35,7 +35,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.lazy
@@ -175,7 +174,7 @@ public class AllTypes(
   public val duration: Duration? = null,
   struct: Map<String, *>? = null,
   list_value: List<*>? = null,
-  value: Any? = null,
+  value_: Any? = null,
   null_value: Nothing? = null,
   @field:WireField(
     tag = 24,
@@ -399,9 +398,10 @@ public class AllTypes(
   @field:WireField(
     tag = 22,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
-    label = WireField.Label.OMIT_IDENTITY
+    label = WireField.Label.OMIT_IDENTITY,
+    declaredName = "value"
   )
-  public val value: Any? = immutableCopyOfStruct("value", value)
+  public val value_: Any? = immutableCopyOfStruct("value_", value_)
 
   @field:WireField(
     tag = 23,
@@ -895,7 +895,7 @@ public class AllTypes(
     if (duration != other.duration) return false
     if (struct != other.struct) return false
     if (list_value != other.list_value) return false
-    if (value != other.value) return false
+    if (value_ != other.value_) return false
     if (null_value != other.null_value) return false
     if (empty != other.empty) return false
     if (timestamp != other.timestamp) return false
@@ -982,46 +982,46 @@ public class AllTypes(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + proto3_kotlin_int32.hashCode()
-      result = result * 37 + proto3_kotlin_uint32.hashCode()
-      result = result * 37 + proto3_kotlin_sint32.hashCode()
-      result = result * 37 + proto3_kotlin_fixed32.hashCode()
-      result = result * 37 + proto3_kotlin_sfixed32.hashCode()
-      result = result * 37 + proto3_kotlin_int64.hashCode()
-      result = result * 37 + proto3_kotlin_uint64.hashCode()
-      result = result * 37 + proto3_kotlin_sint64.hashCode()
-      result = result * 37 + proto3_kotlin_fixed64.hashCode()
-      result = result * 37 + proto3_kotlin_sfixed64.hashCode()
-      result = result * 37 + proto3_kotlin_bool.hashCode()
-      result = result * 37 + proto3_kotlin_float.hashCode()
-      result = result * 37 + proto3_kotlin_double.hashCode()
-      result = result * 37 + proto3_kotlin_string.hashCode()
-      result = result * 37 + proto3_kotlin_bytes.hashCode()
-      result = result * 37 + nested_enum.hashCode()
-      result = result * 37 + nested_message.hashCode()
-      result = result * 37 + any.hashCode()
-      result = result * 37 + duration.hashCode()
-      result = result * 37 + struct.hashCode()
-      result = result * 37 + list_value.hashCode()
-      result = result * 37 + value.hashCode()
-      result = result * 37 + null_value.hashCode()
-      result = result * 37 + empty.hashCode()
-      result = result * 37 + timestamp.hashCode()
-      result = result * 37 + opt_int32.hashCode()
-      result = result * 37 + opt_uint32.hashCode()
-      result = result * 37 + opt_sint32.hashCode()
-      result = result * 37 + opt_fixed32.hashCode()
-      result = result * 37 + opt_sfixed32.hashCode()
-      result = result * 37 + opt_int64.hashCode()
-      result = result * 37 + opt_uint64.hashCode()
-      result = result * 37 + opt_sint64.hashCode()
-      result = result * 37 + opt_fixed64.hashCode()
-      result = result * 37 + opt_sfixed64.hashCode()
-      result = result * 37 + opt_bool.hashCode()
-      result = result * 37 + opt_float.hashCode()
-      result = result * 37 + opt_double.hashCode()
-      result = result * 37 + opt_string.hashCode()
-      result = result * 37 + opt_bytes.hashCode()
+      result = result * 37 + (proto3_kotlin_int32?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_uint32?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_sint32?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_int64?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_uint64?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_sint64?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_bool?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_float?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_double?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_string?.hashCode() ?: 0)
+      result = result * 37 + (proto3_kotlin_bytes?.hashCode() ?: 0)
+      result = result * 37 + (nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (nested_message?.hashCode() ?: 0)
+      result = result * 37 + (any?.hashCode() ?: 0)
+      result = result * 37 + (duration?.hashCode() ?: 0)
+      result = result * 37 + (struct?.hashCode() ?: 0)
+      result = result * 37 + (list_value?.hashCode() ?: 0)
+      result = result * 37 + (value_?.hashCode() ?: 0)
+      result = result * 37 + (null_value?.hashCode() ?: 0)
+      result = result * 37 + (empty?.hashCode() ?: 0)
+      result = result * 37 + (timestamp?.hashCode() ?: 0)
+      result = result * 37 + (opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (opt_float?.hashCode() ?: 0)
+      result = result * 37 + (opt_double?.hashCode() ?: 0)
+      result = result * 37 + (opt_string?.hashCode() ?: 0)
+      result = result * 37 + (opt_bytes?.hashCode() ?: 0)
       result = result * 37 + rep_int32.hashCode()
       result = result * 37 + rep_uint32.hashCode()
       result = result * 37 + rep_sint32.hashCode()
@@ -1074,15 +1074,15 @@ public class AllTypes(
       result = result * 37 + map_int32_null_value.hashCode()
       result = result * 37 + map_int32_empty.hashCode()
       result = result * 37 + map_int32_timestamp.hashCode()
-      result = result * 37 + oneof_string.hashCode()
-      result = result * 37 + oneof_int32.hashCode()
-      result = result * 37 + oneof_nested_message.hashCode()
-      result = result * 37 + oneof_any.hashCode()
-      result = result * 37 + oneof_duration.hashCode()
-      result = result * 37 + oneof_struct.hashCode()
-      result = result * 37 + oneof_list_value.hashCode()
-      result = result * 37 + oneof_empty.hashCode()
-      result = result * 37 + oneof_timestamp.hashCode()
+      result = result * 37 + (oneof_string?.hashCode() ?: 0)
+      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
+      result = result * 37 + (oneof_nested_message?.hashCode() ?: 0)
+      result = result * 37 + (oneof_any?.hashCode() ?: 0)
+      result = result * 37 + (oneof_duration?.hashCode() ?: 0)
+      result = result * 37 + (oneof_struct?.hashCode() ?: 0)
+      result = result * 37 + (oneof_list_value?.hashCode() ?: 0)
+      result = result * 37 + (oneof_empty?.hashCode() ?: 0)
+      result = result * 37 + (oneof_timestamp?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -1111,7 +1111,7 @@ public class AllTypes(
     if (duration != null) result += """duration=$duration"""
     if (struct != null) result += """struct=$struct"""
     if (list_value != null) result += """list_value=$list_value"""
-    if (value != null) result += """value=$value"""
+    if (value_ != null) result += """value_=$value_"""
     if (null_value != null) result += """null_value=$null_value"""
     if (empty != null) result += """empty=$empty"""
     if (timestamp != null) result += """timestamp=$timestamp"""
@@ -1218,7 +1218,7 @@ public class AllTypes(
     duration: Duration? = this.duration,
     struct: Map<String, *>? = this.struct,
     list_value: List<*>? = this.list_value,
-    value: Any? = this.value,
+    value_: Any? = this.value_,
     null_value: Nothing? = this.null_value,
     empty: Unit? = this.empty,
     timestamp: Instant? = this.timestamp,
@@ -1303,7 +1303,7 @@ public class AllTypes(
       proto3_kotlin_fixed32, proto3_kotlin_sfixed32, proto3_kotlin_int64, proto3_kotlin_uint64,
       proto3_kotlin_sint64, proto3_kotlin_fixed64, proto3_kotlin_sfixed64, proto3_kotlin_bool,
       proto3_kotlin_float, proto3_kotlin_double, proto3_kotlin_string, proto3_kotlin_bytes,
-      nested_enum, nested_message, any, duration, struct, list_value, value, null_value, empty,
+      nested_enum, nested_message, any, duration, struct, list_value, value_, null_value, empty,
       timestamp, opt_int32, opt_uint32, opt_sint32, opt_fixed32, opt_sfixed32, opt_int64,
       opt_uint64, opt_sint64, opt_fixed64, opt_sfixed64, opt_bool, opt_float, opt_double,
       opt_string, opt_bytes, rep_int32, rep_uint32, rep_sint32, rep_fixed32, rep_sfixed32,
@@ -1363,7 +1363,7 @@ public class AllTypes(
       private val map_int32_timestampAdapter: ProtoAdapter<Map<Int, Instant>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INSTANT) }
 
-      public override fun encodedSize(value: AllTypes): Int {
+      public override fun encodedSize(`value`: AllTypes): Int {
         var size = value.unknownFields.size
         if (value.proto3_kotlin_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1,
             value.proto3_kotlin_int32)
@@ -1406,8 +1406,8 @@ public class AllTypes(
             value.struct)
         if (value.list_value != null) size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(21,
             value.list_value)
-        if (value.value != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(22,
-            value.value)
+        if (value.value_ != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(22,
+            value.value_)
         if (value.null_value != null) size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(23,
             value.null_value)
         if (value.empty != null) size += ProtoAdapter.EMPTY.encodedSizeWithTag(24, value.empty)
@@ -1492,7 +1492,7 @@ public class AllTypes(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: AllTypes): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: AllTypes): Unit {
         if (value.proto3_kotlin_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1,
             value.proto3_kotlin_int32)
         if (value.proto3_kotlin_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2,
@@ -1532,7 +1532,7 @@ public class AllTypes(
         if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 20, value.struct)
         if (value.list_value != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 21,
             value.list_value)
-        if (value.value != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 22, value.value)
+        if (value.value_ != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 22, value.value_)
         if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 23,
             value.null_value)
         if (value.empty != null) ProtoAdapter.EMPTY.encodeWithTag(writer, 24, value.empty)
@@ -1638,7 +1638,7 @@ public class AllTypes(
         var duration: Duration? = null
         var struct: Map<String, *>? = null
         var list_value: List<*>? = null
-        var value: Any? = null
+        var value_: Any? = null
         var null_value: Nothing? = null
         var empty: Unit? = null
         var timestamp: Instant? = null
@@ -1745,7 +1745,7 @@ public class AllTypes(
             19 -> duration = ProtoAdapter.DURATION.decode(reader)
             20 -> struct = ProtoAdapter.STRUCT_MAP.decode(reader)
             21 -> list_value = ProtoAdapter.STRUCT_LIST.decode(reader)
-            22 -> value = ProtoAdapter.STRUCT_VALUE.decode(reader)
+            22 -> value_ = ProtoAdapter.STRUCT_VALUE.decode(reader)
             23 -> try {
               null_value = ProtoAdapter.STRUCT_NULL.decode(reader)
             } catch (e: ProtoAdapter.EnumConstantNotFoundException) {
@@ -1870,7 +1870,7 @@ public class AllTypes(
           duration = duration,
           struct = struct,
           list_value = list_value,
-          value = value,
+          value_ = value_,
           null_value = null_value,
           empty = empty,
           timestamp = timestamp,
@@ -1954,13 +1954,13 @@ public class AllTypes(
         )
       }
 
-      public override fun redact(value: AllTypes): AllTypes = value.copy(
+      public override fun redact(`value`: AllTypes): AllTypes = value.copy(
         nested_message = value.nested_message?.let(NestedMessage.ADAPTER::redact),
         any = value.any?.let(AnyMessage.ADAPTER::redact),
         duration = value.duration?.let(ProtoAdapter.DURATION::redact),
         struct = value.struct?.let(ProtoAdapter.STRUCT_MAP::redact),
         list_value = value.list_value?.let(ProtoAdapter.STRUCT_LIST::redact),
-        value = value.value?.let(ProtoAdapter.STRUCT_VALUE::redact),
+        value_ = value.value_?.let(ProtoAdapter.STRUCT_VALUE::redact),
         empty = value.empty?.let(ProtoAdapter.EMPTY::redact),
         timestamp = value.timestamp?.let(ProtoAdapter.INSTANT::redact),
         rep_nested_message = value.rep_nested_message.redactElements(NestedMessage.ADAPTER),
@@ -1994,7 +1994,7 @@ public class AllTypes(
   }
 
   public enum class NestedEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     UNKNOWN(0),
     A(1),
@@ -2007,11 +2007,11 @@ public class AllTypes(
         PROTO_3, 
         NestedEnum.UNKNOWN
       ) {
-        public override fun fromValue(value: Int): NestedEnum? = NestedEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): NestedEnum? = NestedEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): NestedEnum? = when (value) {
+      public fun fromValue(`value`: Int): NestedEnum? = when (value) {
         0 -> UNKNOWN
         1 -> A
         else -> null
@@ -2047,7 +2047,7 @@ public class AllTypes(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + a.hashCode()
+        result = result * 37 + (a?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -2071,13 +2071,13 @@ public class AllTypes(
         PROTO_3, 
         null
       ) {
-        public override fun encodedSize(value: NestedMessage): Int {
+        public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
           if (value.a != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedMessage): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedMessage): Unit {
           if (value.a != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
           writer.writeBytes(value.unknownFields)
         }
@@ -2096,7 +2096,7 @@ public class AllTypes(
           )
         }
 
-        public override fun redact(value: NestedMessage): NestedMessage = value.copy(
+        public override fun redact(`value`: NestedMessage): NestedMessage = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
@@ -27,7 +27,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -125,13 +124,13 @@ public class Person(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
-      result = result * 37 + id.hashCode()
-      result = result * 37 + email.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
+      result = result * 37 + (id?.hashCode() ?: 0)
+      result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phones.hashCode()
       result = result * 37 + aliases.hashCode()
-      result = result * 37 + foo.hashCode()
-      result = result * 37 + bar.hashCode()
+      result = result * 37 + (foo?.hashCode() ?: 0)
+      result = result * 37 + (bar?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -169,7 +168,7 @@ public class Person(
       PROTO_3, 
       null
     ) {
-      public override fun encodedSize(value: Person): Int {
+      public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
         if (value.name != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         if (value.id != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
@@ -181,7 +180,7 @@ public class Person(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Person): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
         if (value.name != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         if (value.id != 0) ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         if (value.email != "") ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
@@ -224,7 +223,7 @@ public class Person(
         )
       }
 
-      public override fun redact(value: Person): Person = value.copy(
+      public override fun redact(`value`: Person): Person = value.copy(
         phones = value.phones.redactElements(PhoneNumber.ADAPTER),
         unknownFields = ByteString.EMPTY
       )
@@ -237,7 +236,7 @@ public class Person(
    * Represents the type of the phone number: mobile, home or work.
    */
   public enum class PhoneType(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     MOBILE(0),
     HOME(1),
@@ -254,11 +253,11 @@ public class Person(
         PROTO_3, 
         PhoneType.MOBILE
       ) {
-        public override fun fromValue(value: Int): PhoneType? = PhoneType.fromValue(value)
+        public override fun fromValue(`value`: Int): PhoneType? = PhoneType.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): PhoneType? = when (value) {
+      public fun fromValue(`value`: Int): PhoneType? = when (value) {
         0 -> MOBILE
         1 -> HOME
         2 -> WORK
@@ -308,8 +307,8 @@ public class Person(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + number.hashCode()
-        result = result * 37 + type.hashCode()
+        result = result * 37 + (number?.hashCode() ?: 0)
+        result = result * 37 + (type?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -337,7 +336,7 @@ public class Person(
         PROTO_3, 
         null
       ) {
-        public override fun encodedSize(value: PhoneNumber): Int {
+        public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size
           if (value.number != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
           if (value.type != PhoneType.MOBILE) size += PhoneType.ADAPTER.encodedSizeWithTag(2,
@@ -345,7 +344,7 @@ public class Person(
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: PhoneNumber): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: PhoneNumber): Unit {
           if (value.number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
           if (value.type != PhoneType.MOBILE) PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
           writer.writeBytes(value.unknownFields)
@@ -372,7 +371,7 @@ public class Person(
           )
         }
 
-        public override fun redact(value: PhoneNumber): PhoneNumber = value.copy(
+        public override fun redact(`value`: PhoneNumber): PhoneNumber = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/EnumOptionOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/EnumOptionOption.kt
@@ -14,5 +14,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 public annotation class EnumOptionOption(
-  public val value: Boolean
+  public val `value`: Boolean
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/EnumValueOptionOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/EnumValueOptionOption.kt
@@ -14,5 +14,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class EnumValueOptionOption(
-  public val value: Int
+  public val `value`: Int
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -28,7 +28,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -130,14 +129,14 @@ public class FooBar(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + foo.hashCode()
-      result = result * 37 + bar.hashCode()
-      result = result * 37 + baz.hashCode()
-      result = result * 37 + qux.hashCode()
+      result = result * 37 + (foo?.hashCode() ?: 0)
+      result = result * 37 + (bar?.hashCode() ?: 0)
+      result = result * 37 + (baz?.hashCode() ?: 0)
+      result = result * 37 + (qux?.hashCode() ?: 0)
       result = result * 37 + fred.hashCode()
-      result = result * 37 + daisy.hashCode()
+      result = result * 37 + (daisy?.hashCode() ?: 0)
       result = result * 37 + nested.hashCode()
-      result = result * 37 + ext.hashCode()
+      result = result * 37 + (ext?.hashCode() ?: 0)
       result = result * 37 + rep.hashCode()
       super.hashCode = result
     }
@@ -180,7 +179,7 @@ public class FooBar(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: FooBar): Int {
+      public override fun encodedSize(`value`: FooBar): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo)
         size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.bar)
@@ -194,7 +193,7 @@ public class FooBar(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: FooBar): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: FooBar): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)
         ProtoAdapter.STRING.encodeWithTag(writer, 2, value.bar)
         Nested.ADAPTER.encodeWithTag(writer, 3, value.baz)
@@ -253,7 +252,7 @@ public class FooBar(
         )
       }
 
-      public override fun redact(value: FooBar): FooBar = value.copy(
+      public override fun redact(`value`: FooBar): FooBar = value.copy(
         baz = value.baz?.let(Nested.ADAPTER::redact),
         nested = emptyList(),
         unknownFields = ByteString.EMPTY
@@ -266,9 +265,10 @@ public class FooBar(
   public class Nested(
     @field:WireField(
       tag = 1,
-      adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER"
+      adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
+      declaredName = "value"
     )
-    public val value: FooBarBazEnum? = null,
+    public val value_: FooBarBazEnum? = null,
     unknownFields: ByteString = ByteString.EMPTY
   ) : Message<Nested, Nothing>(ADAPTER, unknownFields) {
     @Deprecated(
@@ -282,7 +282,7 @@ public class FooBar(
       if (other === this) return true
       if (other !is Nested) return false
       if (unknownFields != other.unknownFields) return false
-      if (value != other.value) return false
+      if (value_ != other.value_) return false
       return true
     }
 
@@ -290,7 +290,7 @@ public class FooBar(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + value.hashCode()
+        result = result * 37 + (value_?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -298,12 +298,12 @@ public class FooBar(
 
     public override fun toString(): String {
       val result = mutableListOf<String>()
-      if (value != null) result += """value=$value"""
+      if (value_ != null) result += """value_=$value_"""
       return result.joinToString(prefix = "Nested{", separator = ", ", postfix = "}")
     }
 
-    public fun copy(value: FooBarBazEnum? = this.value, unknownFields: ByteString =
-        this.unknownFields): Nested = Nested(value, unknownFields)
+    public fun copy(value_: FooBarBazEnum? = this.value_, unknownFields: ByteString =
+        this.unknownFields): Nested = Nested(value_, unknownFields)
 
     public companion object {
       @JvmField
@@ -314,23 +314,23 @@ public class FooBar(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: Nested): Int {
+        public override fun encodedSize(`value`: Nested): Int {
           var size = value.unknownFields.size
-          size += FooBarBazEnum.ADAPTER.encodedSizeWithTag(1, value.value)
+          size += FooBarBazEnum.ADAPTER.encodedSizeWithTag(1, value.value_)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: Nested): Unit {
-          FooBarBazEnum.ADAPTER.encodeWithTag(writer, 1, value.value)
+        public override fun encode(writer: ProtoWriter, `value`: Nested): Unit {
+          FooBarBazEnum.ADAPTER.encodeWithTag(writer, 1, value.value_)
           writer.writeBytes(value.unknownFields)
         }
 
         public override fun decode(reader: ProtoReader): Nested {
-          var value: FooBarBazEnum? = null
+          var value_: FooBarBazEnum? = null
           val unknownFields = reader.forEachTag { tag ->
             when (tag) {
               1 -> try {
-                value = FooBarBazEnum.ADAPTER.decode(reader)
+                value_ = FooBarBazEnum.ADAPTER.decode(reader)
               } catch (e: ProtoAdapter.EnumConstantNotFoundException) {
                 reader.addUnknownField(tag, FieldEncoding.VARINT, e.value.toLong())
               }
@@ -338,12 +338,12 @@ public class FooBar(
             }
           }
           return Nested(
-            value = value,
+            value_ = value_,
             unknownFields = unknownFields
           )
         }
 
-        public override fun redact(value: Nested): Nested = value.copy(
+        public override fun redact(`value`: Nested): Nested = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -406,13 +406,13 @@ public class FooBar(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: More): Int {
+        public override fun encodedSize(`value`: More): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(1, value.serial)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: More): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: More): Unit {
           ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 1, value.serial)
           writer.writeBytes(value.unknownFields)
         }
@@ -431,7 +431,7 @@ public class FooBar(
           )
         }
 
-        public override fun redact(value: More): More = value.copy(
+        public override fun redact(`value`: More): More = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -442,7 +442,7 @@ public class FooBar(
 
   @EnumOptionOption(true)
   public enum class FooBarBazEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     @EnumValueOptionOption(17)
     FOO(1),
@@ -460,11 +460,11 @@ public class FooBar(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): FooBarBazEnum? = FooBarBazEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): FooBarBazEnum? = FooBarBazEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): FooBarBazEnum? = when (value) {
+      public fun fromValue(`value`: Int): FooBarBazEnum? = when (value) {
         1 -> FOO
         2 -> BAR
         3 -> BAZ

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
@@ -57,12 +57,12 @@ public class MessageWithOptions(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: MessageWithOptions): Int {
+      public override fun encodedSize(`value`: MessageWithOptions): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: MessageWithOptions): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: MessageWithOptions): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -73,7 +73,7 @@ public class MessageWithOptions(
         )
       }
 
-      public override fun redact(value: MessageWithOptions): MessageWithOptions = value.copy(
+      public override fun redact(`value`: MessageWithOptions): MessageWithOptions = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MethodOptionOneOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MethodOptionOneOption.kt
@@ -14,5 +14,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.FUNCTION)
 public annotation class MethodOptionOneOption(
-  public val value: Int
+  public val `value`: Int
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyFieldOptionOneOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyFieldOptionOneOption.kt
@@ -14,5 +14,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class MyFieldOptionOneOption(
-  public val value: Int
+  public val `value`: Int
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyFieldOptionThreeOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyFieldOptionThreeOption.kt
@@ -10,5 +10,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class MyFieldOptionThreeOption(
-  public val value: FooBar.FooBarBazEnum
+  public val `value`: FooBar.FooBarBazEnum
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyFieldOptionTwoOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyFieldOptionTwoOption.kt
@@ -11,5 +11,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class MyFieldOptionTwoOption(
-  public val value: Float
+  public val `value`: Float
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyMessageOptionFourOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyMessageOptionFourOption.kt
@@ -10,5 +10,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 public annotation class MyMessageOptionFourOption(
-  public val value: FooBar.FooBarBazEnum
+  public val `value`: FooBar.FooBarBazEnum
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyMessageOptionTwoOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MyMessageOptionTwoOption.kt
@@ -11,5 +11,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 public annotation class MyMessageOptionTwoOption(
-  public val value: Float
+  public val `value`: Float
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/ServiceOptionOneOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/ServiceOptionOneOption.kt
@@ -14,5 +14,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)
 public annotation class ServiceOptionOneOption(
-  public val value: Int
+  public val `value`: Int
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedEnum.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedEnum.kt
@@ -12,7 +12,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class DeprecatedEnum(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   @Deprecated(message = "DISABLED is deprecated")
   DISABLED(1),
@@ -29,11 +29,11 @@ public enum class DeprecatedEnum(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): DeprecatedEnum? = DeprecatedEnum.fromValue(value)
+      public override fun fromValue(`value`: Int): DeprecatedEnum? = DeprecatedEnum.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): DeprecatedEnum? = when (value) {
+    public fun fromValue(`value`: Int): DeprecatedEnum? = when (value) {
       1 -> DISABLED
       2 -> ENABLED
       3 -> ON

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -52,7 +51,7 @@ public class DeprecatedProto(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + foo.hashCode()
+      result = result * 37 + (foo?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -76,13 +75,13 @@ public class DeprecatedProto(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: DeprecatedProto): Int {
+      public override fun encodedSize(`value`: DeprecatedProto): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: DeprecatedProto): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: DeprecatedProto): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)
         writer.writeBytes(value.unknownFields)
       }
@@ -101,7 +100,7 @@ public class DeprecatedProto(
         )
       }
 
-      public override fun redact(value: DeprecatedProto): DeprecatedProto = value.copy(
+      public override fun redact(`value`: DeprecatedProto): DeprecatedProto = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -23,7 +23,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Set
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -53,8 +52,8 @@ public class Form(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + choice.hashCode()
-      result = result * 37 + decision.hashCode()
+      result = result * 37 + (choice?.hashCode() ?: 0)
+      result = result * 37 + (decision?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -78,7 +77,7 @@ public class Form(
     adapter: ProtoAdapter<T>,
     declaredName: String
   ) : OneOf.Key<T>(tag, adapter, declaredName) {
-    public fun create(value: T) = OneOf(this, value)
+    public fun create(`value`: T) = OneOf(this, value)
 
     public fun decode(reader: ProtoReader): OneOf<Choice<T>, T> = create(adapter.decode(reader))
   }
@@ -88,7 +87,7 @@ public class Form(
     adapter: ProtoAdapter<T>,
     declaredName: String
   ) : OneOf.Key<T>(tag, adapter, declaredName) {
-    public fun create(value: T) = OneOf(this, value)
+    public fun create(`value`: T) = OneOf(this, value)
 
     public fun decode(reader: ProtoReader): OneOf<Decision<T>, T> = create(adapter.decode(reader))
   }
@@ -102,14 +101,14 @@ public class Form(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Form): Int {
+      public override fun encodedSize(`value`: Form): Int {
         var size = value.unknownFields.size
         if (value.choice != null) size += value.choice.encodedSizeWithTag()
         if (value.decision != null) size += value.decision.encodedSizeWithTag()
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Form): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Form): Unit {
         if (value.choice != null) value.choice.encodeWithTag(writer)
         if (value.decision != null) value.decision.encodeWithTag(writer)
         writer.writeBytes(value.unknownFields)
@@ -144,7 +143,7 @@ public class Form(
         )
       }
 
-      public override fun redact(value: Form): Form = value.copy(
+      public override fun redact(`value`: Form): Form = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -261,12 +260,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: ButtonElement): Int {
+        public override fun encodedSize(`value`: ButtonElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: ButtonElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: ButtonElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -277,7 +276,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: ButtonElement): ButtonElement = value.copy(
+        public override fun redact(`value`: ButtonElement): ButtonElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -320,12 +319,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: LocalImageElement): Int {
+        public override fun encodedSize(`value`: LocalImageElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: LocalImageElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: LocalImageElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -336,7 +335,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: LocalImageElement): LocalImageElement = value.copy(
+        public override fun redact(`value`: LocalImageElement): LocalImageElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -379,12 +378,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: RemoteImageElement): Int {
+        public override fun encodedSize(`value`: RemoteImageElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: RemoteImageElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: RemoteImageElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -395,7 +394,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: RemoteImageElement): RemoteImageElement = value.copy(
+        public override fun redact(`value`: RemoteImageElement): RemoteImageElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -437,12 +436,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: MoneyElement): Int {
+        public override fun encodedSize(`value`: MoneyElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: MoneyElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: MoneyElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -453,7 +452,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: MoneyElement): MoneyElement = value.copy(
+        public override fun redact(`value`: MoneyElement): MoneyElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -495,12 +494,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: SpacerElement): Int {
+        public override fun encodedSize(`value`: SpacerElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: SpacerElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: SpacerElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -511,7 +510,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: SpacerElement): SpacerElement = value.copy(
+        public override fun redact(`value`: SpacerElement): SpacerElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -547,7 +546,7 @@ public class Form(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + text.hashCode()
+        result = result * 37 + (text?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -571,13 +570,13 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: TextElement): Int {
+        public override fun encodedSize(`value`: TextElement): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.text)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: TextElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: TextElement): Unit {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.text)
           writer.writeBytes(value.unknownFields)
         }
@@ -596,7 +595,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: TextElement): TextElement = value.copy(
+        public override fun redact(`value`: TextElement): TextElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -639,12 +638,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: CustomizedCardElement): Int {
+        public override fun encodedSize(`value`: CustomizedCardElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: CustomizedCardElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: CustomizedCardElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -655,7 +654,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: CustomizedCardElement): CustomizedCardElement =
+        public override fun redact(`value`: CustomizedCardElement): CustomizedCardElement =
             value.copy(
           unknownFields = ByteString.EMPTY
         )
@@ -698,12 +697,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: AddressElement): Int {
+        public override fun encodedSize(`value`: AddressElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: AddressElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: AddressElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -714,7 +713,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: AddressElement): AddressElement = value.copy(
+        public override fun redact(`value`: AddressElement): AddressElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -756,12 +755,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: TextInputElement): Int {
+        public override fun encodedSize(`value`: TextInputElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: TextInputElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: TextInputElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -772,7 +771,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: TextInputElement): TextInputElement = value.copy(
+        public override fun redact(`value`: TextInputElement): TextInputElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -815,12 +814,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: OptionPickerElement): Int {
+        public override fun encodedSize(`value`: OptionPickerElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: OptionPickerElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: OptionPickerElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -831,7 +830,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: OptionPickerElement): OptionPickerElement = value.copy(
+        public override fun redact(`value`: OptionPickerElement): OptionPickerElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -873,12 +872,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: DetailRowElement): Int {
+        public override fun encodedSize(`value`: DetailRowElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: DetailRowElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: DetailRowElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -889,7 +888,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: DetailRowElement): DetailRowElement = value.copy(
+        public override fun redact(`value`: DetailRowElement): DetailRowElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -932,12 +931,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: CurrencyConversionFlagsElement): Int {
+        public override fun encodedSize(`value`: CurrencyConversionFlagsElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: CurrencyConversionFlagsElement):
+        public override fun encode(writer: ProtoWriter, `value`: CurrencyConversionFlagsElement):
             Unit {
           writer.writeBytes(value.unknownFields)
         }
@@ -949,7 +948,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: CurrencyConversionFlagsElement):
+        public override fun redact(`value`: CurrencyConversionFlagsElement):
             CurrencyConversionFlagsElement = value.copy(
           unknownFields = ByteString.EMPTY
         )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -59,8 +58,8 @@ public class MessageUsingMultipleEnums(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + a.hashCode()
-      result = result * 37 + b.hashCode()
+      result = result * 37 + (a?.hashCode() ?: 0)
+      result = result * 37 + (b?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -90,14 +89,14 @@ public class MessageUsingMultipleEnums(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: MessageUsingMultipleEnums): Int {
+      public override fun encodedSize(`value`: MessageUsingMultipleEnums): Int {
         var size = value.unknownFields.size
         size += MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a)
         size += OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: MessageUsingMultipleEnums): Unit {
         MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)
         OtherMessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 2, value.b)
         writer.writeBytes(value.unknownFields)
@@ -128,7 +127,7 @@ public class MessageUsingMultipleEnums(
         )
       }
 
-      public override fun redact(value: MessageUsingMultipleEnums): MessageUsingMultipleEnums =
+      public override fun redact(`value`: MessageUsingMultipleEnums): MessageUsingMultipleEnums =
           value.copy(
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -58,12 +58,12 @@ public class MessageWithStatus(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: MessageWithStatus): Int {
+      public override fun encodedSize(`value`: MessageWithStatus): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: MessageWithStatus): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: MessageWithStatus): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -74,7 +74,7 @@ public class MessageWithStatus(
         )
       }
 
-      public override fun redact(value: MessageWithStatus): MessageWithStatus = value.copy(
+      public override fun redact(`value`: MessageWithStatus): MessageWithStatus = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -83,7 +83,7 @@ public class MessageWithStatus(
   }
 
   public enum class Status(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     A(1),
     ;
@@ -95,11 +95,11 @@ public class MessageWithStatus(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): Status? = Status.fromValue(value)
+        public override fun fromValue(`value`: Int): Status? = Status.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): Status? = when (value) {
+      public fun fromValue(`value`: Int): Status? = when (value) {
         1 -> A
         else -> null
       }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -55,12 +55,12 @@ public class NoFields(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NoFields): Int {
+      public override fun encodedSize(`value`: NoFields): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NoFields): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NoFields): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -71,7 +71,7 @@ public class NoFields(
         )
       }
 
-      public override fun redact(value: NoFields): NoFields = value.copy(
+      public override fun redact(`value`: NoFields): NoFields = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -21,7 +21,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -82,9 +81,9 @@ public class OneOfMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + foo.hashCode()
-      result = result * 37 + bar.hashCode()
-      result = result * 37 + baz.hashCode()
+      result = result * 37 + (foo?.hashCode() ?: 0)
+      result = result * 37 + (bar?.hashCode() ?: 0)
+      result = result * 37 + (baz?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -114,7 +113,7 @@ public class OneOfMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OneOfMessage): Int {
+      public override fun encodedSize(`value`: OneOfMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo)
         size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar)
@@ -122,7 +121,7 @@ public class OneOfMessage(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OneOfMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OneOfMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.bar)
         ProtoAdapter.STRING.encodeWithTag(writer, 4, value.baz)
@@ -149,7 +148,7 @@ public class OneOfMessage(
         )
       }
 
-      public override fun redact(value: OneOfMessage): OneOfMessage = value.copy(
+      public override fun redact(`value`: OneOfMessage): OneOfMessage = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -22,7 +22,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -54,7 +53,7 @@ public class OptionalEnumUser(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + optional_enum.hashCode()
+      result = result * 37 + (optional_enum?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -78,13 +77,13 @@ public class OptionalEnumUser(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OptionalEnumUser): Int {
+      public override fun encodedSize(`value`: OptionalEnumUser): Int {
         var size = value.unknownFields.size
         size += OptionalEnum.ADAPTER.encodedSizeWithTag(1, value.optional_enum)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OptionalEnumUser): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OptionalEnumUser): Unit {
         OptionalEnum.ADAPTER.encodeWithTag(writer, 1, value.optional_enum)
         writer.writeBytes(value.unknownFields)
       }
@@ -107,7 +106,7 @@ public class OptionalEnumUser(
         )
       }
 
-      public override fun redact(value: OptionalEnumUser): OptionalEnumUser = value.copy(
+      public override fun redact(`value`: OptionalEnumUser): OptionalEnumUser = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -116,7 +115,7 @@ public class OptionalEnumUser(
   }
 
   public enum class OptionalEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     FOO(1),
     BAR(2),
@@ -129,11 +128,11 @@ public class OptionalEnumUser(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): OptionalEnum? = OptionalEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): OptionalEnum? = OptionalEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): OptionalEnum? = when (value) {
+      public fun fromValue(`value`: Int): OptionalEnum? = when (value) {
         1 -> FOO
         2 -> BAR
         else -> null

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -59,12 +59,12 @@ public class OtherMessageWithStatus(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OtherMessageWithStatus): Int {
+      public override fun encodedSize(`value`: OtherMessageWithStatus): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OtherMessageWithStatus): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -75,7 +75,7 @@ public class OtherMessageWithStatus(
         )
       }
 
-      public override fun redact(value: OtherMessageWithStatus): OtherMessageWithStatus =
+      public override fun redact(`value`: OtherMessageWithStatus): OtherMessageWithStatus =
           value.copy(
         unknownFields = ByteString.EMPTY
       )
@@ -85,7 +85,7 @@ public class OtherMessageWithStatus(
   }
 
   public enum class Status(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     A(1),
     ;
@@ -97,11 +97,11 @@ public class OtherMessageWithStatus(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): Status? = Status.fromValue(value)
+        public override fun fromValue(`value`: Int): Status? = Status.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): Status? = when (value) {
+      public fun fromValue(`value`: Int): Status? = when (value) {
         1 -> A
         else -> null
       }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -54,7 +53,7 @@ public class VeryLongProtoNameCausingBrokenLineBreaks(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + foo.hashCode()
+      result = result * 37 + (foo?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -81,14 +80,14 @@ public class VeryLongProtoNameCausingBrokenLineBreaks(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: VeryLongProtoNameCausingBrokenLineBreaks): Int {
+      public override fun encodedSize(`value`: VeryLongProtoNameCausingBrokenLineBreaks): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo)
         return size
       }
 
       public override fun encode(writer: ProtoWriter,
-          value: VeryLongProtoNameCausingBrokenLineBreaks): Unit {
+          `value`: VeryLongProtoNameCausingBrokenLineBreaks): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)
         writer.writeBytes(value.unknownFields)
       }
@@ -107,7 +106,7 @@ public class VeryLongProtoNameCausingBrokenLineBreaks(
         )
       }
 
-      public override fun redact(value: VeryLongProtoNameCausingBrokenLineBreaks):
+      public override fun redact(`value`: VeryLongProtoNameCausingBrokenLineBreaks):
           VeryLongProtoNameCausingBrokenLineBreaks = value.copy(
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -30,7 +30,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.lazy
@@ -1223,23 +1222,23 @@ public class AllTypes(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + opt_int32.hashCode()
-      result = result * 37 + opt_uint32.hashCode()
-      result = result * 37 + opt_sint32.hashCode()
-      result = result * 37 + opt_fixed32.hashCode()
-      result = result * 37 + opt_sfixed32.hashCode()
-      result = result * 37 + opt_int64.hashCode()
-      result = result * 37 + opt_uint64.hashCode()
-      result = result * 37 + opt_sint64.hashCode()
-      result = result * 37 + opt_fixed64.hashCode()
-      result = result * 37 + opt_sfixed64.hashCode()
-      result = result * 37 + opt_bool.hashCode()
-      result = result * 37 + opt_float.hashCode()
-      result = result * 37 + opt_double.hashCode()
-      result = result * 37 + opt_string.hashCode()
-      result = result * 37 + opt_bytes.hashCode()
-      result = result * 37 + opt_nested_enum.hashCode()
-      result = result * 37 + opt_nested_message.hashCode()
+      result = result * 37 + (opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (opt_float?.hashCode() ?: 0)
+      result = result * 37 + (opt_double?.hashCode() ?: 0)
+      result = result * 37 + (opt_string?.hashCode() ?: 0)
+      result = result * 37 + (opt_bytes?.hashCode() ?: 0)
+      result = result * 37 + (opt_nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (opt_nested_message?.hashCode() ?: 0)
       result = result * 37 + req_int32.hashCode()
       result = result * 37 + req_uint32.hashCode()
       result = result * 37 + req_sint32.hashCode()
@@ -1288,43 +1287,43 @@ public class AllTypes(
       result = result * 37 + pack_float.hashCode()
       result = result * 37 + pack_double.hashCode()
       result = result * 37 + pack_nested_enum.hashCode()
-      result = result * 37 + default_int32.hashCode()
-      result = result * 37 + default_uint32.hashCode()
-      result = result * 37 + default_sint32.hashCode()
-      result = result * 37 + default_fixed32.hashCode()
-      result = result * 37 + default_sfixed32.hashCode()
-      result = result * 37 + default_int64.hashCode()
-      result = result * 37 + default_uint64.hashCode()
-      result = result * 37 + default_sint64.hashCode()
-      result = result * 37 + default_fixed64.hashCode()
-      result = result * 37 + default_sfixed64.hashCode()
-      result = result * 37 + default_bool.hashCode()
-      result = result * 37 + default_float.hashCode()
-      result = result * 37 + default_double.hashCode()
-      result = result * 37 + default_string.hashCode()
-      result = result * 37 + default_bytes.hashCode()
-      result = result * 37 + default_nested_enum.hashCode()
+      result = result * 37 + (default_int32?.hashCode() ?: 0)
+      result = result * 37 + (default_uint32?.hashCode() ?: 0)
+      result = result * 37 + (default_sint32?.hashCode() ?: 0)
+      result = result * 37 + (default_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (default_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (default_int64?.hashCode() ?: 0)
+      result = result * 37 + (default_uint64?.hashCode() ?: 0)
+      result = result * 37 + (default_sint64?.hashCode() ?: 0)
+      result = result * 37 + (default_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (default_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (default_bool?.hashCode() ?: 0)
+      result = result * 37 + (default_float?.hashCode() ?: 0)
+      result = result * 37 + (default_double?.hashCode() ?: 0)
+      result = result * 37 + (default_string?.hashCode() ?: 0)
+      result = result * 37 + (default_bytes?.hashCode() ?: 0)
+      result = result * 37 + (default_nested_enum?.hashCode() ?: 0)
       result = result * 37 + map_int32_int32.hashCode()
       result = result * 37 + map_string_string.hashCode()
       result = result * 37 + map_string_message.hashCode()
       result = result * 37 + map_string_enum.hashCode()
-      result = result * 37 + ext_opt_int32.hashCode()
-      result = result * 37 + ext_opt_uint32.hashCode()
-      result = result * 37 + ext_opt_sint32.hashCode()
-      result = result * 37 + ext_opt_fixed32.hashCode()
-      result = result * 37 + ext_opt_sfixed32.hashCode()
-      result = result * 37 + ext_opt_int64.hashCode()
-      result = result * 37 + ext_opt_uint64.hashCode()
-      result = result * 37 + ext_opt_sint64.hashCode()
-      result = result * 37 + ext_opt_fixed64.hashCode()
-      result = result * 37 + ext_opt_sfixed64.hashCode()
-      result = result * 37 + ext_opt_bool.hashCode()
-      result = result * 37 + ext_opt_float.hashCode()
-      result = result * 37 + ext_opt_double.hashCode()
-      result = result * 37 + ext_opt_string.hashCode()
-      result = result * 37 + ext_opt_bytes.hashCode()
-      result = result * 37 + ext_opt_nested_enum.hashCode()
-      result = result * 37 + ext_opt_nested_message.hashCode()
+      result = result * 37 + (ext_opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_float?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_double?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_string?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_bytes?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_nested_message?.hashCode() ?: 0)
       result = result * 37 + ext_rep_int32.hashCode()
       result = result * 37 + ext_rep_uint32.hashCode()
       result = result * 37 + ext_rep_sint32.hashCode()
@@ -1719,7 +1718,7 @@ public class AllTypes(
       private val map_string_enumAdapter: ProtoAdapter<Map<String, NestedEnum>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, NestedEnum.ADAPTER) }
 
-      public override fun encodedSize(value: AllTypes): Int {
+      public override fun encodedSize(`value`: AllTypes): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32)
         size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.opt_uint32)
@@ -1858,7 +1857,7 @@ public class AllTypes(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: AllTypes): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: AllTypes): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.opt_int32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.opt_uint32)
         ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.opt_sint32)
@@ -2439,7 +2438,7 @@ public class AllTypes(
         )
       }
 
-      public override fun redact(value: AllTypes): AllTypes = value.copy(
+      public override fun redact(`value`: AllTypes): AllTypes = value.copy(
         opt_nested_message = value.opt_nested_message?.let(NestedMessage.ADAPTER::redact),
         req_nested_message = NestedMessage.ADAPTER.redact(value.req_nested_message),
         rep_nested_message = value.rep_nested_message.redactElements(NestedMessage.ADAPTER),
@@ -2454,7 +2453,7 @@ public class AllTypes(
   }
 
   public enum class NestedEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     UNKNOWN(0),
     A(1),
@@ -2467,11 +2466,11 @@ public class AllTypes(
         PROTO_2, 
         NestedEnum.UNKNOWN
       ) {
-        public override fun fromValue(value: Int): NestedEnum? = NestedEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): NestedEnum? = NestedEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): NestedEnum? = when (value) {
+      public fun fromValue(`value`: Int): NestedEnum? = when (value) {
         0 -> UNKNOWN
         1 -> A
         else -> null
@@ -2506,7 +2505,7 @@ public class AllTypes(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + a.hashCode()
+        result = result * 37 + (a?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -2530,13 +2529,13 @@ public class AllTypes(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: NestedMessage): Int {
+        public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedMessage): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedMessage): Unit {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
           writer.writeBytes(value.unknownFields)
         }
@@ -2555,7 +2554,7 @@ public class AllTypes(
           )
         }
 
-        public override fun redact(value: NestedMessage): NestedMessage = value.copy(
+        public override fun redact(`value`: NestedMessage): NestedMessage = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/bool/TrueBoolean.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/bool/TrueBoolean.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -50,7 +49,7 @@ public class TrueBoolean(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + isTrue.hashCode()
+      result = result * 37 + (isTrue?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -74,13 +73,13 @@ public class TrueBoolean(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: TrueBoolean): Int {
+      public override fun encodedSize(`value`: TrueBoolean): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.isTrue)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: TrueBoolean): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: TrueBoolean): Unit {
         ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.isTrue)
         writer.writeBytes(value.unknownFields)
       }
@@ -99,7 +98,7 @@ public class TrueBoolean(
         )
       }
 
-      public override fun redact(value: TrueBoolean): TrueBoolean = value.copy(
+      public override fun redact(`value`: TrueBoolean): TrueBoolean = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
@@ -54,12 +54,12 @@ public class NoFields(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NoFields): Int {
+      public override fun encodedSize(`value`: NoFields): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NoFields): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NoFields): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -70,7 +70,7 @@ public class NoFields(
         )
       }
 
-      public override fun redact(value: NoFields): NoFields = value.copy(
+      public override fun redact(`value`: NoFields): NoFields = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -50,7 +49,7 @@ public class OneBytesField(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + opt_bytes.hashCode()
+      result = result * 37 + (opt_bytes?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -74,13 +73,13 @@ public class OneBytesField(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OneBytesField): Int {
+      public override fun encodedSize(`value`: OneBytesField): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.BYTES.encodedSizeWithTag(1, value.opt_bytes)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OneBytesField): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OneBytesField): Unit {
         ProtoAdapter.BYTES.encodeWithTag(writer, 1, value.opt_bytes)
         writer.writeBytes(value.unknownFields)
       }
@@ -99,7 +98,7 @@ public class OneBytesField(
         )
       }
 
-      public override fun redact(value: OneBytesField): OneBytesField = value.copy(
+      public override fun redact(`value`: OneBytesField): OneBytesField = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -50,7 +49,7 @@ public class OneField(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + opt_int32.hashCode()
+      result = result * 37 + (opt_int32?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -74,13 +73,13 @@ public class OneField(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OneField): Int {
+      public override fun encodedSize(`value`: OneField): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OneField): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OneField): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.opt_int32)
         writer.writeBytes(value.unknownFields)
       }
@@ -99,7 +98,7 @@ public class OneField(
         )
       }
 
-      public override fun redact(value: OneField): OneField = value.copy(
+      public override fun redact(`value`: OneField): OneField = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
@@ -19,16 +19,16 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
 public class Recursive(
   @field:WireField(
     tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32"
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    declaredName = "value"
   )
-  public val value: Int? = null,
+  public val value_: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.edgecases.Recursive#ADAPTER"
@@ -47,7 +47,7 @@ public class Recursive(
     if (other === this) return true
     if (other !is Recursive) return false
     if (unknownFields != other.unknownFields) return false
-    if (value != other.value) return false
+    if (value_ != other.value_) return false
     if (recursive != other.recursive) return false
     return true
   }
@@ -56,8 +56,8 @@ public class Recursive(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + value.hashCode()
-      result = result * 37 + recursive.hashCode()
+      result = result * 37 + (value_?.hashCode() ?: 0)
+      result = result * 37 + (recursive?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -65,16 +65,16 @@ public class Recursive(
 
   public override fun toString(): String {
     val result = mutableListOf<String>()
-    if (value != null) result += """value=$value"""
+    if (value_ != null) result += """value_=$value_"""
     if (recursive != null) result += """recursive=$recursive"""
     return result.joinToString(prefix = "Recursive{", separator = ", ", postfix = "}")
   }
 
   public fun copy(
-    value: Int? = this.value,
+    value_: Int? = this.value_,
     recursive: Recursive? = this.recursive,
     unknownFields: ByteString = this.unknownFields
-  ): Recursive = Recursive(value, recursive, unknownFields)
+  ): Recursive = Recursive(value_, recursive, unknownFields)
 
   public companion object {
     @JvmField
@@ -85,37 +85,37 @@ public class Recursive(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Recursive): Int {
+      public override fun encodedSize(`value`: Recursive): Int {
         var size = value.unknownFields.size
-        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.value)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.value_)
         size += Recursive.ADAPTER.encodedSizeWithTag(2, value.recursive)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Recursive): Unit {
-        ProtoAdapter.INT32.encodeWithTag(writer, 1, value.value)
+      public override fun encode(writer: ProtoWriter, `value`: Recursive): Unit {
+        ProtoAdapter.INT32.encodeWithTag(writer, 1, value.value_)
         Recursive.ADAPTER.encodeWithTag(writer, 2, value.recursive)
         writer.writeBytes(value.unknownFields)
       }
 
       public override fun decode(reader: ProtoReader): Recursive {
-        var value: Int? = null
+        var value_: Int? = null
         var recursive: Recursive? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
-            1 -> value = ProtoAdapter.INT32.decode(reader)
+            1 -> value_ = ProtoAdapter.INT32.decode(reader)
             2 -> recursive = Recursive.ADAPTER.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
         return Recursive(
-          value = value,
+          value_ = value_,
           recursive = recursive,
           unknownFields = unknownFields
         )
       }
 
-      public override fun redact(value: Recursive): Recursive = value.copy(
+      public override fun redact(`value`: Recursive): Recursive = value.copy(
         recursive = value.recursive?.let(Recursive.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnum.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnum.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class ForeignEnum(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   BAV(0),
   BAX(1),
@@ -24,11 +24,11 @@ public enum class ForeignEnum(
       PROTO_2, 
       ForeignEnum.BAV
     ) {
-      public override fun fromValue(value: Int): ForeignEnum? = ForeignEnum.fromValue(value)
+      public override fun fromValue(`value`: Int): ForeignEnum? = ForeignEnum.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): ForeignEnum? = when (value) {
+    public fun fromValue(`value`: Int): ForeignEnum? = when (value) {
       0 -> BAV
       1 -> BAX
       else -> null

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnumValueOptionOption.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnumValueOptionOption.kt
@@ -11,5 +11,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class ForeignEnumValueOptionOption(
-  public val value: Boolean
+  public val `value`: Boolean
 )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -59,8 +58,8 @@ public class ForeignMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + j.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (j?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -88,14 +87,14 @@ public class ForeignMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: ForeignMessage): Int {
+      public override fun encodedSize(`value`: ForeignMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += ProtoAdapter.INT32.encodedSizeWithTag(100, value.j)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: ForeignMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: ForeignMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         ProtoAdapter.INT32.encodeWithTag(writer, 100, value.j)
         writer.writeBytes(value.unknownFields)
@@ -118,7 +117,7 @@ public class ForeignMessage(
         )
       }
 
-      public override fun redact(value: ForeignMessage): ForeignMessage = value.copy(
+      public override fun redact(`value`: ForeignMessage): ForeignMessage = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -83,13 +83,13 @@ public class Mappy(
       private val thingsAdapter: ProtoAdapter<Map<String, Thing>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER) }
 
-      public override fun encodedSize(value: Mappy): Int {
+      public override fun encodedSize(`value`: Mappy): Int {
         var size = value.unknownFields.size
         size += thingsAdapter.encodedSizeWithTag(1, value.things)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Mappy): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Mappy): Unit {
         thingsAdapter.encodeWithTag(writer, 1, value.things)
         writer.writeBytes(value.unknownFields)
       }
@@ -108,7 +108,7 @@ public class Mappy(
         )
       }
 
-      public override fun redact(value: Mappy): Mappy = value.copy(
+      public override fun redact(`value`: Mappy): Mappy = value.copy(
         things = value.things.redactElements(Thing.ADAPTER),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -51,7 +50,7 @@ public class Thing(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -75,13 +74,13 @@ public class Thing(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Thing): Int {
+      public override fun encodedSize(`value`: Thing): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Thing): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Thing): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         writer.writeBytes(value.unknownFields)
       }
@@ -100,7 +99,7 @@ public class Thing(
         )
       }
 
-      public override fun redact(value: Thing): Thing = value.copy(
+      public override fun redact(`value`: Thing): Thing = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -27,7 +27,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -108,7 +107,7 @@ public class Person(
       result = unknownFields.hashCode()
       result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
-      result = result * 37 + email.hashCode()
+      result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       result = result * 37 + aliases.hashCode()
       super.hashCode = result
@@ -144,7 +143,7 @@ public class Person(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Person): Int {
+      public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
@@ -154,7 +153,7 @@ public class Person(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Person): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
@@ -189,7 +188,7 @@ public class Person(
         )
       }
 
-      public override fun redact(value: Person): Person = value.copy(
+      public override fun redact(`value`: Person): Person = value.copy(
         phone = value.phone.redactElements(PhoneNumber.ADAPTER),
         unknownFields = ByteString.EMPTY
       )
@@ -202,7 +201,7 @@ public class Person(
    * Represents the type of the phone number: mobile, home or work.
    */
   public enum class PhoneType(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     MOBILE(0),
     HOME(1),
@@ -219,11 +218,11 @@ public class Person(
         PROTO_2, 
         PhoneType.MOBILE
       ) {
-        public override fun fromValue(value: Int): PhoneType? = PhoneType.fromValue(value)
+        public override fun fromValue(`value`: Int): PhoneType? = PhoneType.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): PhoneType? = when (value) {
+      public fun fromValue(`value`: Int): PhoneType? = when (value) {
         0 -> MOBILE
         1 -> HOME
         2 -> WORK
@@ -273,7 +272,7 @@ public class Person(
       if (result == 0) {
         result = unknownFields.hashCode()
         result = result * 37 + number.hashCode()
-        result = result * 37 + type.hashCode()
+        result = result * 37 + (type?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -304,14 +303,14 @@ public class Person(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: PhoneNumber): Int {
+        public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
           size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: PhoneNumber): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: PhoneNumber): Unit {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
           PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
           writer.writeBytes(value.unknownFields)
@@ -338,7 +337,7 @@ public class Person(
           )
         }
 
-        public override fun redact(value: PhoneNumber): PhoneNumber = value.copy(
+        public override fun redact(`value`: PhoneNumber): PhoneNumber = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -57,8 +56,8 @@ public class NotRedacted(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + a.hashCode()
-      result = result * 37 + b.hashCode()
+      result = result * 37 + (a?.hashCode() ?: 0)
+      result = result * 37 + (b?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -86,14 +85,14 @@ public class NotRedacted(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NotRedacted): Int {
+      public override fun encodedSize(`value`: NotRedacted): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
         size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.b)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NotRedacted): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NotRedacted): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)
         ProtoAdapter.STRING.encodeWithTag(writer, 2, value.b)
         writer.writeBytes(value.unknownFields)
@@ -116,7 +115,7 @@ public class NotRedacted(
         )
       }
 
-      public override fun redact(value: NotRedacted): NotRedacted = value.copy(
+      public override fun redact(`value`: NotRedacted): NotRedacted = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -63,9 +62,9 @@ public class RedactedChild(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + a.hashCode()
-      result = result * 37 + b.hashCode()
-      result = result * 37 + c.hashCode()
+      result = result * 37 + (a?.hashCode() ?: 0)
+      result = result * 37 + (b?.hashCode() ?: 0)
+      result = result * 37 + (c?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -95,7 +94,7 @@ public class RedactedChild(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedChild): Int {
+      public override fun encodedSize(`value`: RedactedChild): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
         size += RedactedFields.ADAPTER.encodedSizeWithTag(2, value.b)
@@ -103,7 +102,7 @@ public class RedactedChild(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedChild): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedChild): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)
         RedactedFields.ADAPTER.encodeWithTag(writer, 2, value.b)
         NotRedacted.ADAPTER.encodeWithTag(writer, 3, value.c)
@@ -130,7 +129,7 @@ public class RedactedChild(
         )
       }
 
-      public override fun redact(value: RedactedChild): RedactedChild = value.copy(
+      public override fun redact(`value`: RedactedChild): RedactedChild = value.copy(
         b = value.b?.let(RedactedFields.ADAPTER::redact),
         c = value.c?.let(NotRedacted.ADAPTER::redact),
         unknownFields = ByteString.EMPTY

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -50,7 +49,7 @@ public class RedactedCycleA(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + b.hashCode()
+      result = result * 37 + (b?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -74,13 +73,13 @@ public class RedactedCycleA(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedCycleA): Int {
+      public override fun encodedSize(`value`: RedactedCycleA): Int {
         var size = value.unknownFields.size
         size += RedactedCycleB.ADAPTER.encodedSizeWithTag(1, value.b)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedCycleA): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedCycleA): Unit {
         RedactedCycleB.ADAPTER.encodeWithTag(writer, 1, value.b)
         writer.writeBytes(value.unknownFields)
       }
@@ -99,7 +98,7 @@ public class RedactedCycleA(
         )
       }
 
-      public override fun redact(value: RedactedCycleA): RedactedCycleA = value.copy(
+      public override fun redact(`value`: RedactedCycleA): RedactedCycleA = value.copy(
         b = value.b?.let(RedactedCycleB.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -50,7 +49,7 @@ public class RedactedCycleB(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + a.hashCode()
+      result = result * 37 + (a?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -74,13 +73,13 @@ public class RedactedCycleB(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedCycleB): Int {
+      public override fun encodedSize(`value`: RedactedCycleB): Int {
         var size = value.unknownFields.size
         size += RedactedCycleA.ADAPTER.encodedSizeWithTag(1, value.a)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedCycleB): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedCycleB): Unit {
         RedactedCycleA.ADAPTER.encodeWithTag(writer, 1, value.a)
         writer.writeBytes(value.unknownFields)
       }
@@ -99,7 +98,7 @@ public class RedactedCycleB(
         )
       }
 
-      public override fun redact(value: RedactedCycleB): RedactedCycleB = value.copy(
+      public override fun redact(`value`: RedactedCycleB): RedactedCycleB = value.copy(
         a = value.a?.let(RedactedCycleA.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -58,8 +57,8 @@ public class RedactedExtension(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + d.hashCode()
-      result = result * 37 + e.hashCode()
+      result = result * 37 + (d?.hashCode() ?: 0)
+      result = result * 37 + (e?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -87,14 +86,14 @@ public class RedactedExtension(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedExtension): Int {
+      public override fun encodedSize(`value`: RedactedExtension): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.d)
         size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.e)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedExtension): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedExtension): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.d)
         ProtoAdapter.STRING.encodeWithTag(writer, 2, value.e)
         writer.writeBytes(value.unknownFields)
@@ -117,7 +116,7 @@ public class RedactedExtension(
         )
       }
 
-      public override fun redact(value: RedactedExtension): RedactedExtension = value.copy(
+      public override fun redact(`value`: RedactedExtension): RedactedExtension = value.copy(
         d = null,
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedFields.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -73,10 +72,10 @@ public class RedactedFields(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + a.hashCode()
-      result = result * 37 + b.hashCode()
-      result = result * 37 + c.hashCode()
-      result = result * 37 + extension.hashCode()
+      result = result * 37 + (a?.hashCode() ?: 0)
+      result = result * 37 + (b?.hashCode() ?: 0)
+      result = result * 37 + (c?.hashCode() ?: 0)
+      result = result * 37 + (extension?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -108,7 +107,7 @@ public class RedactedFields(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedFields): Int {
+      public override fun encodedSize(`value`: RedactedFields): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
         size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.b)
@@ -117,7 +116,7 @@ public class RedactedFields(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedFields): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedFields): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)
         ProtoAdapter.STRING.encodeWithTag(writer, 2, value.b)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.c)
@@ -148,7 +147,7 @@ public class RedactedFields(
         )
       }
 
-      public override fun redact(value: RedactedFields): RedactedFields = value.copy(
+      public override fun redact(`value`: RedactedFields): RedactedFields = value.copy(
         a = null,
         extension = value.extension?.let(RedactedExtension.ADAPTER::redact),
         unknownFields = ByteString.EMPTY

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -64,8 +63,8 @@ public class RedactedOneOf(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + b.hashCode()
-      result = result * 37 + c.hashCode()
+      result = result * 37 + (b?.hashCode() ?: 0)
+      result = result * 37 + (c?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -93,14 +92,14 @@ public class RedactedOneOf(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedOneOf): Int {
+      public override fun encodedSize(`value`: RedactedOneOf): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.b)
         size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.c)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedOneOf): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedOneOf): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.b)
         ProtoAdapter.STRING.encodeWithTag(writer, 2, value.c)
         writer.writeBytes(value.unknownFields)
@@ -123,7 +122,7 @@ public class RedactedOneOf(
         )
       }
 
-      public override fun redact(value: RedactedOneOf): RedactedOneOf = value.copy(
+      public override fun redact(`value`: RedactedOneOf): RedactedOneOf = value.copy(
         c = null,
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -97,14 +97,14 @@ public class RedactedRepeated(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedRepeated): Int {
+      public override fun encodedSize(`value`: RedactedRepeated): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1, value.a)
         size += RedactedFields.ADAPTER.asRepeated().encodedSizeWithTag(2, value.b)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedRepeated): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedRepeated): Unit {
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 1, value.a)
         RedactedFields.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.b)
         writer.writeBytes(value.unknownFields)
@@ -127,7 +127,7 @@ public class RedactedRepeated(
         )
       }
 
-      public override fun redact(value: RedactedRepeated): RedactedRepeated = value.copy(
+      public override fun redact(`value`: RedactedRepeated): RedactedRepeated = value.copy(
         a = emptyList(),
         b = value.b.redactElements(RedactedFields.ADAPTER),
         unknownFields = ByteString.EMPTY

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
@@ -77,13 +77,13 @@ public class RedactedRequired(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedRequired): Int {
+      public override fun encodedSize(`value`: RedactedRequired): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.a)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedRequired): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedRequired): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.a)
         writer.writeBytes(value.unknownFields)
       }
@@ -102,7 +102,7 @@ public class RedactedRequired(
         )
       }
 
-      public override fun redact(value: RedactedRequired): RedactedRequired = throw
+      public override fun redact(`value`: RedactedRequired): RedactedRequired = throw
           UnsupportedOperationException("Field 'a' is required and cannot be redacted.")
     }
 

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -22,7 +22,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -101,12 +100,12 @@ public class ExternalMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + f.hashCode()
+      result = result * 37 + (f?.hashCode() ?: 0)
       result = result * 37 + fooext.hashCode()
-      result = result * 37 + barext.hashCode()
-      result = result * 37 + bazext.hashCode()
-      result = result * 37 + nested_message_ext.hashCode()
-      result = result * 37 + nested_enum_ext.hashCode()
+      result = result * 37 + (barext?.hashCode() ?: 0)
+      result = result * 37 + (bazext?.hashCode() ?: 0)
+      result = result * 37 + (nested_message_ext?.hashCode() ?: 0)
+      result = result * 37 + (nested_enum_ext?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -145,7 +144,7 @@ public class ExternalMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: ExternalMessage): Int {
+      public override fun encodedSize(`value`: ExternalMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.f)
         size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(125, value.fooext)
@@ -157,7 +156,7 @@ public class ExternalMessage(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: ExternalMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: ExternalMessage): Unit {
         ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.f)
         ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 125, value.fooext)
         ProtoAdapter.INT32.encodeWithTag(writer, 126, value.barext)
@@ -200,7 +199,7 @@ public class ExternalMessage(
         )
       }
 
-      public override fun redact(value: ExternalMessage): ExternalMessage = value.copy(
+      public override fun redact(`value`: ExternalMessage): ExternalMessage = value.copy(
         nested_message_ext =
             value.nested_message_ext?.let(SimpleMessage.NestedMessage.ADAPTER::redact),
         unknownFields = ByteString.EMPTY

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -28,7 +28,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -169,18 +168,18 @@ public class SimpleMessage(
     var result_ = super.hashCode
     if (result_ == 0) {
       result_ = unknownFields.hashCode()
-      result_ = result_ * 37 + optional_int32.hashCode()
-      result_ = result_ * 37 + optional_nested_msg.hashCode()
-      result_ = result_ * 37 + optional_external_msg.hashCode()
-      result_ = result_ * 37 + default_nested_enum.hashCode()
+      result_ = result_ * 37 + (optional_int32?.hashCode() ?: 0)
+      result_ = result_ * 37 + (optional_nested_msg?.hashCode() ?: 0)
+      result_ = result_ * 37 + (optional_external_msg?.hashCode() ?: 0)
+      result_ = result_ * 37 + (default_nested_enum?.hashCode() ?: 0)
       result_ = result_ * 37 + required_int32.hashCode()
       result_ = result_ * 37 + repeated_double.hashCode()
-      result_ = result_ * 37 + default_foreign_enum.hashCode()
-      result_ = result_ * 37 + no_default_foreign_enum.hashCode()
-      result_ = result_ * 37 + package_.hashCode()
-      result_ = result_ * 37 + result.hashCode()
-      result_ = result_ * 37 + other.hashCode()
-      result_ = result_ * 37 + o.hashCode()
+      result_ = result_ * 37 + (default_foreign_enum?.hashCode() ?: 0)
+      result_ = result_ * 37 + (no_default_foreign_enum?.hashCode() ?: 0)
+      result_ = result_ * 37 + (package_?.hashCode() ?: 0)
+      result_ = result_ * 37 + (result?.hashCode() ?: 0)
+      result_ = result_ * 37 + (other?.hashCode() ?: 0)
+      result_ = result_ * 37 + (o?.hashCode() ?: 0)
       super.hashCode = result_
     }
     return result_
@@ -241,7 +240,7 @@ public class SimpleMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: SimpleMessage): Int {
+      public override fun encodedSize(`value`: SimpleMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.optional_int32)
         size += NestedMessage.ADAPTER.encodedSizeWithTag(2, value.optional_nested_msg)
@@ -258,7 +257,7 @@ public class SimpleMessage(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: SimpleMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: SimpleMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.optional_int32)
         NestedMessage.ADAPTER.encodeWithTag(writer, 2, value.optional_nested_msg)
         ExternalMessage.ADAPTER.encodeWithTag(writer, 3, value.optional_external_msg)
@@ -334,7 +333,7 @@ public class SimpleMessage(
         )
       }
 
-      public override fun redact(value: SimpleMessage): SimpleMessage = value.copy(
+      public override fun redact(`value`: SimpleMessage): SimpleMessage = value.copy(
         optional_nested_msg = value.optional_nested_msg?.let(NestedMessage.ADAPTER::redact),
         optional_external_msg = value.optional_external_msg?.let(ExternalMessage.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
@@ -374,7 +373,7 @@ public class SimpleMessage(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + bb.hashCode()
+        result = result * 37 + (bb?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -398,13 +397,13 @@ public class SimpleMessage(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: NestedMessage): Int {
+        public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.bb)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedMessage): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedMessage): Unit {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.bb)
           writer.writeBytes(value.unknownFields)
         }
@@ -423,7 +422,7 @@ public class SimpleMessage(
           )
         }
 
-        public override fun redact(value: NestedMessage): NestedMessage = value.copy(
+        public override fun redact(`value`: NestedMessage): NestedMessage = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -433,7 +432,7 @@ public class SimpleMessage(
   }
 
   public enum class NestedEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     FOO(1),
     BAR(2),
@@ -449,11 +448,11 @@ public class SimpleMessage(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): NestedEnum? = NestedEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): NestedEnum? = NestedEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): NestedEnum? = when (value) {
+      public fun fromValue(`value`: Int): NestedEnum? = when (value) {
         1 -> FOO
         2 -> BAR
         3 -> BAZ

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionOne.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class EnumVersionOne(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   SHREK_V1(1),
   DONKEY_V1(2),
@@ -25,11 +25,11 @@ public enum class EnumVersionOne(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): EnumVersionOne? = EnumVersionOne.fromValue(value)
+      public override fun fromValue(`value`: Int): EnumVersionOne? = EnumVersionOne.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): EnumVersionOne? = when (value) {
+    public fun fromValue(`value`: Int): EnumVersionOne? = when (value) {
       1 -> SHREK_V1
       2 -> DONKEY_V1
       3 -> FIONA_V1

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionTwo.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class EnumVersionTwo(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   SHREK_V2(1),
   DONKEY_V2(2),
@@ -26,11 +26,11 @@ public enum class EnumVersionTwo(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): EnumVersionTwo? = EnumVersionTwo.fromValue(value)
+      public override fun fromValue(`value`: Int): EnumVersionTwo? = EnumVersionTwo.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): EnumVersionTwo? = when (value) {
+    public fun fromValue(`value`: Int): EnumVersionTwo? = when (value) {
       1 -> SHREK_V2
       2 -> DONKEY_V2
       3 -> FIONA_V2

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -50,7 +49,7 @@ public class NestedVersionOne(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -74,13 +73,13 @@ public class NestedVersionOne(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NestedVersionOne): Int {
+      public override fun encodedSize(`value`: NestedVersionOne): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NestedVersionOne): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NestedVersionOne): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         writer.writeBytes(value.unknownFields)
       }
@@ -99,7 +98,7 @@ public class NestedVersionOne(
         )
       }
 
-      public override fun redact(value: NestedVersionOne): NestedVersionOne = value.copy(
+      public override fun redact(`value`: NestedVersionOne): NestedVersionOne = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -22,7 +22,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -86,11 +85,11 @@ public class NestedVersionTwo(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + v2_i.hashCode()
-      result = result * 37 + v2_s.hashCode()
-      result = result * 37 + v2_f32.hashCode()
-      result = result * 37 + v2_f64.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (v2_i?.hashCode() ?: 0)
+      result = result * 37 + (v2_s?.hashCode() ?: 0)
+      result = result * 37 + (v2_f32?.hashCode() ?: 0)
+      result = result * 37 + (v2_f64?.hashCode() ?: 0)
       result = result * 37 + v2_rs.hashCode()
       super.hashCode = result
     }
@@ -127,7 +126,7 @@ public class NestedVersionTwo(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NestedVersionTwo): Int {
+      public override fun encodedSize(`value`: NestedVersionTwo): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
@@ -138,7 +137,7 @@ public class NestedVersionTwo(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NestedVersionTwo): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NestedVersionTwo): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.v2_i)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.v2_s)
@@ -177,7 +176,7 @@ public class NestedVersionTwo(
         )
       }
 
-      public override fun redact(value: NestedVersionTwo): NestedVersionTwo = value.copy(
+      public override fun redact(`value`: NestedVersionTwo): NestedVersionTwo = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -62,9 +61,9 @@ public class VersionOne(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + obj.hashCode()
-      result = result * 37 + en.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (obj?.hashCode() ?: 0)
+      result = result * 37 + (en?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -94,7 +93,7 @@ public class VersionOne(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: VersionOne): Int {
+      public override fun encodedSize(`value`: VersionOne): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += NestedVersionOne.ADAPTER.encodedSizeWithTag(7, value.obj)
@@ -102,7 +101,7 @@ public class VersionOne(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: VersionOne): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: VersionOne): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         NestedVersionOne.ADAPTER.encodeWithTag(writer, 7, value.obj)
         EnumVersionOne.ADAPTER.encodeWithTag(writer, 8, value.en)
@@ -133,7 +132,7 @@ public class VersionOne(
         )
       }
 
-      public override fun redact(value: VersionOne): VersionOne = value.copy(
+      public override fun redact(`value`: VersionOne): VersionOne = value.copy(
         obj = value.obj?.let(NestedVersionOne.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -22,7 +22,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -98,14 +97,14 @@ public class VersionTwo(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + v2_i.hashCode()
-      result = result * 37 + v2_s.hashCode()
-      result = result * 37 + v2_f32.hashCode()
-      result = result * 37 + v2_f64.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (v2_i?.hashCode() ?: 0)
+      result = result * 37 + (v2_s?.hashCode() ?: 0)
+      result = result * 37 + (v2_f32?.hashCode() ?: 0)
+      result = result * 37 + (v2_f64?.hashCode() ?: 0)
       result = result * 37 + v2_rs.hashCode()
-      result = result * 37 + obj.hashCode()
-      result = result * 37 + en.hashCode()
+      result = result * 37 + (obj?.hashCode() ?: 0)
+      result = result * 37 + (en?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -145,7 +144,7 @@ public class VersionTwo(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: VersionTwo): Int {
+      public override fun encodedSize(`value`: VersionTwo): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
@@ -158,7 +157,7 @@ public class VersionTwo(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: VersionTwo): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: VersionTwo): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.v2_i)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.v2_s)
@@ -209,7 +208,7 @@ public class VersionTwo(
         )
       }
 
-      public override fun redact(value: VersionTwo): VersionTwo = value.copy(
+      public override fun redact(`value`: VersionTwo): VersionTwo = value.copy(
         obj = value.obj?.let(NestedVersionTwo.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -23,7 +23,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -63,7 +62,7 @@ public class UsesAny(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + just_one.hashCode()
+      result = result * 37 + (just_one?.hashCode() ?: 0)
       result = result * 37 + many_anys.hashCode()
       super.hashCode = result
     }
@@ -92,14 +91,14 @@ public class UsesAny(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: UsesAny): Int {
+      public override fun encodedSize(`value`: UsesAny): Int {
         var size = value.unknownFields.size
         size += AnyMessage.ADAPTER.encodedSizeWithTag(1, value.just_one)
         size += AnyMessage.ADAPTER.asRepeated().encodedSizeWithTag(2, value.many_anys)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: UsesAny): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: UsesAny): Unit {
         AnyMessage.ADAPTER.encodeWithTag(writer, 1, value.just_one)
         AnyMessage.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.many_anys)
         writer.writeBytes(value.unknownFields)
@@ -122,7 +121,7 @@ public class UsesAny(
         )
       }
 
-      public override fun redact(value: UsesAny): UsesAny = value.copy(
+      public override fun redact(`value`: UsesAny): UsesAny = value.copy(
         just_one = value.just_one?.let(AnyMessage.ADAPTER::redact),
         many_anys = value.many_anys.redactElements(AnyMessage.ADAPTER),
         unknownFields = ByteString.EMPTY

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -21,7 +21,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -63,7 +62,7 @@ public class EmbeddedMessage(
     if (result == 0) {
       result = unknownFields.hashCode()
       result = result * 37 + inner_repeated_number.hashCode()
-      result = result * 37 + inner_number_after.hashCode()
+      result = result * 37 + (inner_number_after?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -92,14 +91,14 @@ public class EmbeddedMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: EmbeddedMessage): Int {
+      public override fun encodedSize(`value`: EmbeddedMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.inner_repeated_number)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.inner_number_after)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: EmbeddedMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: EmbeddedMessage): Unit {
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.inner_repeated_number)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.inner_number_after)
         writer.writeBytes(value.unknownFields)
@@ -122,7 +121,7 @@ public class EmbeddedMessage(
         )
       }
 
-      public override fun redact(value: EmbeddedMessage): EmbeddedMessage = value.copy(
+      public override fun redact(`value`: EmbeddedMessage): EmbeddedMessage = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -56,8 +55,8 @@ public class OuterMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + outer_number_before.hashCode()
-      result = result * 37 + embedded_message.hashCode()
+      result = result * 37 + (outer_number_before?.hashCode() ?: 0)
+      result = result * 37 + (embedded_message?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -85,14 +84,14 @@ public class OuterMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OuterMessage): Int {
+      public override fun encodedSize(`value`: OuterMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.outer_number_before)
         size += EmbeddedMessage.ADAPTER.encodedSizeWithTag(2, value.embedded_message)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OuterMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OuterMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.outer_number_before)
         EmbeddedMessage.ADAPTER.encodeWithTag(writer, 2, value.embedded_message)
         writer.writeBytes(value.unknownFields)
@@ -115,7 +114,7 @@ public class OuterMessage(
         )
       }
 
-      public override fun redact(value: OuterMessage): OuterMessage = value.copy(
+      public override fun redact(`value`: OuterMessage): OuterMessage = value.copy(
         embedded_message = value.embedded_message?.let(EmbeddedMessage.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -28,7 +28,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.lazy
@@ -1516,23 +1515,23 @@ public class AllTypes(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + opt_int32.hashCode()
-      result = result * 37 + opt_uint32.hashCode()
-      result = result * 37 + opt_sint32.hashCode()
-      result = result * 37 + opt_fixed32.hashCode()
-      result = result * 37 + opt_sfixed32.hashCode()
-      result = result * 37 + opt_int64.hashCode()
-      result = result * 37 + opt_uint64.hashCode()
-      result = result * 37 + opt_sint64.hashCode()
-      result = result * 37 + opt_fixed64.hashCode()
-      result = result * 37 + opt_sfixed64.hashCode()
-      result = result * 37 + opt_bool.hashCode()
-      result = result * 37 + opt_float.hashCode()
-      result = result * 37 + opt_double.hashCode()
-      result = result * 37 + opt_string.hashCode()
-      result = result * 37 + opt_bytes.hashCode()
-      result = result * 37 + opt_nested_enum.hashCode()
-      result = result * 37 + opt_nested_message.hashCode()
+      result = result * 37 + (opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (opt_float?.hashCode() ?: 0)
+      result = result * 37 + (opt_double?.hashCode() ?: 0)
+      result = result * 37 + (opt_string?.hashCode() ?: 0)
+      result = result * 37 + (opt_bytes?.hashCode() ?: 0)
+      result = result * 37 + (opt_nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (opt_nested_message?.hashCode() ?: 0)
       result = result * 37 + req_int32.hashCode()
       result = result * 37 + req_uint32.hashCode()
       result = result * 37 + req_sint32.hashCode()
@@ -1581,43 +1580,43 @@ public class AllTypes(
       result = result * 37 + pack_float.hashCode()
       result = result * 37 + pack_double.hashCode()
       result = result * 37 + pack_nested_enum.hashCode()
-      result = result * 37 + default_int32.hashCode()
-      result = result * 37 + default_uint32.hashCode()
-      result = result * 37 + default_sint32.hashCode()
-      result = result * 37 + default_fixed32.hashCode()
-      result = result * 37 + default_sfixed32.hashCode()
-      result = result * 37 + default_int64.hashCode()
-      result = result * 37 + default_uint64.hashCode()
-      result = result * 37 + default_sint64.hashCode()
-      result = result * 37 + default_fixed64.hashCode()
-      result = result * 37 + default_sfixed64.hashCode()
-      result = result * 37 + default_bool.hashCode()
-      result = result * 37 + default_float.hashCode()
-      result = result * 37 + default_double.hashCode()
-      result = result * 37 + default_string.hashCode()
-      result = result * 37 + default_bytes.hashCode()
-      result = result * 37 + default_nested_enum.hashCode()
+      result = result * 37 + (default_int32?.hashCode() ?: 0)
+      result = result * 37 + (default_uint32?.hashCode() ?: 0)
+      result = result * 37 + (default_sint32?.hashCode() ?: 0)
+      result = result * 37 + (default_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (default_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (default_int64?.hashCode() ?: 0)
+      result = result * 37 + (default_uint64?.hashCode() ?: 0)
+      result = result * 37 + (default_sint64?.hashCode() ?: 0)
+      result = result * 37 + (default_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (default_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (default_bool?.hashCode() ?: 0)
+      result = result * 37 + (default_float?.hashCode() ?: 0)
+      result = result * 37 + (default_double?.hashCode() ?: 0)
+      result = result * 37 + (default_string?.hashCode() ?: 0)
+      result = result * 37 + (default_bytes?.hashCode() ?: 0)
+      result = result * 37 + (default_nested_enum?.hashCode() ?: 0)
       result = result * 37 + map_int32_int32.hashCode()
       result = result * 37 + map_string_string.hashCode()
       result = result * 37 + map_string_message.hashCode()
       result = result * 37 + map_string_enum.hashCode()
-      result = result * 37 + ext_opt_int32.hashCode()
-      result = result * 37 + ext_opt_uint32.hashCode()
-      result = result * 37 + ext_opt_sint32.hashCode()
-      result = result * 37 + ext_opt_fixed32.hashCode()
-      result = result * 37 + ext_opt_sfixed32.hashCode()
-      result = result * 37 + ext_opt_int64.hashCode()
-      result = result * 37 + ext_opt_uint64.hashCode()
-      result = result * 37 + ext_opt_sint64.hashCode()
-      result = result * 37 + ext_opt_fixed64.hashCode()
-      result = result * 37 + ext_opt_sfixed64.hashCode()
-      result = result * 37 + ext_opt_bool.hashCode()
-      result = result * 37 + ext_opt_float.hashCode()
-      result = result * 37 + ext_opt_double.hashCode()
-      result = result * 37 + ext_opt_string.hashCode()
-      result = result * 37 + ext_opt_bytes.hashCode()
-      result = result * 37 + ext_opt_nested_enum.hashCode()
-      result = result * 37 + ext_opt_nested_message.hashCode()
+      result = result * 37 + (ext_opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_float?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_double?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_string?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_bytes?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_nested_message?.hashCode() ?: 0)
       result = result * 37 + ext_rep_int32.hashCode()
       result = result * 37 + ext_rep_uint32.hashCode()
       result = result * 37 + ext_rep_sint32.hashCode()
@@ -1649,9 +1648,9 @@ public class AllTypes(
       result = result * 37 + ext_pack_float.hashCode()
       result = result * 37 + ext_pack_double.hashCode()
       result = result * 37 + ext_pack_nested_enum.hashCode()
-      result = result * 37 + oneof_string.hashCode()
-      result = result * 37 + oneof_int32.hashCode()
-      result = result * 37 + oneof_nested_message.hashCode()
+      result = result * 37 + (oneof_string?.hashCode() ?: 0)
+      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
+      result = result * 37 + (oneof_nested_message?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -3321,7 +3320,7 @@ public class AllTypes(
       private val map_string_enumAdapter: ProtoAdapter<Map<String, NestedEnum>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, NestedEnum.ADAPTER) }
 
-      public override fun encodedSize(value: AllTypes): Int {
+      public override fun encodedSize(`value`: AllTypes): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32)
         size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.opt_uint32)
@@ -3463,7 +3462,7 @@ public class AllTypes(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: AllTypes): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: AllTypes): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.opt_int32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.opt_uint32)
         ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.opt_sint32)
@@ -4056,7 +4055,7 @@ public class AllTypes(
         )
       }
 
-      public override fun redact(value: AllTypes): AllTypes = value.copy(
+      public override fun redact(`value`: AllTypes): AllTypes = value.copy(
         opt_nested_message = value.opt_nested_message?.let(NestedMessage.ADAPTER::redact),
         req_nested_message = NestedMessage.ADAPTER.redact(value.req_nested_message),
         rep_nested_message = value.rep_nested_message.redactElements(NestedMessage.ADAPTER),
@@ -4072,7 +4071,7 @@ public class AllTypes(
   }
 
   public enum class NestedEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     UNKNOWN(0),
     A(1),
@@ -4085,11 +4084,11 @@ public class AllTypes(
         PROTO_2, 
         NestedEnum.UNKNOWN
       ) {
-        public override fun fromValue(value: Int): NestedEnum? = NestedEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): NestedEnum? = NestedEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): NestedEnum? = when (value) {
+      public fun fromValue(`value`: Int): NestedEnum? = when (value) {
         0 -> UNKNOWN
         1 -> A
         else -> null
@@ -4125,7 +4124,7 @@ public class AllTypes(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + a.hashCode()
+        result = result * 37 + (a?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -4164,13 +4163,13 @@ public class AllTypes(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: NestedMessage): Int {
+        public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedMessage): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedMessage): Unit {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
           writer.writeBytes(value.unknownFields)
         }
@@ -4189,7 +4188,7 @@ public class AllTypes(
           )
         }
 
-        public override fun redact(value: NestedMessage): NestedMessage = value.copy(
+        public override fun redact(`value`: NestedMessage): NestedMessage = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
@@ -27,7 +27,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.lazy
@@ -816,38 +815,38 @@ public class AllTypes(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + my_int32.hashCode()
-      result = result * 37 + my_uint32.hashCode()
-      result = result * 37 + my_sint32.hashCode()
-      result = result * 37 + my_fixed32.hashCode()
-      result = result * 37 + my_sfixed32.hashCode()
-      result = result * 37 + my_int64.hashCode()
-      result = result * 37 + my_uint64.hashCode()
-      result = result * 37 + my_sint64.hashCode()
-      result = result * 37 + my_fixed64.hashCode()
-      result = result * 37 + my_sfixed64.hashCode()
-      result = result * 37 + my_bool.hashCode()
-      result = result * 37 + my_float.hashCode()
-      result = result * 37 + my_double.hashCode()
-      result = result * 37 + my_string.hashCode()
-      result = result * 37 + my_bytes.hashCode()
-      result = result * 37 + nested_enum.hashCode()
-      result = result * 37 + nested_message.hashCode()
-      result = result * 37 + opt_int32.hashCode()
-      result = result * 37 + opt_uint32.hashCode()
-      result = result * 37 + opt_sint32.hashCode()
-      result = result * 37 + opt_fixed32.hashCode()
-      result = result * 37 + opt_sfixed32.hashCode()
-      result = result * 37 + opt_int64.hashCode()
-      result = result * 37 + opt_uint64.hashCode()
-      result = result * 37 + opt_sint64.hashCode()
-      result = result * 37 + opt_fixed64.hashCode()
-      result = result * 37 + opt_sfixed64.hashCode()
-      result = result * 37 + opt_bool.hashCode()
-      result = result * 37 + opt_float.hashCode()
-      result = result * 37 + opt_double.hashCode()
-      result = result * 37 + opt_string.hashCode()
-      result = result * 37 + opt_bytes.hashCode()
+      result = result * 37 + (my_int32?.hashCode() ?: 0)
+      result = result * 37 + (my_uint32?.hashCode() ?: 0)
+      result = result * 37 + (my_sint32?.hashCode() ?: 0)
+      result = result * 37 + (my_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (my_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (my_int64?.hashCode() ?: 0)
+      result = result * 37 + (my_uint64?.hashCode() ?: 0)
+      result = result * 37 + (my_sint64?.hashCode() ?: 0)
+      result = result * 37 + (my_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (my_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (my_bool?.hashCode() ?: 0)
+      result = result * 37 + (my_float?.hashCode() ?: 0)
+      result = result * 37 + (my_double?.hashCode() ?: 0)
+      result = result * 37 + (my_string?.hashCode() ?: 0)
+      result = result * 37 + (my_bytes?.hashCode() ?: 0)
+      result = result * 37 + (nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (nested_message?.hashCode() ?: 0)
+      result = result * 37 + (opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (opt_float?.hashCode() ?: 0)
+      result = result * 37 + (opt_double?.hashCode() ?: 0)
+      result = result * 37 + (opt_string?.hashCode() ?: 0)
+      result = result * 37 + (opt_bytes?.hashCode() ?: 0)
       result = result * 37 + rep_int32.hashCode()
       result = result * 37 + rep_uint32.hashCode()
       result = result * 37 + rep_sint32.hashCode()
@@ -883,9 +882,9 @@ public class AllTypes(
       result = result * 37 + map_string_string.hashCode()
       result = result * 37 + map_string_message.hashCode()
       result = result * 37 + map_string_enum.hashCode()
-      result = result * 37 + oneof_string.hashCode()
-      result = result * 37 + oneof_int32.hashCode()
-      result = result * 37 + oneof_nested_message.hashCode()
+      result = result * 37 + (oneof_string?.hashCode() ?: 0)
+      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
+      result = result * 37 + (oneof_nested_message?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -1744,7 +1743,7 @@ public class AllTypes(
       private val map_string_enumAdapter: ProtoAdapter<Map<String, NestedEnum>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, NestedEnum.ADAPTER) }
 
-      public override fun encodedSize(value: AllTypes): Int {
+      public override fun encodedSize(`value`: AllTypes): Int {
         var size = value.unknownFields.size
         if (value.my_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.my_int32)
         if (value.my_uint32 != 0) size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.my_uint32)
@@ -1830,7 +1829,7 @@ public class AllTypes(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: AllTypes): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: AllTypes): Unit {
         if (value.my_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
         if (value.my_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
         if (value.my_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
@@ -2142,7 +2141,7 @@ public class AllTypes(
         )
       }
 
-      public override fun redact(value: AllTypes): AllTypes = value.copy(
+      public override fun redact(`value`: AllTypes): AllTypes = value.copy(
         nested_message = value.nested_message?.let(NestedMessage.ADAPTER::redact),
         rep_nested_message = value.rep_nested_message.redactElements(NestedMessage.ADAPTER),
         map_string_message = value.map_string_message.redactElements(NestedMessage.ADAPTER),
@@ -2155,7 +2154,7 @@ public class AllTypes(
   }
 
   public enum class NestedEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     UNKNOWN(0),
     A(1),
@@ -2168,11 +2167,11 @@ public class AllTypes(
         PROTO_3, 
         NestedEnum.UNKNOWN
       ) {
-        public override fun fromValue(value: Int): NestedEnum? = NestedEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): NestedEnum? = NestedEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): NestedEnum? = when (value) {
+      public fun fromValue(`value`: Int): NestedEnum? = when (value) {
         0 -> UNKNOWN
         1 -> A
         else -> null
@@ -2209,7 +2208,7 @@ public class AllTypes(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + a.hashCode()
+        result = result * 37 + (a?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -2248,13 +2247,13 @@ public class AllTypes(
         PROTO_3, 
         null
       ) {
-        public override fun encodedSize(value: NestedMessage): Int {
+        public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
           if (value.a != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedMessage): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedMessage): Unit {
           if (value.a != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
           writer.writeBytes(value.unknownFields)
         }
@@ -2273,7 +2272,7 @@ public class AllTypes(
           )
         }
 
-        public override fun redact(value: NestedMessage): NestedMessage = value.copy(
+        public override fun redact(`value`: NestedMessage): NestedMessage = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
@@ -20,7 +20,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.lazy
 import okio.ByteString
@@ -304,11 +303,11 @@ public class All32(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + my_int32.hashCode()
-      result = result * 37 + my_uint32.hashCode()
-      result = result * 37 + my_sint32.hashCode()
-      result = result * 37 + my_fixed32.hashCode()
-      result = result * 37 + my_sfixed32.hashCode()
+      result = result * 37 + (my_int32?.hashCode() ?: 0)
+      result = result * 37 + (my_uint32?.hashCode() ?: 0)
+      result = result * 37 + (my_sint32?.hashCode() ?: 0)
+      result = result * 37 + (my_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (my_sfixed32?.hashCode() ?: 0)
       result = result * 37 + rep_int32.hashCode()
       result = result * 37 + rep_uint32.hashCode()
       result = result * 37 + rep_sint32.hashCode()
@@ -324,8 +323,8 @@ public class All32(
       result = result * 37 + map_int32_sint32.hashCode()
       result = result * 37 + map_int32_fixed32.hashCode()
       result = result * 37 + map_int32_sfixed32.hashCode()
-      result = result * 37 + oneof_int32.hashCode()
-      result = result * 37 + oneof_sfixed32.hashCode()
+      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
+      result = result * 37 + (oneof_sfixed32?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -630,7 +629,7 @@ public class All32(
       private val map_int32_sfixed32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.SFIXED32) }
 
-      public override fun encodedSize(value: All32): Int {
+      public override fun encodedSize(`value`: All32): Int {
         var size = value.unknownFields.size
         if (value.my_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.my_int32)
         if (value.my_uint32 != 0) size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.my_uint32)
@@ -659,7 +658,7 @@ public class All32(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: All32): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: All32): Unit {
         if (value.my_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
         if (value.my_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
         if (value.my_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
@@ -763,7 +762,7 @@ public class All32(
         )
       }
 
-      public override fun redact(value: All32): All32 = value.copy(
+      public override fun redact(`value`: All32): All32 = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
@@ -20,7 +20,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.lazy
 import okio.ByteString
@@ -306,11 +305,11 @@ public class All64(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + my_int64.hashCode()
-      result = result * 37 + my_uint64.hashCode()
-      result = result * 37 + my_sint64.hashCode()
-      result = result * 37 + my_fixed64.hashCode()
-      result = result * 37 + my_sfixed64.hashCode()
+      result = result * 37 + (my_int64?.hashCode() ?: 0)
+      result = result * 37 + (my_uint64?.hashCode() ?: 0)
+      result = result * 37 + (my_sint64?.hashCode() ?: 0)
+      result = result * 37 + (my_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (my_sfixed64?.hashCode() ?: 0)
       result = result * 37 + rep_int64.hashCode()
       result = result * 37 + rep_uint64.hashCode()
       result = result * 37 + rep_sint64.hashCode()
@@ -326,8 +325,8 @@ public class All64(
       result = result * 37 + map_int64_sint64.hashCode()
       result = result * 37 + map_int64_fixed64.hashCode()
       result = result * 37 + map_int64_sfixed64.hashCode()
-      result = result * 37 + oneof_int64.hashCode()
-      result = result * 37 + oneof_sfixed64.hashCode()
+      result = result * 37 + (oneof_int64?.hashCode() ?: 0)
+      result = result * 37 + (oneof_sfixed64?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -632,7 +631,7 @@ public class All64(
       private val map_int64_sfixed64Adapter: ProtoAdapter<Map<Long, Long>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT64, ProtoAdapter.SFIXED64) }
 
-      public override fun encodedSize(value: All64): Int {
+      public override fun encodedSize(`value`: All64): Int {
         var size = value.unknownFields.size
         if (value.my_int64 != 0L) size += ProtoAdapter.INT64.encodedSizeWithTag(1, value.my_int64)
         if (value.my_uint64 != 0L) size += ProtoAdapter.UINT64.encodedSizeWithTag(2,
@@ -663,7 +662,7 @@ public class All64(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: All64): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: All64): Unit {
         if (value.my_int64 != 0L) ProtoAdapter.INT64.encodeWithTag(writer, 1, value.my_int64)
         if (value.my_uint64 != 0L) ProtoAdapter.UINT64.encodeWithTag(writer, 2, value.my_uint64)
         if (value.my_sint64 != 0L) ProtoAdapter.SINT64.encodeWithTag(writer, 3, value.my_sint64)
@@ -767,7 +766,7 @@ public class All64(
         )
       }
 
-      public override fun redact(value: All64): All64 = value.copy(
+      public override fun redact(`value`: All64): All64 = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
@@ -23,7 +23,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.lazy
 import okio.ByteString
@@ -283,15 +282,15 @@ public class AllStructs(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + struct.hashCode()
-      result = result * 37 + list.hashCode()
-      result = result * 37 + null_value.hashCode()
-      result = result * 37 + value_a.hashCode()
-      result = result * 37 + value_b.hashCode()
-      result = result * 37 + value_c.hashCode()
-      result = result * 37 + value_d.hashCode()
-      result = result * 37 + value_e.hashCode()
-      result = result * 37 + value_f.hashCode()
+      result = result * 37 + (struct?.hashCode() ?: 0)
+      result = result * 37 + (list?.hashCode() ?: 0)
+      result = result * 37 + (null_value?.hashCode() ?: 0)
+      result = result * 37 + (value_a?.hashCode() ?: 0)
+      result = result * 37 + (value_b?.hashCode() ?: 0)
+      result = result * 37 + (value_c?.hashCode() ?: 0)
+      result = result * 37 + (value_d?.hashCode() ?: 0)
+      result = result * 37 + (value_e?.hashCode() ?: 0)
+      result = result * 37 + (value_f?.hashCode() ?: 0)
       result = result * 37 + rep_struct.hashCode()
       result = result * 37 + rep_list.hashCode()
       result = result * 37 + rep_value_a.hashCode()
@@ -300,8 +299,8 @@ public class AllStructs(
       result = result * 37 + map_int32_list.hashCode()
       result = result * 37 + map_int32_value_a.hashCode()
       result = result * 37 + map_int32_null_value.hashCode()
-      result = result * 37 + oneof_struct.hashCode()
-      result = result * 37 + oneof_list.hashCode()
+      result = result * 37 + (oneof_struct?.hashCode() ?: 0)
+      result = result * 37 + (oneof_list?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -561,7 +560,7 @@ public class AllStructs(
       private val map_int32_null_valueAdapter: ProtoAdapter<Map<Int, Nothing?>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.STRUCT_NULL) }
 
-      public override fun encodedSize(value: AllStructs): Int {
+      public override fun encodedSize(`value`: AllStructs): Int {
         var size = value.unknownFields.size
         if (value.struct != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(1,
             value.struct)
@@ -593,7 +592,7 @@ public class AllStructs(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: AllStructs): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: AllStructs): Unit {
         if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
         if (value.list != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
         if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3,
@@ -693,7 +692,7 @@ public class AllStructs(
         )
       }
 
-      public override fun redact(value: AllStructs): AllStructs = value.copy(
+      public override fun redact(`value`: AllStructs): AllStructs = value.copy(
         struct = value.struct?.let(ProtoAdapter.STRUCT_MAP::redact),
         list = value.list?.let(ProtoAdapter.STRUCT_LIST::redact),
         value_a = value.value_a?.let(ProtoAdapter.STRUCT_VALUE::redact),

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
@@ -22,7 +22,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.lazy
 import okio.ByteString
@@ -363,15 +362,15 @@ public class AllWrappers(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + double_value.hashCode()
-      result = result * 37 + float_value.hashCode()
-      result = result * 37 + int64_value.hashCode()
-      result = result * 37 + uint64_value.hashCode()
-      result = result * 37 + int32_value.hashCode()
-      result = result * 37 + uint32_value.hashCode()
-      result = result * 37 + bool_value.hashCode()
-      result = result * 37 + string_value.hashCode()
-      result = result * 37 + bytes_value.hashCode()
+      result = result * 37 + (double_value?.hashCode() ?: 0)
+      result = result * 37 + (float_value?.hashCode() ?: 0)
+      result = result * 37 + (int64_value?.hashCode() ?: 0)
+      result = result * 37 + (uint64_value?.hashCode() ?: 0)
+      result = result * 37 + (int32_value?.hashCode() ?: 0)
+      result = result * 37 + (uint32_value?.hashCode() ?: 0)
+      result = result * 37 + (bool_value?.hashCode() ?: 0)
+      result = result * 37 + (string_value?.hashCode() ?: 0)
+      result = result * 37 + (bytes_value?.hashCode() ?: 0)
       result = result * 37 + rep_double_value.hashCode()
       result = result * 37 + rep_float_value.hashCode()
       result = result * 37 + rep_int64_value.hashCode()
@@ -766,7 +765,7 @@ public class AllWrappers(
       private val map_int32_bytes_valueAdapter: ProtoAdapter<Map<Int, ByteString?>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.BYTES_VALUE) }
 
-      public override fun encodedSize(value: AllWrappers): Int {
+      public override fun encodedSize(`value`: AllWrappers): Int {
         var size = value.unknownFields.size
         if (value.double_value != null) size += ProtoAdapter.DOUBLE_VALUE.encodedSizeWithTag(1,
             value.double_value)
@@ -811,7 +810,7 @@ public class AllWrappers(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: AllWrappers): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: AllWrappers): Unit {
         if (value.double_value != null) ProtoAdapter.DOUBLE_VALUE.encodeWithTag(writer, 1,
             value.double_value)
         if (value.float_value != null) ProtoAdapter.FLOAT_VALUE.encodeWithTag(writer, 2,
@@ -943,7 +942,7 @@ public class AllWrappers(
         )
       }
 
-      public override fun redact(value: AllWrappers): AllWrappers = value.copy(
+      public override fun redact(`value`: AllWrappers): AllWrappers = value.copy(
         double_value = value.double_value?.let(ProtoAdapter.DOUBLE_VALUE::redact),
         float_value = value.float_value?.let(ProtoAdapter.FLOAT_VALUE::redact),
         int64_value = value.int64_value?.let(ProtoAdapter.INT64_VALUE::redact),

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -16,7 +16,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -49,7 +48,7 @@ public class BuyOneGetOnePromotion(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + coupon.hashCode()
+      result = result * 37 + (coupon?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -89,13 +88,13 @@ public class BuyOneGetOnePromotion(
       PROTO_3, 
       null
     ) {
-      public override fun encodedSize(value: BuyOneGetOnePromotion): Int {
+      public override fun encodedSize(`value`: BuyOneGetOnePromotion): Int {
         var size = value.unknownFields.size
         if (value.coupon != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.coupon)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: BuyOneGetOnePromotion): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: BuyOneGetOnePromotion): Unit {
         if (value.coupon != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
         writer.writeBytes(value.unknownFields)
       }
@@ -114,7 +113,8 @@ public class BuyOneGetOnePromotion(
         )
       }
 
-      public override fun redact(value: BuyOneGetOnePromotion): BuyOneGetOnePromotion = value.copy(
+      public override fun redact(`value`: BuyOneGetOnePromotion): BuyOneGetOnePromotion =
+          value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
@@ -21,7 +21,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.lazy
 import okio.ByteString
@@ -90,9 +89,9 @@ public class CamelCase(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + nested__message.hashCode()
+      result = result * 37 + (nested__message?.hashCode() ?: 0)
       result = result * 37 + _Rep_int32.hashCode()
-      result = result * 37 + IDitIt_my_wAy.hashCode()
+      result = result * 37 + (IDitIt_my_wAy?.hashCode() ?: 0)
       result = result * 37 + map_int32_Int32.hashCode()
       super.hashCode = result
     }
@@ -172,7 +171,7 @@ public class CamelCase(
       private val map_int32_Int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }
 
-      public override fun encodedSize(value: CamelCase): Int {
+      public override fun encodedSize(`value`: CamelCase): Int {
         var size = value.unknownFields.size
         if (value.nested__message != null) size += NestedCamelCase.ADAPTER.encodedSizeWithTag(1,
             value.nested__message)
@@ -183,7 +182,7 @@ public class CamelCase(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: CamelCase): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: CamelCase): Unit {
         if (value.nested__message != null) NestedCamelCase.ADAPTER.encodeWithTag(writer, 1,
             value.nested__message)
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 2, value._Rep_int32)
@@ -216,7 +215,7 @@ public class CamelCase(
         )
       }
 
-      public override fun redact(value: CamelCase): CamelCase = value.copy(
+      public override fun redact(`value`: CamelCase): CamelCase = value.copy(
         nested__message = value.nested__message?.let(NestedCamelCase.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )
@@ -255,7 +254,7 @@ public class CamelCase(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + one_int32.hashCode()
+        result = result * 37 + (one_int32?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -294,14 +293,14 @@ public class CamelCase(
         PROTO_3, 
         null
       ) {
-        public override fun encodedSize(value: NestedCamelCase): Int {
+        public override fun encodedSize(`value`: NestedCamelCase): Int {
           var size = value.unknownFields.size
           if (value.one_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1,
               value.one_int32)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedCamelCase): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedCamelCase): Unit {
           if (value.one_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.one_int32)
           writer.writeBytes(value.unknownFields)
         }
@@ -320,7 +319,7 @@ public class CamelCase(
           )
         }
 
-        public override fun redact(value: NestedCamelCase): NestedCamelCase = value.copy(
+        public override fun redact(`value`: NestedCamelCase): NestedCamelCase = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
@@ -18,7 +18,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -52,7 +51,7 @@ public class FreeDrinkPromotion(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + drink.hashCode()
+      result = result * 37 + (drink?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -92,13 +91,13 @@ public class FreeDrinkPromotion(
       PROTO_3, 
       null
     ) {
-      public override fun encodedSize(value: FreeDrinkPromotion): Int {
+      public override fun encodedSize(`value`: FreeDrinkPromotion): Int {
         var size = value.unknownFields.size
         if (value.drink != Drink.UNKNOWN) size += Drink.ADAPTER.encodedSizeWithTag(1, value.drink)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: FreeDrinkPromotion): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: FreeDrinkPromotion): Unit {
         if (value.drink != Drink.UNKNOWN) Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
         writer.writeBytes(value.unknownFields)
       }
@@ -121,7 +120,7 @@ public class FreeDrinkPromotion(
         )
       }
 
-      public override fun redact(value: FreeDrinkPromotion): FreeDrinkPromotion = value.copy(
+      public override fun redact(`value`: FreeDrinkPromotion): FreeDrinkPromotion = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -130,7 +129,7 @@ public class FreeDrinkPromotion(
   }
 
   public enum class Drink(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     UNKNOWN(0),
     PEPSI(1),
@@ -145,11 +144,11 @@ public class FreeDrinkPromotion(
         PROTO_3, 
         Drink.UNKNOWN
       ) {
-        public override fun fromValue(value: Int): Drink? = Drink.fromValue(value)
+        public override fun fromValue(`value`: Int): Drink? = Drink.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): Drink? = when (value) {
+      public fun fromValue(`value`: Int): Drink? = when (value) {
         0 -> UNKNOWN
         1 -> PEPSI
         2 -> MOUNTAIN_DEW

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -15,7 +15,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -49,7 +48,7 @@ public class FreeGarlicBreadPromotion(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + is_extra_cheesey.hashCode()
+      result = result * 37 + (is_extra_cheesey?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -91,14 +90,14 @@ public class FreeGarlicBreadPromotion(
       PROTO_3, 
       null
     ) {
-      public override fun encodedSize(value: FreeGarlicBreadPromotion): Int {
+      public override fun encodedSize(`value`: FreeGarlicBreadPromotion): Int {
         var size = value.unknownFields.size
         if (value.is_extra_cheesey != false) size += ProtoAdapter.BOOL.encodedSizeWithTag(1,
             value.is_extra_cheesey)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: FreeGarlicBreadPromotion): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: FreeGarlicBreadPromotion): Unit {
         if (value.is_extra_cheesey != false) ProtoAdapter.BOOL.encodeWithTag(writer, 1,
             value.is_extra_cheesey)
         writer.writeBytes(value.unknownFields)
@@ -118,7 +117,7 @@ public class FreeGarlicBreadPromotion(
         )
       }
 
-      public override fun redact(value: FreeGarlicBreadPromotion): FreeGarlicBreadPromotion =
+      public override fun redact(`value`: FreeGarlicBreadPromotion): FreeGarlicBreadPromotion =
           value.copy(
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/MapTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/MapTypes.kt
@@ -381,7 +381,7 @@ public class MapTypes(
       private val map_uint64_uint64Adapter: ProtoAdapter<Map<Long, Long>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.UINT64, ProtoAdapter.UINT64) }
 
-      public override fun encodedSize(value: MapTypes): Int {
+      public override fun encodedSize(`value`: MapTypes): Int {
         var size = value.unknownFields.size
         size += map_string_stringAdapter.encodedSizeWithTag(1, value.map_string_string)
         size += map_int32_int32Adapter.encodedSizeWithTag(2, value.map_int32_int32)
@@ -397,7 +397,7 @@ public class MapTypes(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: MapTypes): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: MapTypes): Unit {
         map_string_stringAdapter.encodeWithTag(writer, 1, value.map_string_string)
         map_int32_int32Adapter.encodeWithTag(writer, 2, value.map_int32_int32)
         map_sint32_sint32Adapter.encodeWithTag(writer, 3, value.map_sint32_sint32)
@@ -456,7 +456,7 @@ public class MapTypes(
         )
       }
 
-      public override fun redact(value: MapTypes): MapTypes = value.copy(
+      public override fun redact(`value`: MapTypes): MapTypes = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
@@ -93,13 +93,13 @@ public class Pizza(
       PROTO_3, 
       null
     ) {
-      public override fun encodedSize(value: Pizza): Int {
+      public override fun encodedSize(`value`: Pizza): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(1, value.toppings)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Pizza): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Pizza): Unit {
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 1, value.toppings)
         writer.writeBytes(value.unknownFields)
       }
@@ -118,7 +118,7 @@ public class Pizza(
         )
       }
 
-      public override fun redact(value: Pizza): Pizza = value.copy(
+      public override fun redact(`value`: Pizza): Pizza = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
@@ -25,7 +25,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -119,13 +118,13 @@ public class PizzaDelivery(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + phone_number.hashCode()
-      result = result * 37 + address.hashCode()
+      result = result * 37 + (phone_number?.hashCode() ?: 0)
+      result = result * 37 + (address?.hashCode() ?: 0)
       result = result * 37 + pizzas.hashCode()
-      result = result * 37 + promotion.hashCode()
-      result = result * 37 + delivered_within_or_free.hashCode()
-      result = result * 37 + loyalty.hashCode()
-      result = result * 37 + ordered_at.hashCode()
+      result = result * 37 + (promotion?.hashCode() ?: 0)
+      result = result * 37 + (delivered_within_or_free?.hashCode() ?: 0)
+      result = result * 37 + (loyalty?.hashCode() ?: 0)
+      result = result * 37 + (ordered_at?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -235,7 +234,7 @@ public class PizzaDelivery(
       PROTO_3, 
       null
     ) {
-      public override fun encodedSize(value: PizzaDelivery): Int {
+      public override fun encodedSize(`value`: PizzaDelivery): Int {
         var size = value.unknownFields.size
         if (value.phone_number != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1,
             value.phone_number)
@@ -252,7 +251,7 @@ public class PizzaDelivery(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: PizzaDelivery): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: PizzaDelivery): Unit {
         if (value.phone_number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1,
             value.phone_number)
         if (value.address != "") ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
@@ -298,7 +297,7 @@ public class PizzaDelivery(
         )
       }
 
-      public override fun redact(value: PizzaDelivery): PizzaDelivery = value.copy(
+      public override fun redact(`value`: PizzaDelivery): PizzaDelivery = value.copy(
         pizzas = value.pizzas.redactElements(Pizza.ADAPTER),
         promotion = value.promotion?.let(AnyMessage.ADAPTER::redact),
         delivered_within_or_free =

--- a/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -28,7 +28,6 @@ import kotlin.Nothing
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -109,7 +108,7 @@ public class Person(
       result = unknownFields.hashCode()
       result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
-      result = result * 37 + email.hashCode()
+      result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       result = result * 37 + aliases.hashCode()
       super.hashCode = result
@@ -145,7 +144,7 @@ public class Person(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Person): Int {
+      public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
@@ -155,7 +154,7 @@ public class Person(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Person): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
@@ -190,7 +189,7 @@ public class Person(
         )
       }
 
-      public override fun redact(value: Person): Person = value.copy(
+      public override fun redact(`value`: Person): Person = value.copy(
         phone = value.phone.redactElements(PhoneNumber.ADAPTER),
         unknownFields = ByteString.EMPTY
       )
@@ -206,7 +205,7 @@ public class Person(
    * Represents the type of the phone number: mobile, home or work.
    */
   public enum class PhoneType(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     MOBILE(0),
     HOME(1),
@@ -223,11 +222,11 @@ public class Person(
         PROTO_2, 
         PhoneType.MOBILE
       ) {
-        public override fun fromValue(value: Int): PhoneType? = PhoneType.fromValue(value)
+        public override fun fromValue(`value`: Int): PhoneType? = PhoneType.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): PhoneType? = when (value) {
+      public fun fromValue(`value`: Int): PhoneType? = when (value) {
         0 -> MOBILE
         1 -> HOME
         2 -> WORK
@@ -277,7 +276,7 @@ public class Person(
       if (result == 0) {
         result = unknownFields.hashCode()
         result = result * 37 + number.hashCode()
-        result = result * 37 + type.hashCode()
+        result = result * 37 + (type?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -308,14 +307,14 @@ public class Person(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: PhoneNumber): Int {
+        public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
           size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: PhoneNumber): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: PhoneNumber): Unit {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
           PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
           writer.writeBytes(value.unknownFields)
@@ -342,7 +341,7 @@ public class Person(
           )
         }
 
-        public override fun redact(value: PhoneNumber): PhoneNumber = value.copy(
+        public override fun redact(`value`: PhoneNumber): PhoneNumber = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
@@ -18,7 +18,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.lazy
 import okio.ByteString
@@ -85,8 +84,8 @@ public class ModelEvaluation(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
-      result = result * 37 + score.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
+      result = result * 37 + (score?.hashCode() ?: 0)
       result = result * 37 + models.hashCode()
       super.hashCode = result
     }
@@ -153,7 +152,7 @@ public class ModelEvaluation(
       private val modelsAdapter: ProtoAdapter<Map<String, ModelEvaluation>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ModelEvaluation.ADAPTER) }
 
-      public override fun encodedSize(value: ModelEvaluation): Int {
+      public override fun encodedSize(`value`: ModelEvaluation): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.DOUBLE.encodedSizeWithTag(2, value.score)
@@ -161,7 +160,7 @@ public class ModelEvaluation(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: ModelEvaluation): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: ModelEvaluation): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.DOUBLE.encodeWithTag(writer, 2, value.score)
         modelsAdapter.encodeWithTag(writer, 3, value.models)
@@ -188,7 +187,7 @@ public class ModelEvaluation(
         )
       }
 
-      public override fun redact(value: ModelEvaluation): ModelEvaluation = value.copy(
+      public override fun redact(`value`: ModelEvaluation): ModelEvaluation = value.copy(
         models = value.models.redactElements(ModelEvaluation.ADAPTER),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -17,7 +17,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -50,7 +49,7 @@ public class DeprecatedProto(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + foo.hashCode()
+      result = result * 37 + (foo?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -90,13 +89,13 @@ public class DeprecatedProto(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: DeprecatedProto): Int {
+      public override fun encodedSize(`value`: DeprecatedProto): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.foo)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: DeprecatedProto): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: DeprecatedProto): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.foo)
         writer.writeBytes(value.unknownFields)
       }
@@ -115,7 +114,7 @@ public class DeprecatedProto(
         )
       }
 
-      public override fun redact(value: DeprecatedProto): DeprecatedProto = value.copy(
+      public override fun redact(`value`: DeprecatedProto): DeprecatedProto = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Set
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -53,8 +52,8 @@ public class Form(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + choice.hashCode()
-      result = result * 37 + decision.hashCode()
+      result = result * 37 + (choice?.hashCode() ?: 0)
+      result = result * 37 + (decision?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -102,7 +101,7 @@ public class Form(
     adapter: ProtoAdapter<T>,
     declaredName: String
   ) : OneOf.Key<T>(tag, adapter, declaredName) {
-    public fun create(value: T) = OneOf(this, value)
+    public fun create(`value`: T) = OneOf(this, value)
 
     public fun decode(reader: ProtoReader): OneOf<Choice<T>, T> = create(adapter.decode(reader))
   }
@@ -112,7 +111,7 @@ public class Form(
     adapter: ProtoAdapter<T>,
     declaredName: String
   ) : OneOf.Key<T>(tag, adapter, declaredName) {
-    public fun create(value: T) = OneOf(this, value)
+    public fun create(`value`: T) = OneOf(this, value)
 
     public fun decode(reader: ProtoReader): OneOf<Decision<T>, T> = create(adapter.decode(reader))
   }
@@ -126,14 +125,14 @@ public class Form(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Form): Int {
+      public override fun encodedSize(`value`: Form): Int {
         var size = value.unknownFields.size
         if (value.choice != null) size += value.choice.encodedSizeWithTag()
         if (value.decision != null) size += value.decision.encodedSizeWithTag()
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Form): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Form): Unit {
         if (value.choice != null) value.choice.encodeWithTag(writer)
         if (value.decision != null) value.decision.encodeWithTag(writer)
         writer.writeBytes(value.unknownFields)
@@ -168,7 +167,7 @@ public class Form(
         )
       }
 
-      public override fun redact(value: Form): Form = value.copy(
+      public override fun redact(`value`: Form): Form = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -290,12 +289,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: ButtonElement): Int {
+        public override fun encodedSize(`value`: ButtonElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: ButtonElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: ButtonElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -306,7 +305,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: ButtonElement): ButtonElement = value.copy(
+        public override fun redact(`value`: ButtonElement): ButtonElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -354,12 +353,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: LocalImageElement): Int {
+        public override fun encodedSize(`value`: LocalImageElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: LocalImageElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: LocalImageElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -370,7 +369,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: LocalImageElement): LocalImageElement = value.copy(
+        public override fun redact(`value`: LocalImageElement): LocalImageElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -418,12 +417,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: RemoteImageElement): Int {
+        public override fun encodedSize(`value`: RemoteImageElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: RemoteImageElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: RemoteImageElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -434,7 +433,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: RemoteImageElement): RemoteImageElement = value.copy(
+        public override fun redact(`value`: RemoteImageElement): RemoteImageElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -481,12 +480,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: MoneyElement): Int {
+        public override fun encodedSize(`value`: MoneyElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: MoneyElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: MoneyElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -497,7 +496,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: MoneyElement): MoneyElement = value.copy(
+        public override fun redact(`value`: MoneyElement): MoneyElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -544,12 +543,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: SpacerElement): Int {
+        public override fun encodedSize(`value`: SpacerElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: SpacerElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: SpacerElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -560,7 +559,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: SpacerElement): SpacerElement = value.copy(
+        public override fun redact(`value`: SpacerElement): SpacerElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -597,7 +596,7 @@ public class Form(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + text.hashCode()
+        result = result * 37 + (text?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -636,13 +635,13 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: TextElement): Int {
+        public override fun encodedSize(`value`: TextElement): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.text)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: TextElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: TextElement): Unit {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.text)
           writer.writeBytes(value.unknownFields)
         }
@@ -661,7 +660,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: TextElement): TextElement = value.copy(
+        public override fun redact(`value`: TextElement): TextElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -709,12 +708,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: CustomizedCardElement): Int {
+        public override fun encodedSize(`value`: CustomizedCardElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: CustomizedCardElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: CustomizedCardElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -725,7 +724,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: CustomizedCardElement): CustomizedCardElement =
+        public override fun redact(`value`: CustomizedCardElement): CustomizedCardElement =
             value.copy(
           unknownFields = ByteString.EMPTY
         )
@@ -773,12 +772,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: AddressElement): Int {
+        public override fun encodedSize(`value`: AddressElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: AddressElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: AddressElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -789,7 +788,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: AddressElement): AddressElement = value.copy(
+        public override fun redact(`value`: AddressElement): AddressElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -836,12 +835,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: TextInputElement): Int {
+        public override fun encodedSize(`value`: TextInputElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: TextInputElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: TextInputElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -852,7 +851,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: TextInputElement): TextInputElement = value.copy(
+        public override fun redact(`value`: TextInputElement): TextInputElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -900,12 +899,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: OptionPickerElement): Int {
+        public override fun encodedSize(`value`: OptionPickerElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: OptionPickerElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: OptionPickerElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -916,7 +915,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: OptionPickerElement): OptionPickerElement = value.copy(
+        public override fun redact(`value`: OptionPickerElement): OptionPickerElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -963,12 +962,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: DetailRowElement): Int {
+        public override fun encodedSize(`value`: DetailRowElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: DetailRowElement): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: DetailRowElement): Unit {
           writer.writeBytes(value.unknownFields)
         }
 
@@ -979,7 +978,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: DetailRowElement): DetailRowElement = value.copy(
+        public override fun redact(`value`: DetailRowElement): DetailRowElement = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -1028,12 +1027,12 @@ public class Form(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: CurrencyConversionFlagsElement): Int {
+        public override fun encodedSize(`value`: CurrencyConversionFlagsElement): Int {
           var size = value.unknownFields.size
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: CurrencyConversionFlagsElement):
+        public override fun encode(writer: ProtoWriter, `value`: CurrencyConversionFlagsElement):
             Unit {
           writer.writeBytes(value.unknownFields)
         }
@@ -1045,7 +1044,7 @@ public class Form(
           )
         }
 
-        public override fun redact(value: CurrencyConversionFlagsElement):
+        public override fun redact(`value`: CurrencyConversionFlagsElement):
             CurrencyConversionFlagsElement = value.copy(
           unknownFields = ByteString.EMPTY
         )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -15,7 +15,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -58,8 +57,8 @@ public class MessageUsingMultipleEnums(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + a.hashCode()
-      result = result * 37 + b.hashCode()
+      result = result * 37 + (a?.hashCode() ?: 0)
+      result = result * 37 + (b?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -113,14 +112,14 @@ public class MessageUsingMultipleEnums(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: MessageUsingMultipleEnums): Int {
+      public override fun encodedSize(`value`: MessageUsingMultipleEnums): Int {
         var size = value.unknownFields.size
         size += MessageWithStatus.Status.ADAPTER.encodedSizeWithTag(1, value.a)
         size += OtherMessageWithStatus.Status.ADAPTER.encodedSizeWithTag(2, value.b)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: MessageUsingMultipleEnums): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: MessageUsingMultipleEnums): Unit {
         MessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 1, value.a)
         OtherMessageWithStatus.Status.ADAPTER.encodeWithTag(writer, 2, value.b)
         writer.writeBytes(value.unknownFields)
@@ -151,7 +150,7 @@ public class MessageUsingMultipleEnums(
         )
       }
 
-      public override fun redact(value: MessageUsingMultipleEnums): MessageUsingMultipleEnums =
+      public override fun redact(`value`: MessageUsingMultipleEnums): MessageUsingMultipleEnums =
           value.copy(
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -59,12 +59,12 @@ public class MessageWithStatus(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: MessageWithStatus): Int {
+      public override fun encodedSize(`value`: MessageWithStatus): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: MessageWithStatus): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: MessageWithStatus): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -75,7 +75,7 @@ public class MessageWithStatus(
         )
       }
 
-      public override fun redact(value: MessageWithStatus): MessageWithStatus = value.copy(
+      public override fun redact(`value`: MessageWithStatus): MessageWithStatus = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }
@@ -84,7 +84,7 @@ public class MessageWithStatus(
   }
 
   public enum class Status(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     A(1),
     ;
@@ -96,11 +96,11 @@ public class MessageWithStatus(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): Status? = Status.fromValue(value)
+        public override fun fromValue(`value`: Int): Status? = Status.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): Status? = when (value) {
+      public fun fromValue(`value`: Int): Status? = when (value) {
         1 -> A
         else -> null
       }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -57,12 +57,12 @@ public class NoFields(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NoFields): Int {
+      public override fun encodedSize(`value`: NoFields): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NoFields): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NoFields): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -73,7 +73,7 @@ public class NoFields(
         )
       }
 
-      public override fun redact(value: NoFields): NoFields = value.copy(
+      public override fun redact(`value`: NoFields): NoFields = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -17,7 +17,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -83,9 +82,9 @@ public class OneOfMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + foo.hashCode()
-      result = result * 37 + bar.hashCode()
-      result = result * 37 + baz.hashCode()
+      result = result * 37 + (foo?.hashCode() ?: 0)
+      result = result * 37 + (bar?.hashCode() ?: 0)
+      result = result * 37 + (baz?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -163,7 +162,7 @@ public class OneOfMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OneOfMessage): Int {
+      public override fun encodedSize(`value`: OneOfMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.foo)
         size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.bar)
@@ -171,7 +170,7 @@ public class OneOfMessage(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OneOfMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OneOfMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.foo)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.bar)
         ProtoAdapter.STRING.encodeWithTag(writer, 4, value.baz)
@@ -198,7 +197,7 @@ public class OneOfMessage(
         )
       }
 
-      public override fun redact(value: OneOfMessage): OneOfMessage = value.copy(
+      public override fun redact(`value`: OneOfMessage): OneOfMessage = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -60,12 +60,12 @@ public class OtherMessageWithStatus(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OtherMessageWithStatus): Int {
+      public override fun encodedSize(`value`: OtherMessageWithStatus): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OtherMessageWithStatus): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OtherMessageWithStatus): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -76,7 +76,7 @@ public class OtherMessageWithStatus(
         )
       }
 
-      public override fun redact(value: OtherMessageWithStatus): OtherMessageWithStatus =
+      public override fun redact(`value`: OtherMessageWithStatus): OtherMessageWithStatus =
           value.copy(
         unknownFields = ByteString.EMPTY
       )
@@ -86,7 +86,7 @@ public class OtherMessageWithStatus(
   }
 
   public enum class Status(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     A(1),
     ;
@@ -98,11 +98,11 @@ public class OtherMessageWithStatus(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): Status? = Status.fromValue(value)
+        public override fun fromValue(`value`: Int): Status? = Status.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): Status? = when (value) {
+      public fun fromValue(`value`: Int): Status? = when (value) {
         1 -> A
         else -> null
       }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
@@ -16,7 +16,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -51,7 +50,7 @@ public class Percents(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + text.hashCode()
+      result = result * 37 + (text?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -93,13 +92,13 @@ public class Percents(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Percents): Int {
+      public override fun encodedSize(`value`: Percents): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.text)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Percents): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Percents): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.text)
         writer.writeBytes(value.unknownFields)
       }
@@ -118,7 +117,7 @@ public class Percents(
         )
       }
 
-      public override fun redact(value: Percents): Percents = value.copy(
+      public override fun redact(`value`: Percents): Percents = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -27,7 +27,6 @@ import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
 import kotlin.collections.Map
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import kotlin.lazy
@@ -1485,23 +1484,23 @@ public class AllTypes(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + opt_int32.hashCode()
-      result = result * 37 + opt_uint32.hashCode()
-      result = result * 37 + opt_sint32.hashCode()
-      result = result * 37 + opt_fixed32.hashCode()
-      result = result * 37 + opt_sfixed32.hashCode()
-      result = result * 37 + opt_int64.hashCode()
-      result = result * 37 + opt_uint64.hashCode()
-      result = result * 37 + opt_sint64.hashCode()
-      result = result * 37 + opt_fixed64.hashCode()
-      result = result * 37 + opt_sfixed64.hashCode()
-      result = result * 37 + opt_bool.hashCode()
-      result = result * 37 + opt_float.hashCode()
-      result = result * 37 + opt_double.hashCode()
-      result = result * 37 + opt_string.hashCode()
-      result = result * 37 + opt_bytes.hashCode()
-      result = result * 37 + opt_nested_enum.hashCode()
-      result = result * 37 + opt_nested_message.hashCode()
+      result = result * 37 + (opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (opt_float?.hashCode() ?: 0)
+      result = result * 37 + (opt_double?.hashCode() ?: 0)
+      result = result * 37 + (opt_string?.hashCode() ?: 0)
+      result = result * 37 + (opt_bytes?.hashCode() ?: 0)
+      result = result * 37 + (opt_nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (opt_nested_message?.hashCode() ?: 0)
       result = result * 37 + req_int32.hashCode()
       result = result * 37 + req_uint32.hashCode()
       result = result * 37 + req_sint32.hashCode()
@@ -1550,43 +1549,43 @@ public class AllTypes(
       result = result * 37 + pack_float.hashCode()
       result = result * 37 + pack_double.hashCode()
       result = result * 37 + pack_nested_enum.hashCode()
-      result = result * 37 + default_int32.hashCode()
-      result = result * 37 + default_uint32.hashCode()
-      result = result * 37 + default_sint32.hashCode()
-      result = result * 37 + default_fixed32.hashCode()
-      result = result * 37 + default_sfixed32.hashCode()
-      result = result * 37 + default_int64.hashCode()
-      result = result * 37 + default_uint64.hashCode()
-      result = result * 37 + default_sint64.hashCode()
-      result = result * 37 + default_fixed64.hashCode()
-      result = result * 37 + default_sfixed64.hashCode()
-      result = result * 37 + default_bool.hashCode()
-      result = result * 37 + default_float.hashCode()
-      result = result * 37 + default_double.hashCode()
-      result = result * 37 + default_string.hashCode()
-      result = result * 37 + default_bytes.hashCode()
-      result = result * 37 + default_nested_enum.hashCode()
+      result = result * 37 + (default_int32?.hashCode() ?: 0)
+      result = result * 37 + (default_uint32?.hashCode() ?: 0)
+      result = result * 37 + (default_sint32?.hashCode() ?: 0)
+      result = result * 37 + (default_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (default_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (default_int64?.hashCode() ?: 0)
+      result = result * 37 + (default_uint64?.hashCode() ?: 0)
+      result = result * 37 + (default_sint64?.hashCode() ?: 0)
+      result = result * 37 + (default_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (default_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (default_bool?.hashCode() ?: 0)
+      result = result * 37 + (default_float?.hashCode() ?: 0)
+      result = result * 37 + (default_double?.hashCode() ?: 0)
+      result = result * 37 + (default_string?.hashCode() ?: 0)
+      result = result * 37 + (default_bytes?.hashCode() ?: 0)
+      result = result * 37 + (default_nested_enum?.hashCode() ?: 0)
       result = result * 37 + map_int32_int32.hashCode()
       result = result * 37 + map_string_string.hashCode()
       result = result * 37 + map_string_message.hashCode()
       result = result * 37 + map_string_enum.hashCode()
-      result = result * 37 + ext_opt_int32.hashCode()
-      result = result * 37 + ext_opt_uint32.hashCode()
-      result = result * 37 + ext_opt_sint32.hashCode()
-      result = result * 37 + ext_opt_fixed32.hashCode()
-      result = result * 37 + ext_opt_sfixed32.hashCode()
-      result = result * 37 + ext_opt_int64.hashCode()
-      result = result * 37 + ext_opt_uint64.hashCode()
-      result = result * 37 + ext_opt_sint64.hashCode()
-      result = result * 37 + ext_opt_fixed64.hashCode()
-      result = result * 37 + ext_opt_sfixed64.hashCode()
-      result = result * 37 + ext_opt_bool.hashCode()
-      result = result * 37 + ext_opt_float.hashCode()
-      result = result * 37 + ext_opt_double.hashCode()
-      result = result * 37 + ext_opt_string.hashCode()
-      result = result * 37 + ext_opt_bytes.hashCode()
-      result = result * 37 + ext_opt_nested_enum.hashCode()
-      result = result * 37 + ext_opt_nested_message.hashCode()
+      result = result * 37 + (ext_opt_int32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_uint32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sint32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_fixed32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_int64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_uint64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sint64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_fixed64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_bool?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_float?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_double?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_string?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_bytes?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_nested_enum?.hashCode() ?: 0)
+      result = result * 37 + (ext_opt_nested_message?.hashCode() ?: 0)
       result = result * 37 + ext_rep_int32.hashCode()
       result = result * 37 + ext_rep_uint32.hashCode()
       result = result * 37 + ext_rep_sint32.hashCode()
@@ -3248,7 +3247,7 @@ public class AllTypes(
       private val map_string_enumAdapter: ProtoAdapter<Map<String, NestedEnum>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, NestedEnum.ADAPTER) }
 
-      public override fun encodedSize(value: AllTypes): Int {
+      public override fun encodedSize(`value`: AllTypes): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.opt_int32)
         size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.opt_uint32)
@@ -3387,7 +3386,7 @@ public class AllTypes(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: AllTypes): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: AllTypes): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.opt_int32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.opt_uint32)
         ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.opt_sint32)
@@ -3968,7 +3967,7 @@ public class AllTypes(
         )
       }
 
-      public override fun redact(value: AllTypes): AllTypes = value.copy(
+      public override fun redact(`value`: AllTypes): AllTypes = value.copy(
         opt_nested_message = value.opt_nested_message?.let(NestedMessage.ADAPTER::redact),
         req_nested_message = NestedMessage.ADAPTER.redact(value.req_nested_message),
         rep_nested_message = value.rep_nested_message.redactElements(NestedMessage.ADAPTER),
@@ -3983,7 +3982,7 @@ public class AllTypes(
   }
 
   public enum class NestedEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     UNKNOWN(0),
     A(1),
@@ -3996,11 +3995,11 @@ public class AllTypes(
         PROTO_2, 
         NestedEnum.UNKNOWN
       ) {
-        public override fun fromValue(value: Int): NestedEnum? = NestedEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): NestedEnum? = NestedEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): NestedEnum? = when (value) {
+      public fun fromValue(`value`: Int): NestedEnum? = when (value) {
         0 -> UNKNOWN
         1 -> A
         else -> null
@@ -4036,7 +4035,7 @@ public class AllTypes(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + a.hashCode()
+        result = result * 37 + (a?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -4075,13 +4074,13 @@ public class AllTypes(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: NestedMessage): Int {
+        public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedMessage): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedMessage): Unit {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
           writer.writeBytes(value.unknownFields)
         }
@@ -4100,7 +4099,7 @@ public class AllTypes(
           )
         }
 
-        public override fun redact(value: NestedMessage): NestedMessage = value.copy(
+        public override fun redact(`value`: NestedMessage): NestedMessage = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnum.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnum.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class ForeignEnum(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   BAV(0),
   BAX(1),
@@ -24,11 +24,11 @@ public enum class ForeignEnum(
       PROTO_2, 
       ForeignEnum.BAV
     ) {
-      public override fun fromValue(value: Int): ForeignEnum? = ForeignEnum.fromValue(value)
+      public override fun fromValue(`value`: Int): ForeignEnum? = ForeignEnum.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): ForeignEnum? = when (value) {
+    public fun fromValue(`value`: Int): ForeignEnum? = when (value) {
       0 -> BAV
       1 -> BAX
       else -> null

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnumValueOptionOption.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignEnumValueOptionOption.kt
@@ -11,5 +11,5 @@ import kotlin.`annotation`.Target
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.PROPERTY)
 public annotation class ForeignEnumValueOptionOption(
-  public val value: Boolean
+  public val `value`: Boolean
 )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -15,7 +15,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -58,8 +57,8 @@ public class ForeignMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + j.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (j?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -111,14 +110,14 @@ public class ForeignMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: ForeignMessage): Int {
+      public override fun encodedSize(`value`: ForeignMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += ProtoAdapter.INT32.encodedSizeWithTag(100, value.j)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: ForeignMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: ForeignMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         ProtoAdapter.INT32.encodeWithTag(writer, 100, value.j)
         writer.writeBytes(value.unknownFields)
@@ -141,7 +140,7 @@ public class ForeignMessage(
         )
       }
 
-      public override fun redact(value: ForeignMessage): ForeignMessage = value.copy(
+      public override fun redact(`value`: ForeignMessage): ForeignMessage = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -95,13 +95,13 @@ public class Mappy(
       private val thingsAdapter: ProtoAdapter<Map<String, Thing>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER) }
 
-      public override fun encodedSize(value: Mappy): Int {
+      public override fun encodedSize(`value`: Mappy): Int {
         var size = value.unknownFields.size
         size += thingsAdapter.encodedSizeWithTag(1, value.things)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Mappy): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Mappy): Unit {
         thingsAdapter.encodeWithTag(writer, 1, value.things)
         writer.writeBytes(value.unknownFields)
       }
@@ -120,7 +120,7 @@ public class Mappy(
         )
       }
 
-      public override fun redact(value: Mappy): Mappy = value.copy(
+      public override fun redact(`value`: Mappy): Mappy = value.copy(
         things = value.things.redactElements(Thing.ADAPTER),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -16,7 +16,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -48,7 +47,7 @@ public class Thing(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -87,13 +86,13 @@ public class Thing(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Thing): Int {
+      public override fun encodedSize(`value`: Thing): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Thing): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Thing): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         writer.writeBytes(value.unknownFields)
       }
@@ -112,7 +111,7 @@ public class Thing(
         )
       }
 
-      public override fun redact(value: Thing): Thing = value.copy(
+      public override fun redact(`value`: Thing): Thing = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -24,7 +24,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -114,7 +113,7 @@ public class Person(
       result = unknownFields.hashCode()
       result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
-      result = result * 37 + email.hashCode()
+      result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       result = result * 37 + aliases.hashCode()
       super.hashCode = result
@@ -215,7 +214,7 @@ public class Person(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Person): Int {
+      public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
@@ -225,7 +224,7 @@ public class Person(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Person): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
@@ -260,7 +259,7 @@ public class Person(
         )
       }
 
-      public override fun redact(value: Person): Person = value.copy(
+      public override fun redact(`value`: Person): Person = value.copy(
         phone = value.phone.redactElements(PhoneNumber.ADAPTER),
         unknownFields = ByteString.EMPTY
       )
@@ -273,7 +272,7 @@ public class Person(
    * Represents the type of the phone number: mobile, home or work.
    */
   public enum class PhoneType(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     MOBILE(0),
     HOME(1),
@@ -290,11 +289,11 @@ public class Person(
         PROTO_2, 
         PhoneType.MOBILE
       ) {
-        public override fun fromValue(value: Int): PhoneType? = PhoneType.fromValue(value)
+        public override fun fromValue(`value`: Int): PhoneType? = PhoneType.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): PhoneType? = when (value) {
+      public fun fromValue(`value`: Int): PhoneType? = when (value) {
         0 -> MOBILE
         1 -> HOME
         2 -> WORK
@@ -347,7 +346,7 @@ public class Person(
       if (result == 0) {
         result = unknownFields.hashCode()
         result = result * 37 + number.hashCode()
-        result = result * 37 + type.hashCode()
+        result = result * 37 + (type?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -408,14 +407,14 @@ public class Person(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: PhoneNumber): Int {
+        public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
           size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: PhoneNumber): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: PhoneNumber): Unit {
           ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
           PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
           writer.writeBytes(value.unknownFields)
@@ -442,7 +441,7 @@ public class Person(
           )
         }
 
-        public override fun redact(value: PhoneNumber): PhoneNumber = value.copy(
+        public override fun redact(`value`: PhoneNumber): PhoneNumber = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -16,7 +16,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -63,8 +62,8 @@ public class RedactedOneOf(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + b.hashCode()
-      result = result * 37 + c.hashCode()
+      result = result * 37 + (b?.hashCode() ?: 0)
+      result = result * 37 + (c?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -118,14 +117,14 @@ public class RedactedOneOf(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: RedactedOneOf): Int {
+      public override fun encodedSize(`value`: RedactedOneOf): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.b)
         size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.c)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: RedactedOneOf): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: RedactedOneOf): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.b)
         ProtoAdapter.STRING.encodeWithTag(writer, 2, value.c)
         writer.writeBytes(value.unknownFields)
@@ -148,7 +147,7 @@ public class RedactedOneOf(
         )
       }
 
-      public override fun redact(value: RedactedOneOf): RedactedOneOf = value.copy(
+      public override fun redact(`value`: RedactedOneOf): RedactedOneOf = value.copy(
         c = null,
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
@@ -93,13 +93,13 @@ public class Repeated(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Repeated): Int {
+      public override fun encodedSize(`value`: Repeated): Int {
         var size = value.unknownFields.size
         size += Thing.ADAPTER.asRepeated().encodedSizeWithTag(1, value.things)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Repeated): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Repeated): Unit {
         Thing.ADAPTER.asRepeated().encodeWithTag(writer, 1, value.things)
         writer.writeBytes(value.unknownFields)
       }
@@ -118,7 +118,7 @@ public class Repeated(
         )
       }
 
-      public override fun redact(value: Repeated): Repeated = value.copy(
+      public override fun redact(`value`: Repeated): Repeated = value.copy(
         things = value.things.redactElements(Thing.ADAPTER),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
@@ -16,7 +16,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -48,7 +47,7 @@ public class Thing(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
+      result = result * 37 + (name?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -87,13 +86,13 @@ public class Thing(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: Thing): Int {
+      public override fun encodedSize(`value`: Thing): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: Thing): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: Thing): Unit {
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         writer.writeBytes(value.unknownFields)
       }
@@ -112,7 +111,7 @@ public class Thing(
         )
       }
 
-      public override fun redact(value: Thing): Thing = value.copy(
+      public override fun redact(`value`: Thing): Thing = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
@@ -54,12 +54,12 @@ public class NoPackageRequest(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NoPackageRequest): Int {
+      public override fun encodedSize(`value`: NoPackageRequest): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NoPackageRequest): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NoPackageRequest): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -70,7 +70,7 @@ public class NoPackageRequest(
         )
       }
 
-      public override fun redact(value: NoPackageRequest): NoPackageRequest = value.copy(
+      public override fun redact(`value`: NoPackageRequest): NoPackageRequest = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
@@ -54,12 +54,12 @@ public class NoPackageResponse(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NoPackageResponse): Int {
+      public override fun encodedSize(`value`: NoPackageResponse): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NoPackageResponse): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NoPackageResponse): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -70,7 +70,7 @@ public class NoPackageResponse(
         )
       }
 
-      public override fun redact(value: NoPackageResponse): NoPackageResponse = value.copy(
+      public override fun redact(`value`: NoPackageResponse): NoPackageResponse = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
@@ -54,12 +54,12 @@ public class SomeRequest(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: SomeRequest): Int {
+      public override fun encodedSize(`value`: SomeRequest): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: SomeRequest): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: SomeRequest): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -70,7 +70,7 @@ public class SomeRequest(
         )
       }
 
-      public override fun redact(value: SomeRequest): SomeRequest = value.copy(
+      public override fun redact(`value`: SomeRequest): SomeRequest = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
@@ -54,12 +54,12 @@ public class SomeResponse(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: SomeResponse): Int {
+      public override fun encodedSize(`value`: SomeResponse): Int {
         var size = value.unknownFields.size
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: SomeResponse): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: SomeResponse): Unit {
         writer.writeBytes(value.unknownFields)
       }
 
@@ -70,7 +70,7 @@ public class SomeResponse(
         )
       }
 
-      public override fun redact(value: SomeResponse): SomeResponse = value.copy(
+      public override fun redact(`value`: SomeResponse): SomeResponse = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -109,12 +108,12 @@ public class ExternalMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + f.hashCode()
+      result = result * 37 + (f?.hashCode() ?: 0)
       result = result * 37 + fooext.hashCode()
-      result = result * 37 + barext.hashCode()
-      result = result * 37 + bazext.hashCode()
-      result = result * 37 + nested_message_ext.hashCode()
-      result = result * 37 + nested_enum_ext.hashCode()
+      result = result * 37 + (barext?.hashCode() ?: 0)
+      result = result * 37 + (bazext?.hashCode() ?: 0)
+      result = result * 37 + (nested_message_ext?.hashCode() ?: 0)
+      result = result * 37 + (nested_enum_ext?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -214,7 +213,7 @@ public class ExternalMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: ExternalMessage): Int {
+      public override fun encodedSize(`value`: ExternalMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.FLOAT.encodedSizeWithTag(1, value.f)
         size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(125, value.fooext)
@@ -226,7 +225,7 @@ public class ExternalMessage(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: ExternalMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: ExternalMessage): Unit {
         ProtoAdapter.FLOAT.encodeWithTag(writer, 1, value.f)
         ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 125, value.fooext)
         ProtoAdapter.INT32.encodeWithTag(writer, 126, value.barext)
@@ -269,7 +268,7 @@ public class ExternalMessage(
         )
       }
 
-      public override fun redact(value: ExternalMessage): ExternalMessage = value.copy(
+      public override fun redact(`value`: ExternalMessage): ExternalMessage = value.copy(
         nested_message_ext =
             value.nested_message_ext?.let(SimpleMessage.NestedMessage.ADAPTER::redact),
         unknownFields = ByteString.EMPTY

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -26,7 +26,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 import okio.ByteString
@@ -190,18 +189,18 @@ public class SimpleMessage(
     var result_ = super.hashCode
     if (result_ == 0) {
       result_ = unknownFields.hashCode()
-      result_ = result_ * 37 + optional_int32.hashCode()
-      result_ = result_ * 37 + optional_nested_msg.hashCode()
-      result_ = result_ * 37 + optional_external_msg.hashCode()
-      result_ = result_ * 37 + default_nested_enum.hashCode()
+      result_ = result_ * 37 + (optional_int32?.hashCode() ?: 0)
+      result_ = result_ * 37 + (optional_nested_msg?.hashCode() ?: 0)
+      result_ = result_ * 37 + (optional_external_msg?.hashCode() ?: 0)
+      result_ = result_ * 37 + (default_nested_enum?.hashCode() ?: 0)
       result_ = result_ * 37 + required_int32.hashCode()
       result_ = result_ * 37 + repeated_double.hashCode()
-      result_ = result_ * 37 + default_foreign_enum.hashCode()
-      result_ = result_ * 37 + no_default_foreign_enum.hashCode()
-      result_ = result_ * 37 + package_.hashCode()
-      result_ = result_ * 37 + result.hashCode()
-      result_ = result_ * 37 + other.hashCode()
-      result_ = result_ * 37 + o.hashCode()
+      result_ = result_ * 37 + (default_foreign_enum?.hashCode() ?: 0)
+      result_ = result_ * 37 + (no_default_foreign_enum?.hashCode() ?: 0)
+      result_ = result_ * 37 + (package_?.hashCode() ?: 0)
+      result_ = result_ * 37 + (result?.hashCode() ?: 0)
+      result_ = result_ * 37 + (other?.hashCode() ?: 0)
+      result_ = result_ * 37 + (o?.hashCode() ?: 0)
       super.hashCode = result_
     }
     return result_
@@ -413,7 +412,7 @@ public class SimpleMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: SimpleMessage): Int {
+      public override fun encodedSize(`value`: SimpleMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.optional_int32)
         size += NestedMessage.ADAPTER.encodedSizeWithTag(2, value.optional_nested_msg)
@@ -430,7 +429,7 @@ public class SimpleMessage(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: SimpleMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: SimpleMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.optional_int32)
         NestedMessage.ADAPTER.encodeWithTag(writer, 2, value.optional_nested_msg)
         ExternalMessage.ADAPTER.encodeWithTag(writer, 3, value.optional_external_msg)
@@ -506,7 +505,7 @@ public class SimpleMessage(
         )
       }
 
-      public override fun redact(value: SimpleMessage): SimpleMessage = value.copy(
+      public override fun redact(`value`: SimpleMessage): SimpleMessage = value.copy(
         optional_nested_msg = value.optional_nested_msg?.let(NestedMessage.ADAPTER::redact),
         optional_external_msg = value.optional_external_msg?.let(ExternalMessage.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
@@ -547,7 +546,7 @@ public class SimpleMessage(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + bb.hashCode()
+        result = result * 37 + (bb?.hashCode() ?: 0)
         super.hashCode = result
       }
       return result
@@ -589,13 +588,13 @@ public class SimpleMessage(
         PROTO_2, 
         null
       ) {
-        public override fun encodedSize(value: NestedMessage): Int {
+        public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
           size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.bb)
           return size
         }
 
-        public override fun encode(writer: ProtoWriter, value: NestedMessage): Unit {
+        public override fun encode(writer: ProtoWriter, `value`: NestedMessage): Unit {
           ProtoAdapter.INT32.encodeWithTag(writer, 1, value.bb)
           writer.writeBytes(value.unknownFields)
         }
@@ -614,7 +613,7 @@ public class SimpleMessage(
           )
         }
 
-        public override fun redact(value: NestedMessage): NestedMessage = value.copy(
+        public override fun redact(`value`: NestedMessage): NestedMessage = value.copy(
           unknownFields = ByteString.EMPTY
         )
       }
@@ -624,7 +623,7 @@ public class SimpleMessage(
   }
 
   public enum class NestedEnum(
-    public override val value: Int
+    public override val `value`: Int
   ) : WireEnum {
     FOO(1),
     BAR(2),
@@ -640,11 +639,11 @@ public class SimpleMessage(
         PROTO_2, 
         null
       ) {
-        public override fun fromValue(value: Int): NestedEnum? = NestedEnum.fromValue(value)
+        public override fun fromValue(`value`: Int): NestedEnum? = NestedEnum.fromValue(value)
       }
 
       @JvmStatic
-      public fun fromValue(value: Int): NestedEnum? = when (value) {
+      public fun fromValue(`value`: Int): NestedEnum? = when (value) {
         1 -> FOO
         2 -> BAR
         3 -> BAZ

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionOne.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class EnumVersionOne(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   SHREK_V1(1),
   DONKEY_V1(2),
@@ -25,11 +25,11 @@ public enum class EnumVersionOne(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): EnumVersionOne? = EnumVersionOne.fromValue(value)
+      public override fun fromValue(`value`: Int): EnumVersionOne? = EnumVersionOne.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): EnumVersionOne? = when (value) {
+    public fun fromValue(`value`: Int): EnumVersionOne? = when (value) {
       1 -> SHREK_V1
       2 -> DONKEY_V1
       3 -> FIONA_V1

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/EnumVersionTwo.kt
@@ -11,7 +11,7 @@ import kotlin.jvm.JvmField
 import kotlin.jvm.JvmStatic
 
 public enum class EnumVersionTwo(
-  public override val value: Int
+  public override val `value`: Int
 ) : WireEnum {
   SHREK_V2(1),
   DONKEY_V2(2),
@@ -26,11 +26,11 @@ public enum class EnumVersionTwo(
       PROTO_2, 
       null
     ) {
-      public override fun fromValue(value: Int): EnumVersionTwo? = EnumVersionTwo.fromValue(value)
+      public override fun fromValue(`value`: Int): EnumVersionTwo? = EnumVersionTwo.fromValue(value)
     }
 
     @JvmStatic
-    public fun fromValue(value: Int): EnumVersionTwo? = when (value) {
+    public fun fromValue(`value`: Int): EnumVersionTwo? = when (value) {
       1 -> SHREK_V2
       2 -> DONKEY_V2
       3 -> FIONA_V2

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -15,7 +15,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -47,7 +46,7 @@ public class NestedVersionOne(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -86,13 +85,13 @@ public class NestedVersionOne(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NestedVersionOne): Int {
+      public override fun encodedSize(`value`: NestedVersionOne): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NestedVersionOne): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NestedVersionOne): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         writer.writeBytes(value.unknownFields)
       }
@@ -111,7 +110,7 @@ public class NestedVersionOne(
         )
       }
 
-      public override fun redact(value: NestedVersionOne): NestedVersionOne = value.copy(
+      public override fun redact(`value`: NestedVersionOne): NestedVersionOne = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -94,11 +93,11 @@ public class NestedVersionTwo(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + v2_i.hashCode()
-      result = result * 37 + v2_s.hashCode()
-      result = result * 37 + v2_f32.hashCode()
-      result = result * 37 + v2_f64.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (v2_i?.hashCode() ?: 0)
+      result = result * 37 + (v2_s?.hashCode() ?: 0)
+      result = result * 37 + (v2_f32?.hashCode() ?: 0)
+      result = result * 37 + (v2_f64?.hashCode() ?: 0)
       result = result * 37 + v2_rs.hashCode()
       super.hashCode = result
     }
@@ -196,7 +195,7 @@ public class NestedVersionTwo(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: NestedVersionTwo): Int {
+      public override fun encodedSize(`value`: NestedVersionTwo): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
@@ -207,7 +206,7 @@ public class NestedVersionTwo(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: NestedVersionTwo): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: NestedVersionTwo): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.v2_i)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.v2_s)
@@ -246,7 +245,7 @@ public class NestedVersionTwo(
         )
       }
 
-      public override fun redact(value: NestedVersionTwo): NestedVersionTwo = value.copy(
+      public override fun redact(`value`: NestedVersionTwo): NestedVersionTwo = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -15,7 +15,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -63,9 +62,9 @@ public class VersionOne(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + obj.hashCode()
-      result = result * 37 + en.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (obj?.hashCode() ?: 0)
+      result = result * 37 + (en?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -128,7 +127,7 @@ public class VersionOne(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: VersionOne): Int {
+      public override fun encodedSize(`value`: VersionOne): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += NestedVersionOne.ADAPTER.encodedSizeWithTag(7, value.obj)
@@ -136,7 +135,7 @@ public class VersionOne(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: VersionOne): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: VersionOne): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         NestedVersionOne.ADAPTER.encodeWithTag(writer, 7, value.obj)
         EnumVersionOne.ADAPTER.encodeWithTag(writer, 8, value.en)
@@ -167,7 +166,7 @@ public class VersionOne(
         )
       }
 
-      public override fun redact(value: VersionOne): VersionOne = value.copy(
+      public override fun redact(`value`: VersionOne): VersionOne = value.copy(
         obj = value.obj?.let(NestedVersionOne.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -19,7 +19,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -110,14 +109,14 @@ public class VersionTwo(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + i.hashCode()
-      result = result * 37 + v2_i.hashCode()
-      result = result * 37 + v2_s.hashCode()
-      result = result * 37 + v2_f32.hashCode()
-      result = result * 37 + v2_f64.hashCode()
+      result = result * 37 + (i?.hashCode() ?: 0)
+      result = result * 37 + (v2_i?.hashCode() ?: 0)
+      result = result * 37 + (v2_s?.hashCode() ?: 0)
+      result = result * 37 + (v2_f32?.hashCode() ?: 0)
+      result = result * 37 + (v2_f64?.hashCode() ?: 0)
       result = result * 37 + v2_rs.hashCode()
-      result = result * 37 + obj.hashCode()
-      result = result * 37 + en.hashCode()
+      result = result * 37 + (obj?.hashCode() ?: 0)
+      result = result * 37 + (en?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -236,7 +235,7 @@ public class VersionTwo(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: VersionTwo): Int {
+      public override fun encodedSize(`value`: VersionTwo): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.i)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.v2_i)
@@ -249,7 +248,7 @@ public class VersionTwo(
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: VersionTwo): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: VersionTwo): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.i)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.v2_i)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.v2_s)
@@ -300,7 +299,7 @@ public class VersionTwo(
         )
       }
 
-      public override fun redact(value: VersionTwo): VersionTwo = value.copy(
+      public override fun redact(`value`: VersionTwo): VersionTwo = value.copy(
         obj = value.obj?.let(NestedVersionTwo.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -20,7 +20,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -63,7 +62,7 @@ public class UsesAny(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + just_one.hashCode()
+      result = result * 37 + (just_one?.hashCode() ?: 0)
       result = result * 37 + many_anys.hashCode()
       super.hashCode = result
     }
@@ -117,14 +116,14 @@ public class UsesAny(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: UsesAny): Int {
+      public override fun encodedSize(`value`: UsesAny): Int {
         var size = value.unknownFields.size
         size += AnyMessage.ADAPTER.encodedSizeWithTag(1, value.just_one)
         size += AnyMessage.ADAPTER.asRepeated().encodedSizeWithTag(2, value.many_anys)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: UsesAny): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: UsesAny): Unit {
         AnyMessage.ADAPTER.encodeWithTag(writer, 1, value.just_one)
         AnyMessage.ADAPTER.asRepeated().encodeWithTag(writer, 2, value.many_anys)
         writer.writeBytes(value.unknownFields)
@@ -147,7 +146,7 @@ public class UsesAny(
         )
       }
 
-      public override fun redact(value: UsesAny): UsesAny = value.copy(
+      public override fun redact(`value`: UsesAny): UsesAny = value.copy(
         just_one = value.just_one?.let(AnyMessage.ADAPTER::redact),
         many_anys = value.many_anys.redactElements(AnyMessage.ADAPTER),
         unknownFields = ByteString.EMPTY

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -18,7 +18,6 @@ import kotlin.Long
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.List
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -63,7 +62,7 @@ public class EmbeddedMessage(
     if (result == 0) {
       result = unknownFields.hashCode()
       result = result * 37 + inner_repeated_number.hashCode()
-      result = result * 37 + inner_number_after.hashCode()
+      result = result * 37 + (inner_number_after?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -117,14 +116,14 @@ public class EmbeddedMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: EmbeddedMessage): Int {
+      public override fun encodedSize(`value`: EmbeddedMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(1, value.inner_repeated_number)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.inner_number_after)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: EmbeddedMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: EmbeddedMessage): Unit {
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 1, value.inner_repeated_number)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.inner_number_after)
         writer.writeBytes(value.unknownFields)
@@ -147,7 +146,7 @@ public class EmbeddedMessage(
         )
       }
 
-      public override fun redact(value: EmbeddedMessage): EmbeddedMessage = value.copy(
+      public override fun redact(`value`: EmbeddedMessage): EmbeddedMessage = value.copy(
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -15,7 +15,6 @@ import kotlin.Int
 import kotlin.Long
 import kotlin.String
 import kotlin.Unit
-import kotlin.hashCode
 import kotlin.jvm.JvmField
 import okio.ByteString
 
@@ -55,8 +54,8 @@ public class OuterMessage(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + outer_number_before.hashCode()
-      result = result * 37 + embedded_message.hashCode()
+      result = result * 37 + (outer_number_before?.hashCode() ?: 0)
+      result = result * 37 + (embedded_message?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -108,14 +107,14 @@ public class OuterMessage(
       PROTO_2, 
       null
     ) {
-      public override fun encodedSize(value: OuterMessage): Int {
+      public override fun encodedSize(`value`: OuterMessage): Int {
         var size = value.unknownFields.size
         size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.outer_number_before)
         size += EmbeddedMessage.ADAPTER.encodedSizeWithTag(2, value.embedded_message)
         return size
       }
 
-      public override fun encode(writer: ProtoWriter, value: OuterMessage): Unit {
+      public override fun encode(writer: ProtoWriter, `value`: OuterMessage): Unit {
         ProtoAdapter.INT32.encodeWithTag(writer, 1, value.outer_number_before)
         EmbeddedMessage.ADAPTER.encodeWithTag(writer, 2, value.embedded_message)
         writer.writeBytes(value.unknownFields)
@@ -138,7 +137,7 @@ public class OuterMessage(
         )
       }
 
-      public override fun redact(value: OuterMessage): OuterMessage = value.copy(
+      public override fun redact(`value`: OuterMessage): OuterMessage = value.copy(
         embedded_message = value.embedded_message?.let(EmbeddedMessage.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )


### PR DESCRIPTION
Our 2 problems are value being escaped all the times. We were using name allocator for the enum's constructor param but we cannot do that. Otherwise it would override nothing if the name changed.
The other problem is `kotlin.hashcode()` being inlined so I inlined its content manually instead. see https://github.com/square/kotlinpoet/issues/1089

2 commits