### PR TITLE
Kotlin generated message's contructor respect fields declaration order

### DIFF
--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -194,10 +194,10 @@ class KotlinGeneratorTest {
     //language=kotlin
     val expected = """
         package routeguide
-        
+
         import com.squareup.wire.Service
         import com.squareup.wire.WireRpc
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -213,7 +213,7 @@ class KotlinGeneratorTest {
           )
           public fun GetFeature(request: Point): Feature
         }
-        
+
         """.trimIndent()
 
     val repoBuilder = RepoBuilder()
@@ -236,11 +236,11 @@ class KotlinGeneratorTest {
     //language=kotlin
     val expected = """
         package routeguide
-        
+
         import com.squareup.wire.MessageSource
         import com.squareup.wire.Service
         import com.squareup.wire.WireRpc
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -256,7 +256,7 @@ class KotlinGeneratorTest {
           )
           public fun RecordRoute(request: MessageSource<Point>): RouteSummary
         }
-        
+
         """.trimIndent()
 
     val repoBuilder = RepoBuilder()
@@ -279,12 +279,12 @@ class KotlinGeneratorTest {
     //language=kotlin
     val expected = """
         package routeguide
-        
+
         import com.squareup.wire.MessageSink
         import com.squareup.wire.Service
         import com.squareup.wire.WireRpc
         import kotlin.Unit
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -300,7 +300,7 @@ class KotlinGeneratorTest {
           )
           public fun ListFeatures(request: Rectangle, response: MessageSink<Feature>): Unit
         }
-        
+
         """.trimIndent()
 
     val repoBuilder = RepoBuilder()
@@ -324,13 +324,13 @@ class KotlinGeneratorTest {
     //language=kotlin
     val expected = """
         package routeguide
-        
+
         import com.squareup.wire.MessageSink
         import com.squareup.wire.MessageSource
         import com.squareup.wire.Service
         import com.squareup.wire.WireRpc
         import kotlin.Unit
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -346,7 +346,7 @@ class KotlinGeneratorTest {
           )
           public fun RouteChat(request: MessageSource<RouteNote>, response: MessageSink<RouteNote>): Unit
         }
-        
+
         """.trimIndent()
 
     val repoBuilder = RepoBuilder()
@@ -373,10 +373,10 @@ class KotlinGeneratorTest {
     //language=kotlin
     val expected = """
         package com.squareup.routeguide
-        
+
         import com.squareup.wire.Service
         import com.squareup.wire.WireRpc
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -392,7 +392,7 @@ class KotlinGeneratorTest {
           )
           public fun GetFeature(request: Point): Feature
         }
-        
+
         """.trimIndent()
 
     val repoBuilder = RepoBuilder()
@@ -654,10 +654,10 @@ class KotlinGeneratorTest {
     //language=kotlin
     val blockingClientInterface = """
         package routeguide
-        
+
         import com.squareup.wire.GrpcStreamingCall
         import com.squareup.wire.Service
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -667,16 +667,16 @@ class KotlinGeneratorTest {
            */
           public fun RouteChat(): GrpcStreamingCall<RouteNote, RouteNote>
         }
-        
+
         """.trimIndent()
     //language=kotlin
     val blockingClientImplementation = """
         package routeguide
-        
+
         import com.squareup.wire.GrpcClient
         import com.squareup.wire.GrpcMethod
         import com.squareup.wire.GrpcStreamingCall
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -693,18 +693,18 @@ class KotlinGeneratorTest {
               responseAdapter = RouteNote.ADAPTER
           ))
         }
-        
+
         """.trimIndent()
     //language=kotlin
     val blockingServer = """
         package routeguide
-        
+
         import com.squareup.wire.MessageSink
         import com.squareup.wire.MessageSource
         import com.squareup.wire.Service
         import com.squareup.wire.WireRpc
         import kotlin.Unit
-        
+
         /**
          * RouteGuide service interface.
          */
@@ -720,15 +720,15 @@ class KotlinGeneratorTest {
           )
           public fun RouteChat(request: MessageSource<RouteNote>, response: MessageSink<RouteNote>): Unit
         }
-        
+
         """.trimIndent()
     //language=kotlin
     val suspendingClientInterface = """
          package routeguide
-         
+
          import com.squareup.wire.GrpcStreamingCall
          import com.squareup.wire.Service
-         
+
          /**
           * RouteGuide service interface.
           */
@@ -738,16 +738,16 @@ class KotlinGeneratorTest {
             */
            public fun RouteChat(): GrpcStreamingCall<RouteNote, RouteNote>
          }
-         
+
          """.trimIndent()
     //language=kotlin
     val suspendingClientImplementation = """
          package routeguide
-         
+
          import com.squareup.wire.GrpcClient
          import com.squareup.wire.GrpcMethod
          import com.squareup.wire.GrpcStreamingCall
-         
+
          /**
           * RouteGuide service interface.
           */
@@ -764,18 +764,18 @@ class KotlinGeneratorTest {
                responseAdapter = RouteNote.ADAPTER
            ))
          }
-         
+
          """.trimIndent()
     //language=kotlin
     val suspendingServer = """
          package routeguide
-         
+
          import com.squareup.wire.Service
          import com.squareup.wire.WireRpc
          import kotlin.Unit
          import kotlinx.coroutines.channels.ReceiveChannel
          import kotlinx.coroutines.channels.SendChannel
-         
+
          /**
           * RouteGuide service interface.
           */
@@ -792,7 +792,7 @@ class KotlinGeneratorTest {
            public suspend fun RouteChat(request: ReceiveChannel<RouteNote>,
                response: SendChannel<RouteNote>): Unit
          }
-         
+
          """.trimIndent()
 
     val repoBuilder = RepoBuilder()
@@ -1534,12 +1534,98 @@ class KotlinGeneratorTest {
       |      public override fun redact(`value`: RedactedFields): RedactedFields = value.copy(
       |        a = "",
       |        b = 0,
-      |        secret_data = null,
       |        c = null,
       |        d = null,
+      |        secret_data = null,
       |        unknownFields = ByteString.EMPTY
       |      )
     """.trimMargin())
+  }
+
+  @Test
+  fun fieldsDeclarationOrderIsRespected() {
+    val repoBuilder = RepoBuilder()
+      .add("message.proto", """
+        |syntax = "proto2";
+        |message SomeMessage {
+        |  optional string a = 1;
+        |  optional string b = 2;
+        |  oneof choice {
+        |    string c = 3;
+        |    string d = 8;
+        |  }
+        |  optional SecretData secret_data = 4;
+        |  optional string e = 5;
+        |  oneof decision {
+        |    string f = 6;
+        |    string g = 7;
+        |    string h = 9;
+        |  }
+        |  optional string i = 10;
+        |  oneof unique {
+        |    string j = 12;
+        |  }
+        |  optional string k = 11;
+        |}
+        |
+        |message SecretData {}
+        |""".trimMargin()
+      )
+    val code = repoBuilder.generateKotlin("SomeMessage", boxOneOfsMinSize = 3)
+    println(code)
+    assertThat(code).contains("""
+      |public class SomeMessage(
+      |  @field:WireField(
+      |    tag = 1,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      |  )
+      |  public val a: String? = null,
+      |  @field:WireField(
+      |    tag = 2,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      |  )
+      |  public val b: String? = null,
+      |  @field:WireField(
+      |    tag = 3,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    oneofName = "choice"
+      |  )
+      |  public val c: String? = null,
+      |  @field:WireField(
+      |    tag = 8,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    oneofName = "choice"
+      |  )
+      |  public val d: String? = null,
+      |  @field:WireField(
+      |    tag = 4,
+      |    adapter = "SecretData#ADAPTER"
+      |  )
+      |  public val secret_data: SecretData? = null,
+      |  @field:WireField(
+      |    tag = 5,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      |  )
+      |  public val e: String? = null,
+      |  public val decision: OneOf<Decision<*>, *>? = null,
+      |  @field:WireField(
+      |    tag = 10,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      |  )
+      |  public val i: String? = null,
+      |  @field:WireField(
+      |    tag = 12,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    oneofName = "unique"
+      |  )
+      |  public val j: String? = null,
+      |  @field:WireField(
+      |    tag = 11,
+      |    adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      |  )
+      |  public val k: String? = null,
+      |  unknownFields: ByteString = ByteString.EMPTY
+      """.trimMargin())
   }
 
   companion object {

--- a/wire-library/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.kt
+++ b/wire-library/wire-test-utils/src/main/java/com/squareup/wire/schema/RepoBuilder.kt
@@ -23,12 +23,12 @@ import com.squareup.wire.java.Profile
 import com.squareup.wire.kotlin.KotlinGenerator
 import com.squareup.wire.kotlin.RpcCallStyle
 import com.squareup.wire.kotlin.RpcRole
-import java.io.File
-import java.io.IOException
 import okio.Path.Companion.toPath
 import okio.buffer
 import okio.fakefilesystem.FakeFileSystem
 import okio.source
+import java.io.File
+import java.io.IOException
 
 /**
  * Builds a repository of `.proto` and `.wire` files to create schemas, profiles, and adapters for
@@ -117,12 +117,14 @@ class RepoBuilder {
 
   fun generateKotlin(
     typeName: String,
-    profileName: String? = null
+    profileName: String? = null,
+    boxOneOfsMinSize: Int = 5_000,
   ): String {
     val schema = schema()
     val kotlinGenerator = KotlinGenerator(
-        schema,
-        profile = profile(profileName),
+      schema,
+      profile = profile(profileName),
+      boxOneOfsMinSize = boxOneOfsMinSize
     )
     val type = schema.getType(typeName)!!
     val typeSpec = kotlinGenerator.generateType(type)

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -3551,9 +3551,6 @@ public class AllTypes(
         map_string_stringAdapter.encodeWithTag(writer, 502, value.map_string_string)
         map_string_messageAdapter.encodeWithTag(writer, 503, value.map_string_message)
         map_string_enumAdapter.encodeWithTag(writer, 504, value.map_string_enum)
-        ProtoAdapter.STRING.encodeWithTag(writer, 601, value.oneof_string)
-        ProtoAdapter.INT32.encodeWithTag(writer, 602, value.oneof_int32)
-        NestedMessage.ADAPTER.encodeWithTag(writer, 603, value.oneof_nested_message)
         ProtoAdapter.INT32.encodeWithTag(writer, 1001, value.ext_opt_int32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 1002, value.ext_opt_uint32)
         ProtoAdapter.SINT32.encodeWithTag(writer, 1003, value.ext_opt_sint32)
@@ -3602,6 +3599,9 @@ public class AllTypes(
         ProtoAdapter.FLOAT.asPacked().encodeWithTag(writer, 1212, value.ext_pack_float)
         ProtoAdapter.DOUBLE.asPacked().encodeWithTag(writer, 1213, value.ext_pack_double)
         NestedEnum.ADAPTER.asPacked().encodeWithTag(writer, 1216, value.ext_pack_nested_enum)
+        ProtoAdapter.STRING.encodeWithTag(writer, 601, value.oneof_string)
+        ProtoAdapter.INT32.encodeWithTag(writer, 602, value.oneof_int32)
+        NestedMessage.ADAPTER.encodeWithTag(writer, 603, value.oneof_nested_message)
         writer.writeBytes(value.unknownFields)
       }
 

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -387,6 +387,27 @@ public class AllTypes(
   map_string_string: Map<String, String> = emptyMap(),
   map_string_message: Map<String, NestedMessage> = emptyMap(),
   map_string_enum: Map<String, NestedEnum> = emptyMap(),
+  @field:WireField(
+    tag = 601,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    oneofName = "choice"
+  )
+  @JvmField
+  public val oneof_string: String? = null,
+  @field:WireField(
+    tag = 602,
+    adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    oneofName = "choice"
+  )
+  @JvmField
+  public val oneof_int32: Int? = null,
+  @field:WireField(
+    tag = 603,
+    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    oneofName = "choice"
+  )
+  @JvmField
+  public val oneof_nested_message: NestedMessage? = null,
   /**
    * Extension source: all_types_proto2.proto
    */
@@ -571,27 +592,6 @@ public class AllTypes(
   ext_pack_float: List<Float> = emptyList(),
   ext_pack_double: List<Double> = emptyList(),
   ext_pack_nested_enum: List<NestedEnum> = emptyList(),
-  @field:WireField(
-    tag = 601,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    oneofName = "choice"
-  )
-  @JvmField
-  public val oneof_string: String? = null,
-  @field:WireField(
-    tag = 602,
-    adapter = "com.squareup.wire.ProtoAdapter#INT32",
-    oneofName = "choice"
-  )
-  @JvmField
-  public val oneof_int32: Int? = null,
-  @field:WireField(
-    tag = 603,
-    adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
-    oneofName = "choice"
-  )
-  @JvmField
-  public val oneof_nested_message: NestedMessage? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<AllTypes, AllTypes.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
@@ -1316,6 +1316,9 @@ public class AllTypes(
     builder.map_string_string = map_string_string
     builder.map_string_message = map_string_message
     builder.map_string_enum = map_string_enum
+    builder.oneof_string = oneof_string
+    builder.oneof_int32 = oneof_int32
+    builder.oneof_nested_message = oneof_nested_message
     builder.ext_opt_int32 = ext_opt_int32
     builder.ext_opt_uint32 = ext_opt_uint32
     builder.ext_opt_sint32 = ext_opt_sint32
@@ -1364,9 +1367,6 @@ public class AllTypes(
     builder.ext_pack_float = ext_pack_float
     builder.ext_pack_double = ext_pack_double
     builder.ext_pack_nested_enum = ext_pack_nested_enum
-    builder.oneof_string = oneof_string
-    builder.oneof_int32 = oneof_int32
-    builder.oneof_nested_message = oneof_nested_message
     builder.addUnknownFields(unknownFields)
     return builder
   }
@@ -1460,6 +1460,9 @@ public class AllTypes(
     if (map_string_string != other.map_string_string) return false
     if (map_string_message != other.map_string_message) return false
     if (map_string_enum != other.map_string_enum) return false
+    if (oneof_string != other.oneof_string) return false
+    if (oneof_int32 != other.oneof_int32) return false
+    if (oneof_nested_message != other.oneof_nested_message) return false
     if (ext_opt_int32 != other.ext_opt_int32) return false
     if (ext_opt_uint32 != other.ext_opt_uint32) return false
     if (ext_opt_sint32 != other.ext_opt_sint32) return false
@@ -1508,9 +1511,6 @@ public class AllTypes(
     if (ext_pack_float != other.ext_pack_float) return false
     if (ext_pack_double != other.ext_pack_double) return false
     if (ext_pack_nested_enum != other.ext_pack_nested_enum) return false
-    if (oneof_string != other.oneof_string) return false
-    if (oneof_int32 != other.oneof_int32) return false
-    if (oneof_nested_message != other.oneof_nested_message) return false
     return true
   }
 
@@ -1603,6 +1603,9 @@ public class AllTypes(
       result = result * 37 + map_string_string.hashCode()
       result = result * 37 + map_string_message.hashCode()
       result = result * 37 + map_string_enum.hashCode()
+      result = result * 37 + (oneof_string?.hashCode() ?: 0)
+      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
+      result = result * 37 + (oneof_nested_message?.hashCode() ?: 0)
       result = result * 37 + (ext_opt_int32?.hashCode() ?: 0)
       result = result * 37 + (ext_opt_uint32?.hashCode() ?: 0)
       result = result * 37 + (ext_opt_sint32?.hashCode() ?: 0)
@@ -1651,9 +1654,6 @@ public class AllTypes(
       result = result * 37 + ext_pack_float.hashCode()
       result = result * 37 + ext_pack_double.hashCode()
       result = result * 37 + ext_pack_nested_enum.hashCode()
-      result = result * 37 + (oneof_string?.hashCode() ?: 0)
-      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
-      result = result * 37 + (oneof_nested_message?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -1746,6 +1746,9 @@ public class AllTypes(
     if (map_string_string.isNotEmpty()) result += """map_string_string=$map_string_string"""
     if (map_string_message.isNotEmpty()) result += """map_string_message=$map_string_message"""
     if (map_string_enum.isNotEmpty()) result += """map_string_enum=$map_string_enum"""
+    if (oneof_string != null) result += """oneof_string=${sanitize(oneof_string)}"""
+    if (oneof_int32 != null) result += """oneof_int32=$oneof_int32"""
+    if (oneof_nested_message != null) result += """oneof_nested_message=$oneof_nested_message"""
     if (ext_opt_int32 != null) result += """ext_opt_int32=$ext_opt_int32"""
     if (ext_opt_uint32 != null) result += """ext_opt_uint32=$ext_opt_uint32"""
     if (ext_opt_sint32 != null) result += """ext_opt_sint32=$ext_opt_sint32"""
@@ -1797,9 +1800,6 @@ public class AllTypes(
     if (ext_pack_double.isNotEmpty()) result += """ext_pack_double=$ext_pack_double"""
     if (ext_pack_nested_enum.isNotEmpty()) result +=
         """ext_pack_nested_enum=$ext_pack_nested_enum"""
-    if (oneof_string != null) result += """oneof_string=${sanitize(oneof_string)}"""
-    if (oneof_int32 != null) result += """oneof_int32=$oneof_int32"""
-    if (oneof_nested_message != null) result += """oneof_nested_message=$oneof_nested_message"""
     return result.joinToString(prefix = "AllTypes{", separator = ", ", postfix = "}")
   }
 
@@ -1889,6 +1889,9 @@ public class AllTypes(
     map_string_string: Map<String, String> = this.map_string_string,
     map_string_message: Map<String, NestedMessage> = this.map_string_message,
     map_string_enum: Map<String, NestedEnum> = this.map_string_enum,
+    oneof_string: String? = this.oneof_string,
+    oneof_int32: Int? = this.oneof_int32,
+    oneof_nested_message: NestedMessage? = this.oneof_nested_message,
     ext_opt_int32: Int? = this.ext_opt_int32,
     ext_opt_uint32: Int? = this.ext_opt_uint32,
     ext_opt_sint32: Int? = this.ext_opt_sint32,
@@ -1937,9 +1940,6 @@ public class AllTypes(
     ext_pack_float: List<Float> = this.ext_pack_float,
     ext_pack_double: List<Double> = this.ext_pack_double,
     ext_pack_nested_enum: List<NestedEnum> = this.ext_pack_nested_enum,
-    oneof_string: String? = this.oneof_string,
-    oneof_int32: Int? = this.oneof_int32,
-    oneof_nested_message: NestedMessage? = this.oneof_nested_message,
     unknownFields: ByteString = this.unknownFields
   ): AllTypes = AllTypes(opt_int32, opt_uint32, opt_sint32, opt_fixed32, opt_sfixed32, opt_int64,
       opt_uint64, opt_sint64, opt_fixed64, opt_sfixed64, opt_bool, opt_float, opt_double,
@@ -1954,17 +1954,17 @@ public class AllTypes(
       default_fixed32, default_sfixed32, default_int64, default_uint64, default_sint64,
       default_fixed64, default_sfixed64, default_bool, default_float, default_double,
       default_string, default_bytes, default_nested_enum, map_int32_int32, map_string_string,
-      map_string_message, map_string_enum, ext_opt_int32, ext_opt_uint32, ext_opt_sint32,
-      ext_opt_fixed32, ext_opt_sfixed32, ext_opt_int64, ext_opt_uint64, ext_opt_sint64,
-      ext_opt_fixed64, ext_opt_sfixed64, ext_opt_bool, ext_opt_float, ext_opt_double,
-      ext_opt_string, ext_opt_bytes, ext_opt_nested_enum, ext_opt_nested_message, ext_rep_int32,
-      ext_rep_uint32, ext_rep_sint32, ext_rep_fixed32, ext_rep_sfixed32, ext_rep_int64,
-      ext_rep_uint64, ext_rep_sint64, ext_rep_fixed64, ext_rep_sfixed64, ext_rep_bool,
-      ext_rep_float, ext_rep_double, ext_rep_string, ext_rep_bytes, ext_rep_nested_enum,
-      ext_rep_nested_message, ext_pack_int32, ext_pack_uint32, ext_pack_sint32, ext_pack_fixed32,
-      ext_pack_sfixed32, ext_pack_int64, ext_pack_uint64, ext_pack_sint64, ext_pack_fixed64,
-      ext_pack_sfixed64, ext_pack_bool, ext_pack_float, ext_pack_double, ext_pack_nested_enum,
-      oneof_string, oneof_int32, oneof_nested_message, unknownFields)
+      map_string_message, map_string_enum, oneof_string, oneof_int32, oneof_nested_message,
+      ext_opt_int32, ext_opt_uint32, ext_opt_sint32, ext_opt_fixed32, ext_opt_sfixed32,
+      ext_opt_int64, ext_opt_uint64, ext_opt_sint64, ext_opt_fixed64, ext_opt_sfixed64,
+      ext_opt_bool, ext_opt_float, ext_opt_double, ext_opt_string, ext_opt_bytes,
+      ext_opt_nested_enum, ext_opt_nested_message, ext_rep_int32, ext_rep_uint32, ext_rep_sint32,
+      ext_rep_fixed32, ext_rep_sfixed32, ext_rep_int64, ext_rep_uint64, ext_rep_sint64,
+      ext_rep_fixed64, ext_rep_sfixed64, ext_rep_bool, ext_rep_float, ext_rep_double,
+      ext_rep_string, ext_rep_bytes, ext_rep_nested_enum, ext_rep_nested_message, ext_pack_int32,
+      ext_pack_uint32, ext_pack_sint32, ext_pack_fixed32, ext_pack_sfixed32, ext_pack_int64,
+      ext_pack_uint64, ext_pack_sint64, ext_pack_fixed64, ext_pack_sfixed64, ext_pack_bool,
+      ext_pack_float, ext_pack_double, ext_pack_nested_enum, unknownFields)
 
   public class Builder : Message.Builder<AllTypes, Builder>() {
     @JvmField
@@ -2223,6 +2223,15 @@ public class AllTypes(
     public var map_string_enum: Map<String, NestedEnum> = emptyMap()
 
     @JvmField
+    public var oneof_string: String? = null
+
+    @JvmField
+    public var oneof_int32: Int? = null
+
+    @JvmField
+    public var oneof_nested_message: NestedMessage? = null
+
+    @JvmField
     public var ext_opt_int32: Int? = null
 
     @JvmField
@@ -2365,15 +2374,6 @@ public class AllTypes(
 
     @JvmField
     public var ext_pack_nested_enum: List<NestedEnum> = emptyList()
-
-    @JvmField
-    public var oneof_string: String? = null
-
-    @JvmField
-    public var oneof_int32: Int? = null
-
-    @JvmField
-    public var oneof_nested_message: NestedMessage? = null
 
     public fun opt_int32(opt_int32: Int?): Builder {
       this.opt_int32 = opt_int32
@@ -3211,6 +3211,9 @@ public class AllTypes(
       map_string_string = map_string_string,
       map_string_message = map_string_message,
       map_string_enum = map_string_enum,
+      oneof_string = oneof_string,
+      oneof_int32 = oneof_int32,
+      oneof_nested_message = oneof_nested_message,
       ext_opt_int32 = ext_opt_int32,
       ext_opt_uint32 = ext_opt_uint32,
       ext_opt_sint32 = ext_opt_sint32,
@@ -3259,9 +3262,6 @@ public class AllTypes(
       ext_pack_float = ext_pack_float,
       ext_pack_double = ext_pack_double,
       ext_pack_nested_enum = ext_pack_nested_enum,
-      oneof_string = oneof_string,
-      oneof_int32 = oneof_int32,
-      oneof_nested_message = oneof_nested_message,
       unknownFields = buildUnknownFields()
     )
   }
@@ -3410,6 +3410,9 @@ public class AllTypes(
         size += map_string_stringAdapter.encodedSizeWithTag(502, value.map_string_string)
         size += map_string_messageAdapter.encodedSizeWithTag(503, value.map_string_message)
         size += map_string_enumAdapter.encodedSizeWithTag(504, value.map_string_enum)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(601, value.oneof_string)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(602, value.oneof_int32)
+        size += NestedMessage.ADAPTER.encodedSizeWithTag(603, value.oneof_nested_message)
         size += ProtoAdapter.INT32.encodedSizeWithTag(1001, value.ext_opt_int32)
         size += ProtoAdapter.UINT32.encodedSizeWithTag(1002, value.ext_opt_uint32)
         size += ProtoAdapter.SINT32.encodedSizeWithTag(1003, value.ext_opt_sint32)
@@ -3459,9 +3462,6 @@ public class AllTypes(
         size += ProtoAdapter.FLOAT.asPacked().encodedSizeWithTag(1212, value.ext_pack_float)
         size += ProtoAdapter.DOUBLE.asPacked().encodedSizeWithTag(1213, value.ext_pack_double)
         size += NestedEnum.ADAPTER.asPacked().encodedSizeWithTag(1216, value.ext_pack_nested_enum)
-        size += ProtoAdapter.STRING.encodedSizeWithTag(601, value.oneof_string)
-        size += ProtoAdapter.INT32.encodedSizeWithTag(602, value.oneof_int32)
-        size += NestedMessage.ADAPTER.encodedSizeWithTag(603, value.oneof_nested_message)
         return size
       }
 
@@ -3551,6 +3551,9 @@ public class AllTypes(
         map_string_stringAdapter.encodeWithTag(writer, 502, value.map_string_string)
         map_string_messageAdapter.encodeWithTag(writer, 503, value.map_string_message)
         map_string_enumAdapter.encodeWithTag(writer, 504, value.map_string_enum)
+        ProtoAdapter.STRING.encodeWithTag(writer, 601, value.oneof_string)
+        ProtoAdapter.INT32.encodeWithTag(writer, 602, value.oneof_int32)
+        NestedMessage.ADAPTER.encodeWithTag(writer, 603, value.oneof_nested_message)
         ProtoAdapter.INT32.encodeWithTag(writer, 1001, value.ext_opt_int32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 1002, value.ext_opt_uint32)
         ProtoAdapter.SINT32.encodeWithTag(writer, 1003, value.ext_opt_sint32)
@@ -3599,9 +3602,6 @@ public class AllTypes(
         ProtoAdapter.FLOAT.asPacked().encodeWithTag(writer, 1212, value.ext_pack_float)
         ProtoAdapter.DOUBLE.asPacked().encodeWithTag(writer, 1213, value.ext_pack_double)
         NestedEnum.ADAPTER.asPacked().encodeWithTag(writer, 1216, value.ext_pack_nested_enum)
-        ProtoAdapter.STRING.encodeWithTag(writer, 601, value.oneof_string)
-        ProtoAdapter.INT32.encodeWithTag(writer, 602, value.oneof_int32)
-        NestedMessage.ADAPTER.encodeWithTag(writer, 603, value.oneof_nested_message)
         writer.writeBytes(value.unknownFields)
       }
 
@@ -3691,6 +3691,9 @@ public class AllTypes(
         val map_string_string = mutableMapOf<String, String>()
         val map_string_message = mutableMapOf<String, NestedMessage>()
         val map_string_enum = mutableMapOf<String, NestedEnum>()
+        var oneof_string: String? = null
+        var oneof_int32: Int? = null
+        var oneof_nested_message: NestedMessage? = null
         var ext_opt_int32: Int? = null
         var ext_opt_uint32: Int? = null
         var ext_opt_sint32: Int? = null
@@ -3739,9 +3742,6 @@ public class AllTypes(
         val ext_pack_float = mutableListOf<Float>()
         val ext_pack_double = mutableListOf<Double>()
         val ext_pack_nested_enum = mutableListOf<NestedEnum>()
-        var oneof_string: String? = null
-        var oneof_int32: Int? = null
-        var oneof_nested_message: NestedMessage? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> opt_int32 = ProtoAdapter.INT32.decode(reader)
@@ -3849,6 +3849,9 @@ public class AllTypes(
             502 -> map_string_string.putAll(map_string_stringAdapter.decode(reader))
             503 -> map_string_message.putAll(map_string_messageAdapter.decode(reader))
             504 -> map_string_enum.putAll(map_string_enumAdapter.decode(reader))
+            601 -> oneof_string = ProtoAdapter.STRING.decode(reader)
+            602 -> oneof_int32 = ProtoAdapter.INT32.decode(reader)
+            603 -> oneof_nested_message = NestedMessage.ADAPTER.decode(reader)
             1001 -> ext_opt_int32 = ProtoAdapter.INT32.decode(reader)
             1002 -> ext_opt_uint32 = ProtoAdapter.UINT32.decode(reader)
             1003 -> ext_opt_sint32 = ProtoAdapter.SINT32.decode(reader)
@@ -3909,9 +3912,6 @@ public class AllTypes(
             } catch (e: ProtoAdapter.EnumConstantNotFoundException) {
               reader.addUnknownField(tag, FieldEncoding.VARINT, e.value.toLong())
             }
-            601 -> oneof_string = ProtoAdapter.STRING.decode(reader)
-            602 -> oneof_int32 = ProtoAdapter.INT32.decode(reader)
-            603 -> oneof_nested_message = NestedMessage.ADAPTER.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -4003,6 +4003,9 @@ public class AllTypes(
           map_string_string = map_string_string,
           map_string_message = map_string_message,
           map_string_enum = map_string_enum,
+          oneof_string = oneof_string,
+          oneof_int32 = oneof_int32,
+          oneof_nested_message = oneof_nested_message,
           ext_opt_int32 = ext_opt_int32,
           ext_opt_uint32 = ext_opt_uint32,
           ext_opt_sint32 = ext_opt_sint32,
@@ -4051,9 +4054,6 @@ public class AllTypes(
           ext_pack_float = ext_pack_float,
           ext_pack_double = ext_pack_double,
           ext_pack_nested_enum = ext_pack_nested_enum,
-          oneof_string = oneof_string,
-          oneof_int32 = oneof_int32,
-          oneof_nested_message = oneof_nested_message,
           unknownFields = unknownFields
         )
       }
@@ -4063,9 +4063,9 @@ public class AllTypes(
         req_nested_message = NestedMessage.ADAPTER.redact(value.req_nested_message),
         rep_nested_message = value.rep_nested_message.redactElements(NestedMessage.ADAPTER),
         map_string_message = value.map_string_message.redactElements(NestedMessage.ADAPTER),
+        oneof_nested_message = value.oneof_nested_message?.let(NestedMessage.ADAPTER::redact),
         ext_opt_nested_message = value.ext_opt_nested_message?.let(NestedMessage.ADAPTER::redact),
         ext_rep_nested_message = value.ext_rep_nested_message.redactElements(NestedMessage.ADAPTER),
-        oneof_nested_message = value.oneof_nested_message?.let(NestedMessage.ADAPTER::redact),
         unknownFields = ByteString.EMPTY
       )
     }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
@@ -677,13 +677,13 @@ public class All32(
         ProtoAdapter.SINT32.asPacked().encodeWithTag(writer, 303, value.pack_sint32)
         ProtoAdapter.FIXED32.asPacked().encodeWithTag(writer, 304, value.pack_fixed32)
         ProtoAdapter.SFIXED32.asPacked().encodeWithTag(writer, 305, value.pack_sfixed32)
-        ProtoAdapter.INT32.encodeWithTag(writer, 401, value.oneof_int32)
-        ProtoAdapter.SFIXED32.encodeWithTag(writer, 402, value.oneof_sfixed32)
         map_int32_int32Adapter.encodeWithTag(writer, 501, value.map_int32_int32)
         map_int32_uint32Adapter.encodeWithTag(writer, 502, value.map_int32_uint32)
         map_int32_sint32Adapter.encodeWithTag(writer, 503, value.map_int32_sint32)
         map_int32_fixed32Adapter.encodeWithTag(writer, 504, value.map_int32_fixed32)
         map_int32_sfixed32Adapter.encodeWithTag(writer, 505, value.map_int32_sfixed32)
+        ProtoAdapter.INT32.encodeWithTag(writer, 401, value.oneof_int32)
+        ProtoAdapter.SFIXED32.encodeWithTag(writer, 402, value.oneof_sfixed32)
         writer.writeBytes(value.unknownFields)
       }
 

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
@@ -78,11 +78,6 @@ public class All32(
   pack_sint32: List<Int> = emptyList(),
   pack_fixed32: List<Int> = emptyList(),
   pack_sfixed32: List<Int> = emptyList(),
-  map_int32_int32: Map<Int, Int> = emptyMap(),
-  map_int32_uint32: Map<Int, Int> = emptyMap(),
-  map_int32_sint32: Map<Int, Int> = emptyMap(),
-  map_int32_fixed32: Map<Int, Int> = emptyMap(),
-  map_int32_sfixed32: Map<Int, Int> = emptyMap(),
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
@@ -99,6 +94,11 @@ public class All32(
   )
   @JvmField
   public val oneof_sfixed32: Int? = null,
+  map_int32_int32: Map<Int, Int> = emptyMap(),
+  map_int32_uint32: Map<Int, Int> = emptyMap(),
+  map_int32_sint32: Map<Int, Int> = emptyMap(),
+  map_int32_fixed32: Map<Int, Int> = emptyMap(),
+  map_int32_sfixed32: Map<Int, Int> = emptyMap(),
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<All32, All32.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
@@ -261,13 +261,13 @@ public class All32(
     builder.pack_sint32 = pack_sint32
     builder.pack_fixed32 = pack_fixed32
     builder.pack_sfixed32 = pack_sfixed32
+    builder.oneof_int32 = oneof_int32
+    builder.oneof_sfixed32 = oneof_sfixed32
     builder.map_int32_int32 = map_int32_int32
     builder.map_int32_uint32 = map_int32_uint32
     builder.map_int32_sint32 = map_int32_sint32
     builder.map_int32_fixed32 = map_int32_fixed32
     builder.map_int32_sfixed32 = map_int32_sfixed32
-    builder.oneof_int32 = oneof_int32
-    builder.oneof_sfixed32 = oneof_sfixed32
     builder.addUnknownFields(unknownFields)
     return builder
   }
@@ -291,13 +291,13 @@ public class All32(
     if (pack_sint32 != other.pack_sint32) return false
     if (pack_fixed32 != other.pack_fixed32) return false
     if (pack_sfixed32 != other.pack_sfixed32) return false
+    if (oneof_int32 != other.oneof_int32) return false
+    if (oneof_sfixed32 != other.oneof_sfixed32) return false
     if (map_int32_int32 != other.map_int32_int32) return false
     if (map_int32_uint32 != other.map_int32_uint32) return false
     if (map_int32_sint32 != other.map_int32_sint32) return false
     if (map_int32_fixed32 != other.map_int32_fixed32) return false
     if (map_int32_sfixed32 != other.map_int32_sfixed32) return false
-    if (oneof_int32 != other.oneof_int32) return false
-    if (oneof_sfixed32 != other.oneof_sfixed32) return false
     return true
   }
 
@@ -320,13 +320,13 @@ public class All32(
       result = result * 37 + pack_sint32.hashCode()
       result = result * 37 + pack_fixed32.hashCode()
       result = result * 37 + pack_sfixed32.hashCode()
+      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
+      result = result * 37 + (oneof_sfixed32?.hashCode() ?: 0)
       result = result * 37 + map_int32_int32.hashCode()
       result = result * 37 + map_int32_uint32.hashCode()
       result = result * 37 + map_int32_sint32.hashCode()
       result = result * 37 + map_int32_fixed32.hashCode()
       result = result * 37 + map_int32_sfixed32.hashCode()
-      result = result * 37 + (oneof_int32?.hashCode() ?: 0)
-      result = result * 37 + (oneof_sfixed32?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -349,13 +349,13 @@ public class All32(
     if (pack_sint32.isNotEmpty()) result += """pack_sint32=$pack_sint32"""
     if (pack_fixed32.isNotEmpty()) result += """pack_fixed32=$pack_fixed32"""
     if (pack_sfixed32.isNotEmpty()) result += """pack_sfixed32=$pack_sfixed32"""
+    if (oneof_int32 != null) result += """oneof_int32=$oneof_int32"""
+    if (oneof_sfixed32 != null) result += """oneof_sfixed32=$oneof_sfixed32"""
     if (map_int32_int32.isNotEmpty()) result += """map_int32_int32=$map_int32_int32"""
     if (map_int32_uint32.isNotEmpty()) result += """map_int32_uint32=$map_int32_uint32"""
     if (map_int32_sint32.isNotEmpty()) result += """map_int32_sint32=$map_int32_sint32"""
     if (map_int32_fixed32.isNotEmpty()) result += """map_int32_fixed32=$map_int32_fixed32"""
     if (map_int32_sfixed32.isNotEmpty()) result += """map_int32_sfixed32=$map_int32_sfixed32"""
-    if (oneof_int32 != null) result += """oneof_int32=$oneof_int32"""
-    if (oneof_sfixed32 != null) result += """oneof_sfixed32=$oneof_sfixed32"""
     return result.joinToString(prefix = "All32{", separator = ", ", postfix = "}")
   }
 
@@ -375,18 +375,18 @@ public class All32(
     pack_sint32: List<Int> = this.pack_sint32,
     pack_fixed32: List<Int> = this.pack_fixed32,
     pack_sfixed32: List<Int> = this.pack_sfixed32,
+    oneof_int32: Int? = this.oneof_int32,
+    oneof_sfixed32: Int? = this.oneof_sfixed32,
     map_int32_int32: Map<Int, Int> = this.map_int32_int32,
     map_int32_uint32: Map<Int, Int> = this.map_int32_uint32,
     map_int32_sint32: Map<Int, Int> = this.map_int32_sint32,
     map_int32_fixed32: Map<Int, Int> = this.map_int32_fixed32,
     map_int32_sfixed32: Map<Int, Int> = this.map_int32_sfixed32,
-    oneof_int32: Int? = this.oneof_int32,
-    oneof_sfixed32: Int? = this.oneof_sfixed32,
     unknownFields: ByteString = this.unknownFields
   ): All32 = All32(my_int32, my_uint32, my_sint32, my_fixed32, my_sfixed32, rep_int32, rep_uint32,
       rep_sint32, rep_fixed32, rep_sfixed32, pack_int32, pack_uint32, pack_sint32, pack_fixed32,
-      pack_sfixed32, map_int32_int32, map_int32_uint32, map_int32_sint32, map_int32_fixed32,
-      map_int32_sfixed32, oneof_int32, oneof_sfixed32, unknownFields)
+      pack_sfixed32, oneof_int32, oneof_sfixed32, map_int32_int32, map_int32_uint32,
+      map_int32_sint32, map_int32_fixed32, map_int32_sfixed32, unknownFields)
 
   public class Builder : Message.Builder<All32, Builder>() {
     @JvmField
@@ -435,6 +435,12 @@ public class All32(
     public var pack_sfixed32: List<Int> = emptyList()
 
     @JvmField
+    public var oneof_int32: Int? = null
+
+    @JvmField
+    public var oneof_sfixed32: Int? = null
+
+    @JvmField
     public var map_int32_int32: Map<Int, Int> = emptyMap()
 
     @JvmField
@@ -448,12 +454,6 @@ public class All32(
 
     @JvmField
     public var map_int32_sfixed32: Map<Int, Int> = emptyMap()
-
-    @JvmField
-    public var oneof_int32: Int? = null
-
-    @JvmField
-    public var oneof_sfixed32: Int? = null
 
     /**
      * Prefixing so the generated code doesn't rename it weirdly.
@@ -596,13 +596,13 @@ public class All32(
       pack_sint32 = pack_sint32,
       pack_fixed32 = pack_fixed32,
       pack_sfixed32 = pack_sfixed32,
+      oneof_int32 = oneof_int32,
+      oneof_sfixed32 = oneof_sfixed32,
       map_int32_int32 = map_int32_int32,
       map_int32_uint32 = map_int32_uint32,
       map_int32_sint32 = map_int32_sint32,
       map_int32_fixed32 = map_int32_fixed32,
       map_int32_sfixed32 = map_int32_sfixed32,
-      oneof_int32 = oneof_int32,
-      oneof_sfixed32 = oneof_sfixed32,
       unknownFields = buildUnknownFields()
     )
   }
@@ -650,13 +650,13 @@ public class All32(
         size += ProtoAdapter.SINT32.asPacked().encodedSizeWithTag(303, value.pack_sint32)
         size += ProtoAdapter.FIXED32.asPacked().encodedSizeWithTag(304, value.pack_fixed32)
         size += ProtoAdapter.SFIXED32.asPacked().encodedSizeWithTag(305, value.pack_sfixed32)
+        size += ProtoAdapter.INT32.encodedSizeWithTag(401, value.oneof_int32)
+        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(402, value.oneof_sfixed32)
         size += map_int32_int32Adapter.encodedSizeWithTag(501, value.map_int32_int32)
         size += map_int32_uint32Adapter.encodedSizeWithTag(502, value.map_int32_uint32)
         size += map_int32_sint32Adapter.encodedSizeWithTag(503, value.map_int32_sint32)
         size += map_int32_fixed32Adapter.encodedSizeWithTag(504, value.map_int32_fixed32)
         size += map_int32_sfixed32Adapter.encodedSizeWithTag(505, value.map_int32_sfixed32)
-        size += ProtoAdapter.INT32.encodedSizeWithTag(401, value.oneof_int32)
-        size += ProtoAdapter.SFIXED32.encodedSizeWithTag(402, value.oneof_sfixed32)
         return size
       }
 
@@ -677,13 +677,13 @@ public class All32(
         ProtoAdapter.SINT32.asPacked().encodeWithTag(writer, 303, value.pack_sint32)
         ProtoAdapter.FIXED32.asPacked().encodeWithTag(writer, 304, value.pack_fixed32)
         ProtoAdapter.SFIXED32.asPacked().encodeWithTag(writer, 305, value.pack_sfixed32)
+        ProtoAdapter.INT32.encodeWithTag(writer, 401, value.oneof_int32)
+        ProtoAdapter.SFIXED32.encodeWithTag(writer, 402, value.oneof_sfixed32)
         map_int32_int32Adapter.encodeWithTag(writer, 501, value.map_int32_int32)
         map_int32_uint32Adapter.encodeWithTag(writer, 502, value.map_int32_uint32)
         map_int32_sint32Adapter.encodeWithTag(writer, 503, value.map_int32_sint32)
         map_int32_fixed32Adapter.encodeWithTag(writer, 504, value.map_int32_fixed32)
         map_int32_sfixed32Adapter.encodeWithTag(writer, 505, value.map_int32_sfixed32)
-        ProtoAdapter.INT32.encodeWithTag(writer, 401, value.oneof_int32)
-        ProtoAdapter.SFIXED32.encodeWithTag(writer, 402, value.oneof_sfixed32)
         writer.writeBytes(value.unknownFields)
       }
 
@@ -703,13 +703,13 @@ public class All32(
         val pack_sint32 = mutableListOf<Int>()
         val pack_fixed32 = mutableListOf<Int>()
         val pack_sfixed32 = mutableListOf<Int>()
+        var oneof_int32: Int? = null
+        var oneof_sfixed32: Int? = null
         val map_int32_int32 = mutableMapOf<Int, Int>()
         val map_int32_uint32 = mutableMapOf<Int, Int>()
         val map_int32_sint32 = mutableMapOf<Int, Int>()
         val map_int32_fixed32 = mutableMapOf<Int, Int>()
         val map_int32_sfixed32 = mutableMapOf<Int, Int>()
-        var oneof_int32: Int? = null
-        var oneof_sfixed32: Int? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> my_int32 = ProtoAdapter.INT32.decode(reader)
@@ -727,13 +727,13 @@ public class All32(
             303 -> pack_sint32.add(ProtoAdapter.SINT32.decode(reader))
             304 -> pack_fixed32.add(ProtoAdapter.FIXED32.decode(reader))
             305 -> pack_sfixed32.add(ProtoAdapter.SFIXED32.decode(reader))
+            401 -> oneof_int32 = ProtoAdapter.INT32.decode(reader)
+            402 -> oneof_sfixed32 = ProtoAdapter.SFIXED32.decode(reader)
             501 -> map_int32_int32.putAll(map_int32_int32Adapter.decode(reader))
             502 -> map_int32_uint32.putAll(map_int32_uint32Adapter.decode(reader))
             503 -> map_int32_sint32.putAll(map_int32_sint32Adapter.decode(reader))
             504 -> map_int32_fixed32.putAll(map_int32_fixed32Adapter.decode(reader))
             505 -> map_int32_sfixed32.putAll(map_int32_sfixed32Adapter.decode(reader))
-            401 -> oneof_int32 = ProtoAdapter.INT32.decode(reader)
-            402 -> oneof_sfixed32 = ProtoAdapter.SFIXED32.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -753,13 +753,13 @@ public class All32(
           pack_sint32 = pack_sint32,
           pack_fixed32 = pack_fixed32,
           pack_sfixed32 = pack_sfixed32,
+          oneof_int32 = oneof_int32,
+          oneof_sfixed32 = oneof_sfixed32,
           map_int32_int32 = map_int32_int32,
           map_int32_uint32 = map_int32_uint32,
           map_int32_sint32 = map_int32_sint32,
           map_int32_fixed32 = map_int32_fixed32,
           map_int32_sfixed32 = map_int32_sfixed32,
-          oneof_int32 = oneof_int32,
-          oneof_sfixed32 = oneof_sfixed32,
           unknownFields = unknownFields
         )
       }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
@@ -78,11 +78,6 @@ public class All64(
   pack_sint64: List<Long> = emptyList(),
   pack_fixed64: List<Long> = emptyList(),
   pack_sfixed64: List<Long> = emptyList(),
-  map_int64_int64: Map<Long, Long> = emptyMap(),
-  map_int64_uint64: Map<Long, Long> = emptyMap(),
-  map_int64_sint64: Map<Long, Long> = emptyMap(),
-  map_int64_fixed64: Map<Long, Long> = emptyMap(),
-  map_int64_sfixed64: Map<Long, Long> = emptyMap(),
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
@@ -99,6 +94,11 @@ public class All64(
   )
   @JvmField
   public val oneof_sfixed64: Long? = null,
+  map_int64_int64: Map<Long, Long> = emptyMap(),
+  map_int64_uint64: Map<Long, Long> = emptyMap(),
+  map_int64_sint64: Map<Long, Long> = emptyMap(),
+  map_int64_fixed64: Map<Long, Long> = emptyMap(),
+  map_int64_sfixed64: Map<Long, Long> = emptyMap(),
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<All64, All64.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
@@ -263,13 +263,13 @@ public class All64(
     builder.pack_sint64 = pack_sint64
     builder.pack_fixed64 = pack_fixed64
     builder.pack_sfixed64 = pack_sfixed64
+    builder.oneof_int64 = oneof_int64
+    builder.oneof_sfixed64 = oneof_sfixed64
     builder.map_int64_int64 = map_int64_int64
     builder.map_int64_uint64 = map_int64_uint64
     builder.map_int64_sint64 = map_int64_sint64
     builder.map_int64_fixed64 = map_int64_fixed64
     builder.map_int64_sfixed64 = map_int64_sfixed64
-    builder.oneof_int64 = oneof_int64
-    builder.oneof_sfixed64 = oneof_sfixed64
     builder.addUnknownFields(unknownFields)
     return builder
   }
@@ -293,13 +293,13 @@ public class All64(
     if (pack_sint64 != other.pack_sint64) return false
     if (pack_fixed64 != other.pack_fixed64) return false
     if (pack_sfixed64 != other.pack_sfixed64) return false
+    if (oneof_int64 != other.oneof_int64) return false
+    if (oneof_sfixed64 != other.oneof_sfixed64) return false
     if (map_int64_int64 != other.map_int64_int64) return false
     if (map_int64_uint64 != other.map_int64_uint64) return false
     if (map_int64_sint64 != other.map_int64_sint64) return false
     if (map_int64_fixed64 != other.map_int64_fixed64) return false
     if (map_int64_sfixed64 != other.map_int64_sfixed64) return false
-    if (oneof_int64 != other.oneof_int64) return false
-    if (oneof_sfixed64 != other.oneof_sfixed64) return false
     return true
   }
 
@@ -322,13 +322,13 @@ public class All64(
       result = result * 37 + pack_sint64.hashCode()
       result = result * 37 + pack_fixed64.hashCode()
       result = result * 37 + pack_sfixed64.hashCode()
+      result = result * 37 + (oneof_int64?.hashCode() ?: 0)
+      result = result * 37 + (oneof_sfixed64?.hashCode() ?: 0)
       result = result * 37 + map_int64_int64.hashCode()
       result = result * 37 + map_int64_uint64.hashCode()
       result = result * 37 + map_int64_sint64.hashCode()
       result = result * 37 + map_int64_fixed64.hashCode()
       result = result * 37 + map_int64_sfixed64.hashCode()
-      result = result * 37 + (oneof_int64?.hashCode() ?: 0)
-      result = result * 37 + (oneof_sfixed64?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -351,13 +351,13 @@ public class All64(
     if (pack_sint64.isNotEmpty()) result += """pack_sint64=$pack_sint64"""
     if (pack_fixed64.isNotEmpty()) result += """pack_fixed64=$pack_fixed64"""
     if (pack_sfixed64.isNotEmpty()) result += """pack_sfixed64=$pack_sfixed64"""
+    if (oneof_int64 != null) result += """oneof_int64=$oneof_int64"""
+    if (oneof_sfixed64 != null) result += """oneof_sfixed64=$oneof_sfixed64"""
     if (map_int64_int64.isNotEmpty()) result += """map_int64_int64=$map_int64_int64"""
     if (map_int64_uint64.isNotEmpty()) result += """map_int64_uint64=$map_int64_uint64"""
     if (map_int64_sint64.isNotEmpty()) result += """map_int64_sint64=$map_int64_sint64"""
     if (map_int64_fixed64.isNotEmpty()) result += """map_int64_fixed64=$map_int64_fixed64"""
     if (map_int64_sfixed64.isNotEmpty()) result += """map_int64_sfixed64=$map_int64_sfixed64"""
-    if (oneof_int64 != null) result += """oneof_int64=$oneof_int64"""
-    if (oneof_sfixed64 != null) result += """oneof_sfixed64=$oneof_sfixed64"""
     return result.joinToString(prefix = "All64{", separator = ", ", postfix = "}")
   }
 
@@ -377,18 +377,18 @@ public class All64(
     pack_sint64: List<Long> = this.pack_sint64,
     pack_fixed64: List<Long> = this.pack_fixed64,
     pack_sfixed64: List<Long> = this.pack_sfixed64,
+    oneof_int64: Long? = this.oneof_int64,
+    oneof_sfixed64: Long? = this.oneof_sfixed64,
     map_int64_int64: Map<Long, Long> = this.map_int64_int64,
     map_int64_uint64: Map<Long, Long> = this.map_int64_uint64,
     map_int64_sint64: Map<Long, Long> = this.map_int64_sint64,
     map_int64_fixed64: Map<Long, Long> = this.map_int64_fixed64,
     map_int64_sfixed64: Map<Long, Long> = this.map_int64_sfixed64,
-    oneof_int64: Long? = this.oneof_int64,
-    oneof_sfixed64: Long? = this.oneof_sfixed64,
     unknownFields: ByteString = this.unknownFields
   ): All64 = All64(my_int64, my_uint64, my_sint64, my_fixed64, my_sfixed64, rep_int64, rep_uint64,
       rep_sint64, rep_fixed64, rep_sfixed64, pack_int64, pack_uint64, pack_sint64, pack_fixed64,
-      pack_sfixed64, map_int64_int64, map_int64_uint64, map_int64_sint64, map_int64_fixed64,
-      map_int64_sfixed64, oneof_int64, oneof_sfixed64, unknownFields)
+      pack_sfixed64, oneof_int64, oneof_sfixed64, map_int64_int64, map_int64_uint64,
+      map_int64_sint64, map_int64_fixed64, map_int64_sfixed64, unknownFields)
 
   public class Builder : Message.Builder<All64, Builder>() {
     @JvmField
@@ -437,6 +437,12 @@ public class All64(
     public var pack_sfixed64: List<Long> = emptyList()
 
     @JvmField
+    public var oneof_int64: Long? = null
+
+    @JvmField
+    public var oneof_sfixed64: Long? = null
+
+    @JvmField
     public var map_int64_int64: Map<Long, Long> = emptyMap()
 
     @JvmField
@@ -450,12 +456,6 @@ public class All64(
 
     @JvmField
     public var map_int64_sfixed64: Map<Long, Long> = emptyMap()
-
-    @JvmField
-    public var oneof_int64: Long? = null
-
-    @JvmField
-    public var oneof_sfixed64: Long? = null
 
     /**
      * Prefixing so the generated code doesn't rename it weirdly.
@@ -598,13 +598,13 @@ public class All64(
       pack_sint64 = pack_sint64,
       pack_fixed64 = pack_fixed64,
       pack_sfixed64 = pack_sfixed64,
+      oneof_int64 = oneof_int64,
+      oneof_sfixed64 = oneof_sfixed64,
       map_int64_int64 = map_int64_int64,
       map_int64_uint64 = map_int64_uint64,
       map_int64_sint64 = map_int64_sint64,
       map_int64_fixed64 = map_int64_fixed64,
       map_int64_sfixed64 = map_int64_sfixed64,
-      oneof_int64 = oneof_int64,
-      oneof_sfixed64 = oneof_sfixed64,
       unknownFields = buildUnknownFields()
     )
   }
@@ -654,13 +654,13 @@ public class All64(
         size += ProtoAdapter.SINT64.asPacked().encodedSizeWithTag(303, value.pack_sint64)
         size += ProtoAdapter.FIXED64.asPacked().encodedSizeWithTag(304, value.pack_fixed64)
         size += ProtoAdapter.SFIXED64.asPacked().encodedSizeWithTag(305, value.pack_sfixed64)
+        size += ProtoAdapter.INT64.encodedSizeWithTag(401, value.oneof_int64)
+        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(402, value.oneof_sfixed64)
         size += map_int64_int64Adapter.encodedSizeWithTag(501, value.map_int64_int64)
         size += map_int64_uint64Adapter.encodedSizeWithTag(502, value.map_int64_uint64)
         size += map_int64_sint64Adapter.encodedSizeWithTag(503, value.map_int64_sint64)
         size += map_int64_fixed64Adapter.encodedSizeWithTag(504, value.map_int64_fixed64)
         size += map_int64_sfixed64Adapter.encodedSizeWithTag(505, value.map_int64_sfixed64)
-        size += ProtoAdapter.INT64.encodedSizeWithTag(401, value.oneof_int64)
-        size += ProtoAdapter.SFIXED64.encodedSizeWithTag(402, value.oneof_sfixed64)
         return size
       }
 
@@ -681,13 +681,13 @@ public class All64(
         ProtoAdapter.SINT64.asPacked().encodeWithTag(writer, 303, value.pack_sint64)
         ProtoAdapter.FIXED64.asPacked().encodeWithTag(writer, 304, value.pack_fixed64)
         ProtoAdapter.SFIXED64.asPacked().encodeWithTag(writer, 305, value.pack_sfixed64)
+        ProtoAdapter.INT64.encodeWithTag(writer, 401, value.oneof_int64)
+        ProtoAdapter.SFIXED64.encodeWithTag(writer, 402, value.oneof_sfixed64)
         map_int64_int64Adapter.encodeWithTag(writer, 501, value.map_int64_int64)
         map_int64_uint64Adapter.encodeWithTag(writer, 502, value.map_int64_uint64)
         map_int64_sint64Adapter.encodeWithTag(writer, 503, value.map_int64_sint64)
         map_int64_fixed64Adapter.encodeWithTag(writer, 504, value.map_int64_fixed64)
         map_int64_sfixed64Adapter.encodeWithTag(writer, 505, value.map_int64_sfixed64)
-        ProtoAdapter.INT64.encodeWithTag(writer, 401, value.oneof_int64)
-        ProtoAdapter.SFIXED64.encodeWithTag(writer, 402, value.oneof_sfixed64)
         writer.writeBytes(value.unknownFields)
       }
 
@@ -707,13 +707,13 @@ public class All64(
         val pack_sint64 = mutableListOf<Long>()
         val pack_fixed64 = mutableListOf<Long>()
         val pack_sfixed64 = mutableListOf<Long>()
+        var oneof_int64: Long? = null
+        var oneof_sfixed64: Long? = null
         val map_int64_int64 = mutableMapOf<Long, Long>()
         val map_int64_uint64 = mutableMapOf<Long, Long>()
         val map_int64_sint64 = mutableMapOf<Long, Long>()
         val map_int64_fixed64 = mutableMapOf<Long, Long>()
         val map_int64_sfixed64 = mutableMapOf<Long, Long>()
-        var oneof_int64: Long? = null
-        var oneof_sfixed64: Long? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> my_int64 = ProtoAdapter.INT64.decode(reader)
@@ -731,13 +731,13 @@ public class All64(
             303 -> pack_sint64.add(ProtoAdapter.SINT64.decode(reader))
             304 -> pack_fixed64.add(ProtoAdapter.FIXED64.decode(reader))
             305 -> pack_sfixed64.add(ProtoAdapter.SFIXED64.decode(reader))
+            401 -> oneof_int64 = ProtoAdapter.INT64.decode(reader)
+            402 -> oneof_sfixed64 = ProtoAdapter.SFIXED64.decode(reader)
             501 -> map_int64_int64.putAll(map_int64_int64Adapter.decode(reader))
             502 -> map_int64_uint64.putAll(map_int64_uint64Adapter.decode(reader))
             503 -> map_int64_sint64.putAll(map_int64_sint64Adapter.decode(reader))
             504 -> map_int64_fixed64.putAll(map_int64_fixed64Adapter.decode(reader))
             505 -> map_int64_sfixed64.putAll(map_int64_sfixed64Adapter.decode(reader))
-            401 -> oneof_int64 = ProtoAdapter.INT64.decode(reader)
-            402 -> oneof_sfixed64 = ProtoAdapter.SFIXED64.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -757,13 +757,13 @@ public class All64(
           pack_sint64 = pack_sint64,
           pack_fixed64 = pack_fixed64,
           pack_sfixed64 = pack_sfixed64,
+          oneof_int64 = oneof_int64,
+          oneof_sfixed64 = oneof_sfixed64,
           map_int64_int64 = map_int64_int64,
           map_int64_uint64 = map_int64_uint64,
           map_int64_sint64 = map_int64_sint64,
           map_int64_fixed64 = map_int64_fixed64,
           map_int64_sfixed64 = map_int64_sfixed64,
-          oneof_int64 = oneof_int64,
-          oneof_sfixed64 = oneof_sfixed64,
           unknownFields = unknownFields
         )
       }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
@@ -681,13 +681,13 @@ public class All64(
         ProtoAdapter.SINT64.asPacked().encodeWithTag(writer, 303, value.pack_sint64)
         ProtoAdapter.FIXED64.asPacked().encodeWithTag(writer, 304, value.pack_fixed64)
         ProtoAdapter.SFIXED64.asPacked().encodeWithTag(writer, 305, value.pack_sfixed64)
-        ProtoAdapter.INT64.encodeWithTag(writer, 401, value.oneof_int64)
-        ProtoAdapter.SFIXED64.encodeWithTag(writer, 402, value.oneof_sfixed64)
         map_int64_int64Adapter.encodeWithTag(writer, 501, value.map_int64_int64)
         map_int64_uint64Adapter.encodeWithTag(writer, 502, value.map_int64_uint64)
         map_int64_sint64Adapter.encodeWithTag(writer, 503, value.map_int64_sint64)
         map_int64_fixed64Adapter.encodeWithTag(writer, 504, value.map_int64_fixed64)
         map_int64_sfixed64Adapter.encodeWithTag(writer, 505, value.map_int64_sfixed64)
+        ProtoAdapter.INT64.encodeWithTag(writer, 401, value.oneof_int64)
+        ProtoAdapter.SFIXED64.encodeWithTag(writer, 402, value.oneof_sfixed64)
         writer.writeBytes(value.unknownFields)
       }
 

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
@@ -609,12 +609,12 @@ public class AllStructs(
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
         ProtoAdapter.STRUCT_NULL.asRepeated().encodeWithTag(writer, 104, value.rep_null_value)
-        ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 201, value.oneof_struct)
-        ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 202, value.oneof_list)
         map_int32_structAdapter.encodeWithTag(writer, 301, value.map_int32_struct)
         map_int32_listAdapter.encodeWithTag(writer, 302, value.map_int32_list)
         map_int32_value_aAdapter.encodeWithTag(writer, 303, value.map_int32_value_a)
         map_int32_null_valueAdapter.encodeWithTag(writer, 304, value.map_int32_null_value)
+        ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 201, value.oneof_struct)
+        ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 202, value.oneof_list)
         writer.writeBytes(value.unknownFields)
       }
 

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
@@ -41,12 +41,12 @@ public class AllStructs(
   rep_list: List<List<*>?> = emptyList(),
   rep_value_a: List<Any?> = emptyList(),
   rep_null_value: List<Nothing?> = emptyList(),
+  oneof_struct: Map<String, *>? = null,
+  oneof_list: List<*>? = null,
   map_int32_struct: Map<Int, Map<String, *>?> = emptyMap(),
   map_int32_list: Map<Int, List<*>?> = emptyMap(),
   map_int32_value_a: Map<Int, Any?> = emptyMap(),
   map_int32_null_value: Map<Int, Nothing?> = emptyMap(),
-  oneof_struct: Map<String, *>? = null,
-  oneof_list: List<*>? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<AllStructs, AllStructs.Builder>(ADAPTER, unknownFields) {
   @field:WireField(
@@ -166,6 +166,24 @@ public class AllStructs(
       rep_null_value)
 
   @field:WireField(
+    tag = 201,
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
+    jsonName = "oneofStruct",
+    oneofName = "choice"
+  )
+  @JvmField
+  public val oneof_struct: Map<String, *>? = immutableCopyOfStruct("oneof_struct", oneof_struct)
+
+  @field:WireField(
+    tag = 202,
+    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
+    jsonName = "oneofList",
+    oneofName = "choice"
+  )
+  @JvmField
+  public val oneof_list: List<*>? = immutableCopyOfStruct("oneof_list", oneof_list)
+
+  @field:WireField(
     tag = 301,
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
@@ -205,24 +223,6 @@ public class AllStructs(
   public val map_int32_null_value: Map<Int, Nothing?> =
       immutableCopyOfMapWithStructValues("map_int32_null_value", map_int32_null_value)
 
-  @field:WireField(
-    tag = 201,
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
-    jsonName = "oneofStruct",
-    oneofName = "choice"
-  )
-  @JvmField
-  public val oneof_struct: Map<String, *>? = immutableCopyOfStruct("oneof_struct", oneof_struct)
-
-  @field:WireField(
-    tag = 202,
-    adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
-    jsonName = "oneofList",
-    oneofName = "choice"
-  )
-  @JvmField
-  public val oneof_list: List<*>? = immutableCopyOfStruct("oneof_list", oneof_list)
-
   init {
     require(countNonNull(oneof_struct, oneof_list) <= 1) {
       "At most one of oneof_struct, oneof_list may be non-null"
@@ -244,12 +244,12 @@ public class AllStructs(
     builder.rep_list = rep_list
     builder.rep_value_a = rep_value_a
     builder.rep_null_value = rep_null_value
+    builder.oneof_struct = oneof_struct
+    builder.oneof_list = oneof_list
     builder.map_int32_struct = map_int32_struct
     builder.map_int32_list = map_int32_list
     builder.map_int32_value_a = map_int32_value_a
     builder.map_int32_null_value = map_int32_null_value
-    builder.oneof_struct = oneof_struct
-    builder.oneof_list = oneof_list
     builder.addUnknownFields(unknownFields)
     return builder
   }
@@ -271,12 +271,12 @@ public class AllStructs(
     if (rep_list != other.rep_list) return false
     if (rep_value_a != other.rep_value_a) return false
     if (rep_null_value != other.rep_null_value) return false
+    if (oneof_struct != other.oneof_struct) return false
+    if (oneof_list != other.oneof_list) return false
     if (map_int32_struct != other.map_int32_struct) return false
     if (map_int32_list != other.map_int32_list) return false
     if (map_int32_value_a != other.map_int32_value_a) return false
     if (map_int32_null_value != other.map_int32_null_value) return false
-    if (oneof_struct != other.oneof_struct) return false
-    if (oneof_list != other.oneof_list) return false
     return true
   }
 
@@ -297,12 +297,12 @@ public class AllStructs(
       result = result * 37 + rep_list.hashCode()
       result = result * 37 + rep_value_a.hashCode()
       result = result * 37 + rep_null_value.hashCode()
+      result = result * 37 + (oneof_struct?.hashCode() ?: 0)
+      result = result * 37 + (oneof_list?.hashCode() ?: 0)
       result = result * 37 + map_int32_struct.hashCode()
       result = result * 37 + map_int32_list.hashCode()
       result = result * 37 + map_int32_value_a.hashCode()
       result = result * 37 + map_int32_null_value.hashCode()
-      result = result * 37 + (oneof_struct?.hashCode() ?: 0)
-      result = result * 37 + (oneof_list?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -323,13 +323,13 @@ public class AllStructs(
     if (rep_list.isNotEmpty()) result += """rep_list=$rep_list"""
     if (rep_value_a.isNotEmpty()) result += """rep_value_a=$rep_value_a"""
     if (rep_null_value.isNotEmpty()) result += """rep_null_value=$rep_null_value"""
+    if (oneof_struct != null) result += """oneof_struct=$oneof_struct"""
+    if (oneof_list != null) result += """oneof_list=$oneof_list"""
     if (map_int32_struct.isNotEmpty()) result += """map_int32_struct=$map_int32_struct"""
     if (map_int32_list.isNotEmpty()) result += """map_int32_list=$map_int32_list"""
     if (map_int32_value_a.isNotEmpty()) result += """map_int32_value_a=$map_int32_value_a"""
     if (map_int32_null_value.isNotEmpty()) result +=
         """map_int32_null_value=$map_int32_null_value"""
-    if (oneof_struct != null) result += """oneof_struct=$oneof_struct"""
-    if (oneof_list != null) result += """oneof_list=$oneof_list"""
     return result.joinToString(prefix = "AllStructs{", separator = ", ", postfix = "}")
   }
 
@@ -347,16 +347,16 @@ public class AllStructs(
     rep_list: List<List<*>?> = this.rep_list,
     rep_value_a: List<Any?> = this.rep_value_a,
     rep_null_value: List<Nothing?> = this.rep_null_value,
+    oneof_struct: Map<String, *>? = this.oneof_struct,
+    oneof_list: List<*>? = this.oneof_list,
     map_int32_struct: Map<Int, Map<String, *>?> = this.map_int32_struct,
     map_int32_list: Map<Int, List<*>?> = this.map_int32_list,
     map_int32_value_a: Map<Int, Any?> = this.map_int32_value_a,
     map_int32_null_value: Map<Int, Nothing?> = this.map_int32_null_value,
-    oneof_struct: Map<String, *>? = this.oneof_struct,
-    oneof_list: List<*>? = this.oneof_list,
     unknownFields: ByteString = this.unknownFields
   ): AllStructs = AllStructs(struct, list, null_value, value_a, value_b, value_c, value_d, value_e,
-      value_f, rep_struct, rep_list, rep_value_a, rep_null_value, map_int32_struct, map_int32_list,
-      map_int32_value_a, map_int32_null_value, oneof_struct, oneof_list, unknownFields)
+      value_f, rep_struct, rep_list, rep_value_a, rep_null_value, oneof_struct, oneof_list,
+      map_int32_struct, map_int32_list, map_int32_value_a, map_int32_null_value, unknownFields)
 
   public class Builder : Message.Builder<AllStructs, Builder>() {
     @JvmField
@@ -399,6 +399,12 @@ public class AllStructs(
     public var rep_null_value: List<Nothing?> = emptyList()
 
     @JvmField
+    public var oneof_struct: Map<String, *>? = null
+
+    @JvmField
+    public var oneof_list: List<*>? = null
+
+    @JvmField
     public var map_int32_struct: Map<Int, Map<String, *>?> = emptyMap()
 
     @JvmField
@@ -409,12 +415,6 @@ public class AllStructs(
 
     @JvmField
     public var map_int32_null_value: Map<Int, Nothing?> = emptyMap()
-
-    @JvmField
-    public var oneof_struct: Map<String, *>? = null
-
-    @JvmField
-    public var oneof_list: List<*>? = null
 
     public fun struct(struct: Map<String, *>?): Builder {
       this.struct = struct
@@ -531,12 +531,12 @@ public class AllStructs(
       rep_list = rep_list,
       rep_value_a = rep_value_a,
       rep_null_value = rep_null_value,
+      oneof_struct = oneof_struct,
+      oneof_list = oneof_list,
       map_int32_struct = map_int32_struct,
       map_int32_list = map_int32_list,
       map_int32_value_a = map_int32_value_a,
       map_int32_null_value = map_int32_null_value,
-      oneof_struct = oneof_struct,
-      oneof_list = oneof_list,
       unknownFields = buildUnknownFields()
     )
   }
@@ -585,12 +585,12 @@ public class AllStructs(
         size += ProtoAdapter.STRUCT_LIST.asRepeated().encodedSizeWithTag(102, value.rep_list)
         size += ProtoAdapter.STRUCT_VALUE.asRepeated().encodedSizeWithTag(103, value.rep_value_a)
         size += ProtoAdapter.STRUCT_NULL.asRepeated().encodedSizeWithTag(104, value.rep_null_value)
+        size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(201, value.oneof_struct)
+        size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(202, value.oneof_list)
         size += map_int32_structAdapter.encodedSizeWithTag(301, value.map_int32_struct)
         size += map_int32_listAdapter.encodedSizeWithTag(302, value.map_int32_list)
         size += map_int32_value_aAdapter.encodedSizeWithTag(303, value.map_int32_value_a)
         size += map_int32_null_valueAdapter.encodedSizeWithTag(304, value.map_int32_null_value)
-        size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(201, value.oneof_struct)
-        size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(202, value.oneof_list)
         return size
       }
 
@@ -609,12 +609,12 @@ public class AllStructs(
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
         ProtoAdapter.STRUCT_NULL.asRepeated().encodeWithTag(writer, 104, value.rep_null_value)
+        ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 201, value.oneof_struct)
+        ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 202, value.oneof_list)
         map_int32_structAdapter.encodeWithTag(writer, 301, value.map_int32_struct)
         map_int32_listAdapter.encodeWithTag(writer, 302, value.map_int32_list)
         map_int32_value_aAdapter.encodeWithTag(writer, 303, value.map_int32_value_a)
         map_int32_null_valueAdapter.encodeWithTag(writer, 304, value.map_int32_null_value)
-        ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 201, value.oneof_struct)
-        ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 202, value.oneof_list)
         writer.writeBytes(value.unknownFields)
       }
 
@@ -632,12 +632,12 @@ public class AllStructs(
         val rep_list = mutableListOf<List<*>?>()
         val rep_value_a = mutableListOf<Any?>()
         val rep_null_value = mutableListOf<Nothing?>()
+        var oneof_struct: Map<String, *>? = null
+        var oneof_list: List<*>? = null
         val map_int32_struct = mutableMapOf<Int, Map<String, *>?>()
         val map_int32_list = mutableMapOf<Int, List<*>?>()
         val map_int32_value_a = mutableMapOf<Int, Any?>()
         val map_int32_null_value = mutableMapOf<Int, Nothing?>()
-        var oneof_struct: Map<String, *>? = null
-        var oneof_list: List<*>? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> struct = ProtoAdapter.STRUCT_MAP.decode(reader)
@@ -661,12 +661,12 @@ public class AllStructs(
             } catch (e: ProtoAdapter.EnumConstantNotFoundException) {
               reader.addUnknownField(tag, FieldEncoding.VARINT, e.value.toLong())
             }
+            201 -> oneof_struct = ProtoAdapter.STRUCT_MAP.decode(reader)
+            202 -> oneof_list = ProtoAdapter.STRUCT_LIST.decode(reader)
             301 -> map_int32_struct.putAll(map_int32_structAdapter.decode(reader))
             302 -> map_int32_list.putAll(map_int32_listAdapter.decode(reader))
             303 -> map_int32_value_a.putAll(map_int32_value_aAdapter.decode(reader))
             304 -> map_int32_null_value.putAll(map_int32_null_valueAdapter.decode(reader))
-            201 -> oneof_struct = ProtoAdapter.STRUCT_MAP.decode(reader)
-            202 -> oneof_list = ProtoAdapter.STRUCT_LIST.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -684,12 +684,12 @@ public class AllStructs(
           rep_list = rep_list,
           rep_value_a = rep_value_a,
           rep_null_value = rep_null_value,
+          oneof_struct = oneof_struct,
+          oneof_list = oneof_list,
           map_int32_struct = map_int32_struct,
           map_int32_list = map_int32_list,
           map_int32_value_a = map_int32_value_a,
           map_int32_null_value = map_int32_null_value,
-          oneof_struct = oneof_struct,
-          oneof_list = oneof_list,
           unknownFields = unknownFields
         )
       }
@@ -706,11 +706,11 @@ public class AllStructs(
         rep_struct = value.rep_struct.redactElements(ProtoAdapter.STRUCT_MAP),
         rep_list = value.rep_list.redactElements(ProtoAdapter.STRUCT_LIST),
         rep_value_a = value.rep_value_a.redactElements(ProtoAdapter.STRUCT_VALUE),
+        oneof_struct = value.oneof_struct?.let(ProtoAdapter.STRUCT_MAP::redact),
+        oneof_list = value.oneof_list?.let(ProtoAdapter.STRUCT_LIST::redact),
         map_int32_struct = value.map_int32_struct.redactElements(ProtoAdapter.STRUCT_MAP),
         map_int32_list = value.map_int32_list.redactElements(ProtoAdapter.STRUCT_LIST),
         map_int32_value_a = value.map_int32_value_a.redactElements(ProtoAdapter.STRUCT_VALUE),
-        oneof_struct = value.oneof_struct?.let(ProtoAdapter.STRUCT_MAP::redact),
-        oneof_list = value.oneof_list?.let(ProtoAdapter.STRUCT_LIST::redact),
         unknownFields = ByteString.EMPTY
       )
     }


### PR DESCRIPTION
I hesitated using a sealed class something like `sealed class FieldOrOneOf` but didn't; could be convinced otherwise...
Split in 2 commits.

Here is the before after of how fields were ordered.

Before
------
fields
extensions
flatOneOfs
boxedOneOfs

After
-----
(everything).sortBy { it.location.line }

