### PR TITLE
Add docs indicating wire gRPC server support is experimental

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -316,7 +316,7 @@ data class KotlinTarget(
    */
   val boxOneOfsMinSize: Int = 5_000,
 
-  /** True to also generate gRPC server-compatible classes. */
+  /** True to also generate gRPC server-compatible classes. Experimental feature. */
   val grpcServerCompatible: Boolean = false,
 
   /**

--- a/wire-library/wire-grpc-server-generator/README.md
+++ b/wire-library/wire-grpc-server-generator/README.md
@@ -1,0 +1,3 @@
+Generates service code compatible with https://github.com/grpc/grpc.
+
+This feature is experimental.

--- a/wire-library/wire-grpc-server/README.md
+++ b/wire-library/wire-grpc-server/README.md
@@ -1,0 +1,4 @@
+Compatibility classes to make wire-generated services work with grpc server. Currently used 
+alongside `wire-grpc-server-generator`.
+
+This feature is experimental.


### PR DESCRIPTION
The main entry point for this feature is via the gradle plugin, so adding annotations won't really add anything.