### PR TITLE
[wire-kotlin-generator] `hashCode()` improvement

### DIFF
--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -665,7 +665,7 @@ class KotlinGenerator private constructor(
           is Field -> {
             val fieldName = localNameAllocator[fieldOrOneOf]
             add("%1N = %1N * 37 + ", resultName)
-            if (fieldOrOneOf.isRepeated || fieldOrOneOf.isRequired || fieldOrOneOf.isMap) {
+            if (fieldOrOneOf.isRepeated || fieldOrOneOf.isRequired || fieldOrOneOf.isMap || !fieldOrOneOf.acceptsNull) {
               addStatement("%L.hashCode()", fieldName)
             } else {
               addStatement("(%L?.hashCode() ?: 0)", fieldName)

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
@@ -992,22 +992,22 @@ public class AllTypes(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (proto3_kotlin_int32?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_uint32?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_sint32?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_fixed32?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_sfixed32?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_int64?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_uint64?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_sint64?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_fixed64?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_sfixed64?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_bool?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_float?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_double?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_string?.hashCode() ?: 0)
-      result = result * 37 + (proto3_kotlin_bytes?.hashCode() ?: 0)
-      result = result * 37 + (nested_enum?.hashCode() ?: 0)
+      result = result * 37 + proto3_kotlin_int32.hashCode()
+      result = result * 37 + proto3_kotlin_uint32.hashCode()
+      result = result * 37 + proto3_kotlin_sint32.hashCode()
+      result = result * 37 + proto3_kotlin_fixed32.hashCode()
+      result = result * 37 + proto3_kotlin_sfixed32.hashCode()
+      result = result * 37 + proto3_kotlin_int64.hashCode()
+      result = result * 37 + proto3_kotlin_uint64.hashCode()
+      result = result * 37 + proto3_kotlin_sint64.hashCode()
+      result = result * 37 + proto3_kotlin_fixed64.hashCode()
+      result = result * 37 + proto3_kotlin_sfixed64.hashCode()
+      result = result * 37 + proto3_kotlin_bool.hashCode()
+      result = result * 37 + proto3_kotlin_float.hashCode()
+      result = result * 37 + proto3_kotlin_double.hashCode()
+      result = result * 37 + proto3_kotlin_string.hashCode()
+      result = result * 37 + proto3_kotlin_bytes.hashCode()
+      result = result * 37 + nested_enum.hashCode()
       result = result * 37 + (nested_message?.hashCode() ?: 0)
       result = result * 37 + (any?.hashCode() ?: 0)
       result = result * 37 + (duration?.hashCode() ?: 0)
@@ -2182,7 +2182,7 @@ public class AllTypes(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + (a?.hashCode() ?: 0)
+        result = result * 37 + a.hashCode()
         super.hashCode = result
       }
       return result

--- a/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
+++ b/wire-library/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
@@ -127,9 +127,9 @@ public class Person(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (name?.hashCode() ?: 0)
-      result = result * 37 + (id?.hashCode() ?: 0)
-      result = result * 37 + (email?.hashCode() ?: 0)
+      result = result * 37 + name.hashCode()
+      result = result * 37 + id.hashCode()
+      result = result * 37 + email.hashCode()
       result = result * 37 + phones.hashCode()
       result = result * 37 + aliases.hashCode()
       result = result * 37 + (foo?.hashCode() ?: 0)
@@ -322,8 +322,8 @@ public class Person(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + (number?.hashCode() ?: 0)
-        result = result * 37 + (type?.hashCode() ?: 0)
+        result = result * 37 + number.hashCode()
+        result = result * 37 + type.hashCode()
         super.hashCode = result
       }
       return result

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
@@ -819,22 +819,22 @@ public class AllTypes(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (my_int32?.hashCode() ?: 0)
-      result = result * 37 + (my_uint32?.hashCode() ?: 0)
-      result = result * 37 + (my_sint32?.hashCode() ?: 0)
-      result = result * 37 + (my_fixed32?.hashCode() ?: 0)
-      result = result * 37 + (my_sfixed32?.hashCode() ?: 0)
-      result = result * 37 + (my_int64?.hashCode() ?: 0)
-      result = result * 37 + (my_uint64?.hashCode() ?: 0)
-      result = result * 37 + (my_sint64?.hashCode() ?: 0)
-      result = result * 37 + (my_fixed64?.hashCode() ?: 0)
-      result = result * 37 + (my_sfixed64?.hashCode() ?: 0)
-      result = result * 37 + (my_bool?.hashCode() ?: 0)
-      result = result * 37 + (my_float?.hashCode() ?: 0)
-      result = result * 37 + (my_double?.hashCode() ?: 0)
-      result = result * 37 + (my_string?.hashCode() ?: 0)
-      result = result * 37 + (my_bytes?.hashCode() ?: 0)
-      result = result * 37 + (nested_enum?.hashCode() ?: 0)
+      result = result * 37 + my_int32.hashCode()
+      result = result * 37 + my_uint32.hashCode()
+      result = result * 37 + my_sint32.hashCode()
+      result = result * 37 + my_fixed32.hashCode()
+      result = result * 37 + my_sfixed32.hashCode()
+      result = result * 37 + my_int64.hashCode()
+      result = result * 37 + my_uint64.hashCode()
+      result = result * 37 + my_sint64.hashCode()
+      result = result * 37 + my_fixed64.hashCode()
+      result = result * 37 + my_sfixed64.hashCode()
+      result = result * 37 + my_bool.hashCode()
+      result = result * 37 + my_float.hashCode()
+      result = result * 37 + my_double.hashCode()
+      result = result * 37 + my_string.hashCode()
+      result = result * 37 + my_bytes.hashCode()
+      result = result * 37 + nested_enum.hashCode()
       result = result * 37 + (nested_message?.hashCode() ?: 0)
       result = result * 37 + (opt_int32?.hashCode() ?: 0)
       result = result * 37 + (opt_uint32?.hashCode() ?: 0)
@@ -2292,7 +2292,7 @@ public class AllTypes(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + (a?.hashCode() ?: 0)
+        result = result * 37 + a.hashCode()
         super.hashCode = result
       }
       return result

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
@@ -306,11 +306,11 @@ public class All32(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (my_int32?.hashCode() ?: 0)
-      result = result * 37 + (my_uint32?.hashCode() ?: 0)
-      result = result * 37 + (my_sint32?.hashCode() ?: 0)
-      result = result * 37 + (my_fixed32?.hashCode() ?: 0)
-      result = result * 37 + (my_sfixed32?.hashCode() ?: 0)
+      result = result * 37 + my_int32.hashCode()
+      result = result * 37 + my_uint32.hashCode()
+      result = result * 37 + my_sint32.hashCode()
+      result = result * 37 + my_fixed32.hashCode()
+      result = result * 37 + my_sfixed32.hashCode()
       result = result * 37 + rep_int32.hashCode()
       result = result * 37 + rep_uint32.hashCode()
       result = result * 37 + rep_sint32.hashCode()

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
@@ -308,11 +308,11 @@ public class All64(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (my_int64?.hashCode() ?: 0)
-      result = result * 37 + (my_uint64?.hashCode() ?: 0)
-      result = result * 37 + (my_sint64?.hashCode() ?: 0)
-      result = result * 37 + (my_fixed64?.hashCode() ?: 0)
-      result = result * 37 + (my_sfixed64?.hashCode() ?: 0)
+      result = result * 37 + my_int64.hashCode()
+      result = result * 37 + my_uint64.hashCode()
+      result = result * 37 + my_sint64.hashCode()
+      result = result * 37 + my_fixed64.hashCode()
+      result = result * 37 + my_sfixed64.hashCode()
       result = result * 37 + rep_int64.hashCode()
       result = result * 37 + rep_uint64.hashCode()
       result = result * 37 + rep_sint64.hashCode()

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -49,7 +49,7 @@ public class BuyOneGetOnePromotion(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (coupon?.hashCode() ?: 0)
+      result = result * 37 + coupon.hashCode()
       super.hashCode = result
     }
     return result

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
@@ -92,7 +92,7 @@ public class CamelCase(
       result = unknownFields.hashCode()
       result = result * 37 + (nested__message?.hashCode() ?: 0)
       result = result * 37 + _Rep_int32.hashCode()
-      result = result * 37 + (IDitIt_my_wAy?.hashCode() ?: 0)
+      result = result * 37 + IDitIt_my_wAy.hashCode()
       result = result * 37 + map_int32_Int32.hashCode()
       super.hashCode = result
     }
@@ -266,7 +266,7 @@ public class CamelCase(
       var result = super.hashCode
       if (result == 0) {
         result = unknownFields.hashCode()
-        result = result * 37 + (one_int32?.hashCode() ?: 0)
+        result = result * 37 + one_int32.hashCode()
         super.hashCode = result
       }
       return result

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
@@ -52,7 +52,7 @@ public class FreeDrinkPromotion(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (drink?.hashCode() ?: 0)
+      result = result * 37 + drink.hashCode()
       super.hashCode = result
     }
     return result

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -49,7 +49,7 @@ public class FreeGarlicBreadPromotion(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (is_extra_cheesey?.hashCode() ?: 0)
+      result = result * 37 + is_extra_cheesey.hashCode()
       super.hashCode = result
     }
     return result

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
@@ -119,8 +119,8 @@ public class PizzaDelivery(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + (phone_number?.hashCode() ?: 0)
-      result = result * 37 + (address?.hashCode() ?: 0)
+      result = result * 37 + phone_number.hashCode()
+      result = result * 37 + address.hashCode()
       result = result * 37 + pizzas.hashCode()
       result = result * 37 + (promotion?.hashCode() ?: 0)
       result = result * 37 + (delivered_within_or_free?.hashCode() ?: 0)


### PR DESCRIPTION
Improve `hashCode()` code generation for Kotlin by removing unnecessary null checks which result in `Unnecessary safe call on a non-null receiver` and `Elvis operator (?:) always returns the left operand of non-nullable type`