### PR TITLE
Fixing bug when using custom adaptors in generated kotlin code

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -126,9 +126,12 @@ class KotlinGenerator private constructor(
 
   private val ProtoType.typeName: TypeName
     get() {
-      val profileTypeName = profile.kotlinTarget(this)
-      if (profileTypeName != null) return profileTypeName
-      return typeToKotlinName.getValue(this)
+      return if (isMap) {
+        Map::class.asTypeName()
+          .parameterizedBy(keyType!!.typeName, valueType!!.typeName)
+      } else {
+        profile.kotlinTarget(this) ?: typeToKotlinName.getValue(this)
+      }
     }
   private val ProtoType.isEnum
     get() = schema.getType(this) is EnumType
@@ -1649,7 +1652,6 @@ class KotlinGenerator private constructor(
     return null
   }
 
-  // TODO add support for custom adapters.
   private fun Field.getAdapterName(nameDelimiter: Char = '.'): CodeBlock {
     return if (type!!.isMap) {
       CodeBlock.of("%N", "${name}Adapter")
@@ -1969,12 +1971,6 @@ class KotlinGenerator private constructor(
       }
     }
 
-  private fun ProtoType.asTypeName(): TypeName = when {
-    isMap -> Map::class.asTypeName()
-        .parameterizedBy(keyType!!.asTypeName(), valueType!!.asTypeName())
-    else -> typeToKotlinName.getValue(this)
-  }
-
   private fun EnumType.identity(): CodeBlock {
     val enumConstant = constant(0) ?: return CodeBlock.of("null")
     return CodeBlock.of("%T.%L", type.typeName, nameAllocator(this)[enumConstant])
@@ -1982,7 +1978,7 @@ class KotlinGenerator private constructor(
 
   private fun Field.typeNameForBuilderSetter(): TypeName {
     val type = type!!
-    val baseClass = type.asTypeName()
+    val baseClass = type.typeName
     return when (encodeMode!!) {
       EncodeMode.REPEATED,
       EncodeMode.PACKED -> List::class.asClassName().parameterizedBy(baseClass)
@@ -2220,7 +2216,7 @@ class KotlinGenerator private constructor(
         CodeBlock.of(
           "%T<%T>(%L = %L, %L = %L, %L = %S)",
           boxClassName,
-          field.type!!.asTypeName(),
+          field.type!!.typeName,
           "tag",
           field.tag,
           "adapter",


### PR DESCRIPTION
In the "decode" section of generated kotlin code we are using the incorrect type when referencing a custom adaptor.