### PR TITLE
Add Unit return type to unary rpc calls.

### DIFF
--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
@@ -15,14 +15,8 @@
  */
 package com.squareup.wire.kotlin.grpcserver
 
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.MemberName
-import com.squareup.kotlinpoet.ParameterSpec
+import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.schema.Rpc
 import com.squareup.wire.schema.Service
 import java.io.InputStream
@@ -62,6 +56,7 @@ object ImplBaseGenerator {
         .addParameter(
           "response", ClassName("io.grpc.stub", "StreamObserver").parameterizedBy(responseType)
         )
+        .returns(UNIT)
     }
   }
 

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
@@ -15,8 +15,15 @@
  */
 package com.squareup.wire.kotlin.grpcserver
 
-import com.squareup.kotlinpoet.*
+import com.squareup.kotlinpoet.ClassName
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.MemberName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.UNIT
 import com.squareup.wire.schema.Rpc
 import com.squareup.wire.schema.Service
 import java.io.InputStream

--- a/wire-library/wire-grpc-server-generator/src/test/golden/ImplBase.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/ImplBase.kt
@@ -10,14 +10,15 @@ import io.grpc.stub.ServerCalls.asyncUnaryCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
 import java.lang.UnsupportedOperationException
+import kotlin.Unit
 
 public class RouteGuideWireGrpc {
   public abstract class RouteGuideImplBase : BindableService {
-    public open fun GetFeature(request: Point, response: StreamObserver<Feature>) = throw
+    public open fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit = throw
         UnsupportedOperationException()
 
-    public open fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>) = throw
-        UnsupportedOperationException()
+    public open fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>): Unit =
+        throw UnsupportedOperationException()
 
     public open fun RecordRoute(response: StreamObserver<RouteSummary>): StreamObserver<Point> =
         throw UnsupportedOperationException()

--- a/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -161,11 +161,11 @@ public object RouteGuideWireGrpc {
       RouteGuideBlockingStub(channel)
 
   public abstract class RouteGuideImplBase : BindableService {
-    public open fun GetFeature(request: Point, response: StreamObserver<Feature>) = throw
+    public open fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit = throw
         UnsupportedOperationException()
 
-    public open fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>) = throw
-        UnsupportedOperationException()
+    public open fun ListFeatures(request: Rectangle, response: StreamObserver<Feature>): Unit =
+        throw UnsupportedOperationException()
 
     public open fun RecordRoute(response: StreamObserver<RouteSummary>): StreamObserver<Point> =
         throw UnsupportedOperationException()


### PR DESCRIPTION
This PR addresses #1903. 

### Overview
When specifying unary RPCs, `wire-grpc-server-generator` generates classes that do not compile. Generated methods throw an exception, but do not specify the return type, which is mandatory in this case.

### How to reproduce
1. Add a unary RPC to `samples/wire-grpc-sample/protos/../whiteboard.proto`. For example:
    ```
    service Test {
      rpc Test(WhiteboardCommand) returns (WhiteboardUpdate) { }
    }
    ```
2. Try to compile `samples/wire-grpc-sample/server-plain`. The compilation will fail with "'Nothing' return type needs to be specified explicitly"