### PR TITLE
feat: Keeping the format when toSchema is executed

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -201,6 +201,10 @@ class Options(
         return coerceValueForField(context, value)
       }
 
+      is Pair<*,*> -> {
+        return canonicalizeValue(linker, context, value.second!!)
+      }
+
       else -> {
         throw IllegalArgumentException("Unexpected option value: $value")
       }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -201,8 +201,8 @@ class Options(
         return coerceValueForField(context, value)
       }
 
-      is Pair<*,*> -> {
-        return canonicalizeValue(linker, context, value.second!!)
+      is OptionElement.OptionPrimitive -> {
+        return canonicalizeValue(linker, context, value.value)
       }
 
       else -> {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
@@ -85,6 +85,20 @@ data class OptionElement(
       is String -> {
         append(""""$value"""")
       }
+      is Pair<*,*> -> {
+        if (value.first is Kind) {
+           when (value.first as Kind) {
+             BOOLEAN,
+             NUMBER,
+             ENUM -> {
+               append("${value.second}")
+             }
+             else -> append(formatOptionMapValue(value.second as Any))
+           }
+        } else {
+          append(formatOptionMapValue(value.second as Any))
+        }
+      }
       is Map<*, *> -> {
         append("{\n")
         formatOptionMap(this, value as Map<String, *>)

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
@@ -42,6 +42,7 @@ data class OptionElement(
     LIST,
     OPTION
   }
+
   /** An internal representation of the Option primitive types */
   data class OptionPrimitive(val kind: Kind, val value: Any)
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
@@ -42,6 +42,9 @@ data class OptionElement(
     LIST,
     OPTION
   }
+  /** An internal representation of the Option primitive types */
+  data class OptionPrimitive(val kind: Kind, val value: Any)
+
   private val formattedName = if (isParenthesized) "($name)" else name
 
   fun toSchema(): String = buildString {
@@ -85,19 +88,16 @@ data class OptionElement(
       is String -> {
         append(""""$value"""")
       }
-      is Pair<*,*> -> {
-        if (value.first is Kind) {
-           when (value.first as Kind) {
+      is OptionPrimitive -> {
+           when (value.kind) {
              BOOLEAN,
              NUMBER,
              ENUM -> {
-               append("${value.second}")
+               append("${value.value}")
              }
-             else -> append(formatOptionMapValue(value.second as Any))
+             else -> append(formatOptionMapValue(value.value))
            }
-        } else {
-          append(formatOptionMapValue(value.second as Any))
-        }
+
       }
       is Map<*, *> -> {
         append("{\n")

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionElement.kt
@@ -43,7 +43,7 @@ data class OptionElement(
     OPTION
   }
 
-  /** An internal representation of the Option primitive types */
+  /** An internal representation of the Option primitive types. */
   data class OptionPrimitive(val kind: Kind, val value: Any)
 
   private val formattedName = if (isParenthesized) "($name)" else name
@@ -98,7 +98,6 @@ data class OptionElement(
              }
              else -> append(formatOptionMapValue(value.value))
            }
-
       }
       is Map<*, *> -> {
         append("{\n")

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
@@ -115,7 +115,7 @@ class OptionReader(internal val reader: SyntaxReader) {
       val option = readOption(keyValueSeparator)
       val name = option.name
       val value = if ( option.kind == BOOLEAN || option.kind == ENUM || option.kind == NUMBER) {
-        Pair(option.kind, option.value)
+        OptionElement.OptionPrimitive(option.kind, option.value)
       } else {
         option.value
       }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
@@ -114,7 +114,7 @@ class OptionReader(internal val reader: SyntaxReader) {
 
       val option = readOption(keyValueSeparator)
       val name = option.name
-      val value = if ( option.kind == BOOLEAN || option.kind == ENUM || option.kind == NUMBER) {
+      val value = if (option.kind == BOOLEAN || option.kind == ENUM || option.kind == NUMBER) {
         OptionElement.OptionPrimitive(option.kind, option.value)
       } else {
         option.value

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
@@ -114,7 +114,12 @@ class OptionReader(internal val reader: SyntaxReader) {
 
       val option = readOption(keyValueSeparator)
       val name = option.name
-      val value = option.value
+      val value = if ( option.kind == BOOLEAN || option.kind == ENUM || option.kind == NUMBER) {
+        Pair(option.kind, option.value)
+      } else {
+        option.value
+      }
+
       if (value is OptionElement) {
         var nested = result[name] as? MutableMap<String, Any>
         if (nested == null) {

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
@@ -88,6 +88,67 @@ class OptionsTest {
   }
 
   @Test
+  fun testOptionsToSchema() {
+    val schema = RepoBuilder()
+        .add("foo.proto",
+            """
+            |import "google/protobuf/descriptor.proto";
+            |enum FooParameterType {
+            |   NUMBER = 1;
+            |   STRING = 2;
+            |}
+            | 
+            |message FooOptions {
+            |  optional string name = 1;
+            |  optional FooParameterType type = 2; 
+            |} 
+            |extend google.protobuf.MessageOptions {
+            |  repeated FooOptions foo = 12345;
+            |}
+            |
+            |message Message {
+            |  option (foo) = {
+            |    name: "test"
+            |    type: STRING
+            |  };
+            |  
+            |  option (foo) = {
+            |    name: "test2"
+            |    type: NUMBER
+            |  };
+            |  
+            |  optional int32 b = 2;
+            |}
+            """.trimMargin()
+        )
+        .schema()
+
+    val protoFile = schema.protoFile("foo.proto")
+
+    val optionElements = protoFile!!.types.stream().filter { it is MessageType && it.toElement().name == "Message" }
+        .findFirst().get().options.elements
+
+    assertThat(optionElements[0].toSchema())
+        .isEqualTo("""|(foo) = {
+                      |  name: "test",
+                      |  type: STRING
+                      |}""".trimMargin())
+
+    val foo = ProtoMember.get(Options.MESSAGE_OPTIONS, "foo")
+
+    val name = ProtoMember.get(ProtoType.get("FooOptions"), "name")
+    val type = ProtoMember.get(ProtoType.get("FooOptions"), "type")
+
+    val message = schema.getType("Message") as MessageType
+    message.toElement().name
+
+    assertThat(message.options.map)
+        .isEqualTo(mapOf( foo to
+            arrayListOf(mapOf(name to "test", type to "STRING" ),
+            mapOf ( name to "test2", type to "NUMBER" ) )))
+  }
+
+  @Test
   fun fullyQualifiedOptionFields() {
     val schema = RepoBuilder()
         .add("a/b/more_options.proto",
@@ -147,6 +208,8 @@ class OptionsTest {
     assertThat(message.options.map)
         .isEqualTo(mapOf(moreOptions to mapOf(evenMoreOptions to mapOf(stringOption to "foo"))))
   }
+
+
 
   @Test
   fun resolveFieldPathMatchesLeadingDotFirstSegment() {

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
@@ -209,8 +209,6 @@ class OptionsTest {
         .isEqualTo(mapOf(moreOptions to mapOf(evenMoreOptions to mapOf(stringOption to "foo"))))
   }
 
-
-
   @Test
   fun resolveFieldPathMatchesLeadingDotFirstSegment() {
     assertThat(Options.resolveFieldPath(".a.b.c.d", setOf("a", "z", "y")))

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -1914,20 +1914,20 @@ class ProtoParserTest {
     option_one_map["name"] = "Name"
     option_one_map["class_name"] = "ClassName"
     val option_two_a_map = LinkedHashMap<String, Any>()
-    option_two_a_map["[squareup.options.type]"] = Pair(Kind.ENUM,"EXOTIC")
+    option_two_a_map["[squareup.options.type]"] = OptionElement.OptionPrimitive(Kind.ENUM,"EXOTIC")
     val option_two_b_map = LinkedHashMap<String, List<String>>()
     option_two_b_map["names"] = Arrays.asList("Foo", "Bar")
     val option_three_map = LinkedHashMap<String, Map<String, *>>()
     val option_three_nested_map = LinkedHashMap<String, Any>()
-    option_three_nested_map["y"] = Arrays.asList( Pair(Kind.NUMBER, "1"), Pair(Kind.NUMBER, "2"))
+    option_three_nested_map["y"] = Arrays.asList( OptionElement.OptionPrimitive(Kind.NUMBER, "1"), OptionElement.OptionPrimitive(Kind.NUMBER, "2"))
     option_three_map["x"] = option_three_nested_map
 
     val option_four_map = LinkedHashMap<String, Map<String, *>>()
     val option_four_map_1 = LinkedHashMap<String, Any>()
     val option_four_map_2_a = LinkedHashMap<String, Any>()
-    option_four_map_2_a["z"] =  Pair(Kind.NUMBER, "1")
+    option_four_map_2_a["z"] = OptionElement.OptionPrimitive(Kind.NUMBER, "1")
     val option_four_map_2_b = LinkedHashMap<String, Any>()
-    option_four_map_2_b["z"] =  Pair(Kind.NUMBER, "2")
+    option_four_map_2_b["z"] = OptionElement.OptionPrimitive(Kind.NUMBER, "2")
     option_four_map_1["y"] = listOf(option_four_map_2_a, option_four_map_2_b)
     option_four_map["x"] = option_four_map_1
 
@@ -2932,7 +2932,7 @@ class ProtoParserTest {
                     OptionElement(
                         "custom_rule",
                         Kind.MAP,
-                        mapOf("my_string" to "abc", "my_int" to Pair(Kind.NUMBER,"3"),
+                        mapOf("my_string" to "abc", "my_int" to OptionElement.OptionPrimitive(Kind.NUMBER,"3"),
                             "my_list" to listOf("a", "b", "c")),
                         isParenthesized = true
                     )

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -1232,8 +1232,6 @@ class ProtoParserTest {
     assertThat(ProtoParser.parse(location, proto)).isEqualTo(expected)
   }
 
-
-
   @Test
   fun packageDeclaration() {
     val proto = """
@@ -1919,7 +1917,7 @@ class ProtoParserTest {
     option_two_b_map["names"] = Arrays.asList("Foo", "Bar")
     val option_three_map = LinkedHashMap<String, Map<String, *>>()
     val option_three_nested_map = LinkedHashMap<String, Any>()
-    option_three_nested_map["y"] = Arrays.asList( OptionElement.OptionPrimitive(Kind.NUMBER, "1"), OptionElement.OptionPrimitive(Kind.NUMBER, "2"))
+    option_three_nested_map["y"] = Arrays.asList(OptionElement.OptionPrimitive(Kind.NUMBER, "1"), OptionElement.OptionPrimitive(Kind.NUMBER, "2"))
     option_three_map["x"] = option_three_nested_map
 
     val option_four_map = LinkedHashMap<String, Map<String, *>>()

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -1232,6 +1232,8 @@ class ProtoParserTest {
     assertThat(ProtoParser.parse(location, proto)).isEqualTo(expected)
   }
 
+
+
   @Test
   fun packageDeclaration() {
     val proto = """
@@ -1912,20 +1914,20 @@ class ProtoParserTest {
     option_one_map["name"] = "Name"
     option_one_map["class_name"] = "ClassName"
     val option_two_a_map = LinkedHashMap<String, Any>()
-    option_two_a_map["[squareup.options.type]"] = "EXOTIC"
+    option_two_a_map["[squareup.options.type]"] = Pair(Kind.ENUM,"EXOTIC")
     val option_two_b_map = LinkedHashMap<String, List<String>>()
     option_two_b_map["names"] = Arrays.asList("Foo", "Bar")
     val option_three_map = LinkedHashMap<String, Map<String, *>>()
     val option_three_nested_map = LinkedHashMap<String, Any>()
-    option_three_nested_map["y"] = Arrays.asList("1", "2")
+    option_three_nested_map["y"] = Arrays.asList( Pair(Kind.NUMBER, "1"), Pair(Kind.NUMBER, "2"))
     option_three_map["x"] = option_three_nested_map
 
     val option_four_map = LinkedHashMap<String, Map<String, *>>()
     val option_four_map_1 = LinkedHashMap<String, Any>()
     val option_four_map_2_a = LinkedHashMap<String, Any>()
-    option_four_map_2_a["z"] = "1"
+    option_four_map_2_a["z"] =  Pair(Kind.NUMBER, "1")
     val option_four_map_2_b = LinkedHashMap<String, Any>()
-    option_four_map_2_b["z"] = "2"
+    option_four_map_2_b["z"] =  Pair(Kind.NUMBER, "2")
     option_four_map_1["y"] = listOf(option_four_map_2_a, option_four_map_2_b)
     option_four_map["x"] = option_four_map_1
 
@@ -2930,7 +2932,7 @@ class ProtoParserTest {
                     OptionElement(
                         "custom_rule",
                         Kind.MAP,
-                        mapOf("my_string" to "abc", "my_int" to "3",
+                        mapOf("my_string" to "abc", "my_int" to Pair(Kind.NUMBER,"3"),
                             "my_list" to listOf("a", "b", "c")),
                         isParenthesized = true
                     )


### PR DESCRIPTION
If you have the following schema

```proto
import "google/protobuf/descriptor.proto";
enum FooParameterType {
   NUMBER = 1;
   STRING = 2;
}
 
message FooOptions {
  optional string name = 1;
  optional FooParameterType type = 2; 
} 
extend google.protobuf.MessageOptions {
  repeated FooOptions foo = 12345;
}

message Message {
  option (foo) = {
    name: "test"
    type: STRING
  };
  
  option (foo) = {
    name: "test2"
    type: NUMBER
  };
  
  optional int32 b = 2;
}
```

After it's parsed if you get the string representation of the schema using `ProtoFileElement.toSchema()` the result is

```proto
// Proto schema formatted by Wire, do not edit.
// Source: foo.proto

import "google/protobuf/descriptor.proto";

enum FooParameterType {
  NUMBER = 1;
  STRING = 2;
}

message FooOptions {
  optional string name = 1;

  optional FooParameterType type = 2;
}

message Message {
  option (foo) = {
    name: "test",
    type: "STRING"
  };
  option (foo) = {
    name: "test2",
    type: "NUMBER"
  };

  optional int32 b = 2;
}

extend google.protobuf.MessageOptions {
  repeated FooOptions foo = 12345;
}
```

Which is malformed, the resulting schema should use `type: STRING` instead of `type: "STRING"`.

The intent of this PR is to solve those issues by using a Pair of the Kind and the String value when the nested kind is ENUM, BOOL, or STRING
