### PR TITLE
Use relative path sensitivity and file collection

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -137,9 +137,7 @@ class WirePlugin : Plugin<Project> {
         protoSourceInput.addPaths(project, defaultSourceFolders(source))
       }
 
-      val inputFiles = mutableListOf<String>()
-      inputFiles.addAll(protoSourceInput.inputFiles.map { project.relativePath(it) })
-      inputFiles.addAll(protoPathInput.inputFiles.map { project.relativePath(it) })
+      val inputFiles = project.layout.files(protoSourceInput.inputFiles, protoPathInput.inputFiles)
 
       val projectDependencies = (protoSourceInput.dependencies + protoPathInput.dependencies)
         .filterIsInstance<ProjectDependency>()

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -21,6 +21,7 @@ import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.Target
 import com.squareup.wire.schema.WireRun
 import okio.Path.Companion.toPath
+import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
@@ -83,8 +84,9 @@ open class WireTask : SourceTask() {
   @Input
   var permitPackageCycles: Boolean = false
 
-  @Input
-  lateinit var inputFiles: List<String>
+  @InputFiles
+  @PathSensitive(PathSensitivity.RELATIVE)
+  lateinit var inputFiles: FileCollection
 
   @TaskAction
   fun generateWireFiles() {
@@ -117,8 +119,7 @@ open class WireTask : SourceTask() {
       logger.debug("targets: $targets")
     }
 
-    inputFiles.forEach {
-      val fileObj = project.file(it)
+    inputFiles.forEach { fileObj ->
       check(fileObj.exists()) {
         "Invalid path string: \"${fileObj.path}\". Path does not exist."
       }


### PR DESCRIPTION
This will make it easier to debug cache misses when they happen due to this property since each file with a difference will be tracked individually instead of as a single property.

ref #2006
