### PR TITLE
Add an exclude to protoPath / sourcePath actions

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -192,8 +192,8 @@ class WirePlugin : Plugin<Project> {
           protoPathInput.debug(task.logger)
         }
         task.outputDirectories = targets.map { target -> project.file(target.outDirectory) }
-        task.sourceInput.set(protoSourceInput.toLocations(project.providers))
-        task.protoInput.set(protoPathInput.toLocations(project.providers))
+        task.sourceInput.set(protoSourceInput.toLocations(project))
+        task.protoInput.set(protoPathInput.toLocations(project))
         task.roots = extension.roots.toList()
         task.prunes = extension.prunes.toList()
         task.moves = extension.moves.toList()

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -20,7 +20,6 @@ import com.squareup.wire.gradle.internal.GradleWireLogger
 import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.Target
 import com.squareup.wire.schema.WireRun
-import okio.Path.Companion.toPath
 import org.gradle.api.file.FileCollection
 import org.gradle.api.file.FileTree
 import org.gradle.api.tasks.CacheableTask
@@ -35,8 +34,6 @@ import org.gradle.api.tasks.SkipWhenEmpty
 import org.gradle.api.tasks.SourceTask
 import org.gradle.api.tasks.TaskAction
 import java.io.File
-import java.nio.file.FileSystems
-import java.nio.file.Files
 
 @CacheableTask
 open class WireTask : SourceTask() {
@@ -126,7 +123,7 @@ open class WireTask : SourceTask() {
     }
 
     val wireRun = WireRun(
-      sourcePath = sourceInput.map { expandJarGlobs(it) }.get(),
+      sourcePath = sourceInput.get(),
       protoPath = protoInput.get(),
       treeShakingRoots = if (roots.isEmpty()) includes else roots,
       treeShakingRubbish = if (prunes.isEmpty()) excludes else prunes,
@@ -151,51 +148,5 @@ open class WireTask : SourceTask() {
   @PathSensitive(PathSensitivity.RELATIVE)
   override fun getSource(): FileTree {
     return super.getSource()
-  }
-
-  /**
-   * Expands all glob expressions occurring in [srcInputs] whose base location is a `.jar` file.
-   *
-   * Note that we cannot do it at configuration time because some `.jar` files might be remote.
-   */
-  private fun expandJarGlobs(srcInputs: List<Location>): List<Location> {
-    val (jarInputs, nonJarInputs) = srcInputs.partition { it.base.endsWith(".jar") }
-
-    val expandedJarInputs = mutableSetOf<Location>()
-
-    val jarInputsByBase = jarInputs.groupBy { it.base }
-    for ((jar, inputs) in jarInputsByBase) {
-      val (globInputs, inlinedInputs) = inputs.partition { it.path.contains('*') }
-      expandedJarInputs += inlinedInputs
-
-      if (globInputs.isEmpty()) {
-        continue
-      }
-
-      val jarPath = jar.toPath().toNioPath()
-      FileSystems.newFileSystem(jarPath, null as ClassLoader?).use { jarFs ->
-        val matchers = globInputs.map { jarFs.getPathMatcher("glob:${it.path}") }
-
-        for (root in jarFs.rootDirectories) {
-          Files.walk(root)
-            .map { path ->
-              // The ZipFileProvider implements glob syntax by transforming it to a regex, including
-              // anchors at each end. The file-tree walk yields absolute paths, but the paths we use
-              // in the Wire Gradle plugin are omitting the leading `/`. We thus need to strip the
-              // leading '/' in order for our matchers to work.
-              if (path.isAbsolute) {
-                path.fileSystem.getPath(path.toString().substring(1))
-              } else {
-                path
-              }
-            }
-            .filter { path -> matchers.any { matcher -> matcher.matches(path) } }
-            .map { path -> Location.get(jar, path.toString()) }
-            .forEach { expandedJarInputs += it }
-        }
-      }
-    }
-
-    return nonJarInputs + expandedJarInputs
   }
 }

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -254,6 +254,22 @@ class WirePluginTest {
   }
 
   @Test
+  fun sourceJarMixedWithConflictingProtos() {
+    val fixtureRoot = File("src/test/projects/sourcejar-mixed-conflicts")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":generateProtos")).isNotNull
+    assertThat(result.output)
+      .contains("Writing com.squareup.dinosaurs.Dinosaur")
+      .contains("Writing com.squareup.geology.Period")
+      .doesNotContain("Writing com.excluded.Martian")
+      .contains(
+        "src/test/projects/sourcejar-mixed-conflicts/build/generated/source/wire"
+      )
+  }
+
+  @Test
   fun sourceJarRemoteOneJarMultipleFiles() {
     val fixtureRoot = File("src/test/projects/sourcejar-remote-many-files")
 
@@ -556,6 +572,31 @@ class WirePluginTest {
         File(fixtureRoot, "build/generated/source/wire/com/squareup/geology/Period.kt")
     assertThat(generatedProto1).exists()
     assertThat(generatedProto2).exists()
+  }
+
+  @Test
+  fun sourceDirExclude() {
+    val fixtureRoot = File("src/test/projects/sourcedir-exclude")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":generateMainProtos")).isNotNull
+    assertThat(result.output)
+      .contains("Writing com.squareup.dinosaurs.Dinosaur")
+      .contains("Writing com.squareup.geology.Period")
+      .contains("src/test/projects/sourcedir-exclude/build/generated/source/wire")
+    assertThat(result.output)
+      .doesNotContain("Writing com.excluded.Martian")
+
+    val includedFile1 =
+      File(fixtureRoot, "build/generated/source/wire/com/squareup/dinosaurs/Dinosaur.kt")
+    val includedFile2 =
+      File(fixtureRoot, "build/generated/source/wire/com/squareup/geology/Period.kt")
+    assertThat(includedFile1).exists()
+    assertThat(includedFile2).exists()
+    val excludedFile =
+      File(fixtureRoot, "build/generated/source/wire/com/excluded/Martian.kt")
+    assertThat(excludedFile).doesNotExist()
   }
 
   @Test

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/build.gradle
@@ -1,0 +1,32 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+mainClassName = 'com.squareup.dinosaurs.Sample'
+
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+  mavenCentral()
+}
+
+dependencies {
+  implementation "com.squareup.wire:wire-runtime-multiplatform:$VERSION_NAME"
+}
+
+wire {
+  sourcePath {
+    srcDir 'src/main/proto'
+    exclude 'excluded/**'
+  }
+  kotlin {}
+}
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "1.8"
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/java/com/squareup/dinosaurs/Sample.kt
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/java/com/squareup/dinosaurs/Sample.kt
@@ -1,0 +1,30 @@
+package com.squareup.dinosaurs
+
+import com.squareup.geology.Period
+import java.io.IOException
+import okio.ByteString.Companion.toByteString
+
+class Sample {
+  @Throws(IOException::class)
+  fun run() {
+    // Create an immutable value object with the Builder API.
+    val stegosaurus = Dinosaur(
+        name = "Stegosaurus",
+        period = Period.JURASSIC,
+        length_meters = 9.0,
+        mass_kilograms = 5_000.0,
+        picture_urls = listOf("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67")
+    )
+    // Encode that value to bytes, and print that as base64.
+    val stegosaurusEncoded = Dinosaur.ADAPTER.encode(stegosaurus)
+    println(stegosaurusEncoded.toByteString().base64())
+  }
+
+  companion object {
+    @Throws(IOException::class)
+    @JvmStatic
+    fun main(args: Array<String>) {
+      Sample().run()
+    }
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/proto/excluded/martian.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/proto/excluded/martian.proto
@@ -1,0 +1,9 @@
+syntax = "proto2";
+
+package excluded;
+
+option java_package = "com.excluded";
+
+message Martian {
+  optional string name = 1;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcedir-exclude/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/build.gradle
@@ -1,0 +1,23 @@
+plugins {
+  id 'application'
+  id 'com.squareup.wire'
+}
+
+// See installProtoJars task in wire-gradle-plugin/build.gradle.kts
+repositories {
+  maven {
+    url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+  }
+}
+
+wire {
+  sourcePath {
+    srcJar 'com.squareup.wire.dinosaur:all-protos-plus-martians:+'
+    exclude 'excluded/**'
+  }
+  sourcePath {
+    srcDir 'src/main/proto'
+    include 'squareup/**/*.proto'
+    exclude 'squareup/geology/period.proto'
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
For all the _totally_ hypothetical times when you want to exclude a single file. 😉 

```
Execution failed for task ':service:protos:mle:generateMainProtos'.
> Same type is getting generated by different messages:
    IpInfo at /Users/lei/.gradle/caches/modules-2/files-2.1/com.squareup.protos/all-protos/20210816.224434/ed19365e5b84c9df8ae125b8e6bf6ee958ae8497/all-protos-20210816.224434.jar/squareup/riskapi/datasources/emailage.proto:51:1
    IpInfo at /Users/lei/.gradle/caches/modules-2/files-2.1/com.squareup.protos/all-protos/20210816.224434/ed19365e5b84c9df8ae125b8e6bf6ee958ae8497/all-protos-20210816.224434.jar/squareup/riskapi/datasources/emailage_rapidrisk.proto:161:1
```

Or when two sources have conflicting files. 😭 