### PR TITLE
Add the proto source file to the message adapter

### DIFF
--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -95,7 +95,8 @@ public class Feature(
       Feature::class, 
       "type.googleapis.com/routeguide.Feature", 
       PROTO_2, 
-      null
+      null, 
+      "routeguide/RouteGuideProto.proto"
     ) {
       public override fun encodedSize(`value`: Feature): Int {
         var size = value.unknownFields.size

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -81,7 +81,8 @@ public class FeatureDatabase(
       FeatureDatabase::class, 
       "type.googleapis.com/routeguide.FeatureDatabase", 
       PROTO_2, 
-      null
+      null, 
+      "routeguide/RouteGuideProto.proto"
     ) {
       public override fun encodedSize(`value`: FeatureDatabase): Int {
         var size = value.unknownFields.size

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -89,7 +89,8 @@ public class Point(
       Point::class, 
       "type.googleapis.com/routeguide.Point", 
       PROTO_2, 
-      null
+      null, 
+      "routeguide/RouteGuideProto.proto"
     ) {
       public override fun encodedSize(`value`: Point): Int {
         var size = value.unknownFields.size

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -93,7 +93,8 @@ public class Rectangle(
       Rectangle::class, 
       "type.googleapis.com/routeguide.Rectangle", 
       PROTO_2, 
-      null
+      null, 
+      "routeguide/RouteGuideProto.proto"
     ) {
       public override fun encodedSize(`value`: Rectangle): Int {
         var size = value.unknownFields.size

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -93,7 +93,8 @@ public class RouteNote(
       RouteNote::class, 
       "type.googleapis.com/routeguide.RouteNote", 
       PROTO_2, 
-      null
+      null, 
+      "routeguide/RouteGuideProto.proto"
     ) {
       public override fun encodedSize(`value`: RouteNote): Int {
         var size = value.unknownFields.size

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -120,7 +120,8 @@ public class RouteSummary(
       RouteSummary::class, 
       "type.googleapis.com/routeguide.RouteSummary", 
       PROTO_2, 
-      null
+      null, 
+      "routeguide/RouteGuideProto.proto"
     ) {
       public override fun encodedSize(`value`: RouteSummary): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/RepeatedPackedAndMap.java
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/RepeatedPackedAndMap.java
@@ -144,7 +144,7 @@ public final class RepeatedPackedAndMap extends Message<RepeatedPackedAndMap, Re
     private ProtoAdapter<Map<Integer, Integer>> map_int32_int32;
 
     public ProtoAdapter_RepeatedPackedAndMap() {
-      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.proto2.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.proto2.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null, "collection_types.proto");
     }
 
     @Override

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/java/Dinosaur.java
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/java/Dinosaur.java
@@ -192,7 +192,7 @@ public final class Dinosaur extends Message<Dinosaur, Dinosaur.Builder> {
 
   private static final class ProtoAdapter_Dinosaur extends ProtoAdapter<Dinosaur> {
     public ProtoAdapter_Dinosaur() {
-      super(FieldEncoding.LENGTH_DELIMITED, Dinosaur.class, "type.googleapis.com/squareup.dinosaurs.java.Dinosaur", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Dinosaur.class, "type.googleapis.com/squareup.dinosaurs.java.Dinosaur", Syntax.PROTO_2, null, "dinosaur_java.proto");
     }
 
     @Override

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -188,7 +188,8 @@ public class Dinosaur(
       Dinosaur::class, 
       "type.googleapis.com/squareup.dinosaurs.javainteropkotlin.Dinosaur", 
       PROTO_2, 
-      null
+      null, 
+      "dinosaur_java_interop_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -124,7 +124,8 @@ public class Dinosaur(
       Dinosaur::class, 
       "type.googleapis.com/squareup.dinosaurs.kotlin.Dinosaur", 
       PROTO_2, 
-      null
+      null, 
+      "dinosaur_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordJava.java
+++ b/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordJava.java
@@ -254,7 +254,7 @@ public final class KeywordJava extends Message<KeywordJava, KeywordJava.Builder>
     private ProtoAdapter<Map<String, String>> package_;
 
     public ProtoAdapter_KeywordJava() {
-      super(FieldEncoding.LENGTH_DELIMITED, KeywordJava.class, "type.googleapis.com/squareup.proto2.keywords.KeywordJava", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, KeywordJava.class, "type.googleapis.com/squareup.proto2.keywords.KeywordJava", Syntax.PROTO_2, null, "keyword_java.proto");
     }
 
     @Override

--- a/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -194,7 +194,8 @@ public class KeywordKotlin(
       KeywordKotlin::class, 
       "type.googleapis.com/squareup.proto2.keywords.KeywordKotlin", 
       PROTO_2, 
-      null
+      null, 
+      "keyword_kotlin.proto"
     ) {
       private val funAdapter: ProtoAdapter<Map<String, String>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING) }

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -958,9 +958,9 @@ public final class JavaGenerator {
 
     adapter.addMethod(MethodSpec.constructorBuilder()
         .addModifiers(PUBLIC)
-        .addStatement("super($T.LENGTH_DELIMITED, $T.class, $S, $T.$L, null)",
+        .addStatement("super($T.LENGTH_DELIMITED, $T.class, $S, $T.$L, null, $S)",
             FieldEncoding.class, javaType, type.getType().getTypeUrl(), Syntax.class,
-            type.getSyntax().name())
+            type.getSyntax().name(), type.getLocation().getPath())
         .build());
 
     if (!useBuilder) {

--- a/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-library/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -156,7 +156,7 @@ public final class JavaGeneratorTest {
         + "  private ProtoAdapter<Map<String, Bar>> bars;\n"
         + "\n"
         + "  public AbstractProtoMessageAdapter() {\n"
-        + "    super(FieldEncoding.LENGTH_DELIMITED, JavaMessage.class, \"type.googleapis.com/original.proto.ProtoMessage\", Syntax.PROTO_2, null);\n"
+        + "    super(FieldEncoding.LENGTH_DELIMITED, JavaMessage.class, \"type.googleapis.com/original.proto.ProtoMessage\", Syntax.PROTO_2, null, \"message.proto\");\n"
         + "  }\n"
         + "\n"
         + "  public abstract Foo field(JavaMessage value);\n"

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1305,7 +1305,8 @@ class KotlinGenerator private constructor(
    *    Person::class,
    *    "square.github.io/wire/unknown",
    *    Syntax.PROTO_3,
-   *    null
+   *    null,
+   *    "com/squareup/wire/path.proto",
    *  ) {
    *    override fun encodedSize(value: Person): Int { .. }
    *    override fun encode(writer: ProtoWriter, value: Person) { .. }
@@ -1328,7 +1329,8 @@ class KotlinGenerator private constructor(
         .addSuperclassConstructorParameter("\n%S", type.type.typeUrl!!)
         .addSuperclassConstructorParameter("\n%M",
             MemberName(Syntax::class.asClassName(), type.syntax.name))
-        .addSuperclassConstructorParameter("\nnull\n⇤")
+        .addSuperclassConstructorParameter("\nnull")
+        .addSuperclassConstructorParameter("\n%S\n⇤", type.location.path)
         .addFunction(encodedSizeFun(type))
         .addFunction(encodeFun(type, reverse = false))
         .addFunction(encodeFun(type, reverse = true))

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/RepeatedPackedAndMap.java
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/RepeatedPackedAndMap.java
@@ -144,7 +144,7 @@ public final class RepeatedPackedAndMap extends Message<RepeatedPackedAndMap, Re
     private ProtoAdapter<Map<Integer, Integer>> map_int32_int32;
 
     public ProtoAdapter_RepeatedPackedAndMap() {
-      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.proto2.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.proto2.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null, "collection_types.proto");
     }
 
     @Override

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/java/Dinosaur.java
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/java/Dinosaur.java
@@ -192,7 +192,7 @@ public final class Dinosaur extends Message<Dinosaur, Dinosaur.Builder> {
 
   private static final class ProtoAdapter_Dinosaur extends ProtoAdapter<Dinosaur> {
     public ProtoAdapter_Dinosaur() {
-      super(FieldEncoding.LENGTH_DELIMITED, Dinosaur.class, "type.googleapis.com/squareup.dinosaurs.java.Dinosaur", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Dinosaur.class, "type.googleapis.com/squareup.dinosaurs.java.Dinosaur", Syntax.PROTO_2, null, "dinosaur_java.proto");
     }
 
     @Override

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -188,7 +188,8 @@ public class Dinosaur(
       Dinosaur::class, 
       "type.googleapis.com/squareup.dinosaurs.javainteropkotlin.Dinosaur", 
       PROTO_2, 
-      null
+      null, 
+      "dinosaur_java_interop_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -124,7 +124,8 @@ public class Dinosaur(
       Dinosaur::class, 
       "type.googleapis.com/squareup.dinosaurs.kotlin.Dinosaur", 
       PROTO_2, 
-      null
+      null, 
+      "dinosaur_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: Dinosaur): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/java/Person.java
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/java/Person.java
@@ -354,7 +354,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
     private static final class ProtoAdapter_PhoneNumber extends ProtoAdapter<PhoneNumber> {
       public ProtoAdapter_PhoneNumber() {
-        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.proto2.person.java.Person.PhoneNumber", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.proto2.person.java.Person.PhoneNumber", Syntax.PROTO_2, null, "person_java.proto");
       }
 
       @Override
@@ -415,7 +415,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
   private static final class ProtoAdapter_Person extends ProtoAdapter<Person> {
     public ProtoAdapter_Person() {
-      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.proto2.person.java.Person", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.proto2.person.java.Person", Syntax.PROTO_2, null, "person_java.proto");
     }
 
     @Override

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
@@ -189,7 +189,8 @@ public class Person(
       Person::class, 
       "type.googleapis.com/squareup.proto2.person.javainteropkotlin.Person", 
       PROTO_2, 
-      null
+      null, 
+      "person_java_interop_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
@@ -385,7 +386,8 @@ public class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.proto2.person.javainteropkotlin.Person.PhoneNumber", 
         PROTO_2, 
-        null
+        null, 
+        "person_java_interop_kotlin.proto"
       ) {
         public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
@@ -130,7 +130,8 @@ public class Person(
       Person::class, 
       "type.googleapis.com/squareup.proto2.person.kotlin.Person", 
       PROTO_2, 
-      null
+      null, 
+      "person_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
@@ -293,7 +294,8 @@ public class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.proto2.person.kotlin.Person.PhoneNumber", 
         PROTO_2, 
-        null
+        null, 
+        "person_kotlin.proto"
       ) {
         public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordJava.java
+++ b/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordJava.java
@@ -254,7 +254,7 @@ public final class KeywordJava extends Message<KeywordJava, KeywordJava.Builder>
     private ProtoAdapter<Map<String, String>> package_;
 
     public ProtoAdapter_KeywordJava() {
-      super(FieldEncoding.LENGTH_DELIMITED, KeywordJava.class, "type.googleapis.com/squareup.proto2.keywords.KeywordJava", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, KeywordJava.class, "type.googleapis.com/squareup.proto2.keywords.KeywordJava", Syntax.PROTO_2, null, "keyword_java.proto");
     }
 
     @Override

--- a/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -194,7 +194,8 @@ public class KeywordKotlin(
       KeywordKotlin::class, 
       "type.googleapis.com/squareup.proto2.keywords.KeywordKotlin", 
       PROTO_2, 
-      null
+      null, 
+      "keyword_kotlin.proto"
     ) {
       private val funAdapter: ProtoAdapter<Map<String, String>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING) }

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -41,7 +41,8 @@ expect abstract class ProtoAdapter<E>(
   type: KClass<*>?,
   typeUrl: String?,
   syntax: Syntax,
-  identity: E? = null
+  identity: E? = null,
+  sourceFile: String? = null,
 ) {
   internal val fieldEncoding: FieldEncoding
   val type: KClass<*>?
@@ -74,6 +75,11 @@ expect abstract class ProtoAdapter<E>(
    * | Lists (repeated types)                         | empty list: listOf()          |
    */
   val identity: E?
+
+  /**
+   * Path to the file containing the protobuf definition of this type.
+   */
+  val sourceFile: String?
 
   internal val packedAdapter: ProtoAdapter<List<E>>?
   internal val repeatedAdapter: ProtoAdapter<List<E>>?

--- a/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/jsMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -25,7 +25,8 @@ actual abstract class ProtoAdapter<E> actual constructor(
   actual val type: KClass<*>?,
   actual val typeUrl: String?,
   actual val syntax: Syntax,
-  actual val identity: E?
+  actual val identity: E?,
+  actual val sourceFile: String?
 ) {
   internal actual val packedAdapter: ProtoAdapter<List<E>>? = when {
     this is PackedProtoAdapter<*> || this is RepeatedProtoAdapter<*> -> null

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -32,7 +32,8 @@ actual abstract class ProtoAdapter<E> actual constructor(
   actual val type: KClass<*>?,
   actual val typeUrl: String?,
   actual val syntax: Syntax,
-  actual val identity: E?
+  actual val identity: E?,
+  actual val sourceFile: String?,
 ) {
   internal actual val packedAdapter: ProtoAdapter<List<E>>? = when {
     this is PackedProtoAdapter<*> || this is RepeatedProtoAdapter<*> -> null
@@ -55,6 +56,10 @@ actual abstract class ProtoAdapter<E> actual constructor(
   constructor(fieldEncoding: FieldEncoding, type: Class<*>, typeUrl: String?, syntax: Syntax) :
       this(fieldEncoding, type.kotlin, typeUrl, syntax)
 
+  // Obsolete; for Java classes generated before sourceFile was added.
+  constructor(fieldEncoding: FieldEncoding, type: Class<*>, typeUrl: String?, syntax: Syntax, identity: E?) :
+      this(fieldEncoding, type.kotlin, typeUrl, syntax, identity, null)
+
   // Obsolete; for Kotlin classes generated before typeUrl was added.
   constructor(fieldEncoding: FieldEncoding, type: KClass<*>?) :
       this(fieldEncoding, type, null, Syntax.PROTO_2)
@@ -67,13 +72,24 @@ actual abstract class ProtoAdapter<E> actual constructor(
   constructor(fieldEncoding: FieldEncoding, type: KClass<*>?, typeUrl: String?, syntax: Syntax) :
       this(fieldEncoding, type, typeUrl, syntax, null)
 
+  // Obsolete; for Kotlin classes generated before sourceFile was added.
+  constructor(
+    fieldEncoding: FieldEncoding,
+    type: KClass<*>?,
+    typeUrl: String?,
+    syntax: Syntax,
+    identity: E?
+  ) :
+      this(fieldEncoding, type, typeUrl, syntax, identity, null)
+
   constructor(
     fieldEncoding: FieldEncoding,
     type: Class<*>,
     typeUrl: String?,
     syntax: Syntax,
-    identity: E?
-  ) : this(fieldEncoding, type.kotlin, typeUrl, syntax, identity)
+    identity: E?,
+    sourceFile: String?,
+  ) : this(fieldEncoding, type.kotlin, typeUrl, syntax, identity, sourceFile)
 
   actual abstract fun redact(value: E): E
 

--- a/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/nativeMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -25,7 +25,8 @@ actual abstract class ProtoAdapter<E> actual constructor(
   actual val type: KClass<*>?,
   actual val typeUrl: String?,
   actual val syntax: Syntax,
-  actual val identity: E?
+  actual val identity: E?,
+  actual val sourceFile: String?,
 ) {
   internal actual val packedAdapter: ProtoAdapter<List<E>>? = when {
     this is PackedProtoAdapter<*> || this is RepeatedProtoAdapter<*> -> null

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
@@ -1335,7 +1335,8 @@ public class AllTypes(
       AllTypes::class, 
       "type.googleapis.com/proto3.kotlin.AllTypes", 
       PROTO_3, 
-      null
+      null, 
+      "all_types.proto"
     ) {
       private val map_int32_int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }
@@ -2203,7 +2204,8 @@ public class AllTypes(
         NestedMessage::class, 
         "type.googleapis.com/proto3.kotlin.AllTypes.NestedMessage", 
         PROTO_3, 
-        null
+        null, 
+        "all_types.proto"
       ) {
         public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
@@ -169,7 +169,8 @@ public class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos3.kotlin.person.Person", 
       PROTO_3, 
-      null
+      null, 
+      "person.proto"
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
@@ -348,7 +349,8 @@ public class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos3.kotlin.person.Person.PhoneNumber", 
         PROTO_3, 
-        null
+        null, 
+        "person.proto"
       ) {
         public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -178,7 +178,8 @@ public class FooBar(
       FooBar::class, 
       "type.googleapis.com/squareup.protos.custom_options.FooBar", 
       PROTO_2, 
-      null
+      null, 
+      "custom_options.proto"
     ) {
       public override fun encodedSize(`value`: FooBar): Int {
         var size = value.unknownFields.size
@@ -326,7 +327,8 @@ public class FooBar(
         Nested::class, 
         "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested", 
         PROTO_2, 
-        null
+        null, 
+        "custom_options.proto"
       ) {
         public override fun encodedSize(`value`: Nested): Int {
           var size = value.unknownFields.size
@@ -423,7 +425,8 @@ public class FooBar(
         More::class, 
         "type.googleapis.com/squareup.protos.custom_options.FooBar.More", 
         PROTO_2, 
-        null
+        null, 
+        "custom_options.proto"
       ) {
         public override fun encodedSize(`value`: More): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
@@ -56,7 +56,8 @@ public class MessageWithOptions(
       MessageWithOptions::class, 
       "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions", 
       PROTO_2, 
-      null
+      null, 
+      "custom_options.proto"
     ) {
       public override fun encodedSize(`value`: MessageWithOptions): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -74,7 +74,8 @@ public class DeprecatedProto(
       DeprecatedProto::class, 
       "type.googleapis.com/squareup.protos.kotlin.DeprecatedProto", 
       PROTO_2, 
-      null
+      null, 
+      "deprecated.proto"
     ) {
       public override fun encodedSize(`value`: DeprecatedProto): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -100,7 +100,8 @@ public class Form(
       Form::class, 
       "type.googleapis.com/squareup.protos.kotlin.oneof.Form", 
       PROTO_2, 
-      null
+      null, 
+      "form.proto"
     ) {
       public override fun encodedSize(`value`: Form): Int {
         var size = value.unknownFields.size
@@ -266,7 +267,8 @@ public class Form(
         ButtonElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.ButtonElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: ButtonElement): Int {
           var size = value.unknownFields.size
@@ -329,7 +331,8 @@ public class Form(
         LocalImageElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.LocalImageElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: LocalImageElement): Int {
           var size = value.unknownFields.size
@@ -392,7 +395,8 @@ public class Form(
         RemoteImageElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.RemoteImageElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: RemoteImageElement): Int {
           var size = value.unknownFields.size
@@ -454,7 +458,8 @@ public class Form(
         MoneyElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.MoneyElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: MoneyElement): Int {
           var size = value.unknownFields.size
@@ -516,7 +521,8 @@ public class Form(
         SpacerElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.SpacerElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: SpacerElement): Int {
           var size = value.unknownFields.size
@@ -596,7 +602,8 @@ public class Form(
         TextElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: TextElement): Int {
           var size = value.unknownFields.size
@@ -669,7 +676,8 @@ public class Form(
         CustomizedCardElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CustomizedCardElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: CustomizedCardElement): Int {
           var size = value.unknownFields.size
@@ -733,7 +741,8 @@ public class Form(
         AddressElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.AddressElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: AddressElement): Int {
           var size = value.unknownFields.size
@@ -795,7 +804,8 @@ public class Form(
         TextInputElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextInputElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: TextInputElement): Int {
           var size = value.unknownFields.size
@@ -858,7 +868,8 @@ public class Form(
         OptionPickerElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.OptionPickerElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: OptionPickerElement): Int {
           var size = value.unknownFields.size
@@ -920,7 +931,8 @@ public class Form(
         DetailRowElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.DetailRowElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: DetailRowElement): Int {
           var size = value.unknownFields.size
@@ -983,7 +995,8 @@ public class Form(
         CurrencyConversionFlagsElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CurrencyConversionFlagsElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: CurrencyConversionFlagsElement): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -88,7 +88,8 @@ public class MessageUsingMultipleEnums(
       MessageUsingMultipleEnums::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageUsingMultipleEnums", 
       PROTO_2, 
-      null
+      null, 
+      "same_name_enum.proto"
     ) {
       public override fun encodedSize(`value`: MessageUsingMultipleEnums): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -57,7 +57,8 @@ public class MessageWithStatus(
       MessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageWithStatus", 
       PROTO_2, 
-      null
+      null, 
+      "same_name_enum.proto"
     ) {
       public override fun encodedSize(`value`: MessageWithStatus): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -54,7 +54,8 @@ public class NoFields(
       NoFields::class, 
       "type.googleapis.com/squareup.protos.kotlin.NoFields", 
       PROTO_2, 
-      null
+      null, 
+      "no_fields.proto"
     ) {
       public override fun encodedSize(`value`: NoFields): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -115,7 +115,8 @@ public class OneOfMessage(
       OneOfMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.oneof.OneOfMessage", 
       PROTO_2, 
-      null
+      null, 
+      "one_of.proto"
     ) {
       public override fun encodedSize(`value`: OneOfMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -76,7 +76,8 @@ public class OptionalEnumUser(
       OptionalEnumUser::class, 
       "type.googleapis.com/squareup.protos.kotlin.OptionalEnumUser", 
       PROTO_2, 
-      null
+      null, 
+      "optional_enum.proto"
     ) {
       public override fun encodedSize(`value`: OptionalEnumUser): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -58,7 +58,8 @@ public class OtherMessageWithStatus(
       OtherMessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.OtherMessageWithStatus", 
       PROTO_2, 
-      null
+      null, 
+      "same_name_enum.proto"
     ) {
       public override fun encodedSize(`value`: OtherMessageWithStatus): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
@@ -79,7 +79,8 @@ public class VeryLongProtoNameCausingBrokenLineBreaks(
       VeryLongProtoNameCausingBrokenLineBreaks::class, 
       "type.googleapis.com/squareup.protos.tostring.VeryLongProtoNameCausingBrokenLineBreaks", 
       PROTO_2, 
-      null
+      null, 
+      "to_string.proto"
     ) {
       public override fun encodedSize(`value`: VeryLongProtoNameCausingBrokenLineBreaks): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -1705,7 +1705,8 @@ public class AllTypes(
       AllTypes::class, 
       "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes", 
       PROTO_2, 
-      null
+      null, 
+      "all_types.proto"
     ) {
       private val map_int32_int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }
@@ -2665,7 +2666,8 @@ public class AllTypes(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes.NestedMessage", 
         PROTO_2, 
-        null
+        null, 
+        "all_types.proto"
       ) {
         public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/bool/TrueBoolean.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/bool/TrueBoolean.kt
@@ -72,7 +72,8 @@ public class TrueBoolean(
       TrueBoolean::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.bool.TrueBoolean", 
       PROTO_2, 
-      null
+      null, 
+      "bool.proto"
     ) {
       public override fun encodedSize(`value`: TrueBoolean): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/NoFields.kt
@@ -53,7 +53,8 @@ public class NoFields(
       NoFields::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.NoFields", 
       PROTO_2, 
-      null
+      null, 
+      "edge_cases.proto"
     ) {
       public override fun encodedSize(`value`: NoFields): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
@@ -72,7 +72,8 @@ public class OneBytesField(
       OneBytesField::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.OneBytesField", 
       PROTO_2, 
-      null
+      null, 
+      "edge_cases.proto"
     ) {
       public override fun encodedSize(`value`: OneBytesField): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
@@ -72,7 +72,8 @@ public class OneField(
       OneField::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.OneField", 
       PROTO_2, 
-      null
+      null, 
+      "edge_cases.proto"
     ) {
       public override fun encodedSize(`value`: OneField): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
@@ -84,7 +84,8 @@ public class Recursive(
       Recursive::class, 
       "type.googleapis.com/squareup.protos.kotlin.edgecases.Recursive", 
       PROTO_2, 
-      null
+      null, 
+      "edge_cases.proto"
     ) {
       public override fun encodedSize(`value`: Recursive): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -86,7 +86,8 @@ public class ForeignMessage(
       ForeignMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.foreign.ForeignMessage", 
       PROTO_2, 
-      null
+      null, 
+      "foreign.proto"
     ) {
       public override fun encodedSize(`value`: ForeignMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -79,7 +79,8 @@ public class Mappy(
       Mappy::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Mappy", 
       PROTO_2, 
-      null
+      null, 
+      "map.proto"
     ) {
       private val thingsAdapter: ProtoAdapter<Map<String, Thing>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER) }

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -73,7 +73,8 @@ public class Thing(
       Thing::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Thing", 
       PROTO_2, 
-      null
+      null, 
+      "map.proto"
     ) {
       public override fun encodedSize(`value`: Thing): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -142,7 +142,8 @@ public class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person", 
       PROTO_2, 
-      null
+      null, 
+      "person.proto"
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
@@ -311,7 +312,8 @@ public class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber", 
         PROTO_2, 
-        null
+        null, 
+        "person.proto"
       ) {
         public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
@@ -84,7 +84,8 @@ public class NotRedacted(
       NotRedacted::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.NotRedacted", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: NotRedacted): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
@@ -93,7 +93,8 @@ public class RedactedChild(
       RedactedChild::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedChild", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: RedactedChild): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
@@ -72,7 +72,8 @@ public class RedactedCycleA(
       RedactedCycleA::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedCycleA", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: RedactedCycleA): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
@@ -72,7 +72,8 @@ public class RedactedCycleB(
       RedactedCycleB::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedCycleB", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: RedactedCycleB): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
@@ -85,7 +85,8 @@ public class RedactedExtension(
       RedactedExtension::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedExtension", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: RedactedExtension): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedFields.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedFields.kt
@@ -106,7 +106,8 @@ public class RedactedFields(
       RedactedFields::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedFields", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: RedactedFields): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -93,7 +93,8 @@ public class RedactedOneOf(
       RedactedOneOf::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedOneOf", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_one_of.proto"
     ) {
       public override fun encodedSize(`value`: RedactedOneOf): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -96,7 +96,8 @@ public class RedactedRepeated(
       RedactedRepeated::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedRepeated", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: RedactedRepeated): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
@@ -76,7 +76,8 @@ public class RedactedRequired(
       RedactedRequired::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedRequired", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_test.proto"
     ) {
       public override fun encodedSize(`value`: RedactedRequired): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -143,7 +143,8 @@ public class ExternalMessage(
       ExternalMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.ExternalMessage", 
       PROTO_2, 
-      null
+      null, 
+      "external_message.proto"
     ) {
       public override fun encodedSize(`value`: ExternalMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -239,7 +239,8 @@ public class SimpleMessage(
       SimpleMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage", 
       PROTO_2, 
-      null
+      null, 
+      "simple_message.proto"
     ) {
       public override fun encodedSize(`value`: SimpleMessage): Int {
         var size = value.unknownFields.size
@@ -412,7 +413,8 @@ public class SimpleMessage(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage.NestedMessage", 
         PROTO_2, 
-        null
+        null, 
+        "simple_message.proto"
       ) {
         public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -72,7 +72,8 @@ public class NestedVersionOne(
       NestedVersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionOne", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: NestedVersionOne): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -125,7 +125,8 @@ public class NestedVersionTwo(
       NestedVersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionTwo", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: NestedVersionTwo): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -92,7 +92,8 @@ public class VersionOne(
       VersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionOne", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: VersionOne): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -143,7 +143,8 @@ public class VersionTwo(
       VersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionTwo", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: VersionTwo): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -90,7 +90,8 @@ public class UsesAny(
       UsesAny::class, 
       "type.googleapis.com/squareup.protos.usesany.UsesAny", 
       PROTO_2, 
-      null
+      null, 
+      "uses_any.proto"
     ) {
       public override fun encodedSize(`value`: UsesAny): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -90,7 +90,8 @@ public class EmbeddedMessage(
       EmbeddedMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage", 
       PROTO_2, 
-      null
+      null, 
+      "packed_encoding.proto"
     ) {
       public override fun encodedSize(`value`: EmbeddedMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -83,7 +83,8 @@ public class OuterMessage(
       OuterMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage", 
       PROTO_2, 
-      null
+      null, 
+      "packed_encoding.proto"
     ) {
       public override fun encodedSize(`value`: OuterMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-library/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -376,7 +376,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
 
     private static final class ProtoAdapter_PhoneNumber extends ProtoAdapter<PhoneNumber> {
       public ProtoAdapter_PhoneNumber() {
-        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos.person.Person.PhoneNumber", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos.person.Person.PhoneNumber", Syntax.PROTO_2, null, "person.proto");
       }
 
       @Override
@@ -437,7 +437,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
 
   private static final class ProtoAdapter_Person extends ProtoAdapter<Person> {
     public ProtoAdapter_Person() {
-      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos.person.Person", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos.person.Person", Syntax.PROTO_2, null, "person.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -192,7 +192,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
       private static final class ProtoAdapter_Moo extends ProtoAdapter<Moo> {
         public ProtoAdapter_Moo() {
-          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz.Moo", Syntax.PROTO_2, null);
+          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz.Moo", Syntax.PROTO_2, null, "differentpackage/bar.proto");
         }
 
         @Override
@@ -242,7 +242,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
     private static final class ProtoAdapter_Baz extends ProtoAdapter<Baz> {
       public ProtoAdapter_Baz() {
-        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz", Syntax.PROTO_2, null, "differentpackage/bar.proto");
       }
 
       @Override
@@ -288,7 +288,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.differentpackage.bar.Bar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.differentpackage.bar.Bar", Syntax.PROTO_2, null, "differentpackage/bar.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -93,7 +93,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.differentpackage.foo.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.differentpackage.foo.Foo", Syntax.PROTO_2, null, "differentpackage/foo.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/foobar/protos/bar/Bar.java
@@ -192,7 +192,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
       private static final class ProtoAdapter_Moo extends ProtoAdapter<Moo> {
         public ProtoAdapter_Moo() {
-          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.foobar.Bar.Baz.Moo", Syntax.PROTO_2, null);
+          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.foobar.Bar.Baz.Moo", Syntax.PROTO_2, null, "bar.proto");
         }
 
         @Override
@@ -242,7 +242,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
     private static final class ProtoAdapter_Baz extends ProtoAdapter<Baz> {
       public ProtoAdapter_Baz() {
-        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.foobar.Bar.Baz", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.foobar.Bar.Baz", Syntax.PROTO_2, null, "bar.proto");
       }
 
       @Override
@@ -288,7 +288,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.foobar.Bar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.foobar.Bar", Syntax.PROTO_2, null, "bar.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/foobar/protos/foo/Foo.java
@@ -95,7 +95,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.foobar.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.foobar.Foo", Syntax.PROTO_2, null, "foo.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/HeresAllTheDataRequest.java
@@ -94,7 +94,7 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
 
   private static final class ProtoAdapter_HeresAllTheDataRequest extends ProtoAdapter<HeresAllTheDataRequest> {
     public ProtoAdapter_HeresAllTheDataRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataRequest.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataRequest.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataRequest", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/HeresAllTheDataResponse.java
@@ -94,7 +94,7 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
 
   private static final class ProtoAdapter_HeresAllTheDataResponse extends ProtoAdapter<HeresAllTheDataResponse> {
     public ProtoAdapter_HeresAllTheDataResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataResponse.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataResponse.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataResponse", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/LetsDataRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/LetsDataRequest.java
@@ -94,7 +94,7 @@ public final class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequ
 
   private static final class ProtoAdapter_LetsDataRequest extends ProtoAdapter<LetsDataRequest> {
     public ProtoAdapter_LetsDataRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, LetsDataRequest.class, "type.googleapis.com/com.squareup.services.LetsDataRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, LetsDataRequest.class, "type.googleapis.com/com.squareup.services.LetsDataRequest", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/LetsDataResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/LetsDataResponse.java
@@ -94,7 +94,7 @@ public final class LetsDataResponse extends Message<LetsDataResponse, LetsDataRe
 
   private static final class ProtoAdapter_LetsDataResponse extends ProtoAdapter<LetsDataResponse> {
     public ProtoAdapter_LetsDataResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, LetsDataResponse.class, "type.googleapis.com/com.squareup.services.LetsDataResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, LetsDataResponse.class, "type.googleapis.com/com.squareup.services.LetsDataResponse", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -94,7 +94,7 @@ public final class SendDataRequest extends Message<SendDataRequest, SendDataRequ
 
   private static final class ProtoAdapter_SendDataRequest extends ProtoAdapter<SendDataRequest> {
     public ProtoAdapter_SendDataRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, SendDataRequest.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, SendDataRequest.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataRequest", Syntax.PROTO_2, null, "request_response.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -94,7 +94,7 @@ public final class SendDataResponse extends Message<SendDataResponse, SendDataRe
 
   private static final class ProtoAdapter_SendDataResponse extends ProtoAdapter<SendDataResponse> {
     public ProtoAdapter_SendDataResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, SendDataResponse.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, SendDataResponse.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataResponse", Syntax.PROTO_2, null, "request_response.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/map/Mappy.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/map/Mappy.java
@@ -98,7 +98,7 @@ public final class Mappy extends Message<Mappy, Mappy.Builder> {
     private ProtoAdapter<Map<String, Thing>> things;
 
     public ProtoAdapter_Mappy() {
-      super(FieldEncoding.LENGTH_DELIMITED, Mappy.class, "type.googleapis.com/com.squareup.wire.map.Mappy", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Mappy.class, "type.googleapis.com/com.squareup.wire.map.Mappy", Syntax.PROTO_2, null, "map.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/map/Thing.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/map/Thing.java
@@ -94,7 +94,7 @@ public final class Thing extends Message<Thing, Thing.Builder> {
 
   private static final class ProtoAdapter_Thing extends ProtoAdapter<Thing> {
     public ProtoAdapter_Thing() {
-      super(FieldEncoding.LENGTH_DELIMITED, Thing.class, "type.googleapis.com/com.squareup.wire.map.Thing", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Thing.class, "type.googleapis.com/com.squareup.wire.map.Thing", Syntax.PROTO_2, null, "map.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/ChildPackage.java
@@ -95,7 +95,7 @@ public final class ChildPackage extends Message<ChildPackage, ChildPackage.Build
 
   private static final class ProtoAdapter_ChildPackage extends ProtoAdapter<ChildPackage> {
     public ProtoAdapter_ChildPackage() {
-      super(FieldEncoding.LENGTH_DELIMITED, ChildPackage.class, "type.googleapis.com/squareup.protos.ChildPackage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, ChildPackage.class, "type.googleapis.com/squareup.protos.ChildPackage", Syntax.PROTO_2, null, "child_pkg.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/RepeatedPackedAndMap.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/RepeatedPackedAndMap.java
@@ -144,7 +144,7 @@ public final class RepeatedPackedAndMap extends Message<RepeatedPackedAndMap, Re
     private ProtoAdapter<Map<Integer, Integer>> map_int32_int32;
 
     public ProtoAdapter_RepeatedPackedAndMap() {
-      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.protos.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.protos.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null, "collection_types.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -3117,7 +3117,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
     private static final class ProtoAdapter_NestedMessage extends ProtoAdapter<NestedMessage> {
       public ProtoAdapter_NestedMessage() {
-        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes.NestedMessage", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes.NestedMessage", Syntax.PROTO_2, null, "all_types.proto");
       }
 
       @Override
@@ -3175,7 +3175,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     private ProtoAdapter<Map<String, NestedEnum>> map_string_enum;
 
     public ProtoAdapter_AllTypes() {
-      super(FieldEncoding.LENGTH_DELIMITED, AllTypes.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, AllTypes.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes", Syntax.PROTO_2, null, "all_types.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -346,7 +346,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     private static final class ProtoAdapter_Nested extends ProtoAdapter<Nested> {
       public ProtoAdapter_Nested() {
-        super(FieldEncoding.LENGTH_DELIMITED, Nested.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, Nested.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested", Syntax.PROTO_2, null, "custom_options.proto");
       }
 
       @Override
@@ -478,7 +478,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     private static final class ProtoAdapter_More extends ProtoAdapter<More> {
       public ProtoAdapter_More() {
-        super(FieldEncoding.LENGTH_DELIMITED, More.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.More", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, More.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.More", Syntax.PROTO_2, null, "custom_options.proto");
       }
 
       @Override
@@ -572,7 +572,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
   private static final class ProtoAdapter_FooBar extends ProtoAdapter<FooBar> {
     public ProtoAdapter_FooBar() {
-      super(FieldEncoding.LENGTH_DELIMITED, FooBar.class, "type.googleapis.com/squareup.protos.custom_options.FooBar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, FooBar.class, "type.googleapis.com/squareup.protos.custom_options.FooBar", Syntax.PROTO_2, null, "custom_options.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
@@ -67,7 +67,7 @@ public final class MessageWithOptions extends Message<MessageWithOptions, Messag
 
   private static final class ProtoAdapter_MessageWithOptions extends ProtoAdapter<MessageWithOptions> {
     public ProtoAdapter_MessageWithOptions() {
-      super(FieldEncoding.LENGTH_DELIMITED, MessageWithOptions.class, "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, MessageWithOptions.class, "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions", Syntax.PROTO_2, null, "custom_options.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/depend_on_kotlin_option/Letter.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/depend_on_kotlin_option/Letter.java
@@ -94,7 +94,7 @@ public final class Letter extends Message<Letter, Letter.Builder> {
 
   private static final class ProtoAdapter_Letter extends ProtoAdapter<Letter> {
     public ProtoAdapter_Letter() {
-      super(FieldEncoding.LENGTH_DELIMITED, Letter.class, "type.googleapis.com/squareup.protos.depend_on_kotlin_option.Letter", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Letter.class, "type.googleapis.com/squareup.protos.depend_on_kotlin_option.Letter", Syntax.PROTO_2, null, "depend_on_kotlin_option.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/NoFields.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/NoFields.java
@@ -67,7 +67,7 @@ public final class NoFields extends Message<NoFields, NoFields.Builder> {
 
   private static final class ProtoAdapter_NoFields extends ProtoAdapter<NoFields> {
     public ProtoAdapter_NoFields() {
-      super(FieldEncoding.LENGTH_DELIMITED, NoFields.class, "type.googleapis.com/squareup.protos.edgecases.NoFields", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NoFields.class, "type.googleapis.com/squareup.protos.edgecases.NoFields", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -94,7 +94,7 @@ public final class OneBytesField extends Message<OneBytesField, OneBytesField.Bu
 
   private static final class ProtoAdapter_OneBytesField extends ProtoAdapter<OneBytesField> {
     public ProtoAdapter_OneBytesField() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneBytesField.class, "type.googleapis.com/squareup.protos.edgecases.OneBytesField", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneBytesField.class, "type.googleapis.com/squareup.protos.edgecases.OneBytesField", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/OneField.java
@@ -95,7 +95,7 @@ public final class OneField extends Message<OneField, OneField.Builder> {
 
   private static final class ProtoAdapter_OneField extends ProtoAdapter<OneField> {
     public ProtoAdapter_OneField() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneField.class, "type.googleapis.com/squareup.protos.edgecases.OneField", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneField.class, "type.googleapis.com/squareup.protos.edgecases.OneField", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -113,7 +113,7 @@ public final class Recursive extends Message<Recursive, Recursive.Builder> {
 
   private static final class ProtoAdapter_Recursive extends ProtoAdapter<Recursive> {
     public ProtoAdapter_Recursive() {
-      super(FieldEncoding.LENGTH_DELIMITED, Recursive.class, "type.googleapis.com/squareup.protos.edgecases.Recursive", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Recursive.class, "type.googleapis.com/squareup.protos.edgecases.Recursive", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -118,7 +118,7 @@ public final class ForeignMessage extends Message<ForeignMessage, ForeignMessage
 
   private static final class ProtoAdapter_ForeignMessage extends ProtoAdapter<ForeignMessage> {
     public ProtoAdapter_ForeignMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, ForeignMessage.class, "type.googleapis.com/squareup.protos.foreign.ForeignMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, ForeignMessage.class, "type.googleapis.com/squareup.protos.foreign.ForeignMessage", Syntax.PROTO_2, null, "foreign.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/namecollisions/Message.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/namecollisions/Message.java
@@ -281,7 +281,7 @@ public final class Message extends com.squareup.wire.Message<Message, Message.Bu
 
   private static final class ProtoAdapter_Message extends ProtoAdapter<Message> {
     public ProtoAdapter_Message() {
-      super(FieldEncoding.LENGTH_DELIMITED, Message.class, "type.googleapis.com/squareup.protos.namecollisions.Message", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Message.class, "type.googleapis.com/squareup.protos.namecollisions.Message", Syntax.PROTO_2, null, "name_collisions.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/one_extension/Foo.java
@@ -94,7 +94,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.protos.one_extension.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.protos.one_extension.Foo", Syntax.PROTO_2, null, "one_extension.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -115,7 +115,7 @@ public final class OneExtension extends Message<OneExtension, OneExtension.Build
 
   private static final class ProtoAdapter_OneExtension extends ProtoAdapter<OneExtension> {
     public ProtoAdapter_OneExtension() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneExtension.class, "type.googleapis.com/squareup.protos.one_extension.OneExtension", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneExtension.class, "type.googleapis.com/squareup.protos.one_extension.OneExtension", Syntax.PROTO_2, null, "one_extension.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -165,7 +165,7 @@ public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Build
 
   private static final class ProtoAdapter_OneOfMessage extends ProtoAdapter<OneOfMessage> {
     public ProtoAdapter_OneOfMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneOfMessage.class, "type.googleapis.com/squareup.protos.oneof.OneOfMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneOfMessage.class, "type.googleapis.com/squareup.protos.oneof.OneOfMessage", Syntax.PROTO_2, null, "one_of.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -370,7 +370,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
     private static final class ProtoAdapter_PhoneNumber extends ProtoAdapter<PhoneNumber> {
       public ProtoAdapter_PhoneNumber() {
-        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos.person.Person.PhoneNumber", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos.person.Person.PhoneNumber", Syntax.PROTO_2, null, "person.proto");
       }
 
       @Override
@@ -431,7 +431,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
   private static final class ProtoAdapter_Person extends ProtoAdapter<Person> {
     public ProtoAdapter_Person() {
-      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos.person.Person", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos.person.Person", Syntax.PROTO_2, null, "person.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -114,7 +114,7 @@ public final class NotRedacted extends Message<NotRedacted, NotRedacted.Builder>
 
   private static final class ProtoAdapter_NotRedacted extends ProtoAdapter<NotRedacted> {
     public ProtoAdapter_NotRedacted() {
-      super(FieldEncoding.LENGTH_DELIMITED, NotRedacted.class, "type.googleapis.com/squareup.protos.redacted_test.NotRedacted", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NotRedacted.class, "type.googleapis.com/squareup.protos.redacted_test.NotRedacted", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -130,7 +130,7 @@ public final class RedactedChild extends Message<RedactedChild, RedactedChild.Bu
 
   private static final class ProtoAdapter_RedactedChild extends ProtoAdapter<RedactedChild> {
     public ProtoAdapter_RedactedChild() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedChild.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedChild", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedChild.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedChild", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -92,7 +92,7 @@ public final class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA
 
   private static final class ProtoAdapter_RedactedCycleA extends ProtoAdapter<RedactedCycleA> {
     public ProtoAdapter_RedactedCycleA() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleA.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleA", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleA.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleA", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -92,7 +92,7 @@ public final class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB
 
   private static final class ProtoAdapter_RedactedCycleB extends ProtoAdapter<RedactedCycleB> {
     public ProtoAdapter_RedactedCycleB() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleB.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleB", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleB.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleB", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -115,7 +115,7 @@ public final class RedactedExtension extends Message<RedactedExtension, Redacted
 
   private static final class ProtoAdapter_RedactedExtension extends ProtoAdapter<RedactedExtension> {
     public ProtoAdapter_RedactedExtension() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedExtension.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedExtension", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedExtension.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedExtension", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedFields.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedFields.java
@@ -157,7 +157,7 @@ public final class RedactedFields extends Message<RedactedFields, RedactedFields
 
   private static final class ProtoAdapter_RedactedFields extends ProtoAdapter<RedactedFields> {
     public ProtoAdapter_RedactedFields() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedFields.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedFields", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedFields.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedFields", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -125,7 +125,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
 
   private static final class ProtoAdapter_RedactedRepeated extends ProtoAdapter<RedactedRepeated> {
     public ProtoAdapter_RedactedRepeated() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedRepeated.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRepeated", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedRepeated.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRepeated", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -100,7 +100,7 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
 
   private static final class ProtoAdapter_RedactedRequired extends ProtoAdapter<RedactedRequired> {
     public ProtoAdapter_RedactedRequired() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedRequired.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRequired", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedRequired.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRequired", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/A.java
@@ -125,7 +125,7 @@ public final class A extends Message<A, A.Builder> {
 
   private static final class ProtoAdapter_A extends ProtoAdapter<A> {
     public ProtoAdapter_A() {
-      super(FieldEncoding.LENGTH_DELIMITED, A.class, "type.googleapis.com/squareup.protos.roots.A", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, A.class, "type.googleapis.com/squareup.protos.roots.A", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/B.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/B.java
@@ -96,7 +96,7 @@ public final class B extends Message<B, B.Builder> {
 
   private static final class ProtoAdapter_B extends ProtoAdapter<B> {
     public ProtoAdapter_B() {
-      super(FieldEncoding.LENGTH_DELIMITED, B.class, "type.googleapis.com/squareup.protos.roots.B", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, B.class, "type.googleapis.com/squareup.protos.roots.B", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/C.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/C.java
@@ -95,7 +95,7 @@ public final class C extends Message<C, C.Builder> {
 
   private static final class ProtoAdapter_C extends ProtoAdapter<C> {
     public ProtoAdapter_C() {
-      super(FieldEncoding.LENGTH_DELIMITED, C.class, "type.googleapis.com/squareup.protos.roots.C", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, C.class, "type.googleapis.com/squareup.protos.roots.C", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/D.java
@@ -95,7 +95,7 @@ public final class D extends Message<D, D.Builder> {
 
   private static final class ProtoAdapter_D extends ProtoAdapter<D> {
     public ProtoAdapter_D() {
-      super(FieldEncoding.LENGTH_DELIMITED, D.class, "type.googleapis.com/squareup.protos.roots.D", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, D.class, "type.googleapis.com/squareup.protos.roots.D", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/E.java
@@ -187,7 +187,7 @@ public final class E extends Message<E, E.Builder> {
 
     private static final class ProtoAdapter_F extends ProtoAdapter<F> {
       public ProtoAdapter_F() {
-        super(FieldEncoding.LENGTH_DELIMITED, F.class, "type.googleapis.com/squareup.protos.roots.E.F", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, F.class, "type.googleapis.com/squareup.protos.roots.E.F", Syntax.PROTO_2, null, "roots.proto");
       }
 
       @Override
@@ -237,7 +237,7 @@ public final class E extends Message<E, E.Builder> {
 
   private static final class ProtoAdapter_E extends ProtoAdapter<E> {
     public ProtoAdapter_E() {
-      super(FieldEncoding.LENGTH_DELIMITED, E.class, "type.googleapis.com/squareup.protos.roots.E", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, E.class, "type.googleapis.com/squareup.protos.roots.E", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/H.java
@@ -92,7 +92,7 @@ public final class H extends Message<H, H.Builder> {
 
   private static final class ProtoAdapter_H extends ProtoAdapter<H> {
     public ProtoAdapter_H() {
-      super(FieldEncoding.LENGTH_DELIMITED, H.class, "type.googleapis.com/squareup.protos.roots.H", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, H.class, "type.googleapis.com/squareup.protos.roots.H", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/I.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/I.java
@@ -116,7 +116,7 @@ public final class I extends Message<I, I.Builder> {
 
   private static final class ProtoAdapter_I extends ProtoAdapter<I> {
     public ProtoAdapter_I() {
-      super(FieldEncoding.LENGTH_DELIMITED, I.class, "type.googleapis.com/squareup.protos.roots.I", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, I.class, "type.googleapis.com/squareup.protos.roots.I", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/J.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/J.java
@@ -92,7 +92,7 @@ public final class J extends Message<J, J.Builder> {
 
   private static final class ProtoAdapter_J extends ProtoAdapter<J> {
     public ProtoAdapter_J() {
-      super(FieldEncoding.LENGTH_DELIMITED, J.class, "type.googleapis.com/squareup.protos.roots.J", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, J.class, "type.googleapis.com/squareup.protos.roots.J", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/K.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/K.java
@@ -95,7 +95,7 @@ public final class K extends Message<K, K.Builder> {
 
   private static final class ProtoAdapter_K extends ProtoAdapter<K> {
     public ProtoAdapter_K() {
-      super(FieldEncoding.LENGTH_DELIMITED, K.class, "type.googleapis.com/squareup.protos.roots.K", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, K.class, "type.googleapis.com/squareup.protos.roots.K", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/TheRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/TheRequest.java
@@ -67,7 +67,7 @@ public final class TheRequest extends Message<TheRequest, TheRequest.Builder> {
 
   private static final class ProtoAdapter_TheRequest extends ProtoAdapter<TheRequest> {
     public ProtoAdapter_TheRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, TheRequest.class, "type.googleapis.com/squareup.wire.protos.roots.TheRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, TheRequest.class, "type.googleapis.com/squareup.wire.protos.roots.TheRequest", Syntax.PROTO_2, null, "service_root.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/TheResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/TheResponse.java
@@ -67,7 +67,7 @@ public final class TheResponse extends Message<TheResponse, TheResponse.Builder>
 
   private static final class ProtoAdapter_TheResponse extends ProtoAdapter<TheResponse> {
     public ProtoAdapter_TheResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, TheResponse.class, "type.googleapis.com/squareup.wire.protos.roots.TheResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, TheResponse.class, "type.googleapis.com/squareup.wire.protos.roots.TheResponse", Syntax.PROTO_2, null, "service_root.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
@@ -67,7 +67,7 @@ public final class UnnecessaryResponse extends Message<UnnecessaryResponse, Unne
 
   private static final class ProtoAdapter_UnnecessaryResponse extends ProtoAdapter<UnnecessaryResponse> {
     public ProtoAdapter_UnnecessaryResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, UnnecessaryResponse.class, "type.googleapis.com/squareup.wire.protos.roots.UnnecessaryResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, UnnecessaryResponse.class, "type.googleapis.com/squareup.wire.protos.roots.UnnecessaryResponse", Syntax.PROTO_2, null, "service_root.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -214,7 +214,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
 
   private static final class ProtoAdapter_ExternalMessage extends ProtoAdapter<ExternalMessage> {
     public ProtoAdapter_ExternalMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, ExternalMessage.class, "type.googleapis.com/squareup.protos.simple.ExternalMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, ExternalMessage.class, "type.googleapis.com/squareup.protos.simple.ExternalMessage", Syntax.PROTO_2, null, "external_message.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -483,7 +483,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
 
     private static final class ProtoAdapter_NestedMessage extends ProtoAdapter<NestedMessage> {
       public ProtoAdapter_NestedMessage() {
-        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage.NestedMessage", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage.NestedMessage", Syntax.PROTO_2, null, "simple_message.proto");
       }
 
       @Override
@@ -580,7 +580,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
 
   private static final class ProtoAdapter_SimpleMessage extends ProtoAdapter<SimpleMessage> {
     public ProtoAdapter_SimpleMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, SimpleMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, SimpleMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage", Syntax.PROTO_2, null, "simple_message.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -95,7 +95,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/samebasename.single_level.Bar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/samebasename.single_level.Bar", Syntax.PROTO_2, null, "samebasename/single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -96,7 +96,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
 
   private static final class ProtoAdapter_Bars extends ProtoAdapter<Bars> {
     public ProtoAdapter_Bars() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/samebasename.single_level.Bars", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/samebasename.single_level.Bars", Syntax.PROTO_2, null, "samebasename/single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Foo.java
@@ -95,7 +95,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/single_level.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/single_level.Foo", Syntax.PROTO_2, null, "single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/single_level/Foos.java
@@ -96,7 +96,7 @@ public final class Foos extends Message<Foos, Foos.Builder> {
 
   private static final class ProtoAdapter_Foos extends ProtoAdapter<Foos> {
     public ProtoAdapter_Foos() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foos.class, "type.googleapis.com/single_level.Foos", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foos.class, "type.googleapis.com/single_level.Foos", Syntax.PROTO_2, null, "single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionOne.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionOne.java
@@ -95,7 +95,7 @@ public final class NestedVersionOne extends Message<NestedVersionOne, NestedVers
 
   private static final class ProtoAdapter_NestedVersionOne extends ProtoAdapter<NestedVersionOne> {
     public ProtoAdapter_NestedVersionOne() {
-      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionOne", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionOne", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionTwo.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionTwo.java
@@ -200,7 +200,7 @@ public final class NestedVersionTwo extends Message<NestedVersionTwo, NestedVers
 
   private static final class ProtoAdapter_NestedVersionTwo extends ProtoAdapter<NestedVersionTwo> {
     public ProtoAdapter_NestedVersionTwo() {
-      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionTwo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionTwo", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -133,7 +133,7 @@ public final class VersionOne extends Message<VersionOne, VersionOne.Builder> {
 
   private static final class ProtoAdapter_VersionOne extends ProtoAdapter<VersionOne> {
     public ProtoAdapter_VersionOne() {
-      super(FieldEncoding.LENGTH_DELIMITED, VersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.VersionOne", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, VersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.VersionOne", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -238,7 +238,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
 
   private static final class ProtoAdapter_VersionTwo extends ProtoAdapter<VersionTwo> {
     public ProtoAdapter_VersionTwo() {
-      super(FieldEncoding.LENGTH_DELIMITED, VersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.VersionTwo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, VersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.VersionTwo", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/protos/extension_collision/CollisionSubject.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/protos/extension_collision/CollisionSubject.java
@@ -94,7 +94,7 @@ public final class CollisionSubject extends Message<CollisionSubject, CollisionS
 
   private static final class ProtoAdapter_CollisionSubject extends ProtoAdapter<CollisionSubject> {
     public ProtoAdapter_CollisionSubject() {
-      super(FieldEncoding.LENGTH_DELIMITED, CollisionSubject.class, "type.googleapis.com/squareup.protos.extension_collision.CollisionSubject", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, CollisionSubject.class, "type.googleapis.com/squareup.protos.extension_collision.CollisionSubject", Syntax.PROTO_2, null, "extension_collision.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
@@ -118,7 +118,7 @@ public final class EmbeddedMessage extends Message<EmbeddedMessage, EmbeddedMess
 
   private static final class ProtoAdapter_EmbeddedMessage extends ProtoAdapter<EmbeddedMessage> {
     public ProtoAdapter_EmbeddedMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, EmbeddedMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, EmbeddedMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage", Syntax.PROTO_2, null, "packed_encoding.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/protos/packed_encoding/OuterMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaNoOptionsTest/proto-java/squareup/protos/packed_encoding/OuterMessage.java
@@ -114,7 +114,7 @@ public final class OuterMessage extends Message<OuterMessage, OuterMessage.Build
 
   private static final class ProtoAdapter_OuterMessage extends ProtoAdapter<OuterMessage> {
     public ProtoAdapter_OuterMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, OuterMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OuterMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage", Syntax.PROTO_2, null, "packed_encoding.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/A.java
@@ -107,7 +107,7 @@ public final class A extends Message<A, A.Builder> {
 
   private static final class ProtoAdapter_A extends ProtoAdapter<A> {
     public ProtoAdapter_A() {
-      super(FieldEncoding.LENGTH_DELIMITED, A.class, "type.googleapis.com/squareup.protos.roots.A", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, A.class, "type.googleapis.com/squareup.protos.roots.A", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/D.java
@@ -95,7 +95,7 @@ public final class D extends Message<D, D.Builder> {
 
   private static final class ProtoAdapter_D extends ProtoAdapter<D> {
     public ProtoAdapter_D() {
-      super(FieldEncoding.LENGTH_DELIMITED, D.class, "type.googleapis.com/squareup.protos.roots.D", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, D.class, "type.googleapis.com/squareup.protos.roots.D", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/E.java
@@ -104,7 +104,7 @@ public final class E {
 
     private static final class ProtoAdapter_F extends ProtoAdapter<F> {
       public ProtoAdapter_F() {
-        super(FieldEncoding.LENGTH_DELIMITED, F.class, "type.googleapis.com/squareup.protos.roots.E.F", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, F.class, "type.googleapis.com/squareup.protos.roots.E.F", Syntax.PROTO_2, null, "roots.proto");
       }
 
       @Override

--- a/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-library/wire-tests/src/jvmJavaPrunedTest/proto-java/com/squareup/wire/protos/roots/H.java
@@ -92,7 +92,7 @@ public final class H extends Message<H, H.Builder> {
 
   private static final class ProtoAdapter_H extends ProtoAdapter<H> {
     public ProtoAdapter_H() {
-      super(FieldEncoding.LENGTH_DELIMITED, H.class, "type.googleapis.com/squareup.protos.roots.H", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, H.class, "type.googleapis.com/squareup.protos.roots.H", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/differentpackage/protos/bar/Bar.java
@@ -192,7 +192,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
       private static final class ProtoAdapter_Moo extends ProtoAdapter<Moo> {
         public ProtoAdapter_Moo() {
-          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz.Moo", Syntax.PROTO_2, null);
+          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz.Moo", Syntax.PROTO_2, null, "differentpackage/bar.proto");
         }
 
         @Override
@@ -242,7 +242,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
     private static final class ProtoAdapter_Baz extends ProtoAdapter<Baz> {
       public ProtoAdapter_Baz() {
-        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.differentpackage.bar.Bar.Baz", Syntax.PROTO_2, null, "differentpackage/bar.proto");
       }
 
       @Override
@@ -288,7 +288,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.differentpackage.bar.Bar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.differentpackage.bar.Bar", Syntax.PROTO_2, null, "differentpackage/bar.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/differentpackage/protos/foo/Foo.java
@@ -93,7 +93,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.differentpackage.foo.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.differentpackage.foo.Foo", Syntax.PROTO_2, null, "differentpackage/foo.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/foobar/protos/bar/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/foobar/protos/bar/Bar.java
@@ -192,7 +192,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
       private static final class ProtoAdapter_Moo extends ProtoAdapter<Moo> {
         public ProtoAdapter_Moo() {
-          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.foobar.Bar.Baz.Moo", Syntax.PROTO_2, null);
+          super(FieldEncoding.LENGTH_DELIMITED, Moo.class, "type.googleapis.com/squareup.foobar.Bar.Baz.Moo", Syntax.PROTO_2, null, "bar.proto");
         }
 
         @Override
@@ -242,7 +242,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
     private static final class ProtoAdapter_Baz extends ProtoAdapter<Baz> {
       public ProtoAdapter_Baz() {
-        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.foobar.Bar.Baz", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, Baz.class, "type.googleapis.com/squareup.foobar.Bar.Baz", Syntax.PROTO_2, null, "bar.proto");
       }
 
       @Override
@@ -288,7 +288,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.foobar.Bar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/squareup.foobar.Bar", Syntax.PROTO_2, null, "bar.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/foobar/protos/foo/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/foobar/protos/foo/Foo.java
@@ -95,7 +95,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.foobar.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.foobar.Foo", Syntax.PROTO_2, null, "foo.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/HeresAllTheDataRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/HeresAllTheDataRequest.java
@@ -94,7 +94,7 @@ public final class HeresAllTheDataRequest extends Message<HeresAllTheDataRequest
 
   private static final class ProtoAdapter_HeresAllTheDataRequest extends ProtoAdapter<HeresAllTheDataRequest> {
     public ProtoAdapter_HeresAllTheDataRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataRequest.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataRequest.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataRequest", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/HeresAllTheDataResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/HeresAllTheDataResponse.java
@@ -94,7 +94,7 @@ public final class HeresAllTheDataResponse extends Message<HeresAllTheDataRespon
 
   private static final class ProtoAdapter_HeresAllTheDataResponse extends ProtoAdapter<HeresAllTheDataResponse> {
     public ProtoAdapter_HeresAllTheDataResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataResponse.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, HeresAllTheDataResponse.class, "type.googleapis.com/com.squareup.services.HeresAllTheDataResponse", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/LetsDataRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/LetsDataRequest.java
@@ -94,7 +94,7 @@ public final class LetsDataRequest extends Message<LetsDataRequest, LetsDataRequ
 
   private static final class ProtoAdapter_LetsDataRequest extends ProtoAdapter<LetsDataRequest> {
     public ProtoAdapter_LetsDataRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, LetsDataRequest.class, "type.googleapis.com/com.squareup.services.LetsDataRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, LetsDataRequest.class, "type.googleapis.com/com.squareup.services.LetsDataRequest", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/LetsDataResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/LetsDataResponse.java
@@ -94,7 +94,7 @@ public final class LetsDataResponse extends Message<LetsDataResponse, LetsDataRe
 
   private static final class ProtoAdapter_LetsDataResponse extends ProtoAdapter<LetsDataResponse> {
     public ProtoAdapter_LetsDataResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, LetsDataResponse.class, "type.googleapis.com/com.squareup.services.LetsDataResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, LetsDataResponse.class, "type.googleapis.com/com.squareup.services.LetsDataResponse", Syntax.PROTO_2, null, "simple_service2.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/anotherpackage/SendDataRequest.java
@@ -94,7 +94,7 @@ public final class SendDataRequest extends Message<SendDataRequest, SendDataRequ
 
   private static final class ProtoAdapter_SendDataRequest extends ProtoAdapter<SendDataRequest> {
     public ProtoAdapter_SendDataRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, SendDataRequest.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, SendDataRequest.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataRequest", Syntax.PROTO_2, null, "request_response.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/services/anotherpackage/SendDataResponse.java
@@ -94,7 +94,7 @@ public final class SendDataResponse extends Message<SendDataResponse, SendDataRe
 
   private static final class ProtoAdapter_SendDataResponse extends ProtoAdapter<SendDataResponse> {
     public ProtoAdapter_SendDataResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, SendDataResponse.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, SendDataResponse.class, "type.googleapis.com/com.squareup.services.anotherpackage.SendDataResponse", Syntax.PROTO_2, null, "request_response.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/ModelEvaluation.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/ModelEvaluation.java
@@ -132,7 +132,7 @@ public final class ModelEvaluation extends Message<ModelEvaluation, ModelEvaluat
     private ProtoAdapter<Map<String, ModelEvaluation>> models;
 
     public ProtoAdapter_ModelEvaluation() {
-      super(FieldEncoding.LENGTH_DELIMITED, ModelEvaluation.class, "type.googleapis.com/com.squareup.wire.ModelEvaluation", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, ModelEvaluation.class, "type.googleapis.com/com.squareup.wire.ModelEvaluation", Syntax.PROTO_2, null, "resursive_map.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/map/Mappy.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/map/Mappy.java
@@ -98,7 +98,7 @@ public final class Mappy extends Message<Mappy, Mappy.Builder> {
     private ProtoAdapter<Map<String, Thing>> things;
 
     public ProtoAdapter_Mappy() {
-      super(FieldEncoding.LENGTH_DELIMITED, Mappy.class, "type.googleapis.com/com.squareup.wire.map.Mappy", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Mappy.class, "type.googleapis.com/com.squareup.wire.map.Mappy", Syntax.PROTO_2, null, "map.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/map/Thing.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/map/Thing.java
@@ -94,7 +94,7 @@ public final class Thing extends Message<Thing, Thing.Builder> {
 
   private static final class ProtoAdapter_Thing extends ProtoAdapter<Thing> {
     public ProtoAdapter_Thing() {
-      super(FieldEncoding.LENGTH_DELIMITED, Thing.class, "type.googleapis.com/com.squareup.wire.map.Thing", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Thing.class, "type.googleapis.com/com.squareup.wire.map.Thing", Syntax.PROTO_2, null, "map.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/all_types/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/all_types/AllTypes.java
@@ -2432,7 +2432,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
     private static final class ProtoAdapter_NestedMessage extends ProtoAdapter<NestedMessage> {
       public ProtoAdapter_NestedMessage() {
-        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/proto3.java.AllTypes.NestedMessage", Syntax.PROTO_3, null);
+        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/proto3.java.AllTypes.NestedMessage", Syntax.PROTO_3, null, "all_types.proto");
       }
 
       @Override
@@ -2508,7 +2508,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     private ProtoAdapter<Map<Integer, Instant>> map_int32_timestamp;
 
     public ProtoAdapter_AllTypes() {
-      super(FieldEncoding.LENGTH_DELIMITED, AllTypes.class, "type.googleapis.com/proto3.java.AllTypes", Syntax.PROTO_3, null);
+      super(FieldEncoding.LENGTH_DELIMITED, AllTypes.class, "type.googleapis.com/proto3.java.AllTypes", Syntax.PROTO_3, null, "all_types.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/person/Person.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/proto3/java/person/Person.java
@@ -425,7 +425,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
     private static final class ProtoAdapter_PhoneNumber extends ProtoAdapter<PhoneNumber> {
       public ProtoAdapter_PhoneNumber() {
-        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos3.java.person.Person.PhoneNumber", Syntax.PROTO_3, null);
+        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos3.java.person.Person.PhoneNumber", Syntax.PROTO_3, null, "person.proto");
       }
 
       @Override
@@ -490,7 +490,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
   private static final class ProtoAdapter_Person extends ProtoAdapter<Person> {
     public ProtoAdapter_Person() {
-      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos3.java.person.Person", Syntax.PROTO_3, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos3.java.person.Person", Syntax.PROTO_3, null, "person.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/ChildPackage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/ChildPackage.java
@@ -95,7 +95,7 @@ public final class ChildPackage extends Message<ChildPackage, ChildPackage.Build
 
   private static final class ProtoAdapter_ChildPackage extends ProtoAdapter<ChildPackage> {
     public ProtoAdapter_ChildPackage() {
-      super(FieldEncoding.LENGTH_DELIMITED, ChildPackage.class, "type.googleapis.com/squareup.protos.ChildPackage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, ChildPackage.class, "type.googleapis.com/squareup.protos.ChildPackage", Syntax.PROTO_2, null, "child_pkg.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/RepeatedPackedAndMap.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/RepeatedPackedAndMap.java
@@ -144,7 +144,7 @@ public final class RepeatedPackedAndMap extends Message<RepeatedPackedAndMap, Re
     private ProtoAdapter<Map<Integer, Integer>> map_int32_int32;
 
     public ProtoAdapter_RepeatedPackedAndMap() {
-      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.protos.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RepeatedPackedAndMap.class, "type.googleapis.com/squareup.protos.alltypes.RepeatedPackedAndMap", Syntax.PROTO_2, null, "collection_types.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/alltypes/AllTypes.java
@@ -3117,7 +3117,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
     private static final class ProtoAdapter_NestedMessage extends ProtoAdapter<NestedMessage> {
       public ProtoAdapter_NestedMessage() {
-        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes.NestedMessage", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes.NestedMessage", Syntax.PROTO_2, null, "all_types.proto");
       }
 
       @Override
@@ -3175,7 +3175,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
     private ProtoAdapter<Map<String, NestedEnum>> map_string_enum;
 
     public ProtoAdapter_AllTypes() {
-      super(FieldEncoding.LENGTH_DELIMITED, AllTypes.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, AllTypes.class, "type.googleapis.com/squareup.protos.alltypes.AllTypes", Syntax.PROTO_2, null, "all_types.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/FooBar.java
@@ -353,7 +353,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     private static final class ProtoAdapter_Nested extends ProtoAdapter<Nested> {
       public ProtoAdapter_Nested() {
-        super(FieldEncoding.LENGTH_DELIMITED, Nested.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, Nested.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested", Syntax.PROTO_2, null, "custom_options.proto");
       }
 
       @Override
@@ -485,7 +485,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
     private static final class ProtoAdapter_More extends ProtoAdapter<More> {
       public ProtoAdapter_More() {
-        super(FieldEncoding.LENGTH_DELIMITED, More.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.More", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, More.class, "type.googleapis.com/squareup.protos.custom_options.FooBar.More", Syntax.PROTO_2, null, "custom_options.proto");
       }
 
       @Override
@@ -584,7 +584,7 @@ public final class FooBar extends Message<FooBar, FooBar.Builder> {
 
   private static final class ProtoAdapter_FooBar extends ProtoAdapter<FooBar> {
     public ProtoAdapter_FooBar() {
-      super(FieldEncoding.LENGTH_DELIMITED, FooBar.class, "type.googleapis.com/squareup.protos.custom_options.FooBar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, FooBar.class, "type.googleapis.com/squareup.protos.custom_options.FooBar", Syntax.PROTO_2, null, "custom_options.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/custom_options/MessageWithOptions.java
@@ -69,7 +69,7 @@ public final class MessageWithOptions extends Message<MessageWithOptions, Messag
 
   private static final class ProtoAdapter_MessageWithOptions extends ProtoAdapter<MessageWithOptions> {
     public ProtoAdapter_MessageWithOptions() {
-      super(FieldEncoding.LENGTH_DELIMITED, MessageWithOptions.class, "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, MessageWithOptions.class, "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions", Syntax.PROTO_2, null, "custom_options.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/depend_on_kotlin_option/Letter.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/depend_on_kotlin_option/Letter.java
@@ -96,7 +96,7 @@ public final class Letter extends Message<Letter, Letter.Builder> {
 
   private static final class ProtoAdapter_Letter extends ProtoAdapter<Letter> {
     public ProtoAdapter_Letter() {
-      super(FieldEncoding.LENGTH_DELIMITED, Letter.class, "type.googleapis.com/squareup.protos.depend_on_kotlin_option.Letter", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Letter.class, "type.googleapis.com/squareup.protos.depend_on_kotlin_option.Letter", Syntax.PROTO_2, null, "depend_on_kotlin_option.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/NoFields.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/NoFields.java
@@ -67,7 +67,7 @@ public final class NoFields extends Message<NoFields, NoFields.Builder> {
 
   private static final class ProtoAdapter_NoFields extends ProtoAdapter<NoFields> {
     public ProtoAdapter_NoFields() {
-      super(FieldEncoding.LENGTH_DELIMITED, NoFields.class, "type.googleapis.com/squareup.protos.edgecases.NoFields", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NoFields.class, "type.googleapis.com/squareup.protos.edgecases.NoFields", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/OneBytesField.java
@@ -94,7 +94,7 @@ public final class OneBytesField extends Message<OneBytesField, OneBytesField.Bu
 
   private static final class ProtoAdapter_OneBytesField extends ProtoAdapter<OneBytesField> {
     public ProtoAdapter_OneBytesField() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneBytesField.class, "type.googleapis.com/squareup.protos.edgecases.OneBytesField", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneBytesField.class, "type.googleapis.com/squareup.protos.edgecases.OneBytesField", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/OneField.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/OneField.java
@@ -95,7 +95,7 @@ public final class OneField extends Message<OneField, OneField.Builder> {
 
   private static final class ProtoAdapter_OneField extends ProtoAdapter<OneField> {
     public ProtoAdapter_OneField() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneField.class, "type.googleapis.com/squareup.protos.edgecases.OneField", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneField.class, "type.googleapis.com/squareup.protos.edgecases.OneField", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/edgecases/Recursive.java
@@ -113,7 +113,7 @@ public final class Recursive extends Message<Recursive, Recursive.Builder> {
 
   private static final class ProtoAdapter_Recursive extends ProtoAdapter<Recursive> {
     public ProtoAdapter_Recursive() {
-      super(FieldEncoding.LENGTH_DELIMITED, Recursive.class, "type.googleapis.com/squareup.protos.edgecases.Recursive", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Recursive.class, "type.googleapis.com/squareup.protos.edgecases.Recursive", Syntax.PROTO_2, null, "edge_cases.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/foreign/ForeignMessage.java
@@ -118,7 +118,7 @@ public final class ForeignMessage extends Message<ForeignMessage, ForeignMessage
 
   private static final class ProtoAdapter_ForeignMessage extends ProtoAdapter<ForeignMessage> {
     public ProtoAdapter_ForeignMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, ForeignMessage.class, "type.googleapis.com/squareup.protos.foreign.ForeignMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, ForeignMessage.class, "type.googleapis.com/squareup.protos.foreign.ForeignMessage", Syntax.PROTO_2, null, "foreign.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/namecollisions/Message.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/namecollisions/Message.java
@@ -281,7 +281,7 @@ public final class Message extends com.squareup.wire.Message<Message, Message.Bu
 
   private static final class ProtoAdapter_Message extends ProtoAdapter<Message> {
     public ProtoAdapter_Message() {
-      super(FieldEncoding.LENGTH_DELIMITED, Message.class, "type.googleapis.com/squareup.protos.namecollisions.Message", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Message.class, "type.googleapis.com/squareup.protos.namecollisions.Message", Syntax.PROTO_2, null, "name_collisions.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/one_extension/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/one_extension/Foo.java
@@ -94,7 +94,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.protos.one_extension.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/squareup.protos.one_extension.Foo", Syntax.PROTO_2, null, "one_extension.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/one_extension/OneExtension.java
@@ -115,7 +115,7 @@ public final class OneExtension extends Message<OneExtension, OneExtension.Build
 
   private static final class ProtoAdapter_OneExtension extends ProtoAdapter<OneExtension> {
     public ProtoAdapter_OneExtension() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneExtension.class, "type.googleapis.com/squareup.protos.one_extension.OneExtension", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneExtension.class, "type.googleapis.com/squareup.protos.one_extension.OneExtension", Syntax.PROTO_2, null, "one_extension.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/oneof/OneOfMessage.java
@@ -165,7 +165,7 @@ public final class OneOfMessage extends Message<OneOfMessage, OneOfMessage.Build
 
   private static final class ProtoAdapter_OneOfMessage extends ProtoAdapter<OneOfMessage> {
     public ProtoAdapter_OneOfMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, OneOfMessage.class, "type.googleapis.com/squareup.protos.oneof.OneOfMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OneOfMessage.class, "type.googleapis.com/squareup.protos.oneof.OneOfMessage", Syntax.PROTO_2, null, "one_of.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -370,7 +370,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
     private static final class ProtoAdapter_PhoneNumber extends ProtoAdapter<PhoneNumber> {
       public ProtoAdapter_PhoneNumber() {
-        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos.person.Person.PhoneNumber", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, PhoneNumber.class, "type.googleapis.com/squareup.protos.person.Person.PhoneNumber", Syntax.PROTO_2, null, "person.proto");
       }
 
       @Override
@@ -431,7 +431,7 @@ public final class Person extends Message<Person, Person.Builder> {
 
   private static final class ProtoAdapter_Person extends ProtoAdapter<Person> {
     public ProtoAdapter_Person() {
-      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos.person.Person", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Person.class, "type.googleapis.com/squareup.protos.person.Person", Syntax.PROTO_2, null, "person.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/NotRedacted.java
@@ -114,7 +114,7 @@ public final class NotRedacted extends Message<NotRedacted, NotRedacted.Builder>
 
   private static final class ProtoAdapter_NotRedacted extends ProtoAdapter<NotRedacted> {
     public ProtoAdapter_NotRedacted() {
-      super(FieldEncoding.LENGTH_DELIMITED, NotRedacted.class, "type.googleapis.com/squareup.protos.redacted_test.NotRedacted", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NotRedacted.class, "type.googleapis.com/squareup.protos.redacted_test.NotRedacted", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedChild.java
@@ -130,7 +130,7 @@ public final class RedactedChild extends Message<RedactedChild, RedactedChild.Bu
 
   private static final class ProtoAdapter_RedactedChild extends ProtoAdapter<RedactedChild> {
     public ProtoAdapter_RedactedChild() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedChild.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedChild", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedChild.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedChild", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleA.java
@@ -92,7 +92,7 @@ public final class RedactedCycleA extends Message<RedactedCycleA, RedactedCycleA
 
   private static final class ProtoAdapter_RedactedCycleA extends ProtoAdapter<RedactedCycleA> {
     public ProtoAdapter_RedactedCycleA() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleA.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleA", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleA.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleA", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedCycleB.java
@@ -92,7 +92,7 @@ public final class RedactedCycleB extends Message<RedactedCycleB, RedactedCycleB
 
   private static final class ProtoAdapter_RedactedCycleB extends ProtoAdapter<RedactedCycleB> {
     public ProtoAdapter_RedactedCycleB() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleB.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleB", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedCycleB.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedCycleB", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedExtension.java
@@ -115,7 +115,7 @@ public final class RedactedExtension extends Message<RedactedExtension, Redacted
 
   private static final class ProtoAdapter_RedactedExtension extends ProtoAdapter<RedactedExtension> {
     public ProtoAdapter_RedactedExtension() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedExtension.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedExtension", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedExtension.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedExtension", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedFields.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedFields.java
@@ -157,7 +157,7 @@ public final class RedactedFields extends Message<RedactedFields, RedactedFields
 
   private static final class ProtoAdapter_RedactedFields extends ProtoAdapter<RedactedFields> {
     public ProtoAdapter_RedactedFields() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedFields.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedFields", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedFields.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedFields", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedRepeated.java
@@ -125,7 +125,7 @@ public final class RedactedRepeated extends Message<RedactedRepeated, RedactedRe
 
   private static final class ProtoAdapter_RedactedRepeated extends ProtoAdapter<RedactedRepeated> {
     public ProtoAdapter_RedactedRepeated() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedRepeated.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRepeated", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedRepeated.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRepeated", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/redacted/RedactedRequired.java
@@ -100,7 +100,7 @@ public final class RedactedRequired extends Message<RedactedRequired, RedactedRe
 
   private static final class ProtoAdapter_RedactedRequired extends ProtoAdapter<RedactedRequired> {
     public ProtoAdapter_RedactedRequired() {
-      super(FieldEncoding.LENGTH_DELIMITED, RedactedRequired.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRequired", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, RedactedRequired.class, "type.googleapis.com/squareup.protos.redacted_test.RedactedRequired", Syntax.PROTO_2, null, "redacted_test.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/A.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/A.java
@@ -125,7 +125,7 @@ public final class A extends Message<A, A.Builder> {
 
   private static final class ProtoAdapter_A extends ProtoAdapter<A> {
     public ProtoAdapter_A() {
-      super(FieldEncoding.LENGTH_DELIMITED, A.class, "type.googleapis.com/squareup.protos.roots.A", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, A.class, "type.googleapis.com/squareup.protos.roots.A", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/B.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/B.java
@@ -96,7 +96,7 @@ public final class B extends Message<B, B.Builder> {
 
   private static final class ProtoAdapter_B extends ProtoAdapter<B> {
     public ProtoAdapter_B() {
-      super(FieldEncoding.LENGTH_DELIMITED, B.class, "type.googleapis.com/squareup.protos.roots.B", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, B.class, "type.googleapis.com/squareup.protos.roots.B", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/C.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/C.java
@@ -95,7 +95,7 @@ public final class C extends Message<C, C.Builder> {
 
   private static final class ProtoAdapter_C extends ProtoAdapter<C> {
     public ProtoAdapter_C() {
-      super(FieldEncoding.LENGTH_DELIMITED, C.class, "type.googleapis.com/squareup.protos.roots.C", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, C.class, "type.googleapis.com/squareup.protos.roots.C", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/D.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/D.java
@@ -95,7 +95,7 @@ public final class D extends Message<D, D.Builder> {
 
   private static final class ProtoAdapter_D extends ProtoAdapter<D> {
     public ProtoAdapter_D() {
-      super(FieldEncoding.LENGTH_DELIMITED, D.class, "type.googleapis.com/squareup.protos.roots.D", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, D.class, "type.googleapis.com/squareup.protos.roots.D", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/E.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/E.java
@@ -187,7 +187,7 @@ public final class E extends Message<E, E.Builder> {
 
     private static final class ProtoAdapter_F extends ProtoAdapter<F> {
       public ProtoAdapter_F() {
-        super(FieldEncoding.LENGTH_DELIMITED, F.class, "type.googleapis.com/squareup.protos.roots.E.F", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, F.class, "type.googleapis.com/squareup.protos.roots.E.F", Syntax.PROTO_2, null, "roots.proto");
       }
 
       @Override
@@ -237,7 +237,7 @@ public final class E extends Message<E, E.Builder> {
 
   private static final class ProtoAdapter_E extends ProtoAdapter<E> {
     public ProtoAdapter_E() {
-      super(FieldEncoding.LENGTH_DELIMITED, E.class, "type.googleapis.com/squareup.protos.roots.E", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, E.class, "type.googleapis.com/squareup.protos.roots.E", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/H.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/H.java
@@ -92,7 +92,7 @@ public final class H extends Message<H, H.Builder> {
 
   private static final class ProtoAdapter_H extends ProtoAdapter<H> {
     public ProtoAdapter_H() {
-      super(FieldEncoding.LENGTH_DELIMITED, H.class, "type.googleapis.com/squareup.protos.roots.H", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, H.class, "type.googleapis.com/squareup.protos.roots.H", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/I.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/I.java
@@ -116,7 +116,7 @@ public final class I extends Message<I, I.Builder> {
 
   private static final class ProtoAdapter_I extends ProtoAdapter<I> {
     public ProtoAdapter_I() {
-      super(FieldEncoding.LENGTH_DELIMITED, I.class, "type.googleapis.com/squareup.protos.roots.I", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, I.class, "type.googleapis.com/squareup.protos.roots.I", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/J.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/J.java
@@ -92,7 +92,7 @@ public final class J extends Message<J, J.Builder> {
 
   private static final class ProtoAdapter_J extends ProtoAdapter<J> {
     public ProtoAdapter_J() {
-      super(FieldEncoding.LENGTH_DELIMITED, J.class, "type.googleapis.com/squareup.protos.roots.J", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, J.class, "type.googleapis.com/squareup.protos.roots.J", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/K.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/K.java
@@ -95,7 +95,7 @@ public final class K extends Message<K, K.Builder> {
 
   private static final class ProtoAdapter_K extends ProtoAdapter<K> {
     public ProtoAdapter_K() {
-      super(FieldEncoding.LENGTH_DELIMITED, K.class, "type.googleapis.com/squareup.protos.roots.K", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, K.class, "type.googleapis.com/squareup.protos.roots.K", Syntax.PROTO_2, null, "roots.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/TheRequest.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/TheRequest.java
@@ -67,7 +67,7 @@ public final class TheRequest extends Message<TheRequest, TheRequest.Builder> {
 
   private static final class ProtoAdapter_TheRequest extends ProtoAdapter<TheRequest> {
     public ProtoAdapter_TheRequest() {
-      super(FieldEncoding.LENGTH_DELIMITED, TheRequest.class, "type.googleapis.com/squareup.wire.protos.roots.TheRequest", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, TheRequest.class, "type.googleapis.com/squareup.wire.protos.roots.TheRequest", Syntax.PROTO_2, null, "service_root.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/TheResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/TheResponse.java
@@ -67,7 +67,7 @@ public final class TheResponse extends Message<TheResponse, TheResponse.Builder>
 
   private static final class ProtoAdapter_TheResponse extends ProtoAdapter<TheResponse> {
     public ProtoAdapter_TheResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, TheResponse.class, "type.googleapis.com/squareup.wire.protos.roots.TheResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, TheResponse.class, "type.googleapis.com/squareup.wire.protos.roots.TheResponse", Syntax.PROTO_2, null, "service_root.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/roots/UnnecessaryResponse.java
@@ -67,7 +67,7 @@ public final class UnnecessaryResponse extends Message<UnnecessaryResponse, Unne
 
   private static final class ProtoAdapter_UnnecessaryResponse extends ProtoAdapter<UnnecessaryResponse> {
     public ProtoAdapter_UnnecessaryResponse() {
-      super(FieldEncoding.LENGTH_DELIMITED, UnnecessaryResponse.class, "type.googleapis.com/squareup.wire.protos.roots.UnnecessaryResponse", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, UnnecessaryResponse.class, "type.googleapis.com/squareup.wire.protos.roots.UnnecessaryResponse", Syntax.PROTO_2, null, "service_root.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/simple/ExternalMessage.java
@@ -214,7 +214,7 @@ public final class ExternalMessage extends Message<ExternalMessage, ExternalMess
 
   private static final class ProtoAdapter_ExternalMessage extends ProtoAdapter<ExternalMessage> {
     public ProtoAdapter_ExternalMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, ExternalMessage.class, "type.googleapis.com/squareup.protos.simple.ExternalMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, ExternalMessage.class, "type.googleapis.com/squareup.protos.simple.ExternalMessage", Syntax.PROTO_2, null, "external_message.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/simple/SimpleMessage.java
@@ -483,7 +483,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
 
     private static final class ProtoAdapter_NestedMessage extends ProtoAdapter<NestedMessage> {
       public ProtoAdapter_NestedMessage() {
-        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage.NestedMessage", Syntax.PROTO_2, null);
+        super(FieldEncoding.LENGTH_DELIMITED, NestedMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage.NestedMessage", Syntax.PROTO_2, null, "simple_message.proto");
       }
 
       @Override
@@ -580,7 +580,7 @@ public final class SimpleMessage extends Message<SimpleMessage, SimpleMessage.Bu
 
   private static final class ProtoAdapter_SimpleMessage extends ProtoAdapter<SimpleMessage> {
     public ProtoAdapter_SimpleMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, SimpleMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, SimpleMessage.class, "type.googleapis.com/squareup.protos.simple.SimpleMessage", Syntax.PROTO_2, null, "simple_message.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bar.java
@@ -95,7 +95,7 @@ public final class Bar extends Message<Bar, Bar.Builder> {
 
   private static final class ProtoAdapter_Bar extends ProtoAdapter<Bar> {
     public ProtoAdapter_Bar() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/samebasename.single_level.Bar", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bar.class, "type.googleapis.com/samebasename.single_level.Bar", Syntax.PROTO_2, null, "samebasename/single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Bars.java
@@ -96,7 +96,7 @@ public final class Bars extends Message<Bars, Bars.Builder> {
 
   private static final class ProtoAdapter_Bars extends ProtoAdapter<Bars> {
     public ProtoAdapter_Bars() {
-      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/samebasename.single_level.Bars", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Bars.class, "type.googleapis.com/samebasename.single_level.Bars", Syntax.PROTO_2, null, "samebasename/single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Foo.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Foo.java
@@ -95,7 +95,7 @@ public final class Foo extends Message<Foo, Foo.Builder> {
 
   private static final class ProtoAdapter_Foo extends ProtoAdapter<Foo> {
     public ProtoAdapter_Foo() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/single_level.Foo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foo.class, "type.googleapis.com/single_level.Foo", Syntax.PROTO_2, null, "single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Foos.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/single_level/Foos.java
@@ -96,7 +96,7 @@ public final class Foos extends Message<Foos, Foos.Builder> {
 
   private static final class ProtoAdapter_Foos extends ProtoAdapter<Foos> {
     public ProtoAdapter_Foos() {
-      super(FieldEncoding.LENGTH_DELIMITED, Foos.class, "type.googleapis.com/single_level.Foos", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Foos.class, "type.googleapis.com/single_level.Foos", Syntax.PROTO_2, null, "single_level.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionOne.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionOne.java
@@ -95,7 +95,7 @@ public final class NestedVersionOne extends Message<NestedVersionOne, NestedVers
 
   private static final class ProtoAdapter_NestedVersionOne extends ProtoAdapter<NestedVersionOne> {
     public ProtoAdapter_NestedVersionOne() {
-      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionOne", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionOne", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionTwo.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/NestedVersionTwo.java
@@ -200,7 +200,7 @@ public final class NestedVersionTwo extends Message<NestedVersionTwo, NestedVers
 
   private static final class ProtoAdapter_NestedVersionTwo extends ProtoAdapter<NestedVersionTwo> {
     public ProtoAdapter_NestedVersionTwo() {
-      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionTwo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, NestedVersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.NestedVersionTwo", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/VersionOne.java
@@ -133,7 +133,7 @@ public final class VersionOne extends Message<VersionOne, VersionOne.Builder> {
 
   private static final class ProtoAdapter_VersionOne extends ProtoAdapter<VersionOne> {
     public ProtoAdapter_VersionOne() {
-      super(FieldEncoding.LENGTH_DELIMITED, VersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.VersionOne", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, VersionOne.class, "type.googleapis.com/squareup.protos.unknownfields.VersionOne", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/unknownfields/VersionTwo.java
@@ -238,7 +238,7 @@ public final class VersionTwo extends Message<VersionTwo, VersionTwo.Builder> {
 
   private static final class ProtoAdapter_VersionTwo extends ProtoAdapter<VersionTwo> {
     public ProtoAdapter_VersionTwo() {
-      super(FieldEncoding.LENGTH_DELIMITED, VersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.VersionTwo", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, VersionTwo.class, "type.googleapis.com/squareup.protos.unknownfields.VersionTwo", Syntax.PROTO_2, null, "unknown_fields.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/squareup/protos/extension_collision/CollisionSubject.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/squareup/protos/extension_collision/CollisionSubject.java
@@ -101,7 +101,7 @@ public final class CollisionSubject extends Message<CollisionSubject, CollisionS
 
   private static final class ProtoAdapter_CollisionSubject extends ProtoAdapter<CollisionSubject> {
     public ProtoAdapter_CollisionSubject() {
-      super(FieldEncoding.LENGTH_DELIMITED, CollisionSubject.class, "type.googleapis.com/squareup.protos.extension_collision.CollisionSubject", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, CollisionSubject.class, "type.googleapis.com/squareup.protos.extension_collision.CollisionSubject", Syntax.PROTO_2, null, "extension_collision.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/squareup/protos/packed_encoding/EmbeddedMessage.java
@@ -118,7 +118,7 @@ public final class EmbeddedMessage extends Message<EmbeddedMessage, EmbeddedMess
 
   private static final class ProtoAdapter_EmbeddedMessage extends ProtoAdapter<EmbeddedMessage> {
     public ProtoAdapter_EmbeddedMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, EmbeddedMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, EmbeddedMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage", Syntax.PROTO_2, null, "packed_encoding.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJavaTest/proto-java/squareup/protos/packed_encoding/OuterMessage.java
+++ b/wire-library/wire-tests/src/jvmJavaTest/proto-java/squareup/protos/packed_encoding/OuterMessage.java
@@ -114,7 +114,7 @@ public final class OuterMessage extends Message<OuterMessage, OuterMessage.Build
 
   private static final class ProtoAdapter_OuterMessage extends ProtoAdapter<OuterMessage> {
     public ProtoAdapter_OuterMessage() {
-      super(FieldEncoding.LENGTH_DELIMITED, OuterMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, OuterMessage.class, "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage", Syntax.PROTO_2, null, "packed_encoding.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -3310,7 +3310,8 @@ public class AllTypes(
       AllTypes::class, 
       "type.googleapis.com/squareup.proto2.AllTypes", 
       PROTO_2, 
-      null
+      null, 
+      "all_types_proto2.proto"
     ) {
       private val map_int32_int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }
@@ -4305,7 +4306,8 @@ public class AllTypes(
         NestedMessage::class, 
         "type.googleapis.com/squareup.proto2.AllTypes.NestedMessage", 
         PROTO_2, 
-        null
+        null, 
+        "all_types_proto2.proto"
       ) {
         public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
@@ -1733,7 +1733,8 @@ public class AllTypes(
       AllTypes::class, 
       "type.googleapis.com/squareup.proto3.AllTypes", 
       PROTO_3, 
-      null
+      null, 
+      "all_types_proto3_test_proto3_optional.proto"
     ) {
       private val map_int32_int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }
@@ -2328,7 +2329,8 @@ public class AllTypes(
         NestedMessage::class, 
         "type.googleapis.com/squareup.proto3.AllTypes.NestedMessage", 
         PROTO_3, 
-        null
+        null, 
+        "all_types_proto3_test_proto3_optional.proto"
       ) {
         public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
@@ -615,7 +615,8 @@ public class All32(
       All32::class, 
       "type.googleapis.com/squareup.proto3.All32", 
       PROTO_3, 
-      null
+      null, 
+      "all32.proto"
     ) {
       private val map_int32_int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
@@ -617,7 +617,8 @@ public class All64(
       All64::class, 
       "type.googleapis.com/squareup.proto3.All64", 
       PROTO_3, 
-      null
+      null, 
+      "all64.proto"
     ) {
       private val map_int64_int64Adapter: ProtoAdapter<Map<Long, Long>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT64, ProtoAdapter.INT64) }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
@@ -549,7 +549,8 @@ public class AllStructs(
       AllStructs::class, 
       "type.googleapis.com/squareup.proto3.AllStructs", 
       PROTO_3, 
-      null
+      null, 
+      "all_structs.proto"
     ) {
       private val map_int32_structAdapter: ProtoAdapter<Map<Int, Map<String, *>?>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.STRUCT_MAP) }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
@@ -737,7 +737,8 @@ public class AllWrappers(
       AllWrappers::class, 
       "type.googleapis.com/squareup.proto3.AllWrappers", 
       PROTO_3, 
-      null
+      null, 
+      "all_wrappers.proto"
     ) {
       private val map_int32_double_valueAdapter: ProtoAdapter<Map<Int, Double?>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.DOUBLE_VALUE) }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -87,7 +87,8 @@ public class BuyOneGetOnePromotion(
       BuyOneGetOnePromotion::class, 
       "type.googleapis.com/squareup.proto3.BuyOneGetOnePromotion", 
       PROTO_3, 
-      null
+      null, 
+      "pizza.proto"
     ) {
       public override fun encodedSize(`value`: BuyOneGetOnePromotion): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
@@ -167,7 +167,8 @@ public class CamelCase(
       CamelCase::class, 
       "type.googleapis.com/squareup.proto3.CamelCase", 
       PROTO_3, 
-      null
+      null, 
+      "camel_case.proto"
     ) {
       private val map_int32_Int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }
@@ -302,7 +303,8 @@ public class CamelCase(
         NestedCamelCase::class, 
         "type.googleapis.com/squareup.proto3.CamelCase.NestedCamelCase", 
         PROTO_3, 
-        null
+        null, 
+        "camel_case.proto"
       ) {
         public override fun encodedSize(`value`: NestedCamelCase): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
@@ -90,7 +90,8 @@ public class FreeDrinkPromotion(
       FreeDrinkPromotion::class, 
       "type.googleapis.com/squareup.proto3.FreeDrinkPromotion", 
       PROTO_3, 
-      null
+      null, 
+      "pizza.proto"
     ) {
       public override fun encodedSize(`value`: FreeDrinkPromotion): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -89,7 +89,8 @@ public class FreeGarlicBreadPromotion(
       FreeGarlicBreadPromotion::class, 
       "type.googleapis.com/squareup.proto3.FreeGarlicBreadPromotion", 
       PROTO_3, 
-      null
+      null, 
+      "pizza.proto"
     ) {
       public override fun encodedSize(`value`: FreeGarlicBreadPromotion): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/MapTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/MapTypes.kt
@@ -347,7 +347,8 @@ public class MapTypes(
       MapTypes::class, 
       "type.googleapis.com/squareup.proto3.MapTypes", 
       PROTO_3, 
-      null
+      null, 
+      "map_types.proto"
     ) {
       private val map_string_stringAdapter: ProtoAdapter<Map<String, String>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ProtoAdapter.STRING) }

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
@@ -92,7 +92,8 @@ public class Pizza(
       Pizza::class, 
       "type.googleapis.com/squareup.proto3.Pizza", 
       PROTO_3, 
-      null
+      null, 
+      "pizza.proto"
     ) {
       public override fun encodedSize(`value`: Pizza): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
@@ -233,7 +233,8 @@ public class PizzaDelivery(
       PizzaDelivery::class, 
       "type.googleapis.com/squareup.proto3.PizzaDelivery", 
       PROTO_3, 
-      null
+      null, 
+      "pizza.proto"
     ) {
       public override fun encodedSize(`value`: PizzaDelivery): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -143,7 +143,8 @@ public class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person", 
       PROTO_2, 
-      null
+      null, 
+      "person.proto"
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
@@ -315,7 +316,8 @@ public class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber", 
         PROTO_2, 
-        null
+        null, 
+        "person.proto"
       ) {
         public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
@@ -148,7 +148,8 @@ public class ModelEvaluation(
       ModelEvaluation::class, 
       "type.googleapis.com/ModelEvaluation", 
       PROTO_2, 
-      null
+      null, 
+      "resursive_map.proto"
     ) {
       private val modelsAdapter: ProtoAdapter<Map<String, ModelEvaluation>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, ModelEvaluation.ADAPTER) }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -282,7 +282,8 @@ public class FooBar(
       FooBar::class, 
       "type.googleapis.com/squareup.protos.custom_options.FooBar", 
       PROTO_2, 
-      null
+      null, 
+      "custom_options.proto"
     ) {
       public override fun encodedSize(`value`: FooBar): Int {
         var size = value.unknownFields.size
@@ -446,7 +447,8 @@ public class FooBar(
         Nested::class, 
         "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested", 
         PROTO_2, 
-        null
+        null, 
+        "custom_options.proto"
       ) {
         public override fun encodedSize(`value`: Nested): Int {
           var size = value.unknownFields.size
@@ -560,7 +562,8 @@ public class FooBar(
         More::class, 
         "type.googleapis.com/squareup.protos.custom_options.FooBar.More", 
         PROTO_2, 
-        null
+        null, 
+        "custom_options.proto"
       ) {
         public override fun encodedSize(`value`: More): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/MessageWithOptions.kt
@@ -57,7 +57,8 @@ public class MessageWithOptions(
       MessageWithOptions::class, 
       "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions", 
       PROTO_2, 
-      null
+      null, 
+      "custom_options.proto"
     ) {
       public override fun encodedSize(`value`: MessageWithOptions): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/depend_on_kotlin_option/Letter.java
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/depend_on_kotlin_option/Letter.java
@@ -96,7 +96,7 @@ public final class Letter extends Message<Letter, Letter.Builder> {
 
   private static final class ProtoAdapter_Letter extends ProtoAdapter<Letter> {
     public ProtoAdapter_Letter() {
-      super(FieldEncoding.LENGTH_DELIMITED, Letter.class, "type.googleapis.com/squareup.protos.depend_on_kotlin_option.Letter", Syntax.PROTO_2, null);
+      super(FieldEncoding.LENGTH_DELIMITED, Letter.class, "type.googleapis.com/squareup.protos.depend_on_kotlin_option.Letter", Syntax.PROTO_2, null, "depend_on_kotlin_option.proto");
     }
 
     @Override

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -88,7 +88,8 @@ public class DeprecatedProto(
       DeprecatedProto::class, 
       "type.googleapis.com/squareup.protos.kotlin.DeprecatedProto", 
       PROTO_2, 
-      null
+      null, 
+      "deprecated.proto"
     ) {
       public override fun encodedSize(`value`: DeprecatedProto): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -124,7 +124,8 @@ public class Form(
       Form::class, 
       "type.googleapis.com/squareup.protos.kotlin.oneof.Form", 
       PROTO_2, 
-      null
+      null, 
+      "form.proto"
     ) {
       public override fun encodedSize(`value`: Form): Int {
         var size = value.unknownFields.size
@@ -295,7 +296,8 @@ public class Form(
         ButtonElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.ButtonElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: ButtonElement): Int {
           var size = value.unknownFields.size
@@ -363,7 +365,8 @@ public class Form(
         LocalImageElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.LocalImageElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: LocalImageElement): Int {
           var size = value.unknownFields.size
@@ -431,7 +434,8 @@ public class Form(
         RemoteImageElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.RemoteImageElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: RemoteImageElement): Int {
           var size = value.unknownFields.size
@@ -498,7 +502,8 @@ public class Form(
         MoneyElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.MoneyElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: MoneyElement): Int {
           var size = value.unknownFields.size
@@ -565,7 +570,8 @@ public class Form(
         SpacerElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.SpacerElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: SpacerElement): Int {
           var size = value.unknownFields.size
@@ -661,7 +667,8 @@ public class Form(
         TextElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: TextElement): Int {
           var size = value.unknownFields.size
@@ -739,7 +746,8 @@ public class Form(
         CustomizedCardElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CustomizedCardElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: CustomizedCardElement): Int {
           var size = value.unknownFields.size
@@ -808,7 +816,8 @@ public class Form(
         AddressElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.AddressElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: AddressElement): Int {
           var size = value.unknownFields.size
@@ -875,7 +884,8 @@ public class Form(
         TextInputElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextInputElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: TextInputElement): Int {
           var size = value.unknownFields.size
@@ -943,7 +953,8 @@ public class Form(
         OptionPickerElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.OptionPickerElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: OptionPickerElement): Int {
           var size = value.unknownFields.size
@@ -1010,7 +1021,8 @@ public class Form(
         DetailRowElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.DetailRowElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: DetailRowElement): Int {
           var size = value.unknownFields.size
@@ -1079,7 +1091,8 @@ public class Form(
         CurrencyConversionFlagsElement::class, 
         "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CurrencyConversionFlagsElement", 
         PROTO_2, 
-        null
+        null, 
+        "form.proto"
       ) {
         public override fun encodedSize(`value`: CurrencyConversionFlagsElement): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -111,7 +111,8 @@ public class MessageUsingMultipleEnums(
       MessageUsingMultipleEnums::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageUsingMultipleEnums", 
       PROTO_2, 
-      null
+      null, 
+      "same_name_enum.proto"
     ) {
       public override fun encodedSize(`value`: MessageUsingMultipleEnums): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageWithStatus.kt
@@ -58,7 +58,8 @@ public class MessageWithStatus(
       MessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.MessageWithStatus", 
       PROTO_2, 
-      null
+      null, 
+      "same_name_enum.proto"
     ) {
       public override fun encodedSize(`value`: MessageWithStatus): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/NoFields.kt
@@ -56,7 +56,8 @@ public class NoFields(
       NoFields::class, 
       "type.googleapis.com/squareup.protos.kotlin.NoFields", 
       PROTO_2, 
-      null
+      null, 
+      "no_fields.proto"
     ) {
       public override fun encodedSize(`value`: NoFields): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -164,7 +164,8 @@ public class OneOfMessage(
       OneOfMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.oneof.OneOfMessage", 
       PROTO_2, 
-      null
+      null, 
+      "one_of.proto"
     ) {
       public override fun encodedSize(`value`: OneOfMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OtherMessageWithStatus.kt
@@ -59,7 +59,8 @@ public class OtherMessageWithStatus(
       OtherMessageWithStatus::class, 
       "type.googleapis.com/squareup.protos.kotlin.OtherMessageWithStatus", 
       PROTO_2, 
-      null
+      null, 
+      "same_name_enum.proto"
     ) {
       public override fun encodedSize(`value`: OtherMessageWithStatus): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
@@ -91,7 +91,8 @@ public class Percents(
       Percents::class, 
       "type.googleapis.com/squareup.protos.kotlin.Percents", 
       PROTO_2, 
-      null
+      null, 
+      "percents_in_kdoc.proto"
     ) {
       public override fun encodedSize(`value`: Percents): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -3234,7 +3234,8 @@ public class AllTypes(
       AllTypes::class, 
       "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes", 
       PROTO_2, 
-      null
+      null, 
+      "all_types.proto"
     ) {
       private val map_int32_int32Adapter: ProtoAdapter<Map<Int, Int>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.INT32, ProtoAdapter.INT32) }
@@ -4210,7 +4211,8 @@ public class AllTypes(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes.NestedMessage", 
         PROTO_2, 
-        null
+        null, 
+        "all_types.proto"
       ) {
         public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -109,7 +109,8 @@ public class ForeignMessage(
       ForeignMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.foreign.ForeignMessage", 
       PROTO_2, 
-      null
+      null, 
+      "foreign.proto"
     ) {
       public override fun encodedSize(`value`: ForeignMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -91,7 +91,8 @@ public class Mappy(
       Mappy::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Mappy", 
       PROTO_2, 
-      null
+      null, 
+      "map.proto"
     ) {
       private val thingsAdapter: ProtoAdapter<Map<String, Thing>> by lazy {
           ProtoAdapter.newMapAdapter(ProtoAdapter.STRING, Thing.ADAPTER) }

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -85,7 +85,8 @@ public class Thing(
       Thing::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Thing", 
       PROTO_2, 
-      null
+      null, 
+      "map.proto"
     ) {
       public override fun encodedSize(`value`: Thing): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -213,7 +213,8 @@ public class Person(
       Person::class, 
       "type.googleapis.com/squareup.protos.kotlin.person.Person", 
       PROTO_2, 
-      null
+      null, 
+      "person.proto"
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
@@ -415,7 +416,8 @@ public class Person(
         PhoneNumber::class, 
         "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber", 
         PROTO_2, 
-        null
+        null, 
+        "person.proto"
       ) {
         public override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -118,7 +118,8 @@ public class RedactedOneOf(
       RedactedOneOf::class, 
       "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedOneOf", 
       PROTO_2, 
-      null
+      null, 
+      "redacted_one_of.proto"
     ) {
       public override fun encodedSize(`value`: RedactedOneOf): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
@@ -92,7 +92,8 @@ public class Repeated(
       Repeated::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.repeated.Repeated", 
       PROTO_2, 
-      null
+      null, 
+      "repeated.proto"
     ) {
       public override fun encodedSize(`value`: Repeated): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
@@ -85,7 +85,8 @@ public class Thing(
       Thing::class, 
       "type.googleapis.com/com.squareup.wire.protos.kotlin.repeated.Thing", 
       PROTO_2, 
-      null
+      null, 
+      "repeated.proto"
     ) {
       public override fun encodedSize(`value`: Thing): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageRequest.kt
@@ -53,7 +53,8 @@ public class NoPackageRequest(
       NoPackageRequest::class, 
       "type.googleapis.com/NoPackageRequest", 
       PROTO_2, 
-      null
+      null, 
+      "service_without_package.proto"
     ) {
       public override fun encodedSize(`value`: NoPackageRequest): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/NoPackageResponse.kt
@@ -53,7 +53,8 @@ public class NoPackageResponse(
       NoPackageResponse::class, 
       "type.googleapis.com/NoPackageResponse", 
       PROTO_2, 
-      null
+      null, 
+      "service_without_package.proto"
     ) {
       public override fun encodedSize(`value`: NoPackageResponse): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeRequest.kt
@@ -53,7 +53,8 @@ public class SomeRequest(
       SomeRequest::class, 
       "type.googleapis.com/squareup.protos.kotlin.SomeRequest", 
       PROTO_2, 
-      null
+      null, 
+      "service_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: SomeRequest): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/services/SomeResponse.kt
@@ -53,7 +53,8 @@ public class SomeResponse(
       SomeResponse::class, 
       "type.googleapis.com/squareup.protos.kotlin.SomeResponse", 
       PROTO_2, 
-      null
+      null, 
+      "service_kotlin.proto"
     ) {
       public override fun encodedSize(`value`: SomeResponse): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -212,7 +212,8 @@ public class ExternalMessage(
       ExternalMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.ExternalMessage", 
       PROTO_2, 
-      null
+      null, 
+      "external_message.proto"
     ) {
       public override fun encodedSize(`value`: ExternalMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -411,7 +411,8 @@ public class SimpleMessage(
       SimpleMessage::class, 
       "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage", 
       PROTO_2, 
-      null
+      null, 
+      "simple_message.proto"
     ) {
       public override fun encodedSize(`value`: SimpleMessage): Int {
         var size = value.unknownFields.size
@@ -603,7 +604,8 @@ public class SimpleMessage(
         NestedMessage::class, 
         "type.googleapis.com/squareup.protos.kotlin.simple.SimpleMessage.NestedMessage", 
         PROTO_2, 
-        null
+        null, 
+        "simple_message.proto"
       ) {
         public override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -84,7 +84,8 @@ public class NestedVersionOne(
       NestedVersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionOne", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: NestedVersionOne): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -194,7 +194,8 @@ public class NestedVersionTwo(
       NestedVersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionTwo", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: NestedVersionTwo): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -126,7 +126,8 @@ public class VersionOne(
       VersionOne::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionOne", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: VersionOne): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -234,7 +234,8 @@ public class VersionTwo(
       VersionTwo::class, 
       "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionTwo", 
       PROTO_2, 
-      null
+      null, 
+      "unknown_fields.proto"
     ) {
       public override fun encodedSize(`value`: VersionTwo): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -115,7 +115,8 @@ public class UsesAny(
       UsesAny::class, 
       "type.googleapis.com/squareup.protos.usesany.UsesAny", 
       PROTO_2, 
-      null
+      null, 
+      "uses_any.proto"
     ) {
       public override fun encodedSize(`value`: UsesAny): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -115,7 +115,8 @@ public class EmbeddedMessage(
       EmbeddedMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage", 
       PROTO_2, 
-      null
+      null, 
+      "packed_encoding.proto"
     ) {
       public override fun encodedSize(`value`: EmbeddedMessage): Int {
         var size = value.unknownFields.size

--- a/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-library/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -106,7 +106,8 @@ public class OuterMessage(
       OuterMessage::class, 
       "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage", 
       PROTO_2, 
-      null
+      null, 
+      "packed_encoding.proto"
     ) {
       public override fun encodedSize(`value`: OuterMessage): Int {
         var size = value.unknownFields.size


### PR DESCRIPTION
This PR adds a property to the Wire message adapter to point at the message's proto file path.

This change will be used to integrate Wire with Confluent's Schema Registry. Confluent's protobuf implementation uses the encoded message descriptors in the generated Java code. We need similar functionality in Wire. In order to do that  we need to access the proto file for a message. Wire already supports including the proto file in the classpath resources via ```protoLibrary = true``` configuration option. This change simplifies discovering the proto file for a message by adding it to the adapter.

Checks:
- [X] Code compiles correctly
- [X] Updated ```JavaGeneratorTest.generateAbstractAdapter``` which failed with this new change.
- [X] All tests passing