### PR TITLE
Fix SchemaEncoder to support enums and doubles

### DIFF
--- a/wire-library/wire-schema/build.gradle.kts
+++ b/wire-library/wire-schema/build.gradle.kts
@@ -37,10 +37,11 @@ kotlin {
     val jvmTest by getting {
       dependencies {
         implementation(project(":wire-test-utils"))
-        implementation(deps.junit)
-        implementation(deps.kotlin.test.junit)
         implementation(deps.assertj)
         implementation(deps.jimfs)
+        implementation(deps.junit)
+        implementation(deps.kotlin.test.junit)
+        implementation(deps.protobuf.java)
       }
     }
     if (kmpJsEnabled) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaProtoAdapterFactory.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaProtoAdapterFactory.kt
@@ -88,7 +88,14 @@ internal class SchemaProtoAdapterFactory(
     private val enumType: EnumType
   ) : ProtoAdapter<Any>(VARINT, Any::class, null, enumType.syntax) {
     override fun encodedSize(value: Any): Int {
-      throw UnsupportedOperationException()
+      if (value is String) {
+        val constant = enumType.constant(value)!!
+        return INT32.encodedSize(constant.tag)
+      } else if (value is Int) {
+        return INT32.encodedSize(value)
+      } else {
+        throw IllegalArgumentException("unexpected " + enumType.type + ": " + value)
+      }
     }
 
     override fun encode(writer: ProtoWriter, value: Any) {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
@@ -410,11 +410,13 @@ class SchemaEncoder(
     // TODO: use optionValueToInt(value) when that's available in commonMain.
     return when (field.type) {
       ProtoType.INT32 -> (value as String).toInt()
+      ProtoType.DOUBLE -> (value as String).toDouble()
       ProtoType.BOOL -> (value as String).toBoolean()
       ProtoType.STRING -> value as String
       else -> {
         when (schema.getType(field.type!!)) {
           is MessageType -> toJsonMap(value as Map<ProtoMember, Any?>)
+          is EnumType -> value as String
           else -> error("not implemented yet!!")
         }
       }

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaProtoAdapterTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaProtoAdapterTest.kt
@@ -15,15 +15,15 @@
  */
 package com.squareup.wire.schema
 
-import java.io.EOFException
-import java.io.IOException
-import java.net.ProtocolException
 import okio.Buffer
-import okio.ByteString
 import okio.ByteString.Companion.decodeHex
+import okio.ByteString.Companion.toByteString
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
+import java.io.EOFException
+import java.io.IOException
+import java.net.ProtocolException
 
 class SchemaProtoAdapterTest {
   private val coffeeSchema = RepoBuilder()
@@ -92,8 +92,10 @@ class SchemaProtoAdapterTest {
   @Throws(IOException::class)
   fun encode() {
     val adapter = coffeeSchema.protoAdapter("CafeDrink", true)
-    assertThat(ByteString.of(*adapter.encode(dansCoffee))).isEqualTo(dansCoffeeEncoded)
-    assertThat(ByteString.of(*adapter.encode(jessesCoffee))).isEqualTo(jessesCoffeeEncoded)
+    assertThat(adapter.encode(dansCoffee).toByteString()).isEqualTo(dansCoffeeEncoded)
+    assertThat(adapter.encode(jessesCoffee).toByteString()).isEqualTo(jessesCoffeeEncoded)
+    assertThat(adapter.encodedSize(dansCoffee)).isEqualTo(dansCoffeeEncoded.size)
+    assertThat(adapter.encodedSize(jessesCoffee)).isEqualTo(jessesCoffeeEncoded.size)
   }
 
   @Test
@@ -261,7 +263,7 @@ class SchemaProtoAdapterTest {
         )
     )
     val encoded = "0a0d0a031a014112031a01431a0142120d0a031a014512031a01471a01461a0144".decodeHex()
-    assertThat(ByteString.of(*adapter.encode(value))).isEqualTo(encoded)
+    assertThat(adapter.encode(value).toByteString()).isEqualTo(encoded)
     assertThat(adapter.decode(Buffer().write(encoded))).isEqualTo(value)
   }
 

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/SchemaEncoderTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/SchemaEncoderTest.kt
@@ -1,0 +1,109 @@
+package com.squareup.wire.schema.internal
+
+import com.google.protobuf.DescriptorProtos.DescriptorProto
+import com.google.protobuf.DescriptorProtos.EnumDescriptorProto
+import com.google.protobuf.DescriptorProtos.EnumValueDescriptorProto
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto
+import com.google.protobuf.DescriptorProtos.FileDescriptorProto
+import com.google.protobuf.DescriptorProtos.MethodDescriptorProto
+import com.google.protobuf.DescriptorProtos.MethodOptions
+import com.google.protobuf.DescriptorProtos.ServiceDescriptorProto
+import com.google.protobuf.UnknownFieldSet
+import com.squareup.wire.schema.RepoBuilder
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class SchemaEncoderTest {
+  @Test fun `encode schema`() {
+    val schema = RepoBuilder()
+      .add(
+        "handle_service.proto", """
+            |syntax = "proto2";
+            |
+            |import "google/protobuf/descriptor.proto";
+            |
+            |enum GreekLetter {
+            |  ALPHA = 1;
+            |  BETA = 2;
+            |}
+            |
+            |extend google.protobuf.MethodOptions {
+            |  optional double timeout = 22000;
+            |  optional GreekLetter greek_letter = 22001;
+            |}
+            |
+            |message HandleRequest {
+            |}
+            |
+            |message HandleResponse {
+            |}
+            |
+            |service HandleService {
+            |  rpc Handle ( HandleRequest ) returns ( HandleResponse ) {
+            |    option (timeout) = 2.1;
+            |    option (greek_letter) = BETA;
+            |  }
+            |}
+            |""".trimMargin()
+      )
+      .schema()
+
+    val handleServiceProto = schema.protoFile("handle_service.proto")!!
+    val encoded = SchemaEncoder(schema).encode(handleServiceProto)
+
+    val fileDescriptorProto = FileDescriptorProto.parseFrom(encoded.toByteArray())
+    assertThat(fileDescriptorProto).isEqualTo(FileDescriptorProto.newBuilder()
+      .setName("handle_service.proto")
+      .addDependency("google/protobuf/descriptor.proto")
+      .addEnumType(EnumDescriptorProto.newBuilder()
+        .setName("GreekLetter")
+        .addValue(EnumValueDescriptorProto.newBuilder()
+          .setName("ALPHA")
+          .setNumber(1)
+          .build())
+        .addValue(EnumValueDescriptorProto.newBuilder()
+          .setName("BETA")
+          .setNumber(2)
+          .build())
+        .build())
+      .addMessageType(DescriptorProto.newBuilder()
+        .setName("HandleRequest")
+        .build())
+      .addMessageType(DescriptorProto.newBuilder()
+        .setName("HandleResponse")
+        .build())
+      .addService(ServiceDescriptorProto.newBuilder()
+        .setName("HandleService")
+        .addMethod(MethodDescriptorProto.newBuilder()
+          .setName("Handle")
+          .setInputType(".HandleRequest")
+          .setOutputType(".HandleResponse")
+          .setOptions(MethodOptions.newBuilder()
+            .setUnknownFields(UnknownFieldSet.newBuilder()
+              .addField(22000, UnknownFieldSet.Field.newBuilder()
+                .addFixed64(java.lang.Double.doubleToLongBits(2.1))
+                .build())
+              .addField(22001, UnknownFieldSet.Field.newBuilder()
+                .addVarint(2L)
+                .build())
+              .build())
+          .build())
+        .build()))
+      .addExtension(FieldDescriptorProto.newBuilder()
+        .setName("timeout")
+        .setExtendee(".google.protobuf.MethodOptions")
+        .setNumber(22000)
+        .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+        .setType(FieldDescriptorProto.Type.TYPE_DOUBLE)
+        .build())
+      .addExtension(FieldDescriptorProto.newBuilder()
+        .setName("greek_letter")
+        .setExtendee(".google.protobuf.MethodOptions")
+        .setNumber(22001)
+        .setLabel(FieldDescriptorProto.Label.LABEL_OPTIONAL)
+        .setType(FieldDescriptorProto.Type.TYPE_ENUM)
+        .setTypeName(".GreekLetter")
+        .build())
+      .build())
+  }
+}


### PR DESCRIPTION
This was broken when a schema had an option whose value was either
an enum or a double.