### PR TITLE
(WIP) This PR adds a configuration to the Wire gradle plugin to generate message descriptors

### DIFF
--- a/samples/wire-descriptorgen-sample/build.gradle.kts
+++ b/samples/wire-descriptorgen-sample/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+  kotlin("jvm")
+  id("com.squareup.wire")
+}
+
+val jar by tasks.getting(Jar::class) {
+  manifest {
+    attributes("Automatic-Module-Name" to "wire-descriptorgen-sample")
+  }
+}
+
+dependencies {
+  implementation(deps.wire.descriptor)
+  implementation(project(":samples:wire-descriptorgen-sample:protos"))
+
+  testImplementation(deps.junit)
+  testImplementation(deps.assertj)
+  testImplementation(deps.protobuf.java)
+}
+

--- a/samples/wire-descriptorgen-sample/point-protos/build.gradle.kts
+++ b/samples/wire-descriptorgen-sample/point-protos/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+  kotlin("jvm")
+  id("com.squareup.wire")
+}
+
+wire {
+  protoLibrary = true
+  includeDescriptors = true
+
+  java {}
+}
+
+dependencies {
+  implementation(deps.wire.descriptor)
+}

--- a/samples/wire-descriptorgen-sample/point-protos/src/main/proto/com/squareup/wire/point/point.proto
+++ b/samples/wire-descriptorgen-sample/point-protos/src/main/proto/com/squareup/wire/point/point.proto
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto3";
+
+package com.squareup.wire.point;
+
+option java_package = "com.squareup.wire.point";
+
+message Point {
+  int32 x = 1;
+  int32 y = 2;
+  Color color = 3;
+
+  enum Color {
+    RED = 0;
+    GREEN = 1;
+    YELLOW = 2;
+  }
+}
+
+message PointEvent {
+  oneof whiteboard_event {
+    PointAdded point_added = 1;
+    PointsUpdated points_updated = 2;
+  }
+
+  message PointAdded {
+    Point point = 1;
+  }
+
+  message PointsUpdated {
+    repeated Point points = 1;
+  }
+}
+
+

--- a/samples/wire-descriptorgen-sample/protos/build.gradle.kts
+++ b/samples/wire-descriptorgen-sample/protos/build.gradle.kts
@@ -1,0 +1,20 @@
+plugins {
+  kotlin("jvm")
+  id("com.squareup.wire")
+}
+
+wire {
+  protoLibrary = true
+  includeDescriptors = true
+
+  kotlin {
+    protoPath {
+      srcDir("${project(":samples:wire-descriptorgen-sample:point-protos").projectDir}/src/main/proto")
+    }
+  }
+}
+
+dependencies {
+  api(project(":samples:wire-descriptorgen-sample:point-protos"))
+  implementation(deps.wire.descriptor)
+}

--- a/samples/wire-descriptorgen-sample/protos/src/main/proto/com/squareup/wire/whiteboard/whiteboard.proto
+++ b/samples/wire-descriptorgen-sample/protos/src/main/proto/com/squareup/wire/whiteboard/whiteboard.proto
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package com.squareup.wire.whiteboard;
+
+import "com/squareup/wire/point/point.proto";
+
+option java_package = "com.squareup.wire.whiteboard";
+
+message WhiteBoardEvent {
+  oneof whiteboard_event {
+    BoardInitialised board_initialised = 1;
+    BoardUpdated board_updated = 2;
+  }
+
+  message BoardInitialised {
+    required int32 width = 1;
+    required int32 height = 2;
+  }
+
+  message BoardUpdated {
+    repeated com.squareup.wire.point.Point points = 1;
+  }
+}
+
+

