### PR TITLE
Improve WireTask cacheability by storing project-relative paths instead of absolute ones in the task inputs

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -147,13 +147,13 @@ class WirePlugin : Plugin<Project> {
       val targets = outputs.map { output ->
         output.toTarget(
           if (output.out == null) {
-            source.outputDir(project).path
+            project.relativePath(source.outputDir(project))
           } else {
-            project.file(output.out!!).path
+            output.out!!
           }
         )
       }
-      val generatedSourcesDirectories = targets.map { target -> File(target.outDirectory) }.toSet()
+      val generatedSourcesDirectories = targets.map { target -> project.file(target.outDirectory) }.toSet()
 
       // Both the JavaCompile and KotlinCompile tasks might already have been configured by now.
       // Even though we add the Wire output directories into the corresponding sourceSets, the
@@ -193,7 +193,7 @@ class WirePlugin : Plugin<Project> {
           protoSourceInput.debug(task.logger)
           protoPathInput.debug(task.logger)
         }
-        task.outputDirectories = targets.map { target -> File(target.outDirectory) }
+        task.outputDirectories = targets.map { target -> project.file(target.outDirectory) }
         task.sourceInput.set(protoSourceInput.toLocations(project.providers))
         task.protoInput.set(protoPathInput.toLocations(project.providers))
         task.roots = extension.roots.toList()

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -137,9 +137,9 @@ class WirePlugin : Plugin<Project> {
         protoSourceInput.addPaths(project, defaultSourceFolders(source))
       }
 
-      val inputFiles = mutableListOf<File>()
-      inputFiles.addAll(protoSourceInput.inputFiles)
-      inputFiles.addAll(protoPathInput.inputFiles)
+      val inputFiles = mutableListOf<String>()
+      inputFiles.addAll(protoSourceInput.inputFiles.map { project.relativePath(it) })
+      inputFiles.addAll(protoPathInput.inputFiles.map { project.relativePath(it) })
 
       val projectDependencies = (protoSourceInput.dependencies + protoPathInput.dependencies)
         .filterIsInstance<ProjectDependency>()

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -133,13 +133,13 @@ open class WireTask : SourceTask() {
       sinceVersion = sinceVersion,
       untilVersion = untilVersion,
       onlyVersion = onlyVersion,
-      targets = targets,
+      targets = targets.map { target -> target.copyTarget(outDirectory = project.file(target.outDirectory).path) },
       permitPackageCycles = permitPackageCycles
     )
 
     for (target in targets) {
-      if (target.outDirectory.startsWith(project.buildDir.path)) {
-        File(target.outDirectory).deleteRecursively()
+      if (project.file(target.outDirectory).path.startsWith(project.buildDir.path)) {
+        project.file(target.outDirectory).deleteRecursively()
       }
     }
     wireRun.execute(logger = GradleWireLogger)

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -84,7 +84,7 @@ open class WireTask : SourceTask() {
   var permitPackageCycles: Boolean = false
 
   @Input
-  lateinit var inputFiles: List<File>
+  lateinit var inputFiles: List<String>
 
   @TaskAction
   fun generateWireFiles() {
@@ -118,8 +118,9 @@ open class WireTask : SourceTask() {
     }
 
     inputFiles.forEach {
-      check(it.exists()) {
-        "Invalid path string: \"${it.path}\". Path does not exist."
+      val fileObj = project.file(it)
+      check(fileObj.exists()) {
+        "Invalid path string: \"${fileObj.path}\". Path does not exist."
       }
     }
 

--- a/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-1/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-1/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+// The code in this test project should be identical to
+// the one in cache-relocation-2; the only difference is
+// that the pathname is different. The test ensures that
+// the gradle task is cacheable even when the project
+// gets relocated to a different filesystem path.
+
+wire {
+  kotlin {
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-1/settings.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-1/settings.gradle
@@ -1,0 +1,5 @@
+buildCache {
+  local {
+    directory = new File(rootDir, '../.relocation-build-cache')
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-1/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-1/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-2/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-2/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+// The code in this test project should be identical to
+// the one in cache-relocation-1; the only difference is
+// that the pathname is different. The test ensures that
+// the gradle task is cacheable even when the project
+// gets relocated to a different filesystem path.
+
+wire {
+  kotlin {
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-2/settings.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-2/settings.gradle
@@ -1,0 +1,5 @@
+buildCache {
+  local {
+    directory = new File(rootDir, '../.relocation-build-cache')
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-2/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/cache-relocation-2/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
Fixes #1859 