### PR TITLE
WIP: Adding @WireOneOf annotation to allow reflection of oneof groups…

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -67,6 +67,7 @@ import com.squareup.wire.Syntax
 import com.squareup.wire.WireEnum
 import com.squareup.wire.WireEnumConstant
 import com.squareup.wire.WireField
+import com.squareup.wire.WireOneOf
 import com.squareup.wire.WireRpc
 import com.squareup.wire.internal.boxedOneOfClassName
 import com.squareup.wire.internal.boxedOneOfKeyFieldName
@@ -944,6 +945,13 @@ class KotlinGenerator private constructor(
               addAnnotation(annotation)
             }
             addAnnotation(wireFieldAnnotation(message, field))
+            if (field.isOneOf) {
+              addAnnotation(
+                AnnotationSpec.builder(WireOneOf::class)
+                  .addMember("name = %S", message.oneOfs.find { it.fields.contains(field) }!!.name)
+                  .build()
+              )
+            }
             if (javaInterOp) {
               addAnnotation(JvmField::class)
             }

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1253,9 +1253,9 @@ class KotlinGeneratorTest {
     assertTrue(code.contains("""val text: String = "","""))
     assertTrue(code.contains("""val author: Author? = null,"""))
     assertTrue(code.contains("""val enum_: Enum = Enum.UNKNOWN,"""))
-    assertTrue(code.contains("""val foo: Int? = null,"""))
-    assertTrue(code.contains("""val bar: String? = null,"""))
-    assertTrue(code.contains("""val baz: Baz? = null,"""))
+    assertTrue(code.contains("""@WireOneOf(name = "choice")${'\n'}  public val foo: Int? = null,"""))
+    assertTrue(code.contains("""@WireOneOf(name = "choice")${'\n'}  public val bar: String? = null,"""))
+    assertTrue(code.contains("""@WireOneOf(name = "choice")${'\n'}  public val baz: Baz? = null,"""))
     assertTrue(code.contains("""val count: Long = 0"""))
   }
 

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireOneOf.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireOneOf.kt
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2013 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+@Target(AnnotationTarget.FIELD)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class WireOneOf(
+  val name: String
+)


### PR DESCRIPTION
… in generated types

Introduces a new annotation @WireOneOf that will allow reflective access to the oneof groupings by name in generated Kotlin types. Previously the oneof restriction was only surfaced at construction runtime as an invariant check.