--- a/samples/wire-descriptorgen-sample/src/test/kotlin/com/squareup/wire/descriptor/sample/ProtoTypeDescriptorIntegrationTest.kt
+++ b/samples/wire-descriptorgen-sample/src/test/kotlin/com/squareup/wire/descriptor/sample/ProtoTypeDescriptorIntegrationTest.kt
@@ -1,0 +1,36 @@
+package com.squareup.wire.descriptor.sample
+
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Label
+import com.google.protobuf.DescriptorProtos.FieldDescriptorProto.Type
+import com.squareup.wire.point.Point
+import com.squareup.wire.protos.ProtoTypeDescriptor
+import com.squareup.wire.whiteboard.WhiteBoardEvent
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class ProtoTypeDescriptorIntegrationTest {
+  @Test
+  fun getMessageDescriptor() {
+    val event = WhiteBoardEvent.BoardUpdated(
+      points = listOf(
+        Point(3, 3, Point.Color.RED),
+        Point(0, 0, Point.Color.YELLOW)
+      )
+    )
+
+    val descriptor = ProtoTypeDescriptor.getMessageDescriptor(event)!!
+    assertThat(descriptor.toProto()).isEqualTo(
+      DescriptorProtos.DescriptorProto.newBuilder()
+        .setName("BoardUpdated")
+        .addField(DescriptorProtos.FieldDescriptorProto.newBuilder()
+          .setName("points")
+          .setNumber(1)
+          .setLabel(Label.LABEL_REPEATED)
+          .setType(Type.TYPE_MESSAGE)
+          .setTypeName(".${Point::class.java.canonicalName}")
+          .build())
+        .build()
+    )
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,9 @@ include(":samples:wire-grpc-sample:client")
 include(":samples:wire-grpc-sample:protos")
 include(":samples:wire-grpc-sample:server")
 include(":samples:wire-grpc-sample:server-plain")
+include(":samples:wire-descriptorgen-sample:protos")
+include(":samples:wire-descriptorgen-sample:point-protos")
+include(":samples:wire-descriptorgen-sample")
 include(":wire-benchmarks")
 include(":wire-grpc-tests")
 include(":wire-protoc-compatibility-tests")
@@ -38,5 +41,7 @@ includeBuild("wire-library") {
     substitute(module("com.squareup.wire:wire-runtime")).with(project(":wire-runtime"))
     substitute(module("com.squareup.wire:wire-schema")).with(project(":wire-schema"))
     substitute(module("com.squareup.wire:wire-test-utils")).with(project(":wire-test-utils"))
+    substitute(module("com.squareup.wire:wire-descriptor")).with(project(":wire-descriptor"))
+    substitute(module("com.squareup.wire:wire-kafka")).with(project(":wire-kafka"))
   }
 }

--- a/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
@@ -130,5 +130,10 @@ object deps {
     val runtime = "com.squareup.wire:wire-runtime"
     val schema = "com.squareup.wire:wire-schema"
     val testUtils = "com.squareup.wire:wire-test-utils"
+    var descriptor = "com.squareup.wire:wire-descriptor"
   }
+
+  val schemaRegistryClient = "io.confluent:kafka-schema-registry-client:6.2.0"
+  val googleApisCommonProtos = "com.google.api.grpc:proto-google-common-protos:2.3.2"
+  val kafkaClients = "org.apache.kafka:kafka-clients:2.4.0"
 }

--- a/wire-library/settings.gradle.kts
+++ b/wire-library/settings.gradle.kts
@@ -18,6 +18,8 @@ include(":wire-schema")
 include(":wire-swift-generator")
 include(":wire-test-utils")
 include(":wire-tests")
+include(":wire-descriptor")
+include(":wire-kafka")
 
 if (startParameter.projectProperties.get("swift") != "false") {
   include(":wire-runtime-swift")

--- a/wire-library/wire-compiler/build.gradle.kts
+++ b/wire-library/wire-compiler/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
   implementation(project(":wire-java-generator"))
   implementation(project(":wire-swift-generator"))
   implementation(project(":wire-profiles"))
+  implementation(project(":wire-descriptor"))
   implementation(deps.okio.jvm)
   implementation(deps.guava)
   implementation(deps.kotlin.serialization)

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -972,6 +972,28 @@ class WireRunTest {
     }
   }
 
+  @Test
+  fun generateMessageDescriptor() {
+    writeDocumentationProto()
+    writeTriangleProto()
+    writeNestedPolygon()
+
+    val wireRun = WireRun(
+        sourcePath = listOf(Location.get("polygons/src/main/proto")),
+        protoPath = listOf(Location.get("docs/src/main/proto")),
+        targets = listOf(
+            JavaTarget(outDirectory = "generated/java", exclusive = false),
+            FileDescriptorTarget(outDirectory = "wire/message-descriptors", exclusive = false)
+        )
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.find("wire/message-descriptors")).containsExactlyInAnyOrder(
+        "wire/message-descriptors/squareup/polygons/nested_polygon.desc",
+        "wire/message-descriptors/squareup/polygons/triangle.desc",
+    )
+  }
+
   private fun writeOrangeProto() {
     fs.add("colors/src/main/proto/squareup/colors/orange.proto", """
           |syntax = "proto2";
@@ -1069,6 +1091,36 @@ class WireRunTest {
         |message Octagon {
         |  option (documentation_url) = "https://en.wikipedia.org/wiki/Octagon";
         |  optional bool stop = 1;
+        |}
+        """.trimMargin())
+  }
+
+  private fun writeNestedPolygon() {
+    fs.add("polygons/src/main/proto/squareup/polygons/nested_polygon.proto", """
+        |syntax = "proto2";
+        |
+        |option java_package = "com.squareup.polygons";
+        |
+        |package squareup.polygons;
+        |import "squareup/options/documentation.proto";
+        |import "squareup/polygons/triangle.proto";
+        |
+        |message SquareTriangle {
+        |  option (documentation_url) = "https://en.wikipedia.org/wiki/NestedPolygon";
+        |  optional uint64 length = 1;
+        |  optional NestedTriangle nested_triangle = 2;
+        |  optional Format format = 3;
+        |  
+        |  message NestedTriangle {
+        |    optional uint32 level = 1;
+        |    optional Triangle triangle = 2;
+        |    optional Format format = 3;
+        |  }
+        |}
+        |
+        |message Format {
+        |  optional uint32 line_width = 1;
+        |  optional uint32 color = 2;
         |}
         """.trimMargin())
   }

