### PR TITLE
Fix publishing for JVM artifacts

### DIFF
--- a/wire-library/internal-plugins/src/main/kotlin/com/squareup/gradle/InternalPublishingPlugin.kt
+++ b/wire-library/internal-plugins/src/main/kotlin/com/squareup/gradle/InternalPublishingPlugin.kt
@@ -67,6 +67,16 @@ class InternalPublishingPlugin : Plugin<Project> {
 
     project.extensions.getByType<PublishingExtension>().apply {
       publications {
+        project.afterEvaluate {
+          // Multiplatform projects get publications automatically, but JVM-only do not. Add 'em.
+          if (this@publications.isEmpty()) {
+            create("maven", MavenPublication::class.java) {
+              artifact(project.tasks.named("jar"))
+              artifact(project.tasks.named("kotlinSourcesJar"))
+            }
+          }
+        }
+
         all {
           if (this !is MavenPublication) return@all
 

--- a/wire-library/wire-gradle-plugin/build.gradle.kts
+++ b/wire-library/wire-gradle-plugin/build.gradle.kts
@@ -78,14 +78,3 @@ tasks.withType<AbstractPublishToMaven>().configureEach {
     enabled = false
   }
 }
-
-// Kotlin sources are inexplicably omitted when publishing plugins. Add 'em manually.
-val kotlinSourcesJar: Task = project.tasks.getByName("kotlinSourcesJar")
-project.extensions.getByType<PublishingExtension>().apply {
-  publications {
-    all {
-      if (this !is MavenPublication) return@all
-      artifact(kotlinSourcesJar)
-    }
-  }
-}


### PR DESCRIPTION
I'm doing my best to get consistency between JVM-only and Kotlin
Multiplatform publishing, but unfortunately they start out quite
different.