### PR TITLE
Suppress deprecation warnings on generated fromValue method in Kotlin

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1826,7 +1826,9 @@ class KotlinGenerator private constructor(
         .apply {
           addCode("return when (value) {\n⇥")
           message.constants.forEach { constant ->
-            addCode("%L -> %L\n", constant.tag, nameAllocator[constant])
+            addCode("%L -> ", constant.tag)
+            if (constant.isDeprecated) addCode("@Suppress(\"DEPRECATION\") ")
+            addCode("%L\n", nameAllocator[constant])
           }
           addCode("else -> null")
           addCode("\n⇤}\n") // close the block

--- a/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-library/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1460,6 +1460,10 @@ class KotlinGeneratorTest {
          |  EAST(2),
          """.trimMargin()
     )
+    assertThat(code).contains(
+      """|  2 -> @Suppress("DEPRECATION") EAST
+         """.trimMargin()
+    )
   }
 
   @Test fun deprecatedField() {

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedEnum.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedEnum.kt
@@ -34,8 +34,8 @@ public enum class DeprecatedEnum(
 
     @JvmStatic
     public fun fromValue(`value`: Int): DeprecatedEnum? = when (value) {
-      1 -> DISABLED
-      2 -> ENABLED
+      1 -> @Suppress("DEPRECATION") DISABLED
+      2 -> @Suppress("DEPRECATION") ENABLED
       3 -> ON
       4 -> OFF
       else -> null

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -456,7 +456,7 @@ public class SimpleMessage(
         1 -> FOO
         2 -> BAR
         3 -> BAZ
-        3 -> BUZ
+        3 -> @Suppress("DEPRECATION") BUZ
         else -> null
       }
     }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -647,7 +647,7 @@ public class SimpleMessage(
         1 -> FOO
         2 -> BAR
         3 -> BAZ
-        3 -> BUZ
+        3 -> @Suppress("DEPRECATION") BUZ
         else -> null
       }
     }


### PR DESCRIPTION
This keeps generated code warning-free.