--- a/wire-library/wire-descriptor/build.gradle.kts
+++ b/wire-library/wire-descriptor/build.gradle.kts
@@ -1,0 +1,31 @@
+plugins {
+  kotlin("jvm")
+  id("internal-publishing")
+}
+
+dependencies {
+  implementation(deps.okio.jvm)
+  implementation(deps.protobuf.java)
+  implementation(project(":wire-schema"))
+  implementation("io.github.classgraph:classgraph:4.8.115")
+
+  testImplementation(deps.wire.gsonSupport)
+  testImplementation(deps.wire.moshiAdapter)
+  testImplementation(deps.assertj)
+  testImplementation(deps.junit)
+  testImplementation(deps.protobuf.javaUtil)
+  testImplementation(deps.wire.testUtils)
+}
+
+val test by tasks.getting(Test::class) {
+  testLogging {
+    events("passed", "skipped", "failed")
+    exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+  }
+}
+
+val jar by tasks.getting(Jar::class) {
+  manifest {
+    attributes("Automatic-Module-Name" to "wire-descriptor")
+  }
+}

--- a/wire-library/wire-descriptor/gradle.properties
+++ b/wire-library/wire-descriptor/gradle.properties
@@ -1,0 +1,4 @@
+POM_ARTIFACT_ID=wire-descriptor
+POM_NAME=Wire
+POM_DESCRIPTION=Wire descriptor generates and manages protobufs file descriptors.
+POM_PACKAGING=jar

--- a/wire-library/wire-descriptor/src/main/kotlin/com/squareup/wire/protos/FileDescriptorGenerator.kt
+++ b/wire-library/wire-descriptor/src/main/kotlin/com/squareup/wire/protos/FileDescriptorGenerator.kt
@@ -1,0 +1,73 @@
+package com.squareup.wire.protos
+
+import com.squareup.wire.schema.EnumType
+import com.squareup.wire.schema.MessageType
+import com.squareup.wire.schema.ProtoFile
+import com.squareup.wire.schema.Schema
+import com.squareup.wire.schema.Type
+import com.squareup.wire.schema.internal.SchemaEncoder
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+
+/**
+ * Generates file descriptors for the given type.
+ */
+class FileDescriptorGenerator(
+  private val schema: Schema,
+  private val fs: FileSystem,
+  private val outDirectory: String
+) {
+
+  private val encoder: SchemaEncoder = SchemaEncoder(schema)
+  private val generatedDescriptors = mutableMapOf<ProtoFile, Path>()
+
+  fun generate(type: Type): Path? {
+    if (shouldGenerateDescriptor(type)) {
+      return generateFileDescriptor(type)
+    }
+    return null
+  }
+
+  private fun generateFileDescriptor(type: Type): Path? {
+    val protoFile = schema.protoFile(type.type)
+      ?: throw RuntimeException("Could not find proto file for type ${type.type.simpleName}")
+
+    if (generatedDescriptors.contains(protoFile)) {
+      //return null otherwise Wire's Target errors if the same path is returned
+      //for two different types.
+      return null
+    }
+    val path = writeFileDescriptor(protoFile)
+    generatedDescriptors[protoFile] = path
+    type.nestedTypes.forEach { generateFileDescriptor(it) }
+    return path
+  }
+
+  private fun getDescriptorPath(protoFile: ProtoFile): String {
+    val packageName = protoFile.packageName ?: ""
+    val descriptorName = protoFile.name().plus(".desc")
+    val packagePath = packageName.replace(".", "/")
+    return "$packagePath/$descriptorName"
+  }
+
+  private fun writeFileDescriptor(protoFile: ProtoFile): Path {
+    val content = encoder.encode(protoFile)
+    val descriptorPath = getDescriptorPath(protoFile)
+    val outputPath = outDirectory.toPath() / descriptorPath
+    fs.createDirectories(outputPath.parent!!)
+    fs.write(outputPath) {
+      write(content)
+    }
+    return outputPath
+  }
+
+  private fun shouldGenerateDescriptor(type: Type): Boolean =
+      isMessageType(type) || isEnumType(type)
+
+  private fun isMessageType(type: Type) =
+      type.javaClass == MessageType::class.java
+
+  private fun isEnumType(type: Type) =
+      type.javaClass == EnumType::class.java
+}

