### PR TITLE
Change field order sorting condition

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
@@ -149,7 +149,7 @@ class SchemaEncoder(
       STRING.encodeWithTag(writer, 1, value.type.simpleName)
 
       val fieldsAndOneOfFields = (encodedFields + encodedOneOfs.flatMap { it.fields })
-        .sortedBy { it.field.tag }
+        .sortedWith(compareBy({ it.field.location.line }, { it.field.location.column }))
       fieldEncoder.asRepeated().encodeWithTag(writer, 2, fieldsAndOneOfFields)
 
       // FieldDescriptorProto.ADAPTER.asRepeated().encodeWithTag(writer, 6, value.extension)


### PR DESCRIPTION
We had the fields and oneofs sorted by tag which lead to a subtle FileDescriptor validation error:

	[libprotobuf ERROR external/com_google_protobuf/src/google/protobuf/descriptor.cc:3623]   [redacted].Element.id: Fields in the same oneof must be defined consecutively. "id" cannot be defined before the completion of the "element" oneof definition.
	
Let's sort by location (file and column in stread).