--- a/wire-library/wire-descriptor/src/main/kotlin/com/squareup/wire/protos/ProtoTypeDescriptor.kt
+++ b/wire-library/wire-descriptor/src/main/kotlin/com/squareup/wire/protos/ProtoTypeDescriptor.kt
@@ -1,0 +1,45 @@
+package com.squareup.wire.protos
+
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.Descriptors
+import com.google.protobuf.Descriptors.Descriptor
+import com.squareup.wire.Message
+
+/**
+ * Utility class to retrieve type descriptor from encoded Wire file descriptors.
+ */
+object ProtoTypeDescriptor {
+  fun <T: Message<T, *>> getMessageDescriptor(record: T): Descriptor? {
+    val sourceFile = record.adapter.sourceFile ?: return null
+    val descriptor = getFileDescriptor(sourceFile)
+
+    val recordClass = record::class.java
+    val className = recordClass.canonicalName.removePrefix("${recordClass.packageName}.")
+    val types = className.split(".").iterator()
+    val typeName = types.next()
+    var messageDescriptor = descriptor.messageTypes.find { it.name == typeName }
+      ?: throw RuntimeException("could not find type $typeName in descriptor ${descriptor.fullName}")
+    types.forEachRemaining { type ->
+      messageDescriptor = messageDescriptor.nestedTypes.find { it.name == type }
+        ?: throw RuntimeException("could not find type $type in descriptor ${descriptor.fullName}")
+      }
+    return messageDescriptor
+  }
+
+  private fun getFileDescriptor(sourceFile: String): Descriptors.FileDescriptor {
+    val stream = ClassLoader.getSystemResourceAsStream(sourceFile)
+    // TODO(kalfonso): need to pass extension registry?
+    val descriptorProto = DescriptorProtos.FileDescriptorProto.parseFrom(stream)
+    return Descriptors.FileDescriptor.buildFrom(
+      descriptorProto,
+      dependencies(descriptorProto).toTypedArray()
+    )
+  }
+
+  private fun dependencies(descriptorProto: DescriptorProtos.FileDescriptorProto): List<Descriptors.FileDescriptor> {
+    return descriptorProto.dependencyList.map {
+      val sourceFile = it.removeSuffix(".proto") + ".desc"
+      getFileDescriptor(sourceFile)
+    }
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
@@ -129,6 +129,15 @@ open class WireExtension(project: Project) {
   @get:Optional
   var protoLibrary = false
 
+  /**
+   * True to generate `.proto` files descriptors into the output resources. Use this when you need
+   * file descriptors generated for your protos.
+   *
+   */
+  @get:Input
+  @get:Optional
+  var includeDescriptors = false
+
   @InputFiles
   @Optional
   fun getSourcePaths() = sourcePaths.toSet()
@@ -262,6 +271,12 @@ open class WireExtension(project: Project) {
     val move = objectFactory.newInstance(Move::class.java)
     action.execute(move)
     moves += move
+  }
+
+  fun fileDescriptor(action: Action<FileDescriptorOutput>) {
+    val fileDescriptorOutput = objectFactory.newInstance(FileDescriptorOutput::class.java)
+    action.execute(fileDescriptorOutput)
+    outputs += fileDescriptorOutput
   }
 
   open class ProtoRootSet {

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -18,6 +18,7 @@ package com.squareup.wire.gradle
 import com.squareup.wire.kotlin.RpcCallStyle
 import com.squareup.wire.kotlin.RpcRole
 import com.squareup.wire.schema.CustomTargetBeta
+import com.squareup.wire.schema.FileDescriptorTarget
 import com.squareup.wire.schema.JavaTarget
 import com.squareup.wire.schema.KotlinTarget
 import com.squareup.wire.schema.ProtoTarget
@@ -130,5 +131,11 @@ open class CustomOutput @Inject constructor() : WireOutput() {
         customHandlerClass = customHandlerClass
             ?: throw IllegalArgumentException("customHandlerClass required")
     )
+  }
+}
+
+open class FileDescriptorOutput @Inject constructor() : WireOutput() {
+  override fun toTarget(outputDirectory: String): FileDescriptorTarget {
+    return FileDescriptorTarget(outDirectory = outputDirectory)
   }
 }

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.gradle
 
 import com.squareup.wire.VERSION
+import com.squareup.wire.gradle.internal.descriptorsOutputPath
 import com.squareup.wire.gradle.internal.libraryProtoOutputPath
 import com.squareup.wire.gradle.internal.targetDefaultOutputPath
 import com.squareup.wire.gradle.kotlin.Source
@@ -106,6 +107,17 @@ class WirePlugin : Plugin<Project> {
       }
       extension.proto { protoOutput ->
         protoOutput.out = libraryProtoSources.path
+      }
+    }
+
+    if (extension.includeDescriptors) {
+      val descriptorsSources = File(project.descriptorsOutputPath())
+      val sourceSets = project.extensions.getByType(SourceSetContainer::class.java)
+      sourceSets.getByName("main") { main: SourceSet ->
+        main.resources.srcDir(descriptorsSources)
+      }
+      extension.fileDescriptor() { descriptorOutput ->
+        descriptorOutput.out = descriptorsSources.path
       }
     }
 
@@ -214,7 +226,7 @@ class WirePlugin : Plugin<Project> {
       project.tasks.named(PARENT_TASK).configure {
         it.dependsOn(task)
       }
-      if (extension.protoLibrary) {
+      if (extension.protoLibrary || extension.includeDescriptors) {
         project.tasks.named("processResources").configure {
           it.dependsOn(task)
         }

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/internal/projects.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/internal/projects.kt
@@ -9,3 +9,7 @@ internal fun Project.targetDefaultOutputPath(): String {
 internal fun Project.libraryProtoOutputPath(): String {
   return "${buildDir}/wire/proto-sources"
 }
+
+internal fun Project.descriptorsOutputPath(): String {
+  return "${buildDir}/wire/proto-descriptors"
+}

--- a/wire-library/wire-java-generator/build.gradle.kts
+++ b/wire-library/wire-java-generator/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
   implementation(project(":wire-profiles"))
   implementation(deps.okio.jvm)
   implementation(deps.guava)
+  implementation(deps.protobuf.java)
   api(deps.javapoet)
   compileOnly(deps.jsr305)
   testImplementation(project(":wire-test-utils"))

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -956,11 +956,12 @@ public final class JavaGenerator {
       adapter.addModifiers(PUBLIC, ABSTRACT);
     }
 
+    String path = type.getLocation().getPath().replace(".proto", ".desc");
     adapter.addMethod(MethodSpec.constructorBuilder()
         .addModifiers(PUBLIC)
-        .addStatement("super($T.LENGTH_DELIMITED, $T.class, $S, $T.$L, null)",
+        .addStatement("super($T.LENGTH_DELIMITED, $T.class, $S, $T.$L, null, $S)",
             FieldEncoding.class, javaType, type.getType().getTypeUrl(), Syntax.class,
-            type.getSyntax().name())
+            type.getSyntax().name(), path)
         .build());
 
     if (!useBuilder) {

--- a/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -156,7 +156,7 @@ public final class JavaGeneratorTest {
         + "  private ProtoAdapter<Map<String, Bar>> bars;\n"
         + "\n"
         + "  public AbstractProtoMessageAdapter() {\n"
-        + "    super(FieldEncoding.LENGTH_DELIMITED, JavaMessage.class, \"type.googleapis.com/original.proto.ProtoMessage\", Syntax.PROTO_2, null);\n"
+        + "    super(FieldEncoding.LENGTH_DELIMITED, JavaMessage.class, \"type.googleapis.com/original.proto.ProtoMessage\", Syntax.PROTO_2, null, \"message.desc\");\n"
         + "  }\n"
         + "\n"
         + "  public abstract Foo field(JavaMessage value);\n"

--- a/wire-library/wire-kafka/build.gradle.kts
+++ b/wire-library/wire-kafka/build.gradle.kts
@@ -1,0 +1,40 @@
+repositories {
+    maven("https://packages.confluent.io/maven/")
+    mavenCentral()
+}
+
+plugins {
+    kotlin("jvm")
+    id("internal-publishing")
+}
+
+dependencies {
+    implementation(deps.okio.jvm)
+    implementation(deps.protobuf.java)
+    implementation(deps.schemaRegistryClient)
+    implementation(deps.googleApisCommonProtos)
+    implementation(deps.kafkaClients)
+    implementation(project(":wire-descriptor"))
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-core-jvm:1.2.2")
+    implementation("io.confluent:kafka-protobuf-types:6.2.0")
+    implementation("io.confluent:kafka-protobuf-provider:6.2.0")
+    implementation("io.confluent:kafka-protobuf-serializer:6.2.0")
+
+    testImplementation(deps.assertj)
+    testImplementation(deps.junit)
+    testImplementation(deps.protobuf.javaUtil)
+    testImplementation(project(":wire-test-utils"))
+}
+
+val test by tasks.getting(Test::class) {
+    testLogging {
+        events("passed", "skipped", "failed")
+        exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
+    }
+}
+
+val jar by tasks.getting(Jar::class) {
+    manifest {
+        attributes("Automatic-Module-Name" to "wire-kafka")
+    }
+}

--- a/wire-library/wire-kafka/src/main/kotlin/com/squareup/wire/kafka/KafkaWireSerializer.kt
+++ b/wire-library/wire-kafka/src/main/kotlin/com/squareup/wire/kafka/KafkaWireSerializer.kt
@@ -1,0 +1,251 @@
+package com.squareup.wire.kafka
+
+import com.google.protobuf.Descriptors.Descriptor
+import com.squareup.wire.Message
+import com.squareup.wire.protos.ProtoTypeDescriptor
+import com.squareup.wire.schema.internal.parser.ProtoFileElement
+import io.confluent.kafka.schemaregistry.ParsedSchema
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient
+import io.confluent.kafka.schemaregistry.client.rest.entities.Schema
+import io.confluent.kafka.schemaregistry.client.rest.entities.SchemaReference
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema
+import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDe
+import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializerConfig
+import io.confluent.kafka.serializers.subject.strategy.ReferenceSubjectNameStrategy
+import org.apache.kafka.common.cache.Cache
+import org.apache.kafka.common.cache.LRUCache
+import org.apache.kafka.common.cache.SynchronizedCache
+import org.apache.kafka.common.errors.InvalidConfigurationException
+import org.apache.kafka.common.errors.SerializationException
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.nio.ByteBuffer
+
+class KafkaWireSerializer<T: Message<T, *>>(
+  private val client: SchemaRegistryClient?,
+  private val props: Map<String?, *>?
+): AbstractKafkaSchemaSerDe() {
+
+  private val isKey = false
+  private val config = KafkaProtobufSerializerConfig(props)
+  private var schemaCache: Cache<Descriptor, ProtobufSchema>? = null
+
+  init {
+    schemaCache = SynchronizedCache(LRUCache(DEFAULT_CACHE_CAPACITY))
+  }
+
+  constructor(): this(null, null)
+
+  constructor(client: SchemaRegistryClient): this(client, null)
+
+  fun serialize(topic: String?, record: T): ByteArray? {
+    val descriptor: Descriptor = ProtoTypeDescriptor.getMessageDescriptor(record)
+    var schema = schemaCache!![descriptor]
+    if (schema == null) {
+      schema = ProtobufSchema(descriptor)
+      try {
+        // Ensure dependencies are resolved before caching
+        schema = resolveDependencies(
+          schemaRegistry, config.autoRegisterSchema(),
+          config.useLatestVersion(), config.latestCompatibilityStrict, latestVersions,
+          config.referenceSubjectNameStrategyInstance(), topic, isKey, schema
+        )
+      } catch (e: IOException) {
+        throw SerializationException("Error serializing Protobuf message", e)
+      } catch (e: RestClientException) {
+        throw SerializationException("Error serializing Protobuf message", e)
+      }
+      schemaCache!!.put(descriptor, schema)
+    }
+    return serializeImpl(
+      getSubjectName(topic, isKey, record, schema),
+      topic, isKey, record, schema
+    )
+  }
+
+  fun close() {}
+
+  @Throws(
+    SerializationException::class,
+    InvalidConfigurationException::class
+  ) protected fun serializeImpl(
+    subject: String?, topic: String?, isKey: Boolean, record: T?, schema: ProtobufSchema
+  ): ByteArray? {
+    // null needs to treated specially since the client most likely just wants to send
+    // an individual null value instead of making the subject a null type. Also, null in
+    // Kafka has a special meaning for deletion in a topic with the compact retention policy.
+    // Therefore, we will bypass schema registration and return a null value in Kafka, instead
+    // of an encoded null.
+    var schema = schema
+    if (record == null) {
+      return null
+    }
+    var restClientErrorMsg = ""
+    return try {
+      schema = resolveDependencies(
+        schemaRegistry, config.autoRegisterSchema(),
+        config.useLatestVersion(), config.latestCompatibilityStrict, latestVersions,
+        config.referenceSubjectNameStrategyInstance(), topic, isKey, schema
+      )!!
+      val id: Int
+      if (config.autoRegisterSchema()) {
+        restClientErrorMsg = "Error registering Protobuf schema: "
+        id = schemaRegistry.register(subject, schema)
+      } else if (config.useLatestVersion()) {
+        restClientErrorMsg = "Error retrieving latest version: "
+        schema = lookupLatestVersion(subject, schema, config.latestCompatibilityStrict) as ProtobufSchema
+        id = schemaRegistry.getId(subject, schema)
+      } else {
+        restClientErrorMsg = "Error retrieving Protobuf schema: "
+        id = schemaRegistry.getId(subject, schema)
+      }
+      val out = ByteArrayOutputStream()
+      out.write(MAGIC_BYTE.toInt())
+      out.write(ByteBuffer.allocate(idSize).putInt(id).array())
+      // TODO: load from classpath
+      val indexes = schema.toMessageIndexes(ProtoTypeDescriptor.getMessageDescriptor(record).fullName)
+      out.write(indexes.toByteArray())
+      record.encode(out)
+      val bytes: ByteArray = out.toByteArray()
+      out.close()
+      bytes
+    } catch (e: IOException) {
+      throw SerializationException("Error serializing Protobuf message", e)
+    } catch (e: RuntimeException) {
+      throw SerializationException("Error serializing Protobuf message", e)
+    } catch (e: RestClientException) {
+      throw toKafkaException(e, restClientErrorMsg + schema)
+    }
+  }
+
+  /**
+   * Resolve schema dependencies recursively.
+   *
+   * @param schemaRegistry     schema registry client
+   * @param autoRegisterSchema whether to automatically register schemas
+   * @param useLatestVersion   whether to use the latest schema version for serialization
+   * @param latestCompatStrict whether to check that the latest schema version is backward
+   * compatible with the schema of the object
+   * @param latestVersions     an optional cache of latest schema versions, may be null
+   * @param strategy           the strategy for determining the subject name for a reference
+   * @param topic              the topic
+   * @param isKey              whether the object is the record key
+   * @param schema             the schema
+   * @return the schema with resolved dependencies
+   */
+  @Throws(
+    IOException::class,
+    RestClientException::class
+  ) private fun resolveDependencies(
+    schemaRegistry: SchemaRegistryClient?,
+    autoRegisterSchema: Boolean,
+    useLatestVersion: Boolean,
+    latestCompatStrict: Boolean,
+    latestVersions: Cache<SubjectSchema, ParsedSchema>,
+    strategy: ReferenceSubjectNameStrategy?,
+    topic: String?,
+    isKey: Boolean,
+    schema: ProtobufSchema
+  ): ProtobufSchema? {
+    if (schema.dependencies().isEmpty() || !schema.references().isEmpty()) {
+      // Dependencies already resolved
+      return schema
+    }
+    val s = resolveDependencies(
+      schemaRegistry!!,
+      autoRegisterSchema,
+      useLatestVersion,
+      latestCompatStrict,
+      latestVersions,
+      strategy!!,
+      topic!!,
+      isKey,
+      null,
+      schema.rawSchema(),
+      schema.dependencies()
+    )
+    return schema.copy(s.references)
+  }
+
+  @Throws(
+    IOException::class,
+    RestClientException::class
+  ) private fun resolveDependencies(
+    schemaRegistry: SchemaRegistryClient,
+    autoRegisterSchema: Boolean,
+    useLatestVersion: Boolean,
+    latestCompatStrict: Boolean,
+    latestVersions: Cache<SubjectSchema, ParsedSchema>,
+    strategy: ReferenceSubjectNameStrategy,
+    topic: String,
+    isKey: Boolean,
+    name: String?,
+    protoFileElement: ProtoFileElement?,
+    dependencies: Map<String, ProtoFileElement>
+  ): Schema {
+    val references: MutableList<SchemaReference> = ArrayList()
+    for (dep in protoFileElement!!.imports) {
+      val subschema: Schema = resolveDependencies(
+        schemaRegistry,
+        autoRegisterSchema,
+        useLatestVersion,
+        latestCompatStrict,
+        latestVersions,
+        strategy,
+        topic,
+        isKey,
+        dep,
+        dependencies[dep],
+        dependencies
+      )
+      references.add(SchemaReference(dep, subschema.getSubject(), subschema.getVersion()))
+    }
+    for (dep in protoFileElement.publicImports) {
+      val subschema: Schema = resolveDependencies(
+        schemaRegistry,
+        autoRegisterSchema,
+        useLatestVersion,
+        latestCompatStrict,
+        latestVersions,
+        strategy,
+        topic,
+        isKey,
+        dep,
+        dependencies[dep],
+        dependencies
+      )
+      references.add(SchemaReference(dep, subschema.getSubject(), subschema.getVersion()))
+    }
+    var schema = ProtobufSchema(protoFileElement, references, dependencies)
+    var id: Int? = null
+    var version: Int? = null
+    val subject: String? =
+      if (name != null) strategy.subjectName(name, topic, isKey, schema) else null
+    if (subject != null) {
+      if (autoRegisterSchema) {
+        id = schemaRegistry.register(subject, schema)
+      } else if (useLatestVersion) {
+        schema = lookupLatestVersion(
+          schemaRegistry, subject, schema, latestVersions, latestCompatStrict
+        ) as ProtobufSchema
+        id = schemaRegistry.getId(subject, schema)
+      } else {
+        id = schemaRegistry.getId(subject, schema)
+      }
+      version = schemaRegistry.getVersion(subject, schema)
+    }
+    return Schema(
+      subject,
+      version,
+      id,
+      schema.schemaType(),
+      schema.references(),
+      schema.canonicalString()
+    )
+  }
+
+  companion object {
+    const val DEFAULT_CACHE_CAPACITY = 1000
+  }
+}

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1305,7 +1305,8 @@ class KotlinGenerator private constructor(
    *    Person::class,
    *    "square.github.io/wire/unknown",
    *    Syntax.PROTO_3,
-   *    null
+   *    null,
+   *    "com/squareup/wire/path.desc",
    *  ) {
    *    override fun encodedSize(value: Person): Int { .. }
    *    override fun encode(writer: ProtoWriter, value: Person) { .. }
@@ -1319,6 +1320,7 @@ class KotlinGenerator private constructor(
     val nameAllocator = nameAllocator(type)
     val parentClassName = generatedTypeName(type)
     val adapterName = nameAllocator["ADAPTER"]
+    val path = type.location.path.removeSuffix(".proto").plus(".desc")
 
     val adapterObject = TypeSpec.anonymousClassBuilder()
         .superclass(ProtoAdapter::class.asClassName().parameterizedBy(parentClassName))
@@ -1329,6 +1331,7 @@ class KotlinGenerator private constructor(
         .addSuperclassConstructorParameter("\n%M",
             MemberName(Syntax::class.asClassName(), type.syntax.name))
         .addSuperclassConstructorParameter("\nnull\n⇤")
+        .addSuperclassConstructorParameter("\n%S", path)
         .addFunction(encodedSizeFun(type))
         .addFunction(encodeFun(type, reverse = false))
         .addFunction(encodeFun(type, reverse = true))

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -41,7 +41,8 @@ expect abstract class ProtoAdapter<E>(
   type: KClass<*>?,
   typeUrl: String?,
   syntax: Syntax,
-  identity: E? = null
+  identity: E? = null,
+  sourceFile: String? = null,
 ) {
   internal val fieldEncoding: FieldEncoding
   val type: KClass<*>?
@@ -74,6 +75,11 @@ expect abstract class ProtoAdapter<E>(
    * | Lists (repeated types)                         | empty list: listOf()          |
    */
   val identity: E?
+
+  /**
+   * Path to the encoded file descriptor.
+   */
+  val sourceFile: String?
 
   internal val packedAdapter: ProtoAdapter<List<E>>?
   internal val repeatedAdapter: ProtoAdapter<List<E>>?

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -32,7 +32,8 @@ actual abstract class ProtoAdapter<E> actual constructor(
   actual val type: KClass<*>?,
   actual val typeUrl: String?,
   actual val syntax: Syntax,
-  actual val identity: E?
+  actual val identity: E?,
+  actual val sourceFile: String?,
 ) {
   internal actual val packedAdapter: ProtoAdapter<List<E>>? = when {
     this is PackedProtoAdapter<*> || this is RepeatedProtoAdapter<*> -> null
@@ -72,8 +73,9 @@ actual abstract class ProtoAdapter<E> actual constructor(
     type: Class<*>,
     typeUrl: String?,
     syntax: Syntax,
-    identity: E?
-  ) : this(fieldEncoding, type.kotlin, typeUrl, syntax, identity)
+    identity: E?,
+    sourceFile: String?,
+  ) : this(fieldEncoding, type.kotlin, typeUrl, syntax, identity, sourceFile)
 
   actual abstract fun redact(value: E): E
 


### PR DESCRIPTION
Java protobuf implementation encodes message descriptors in the generated Java code. We need similar functionality in Wire to be able to use tools like Kafka serialization/deserialization using Schema Registry which uses the encoded descriptors in the Java protobufs generated messages.

This PR adds:
- [X] to ability to generate message descriptors via the Wire plugin. The encoded message descriptors are written to a separate file and added to the resources.
- [X] field to ProtoAdapter to hold the path to the message's encoded file descriptor.
- [X] ```FileDescriptorGenerator``` in its own module with the logic to generate encoded file descriptors.
- [X] ```ProtoTypeDescriptor``` utility class to retrieve a message descriptor.
- [X] a sample project to demonstrate file descriptor generation and retrieving the descriptor for a given message

TODO:
- [] generate encoded file descriptors for Google protos: any.proto, descriptor.proto, duration.proto, etc in ```wire-schema```
- [] add test using above Google protos dependencies.
- [] Generate ```sourceFile``` field also for ```EnumAdapter```?
- [] Split out ```KafkaWireSerializer``` to a separate PR.

Checks:
- [] Code compiles correctly
- [] Created tests which fail without the change (if possible)
- [] All tests passing