### PR TITLE
Upgrade to Kotlin 1.5.31

### DIFF
--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
@@ -272,7 +272,7 @@ class GrpcClientTest {
       requestChannel.close()
       assertThat(responseChannel.receive()).isEqualTo(Feature(name = "tree"))
       assertThat(responseChannel.receive()).isEqualTo(Feature(name = "house"))
-      assertThat(responseChannel.receiveOrNull()).isNull()
+      assertThat(responseChannel.receiveCatching().getOrNull()).isNull()
     }
   }
 
@@ -350,7 +350,7 @@ class GrpcClientTest {
       requestChannel.send(RouteNote(message = "rené"))
       requestChannel.close()
       assertThat(responseChannel.receive()).isEqualTo(RouteNote(message = "lacoste"))
-      assertThat(responseChannel.receiveOrNull()).isNull()
+      assertThat(responseChannel.receiveCatching().getOrNull()).isNull()
     }
   }
 
@@ -530,7 +530,7 @@ class GrpcClientTest {
       assertThat(responseChannel.receive()).isEqualTo(RouteNote(message = "polo"))
       requestChannel.send(RouteNote(message = "rené"))
       assertThat(responseChannel.receive()).isEqualTo(RouteNote(message = "lacoste"))
-      assertThat(responseChannel.receiveOrNull()).isNull()
+      assertThat(responseChannel.receiveCatching().getOrNull()).isNull()
       requestChannel.close()
     }
   }
@@ -636,7 +636,7 @@ class GrpcClientTest {
       requestChannel.send(RouteNote(message = "rené"))
       assertThat(responseChannel.receive()).isEqualTo(RouteNote(message = "lacoste"))
       requestChannel.close()
-      assertThat(responseChannel.receiveOrNull()).isNull()
+      assertThat(responseChannel.receiveCatching().getOrNull()).isNull()
 
       // We wait for mockService to process our actions.
       delay(500)
@@ -731,7 +731,7 @@ class GrpcClientTest {
     runBlocking {
       assertThat(responseChannel.receive()).isEqualTo(RouteNote(message = "welcome"))
       requestChannel.close()
-      assertThat(responseChannel.receiveOrNull()).isNull()
+      assertThat(responseChannel.receiveCatching().getOrNull()).isNull()
     }
   }
 
@@ -867,7 +867,7 @@ class GrpcClientTest {
     runBlocking {
       assertThat(responseChannel.receive()).isEqualTo(RouteNote(message = "welcome"))
       requestChannel.close()
-      assertThat(responseChannel.receiveOrNull()).isNull()
+      assertThat(responseChannel.receiveCatching().getOrNull()).isNull()
     }
   }
 

--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcStreamingCallsTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcStreamingCallsTest.kt
@@ -22,7 +22,6 @@ import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 import kotlinx.coroutines.channels.consumeEach
-import kotlinx.coroutines.channels.receiveOrNull
 import kotlinx.coroutines.runBlocking
 import okio.IOException
 import org.assertj.core.api.Assertions.assertThat
@@ -43,7 +42,7 @@ class GrpcStreamingCallsTest {
       requests.send("hello")
       requests.close()
       assertThat(responses.receive()).isEqualTo("HELLO")
-      assertThat(responses.receiveOrNull()).isNull()
+      assertThat(responses.receiveCatching().getOrNull()).isNull()
     }
   }
 
@@ -203,7 +202,7 @@ class GrpcStreamingCallsTest {
       requests2.send("hello")
       requests2.close()
       assertThat(responses2.receive()).isEqualTo("HELLO")
-      assertThat(responses2.receiveOrNull()).isNull()
+      assertThat(responses2.receiveCatching().getOrNull()).isNull()
     }
   }
 

--- a/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
@@ -9,8 +9,8 @@ object versions {
   val animalSniffer = "1.16"
   val animalSnifferGradle = "1.5.0"
   val assertj = "3.11.0"
-  val coroutines = "1.3.9"
-  val dokka = "1.4.20"
+  val coroutines = "1.5.2"
+  val dokka = "1.5.30"
   val errorprone = "2.0.21"
   val grpc = "1.38.1"
   val gson = "2.8.6"
@@ -21,7 +21,7 @@ object versions {
   val jmhPlugin = "0.5.0"
   val jsr305 = "3.0.2"
   val junit = "4.12"
-  val kotlin = "1.5.20"
+  val kotlin = "1.5.31"
   val kotlinpoet = "1.9.0"
   val moshi = "1.12.0"
   val okhttp = "4.9.1"
@@ -119,7 +119,7 @@ object deps {
   }
 
   val truth = "com.google.truth:truth:1.1.3"
-  val vanniktechPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.17.0"
+  val vanniktechPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
 
   object wire {
     val compiler = "com.squareup.wire:wire-compiler"

--- a/wire-library/wire-grpc-client/build.gradle.kts
+++ b/wire-library/wire-grpc-client/build.gradle.kts
@@ -88,14 +88,6 @@ configure<AnimalSnifferExtension> {
   ignore("com.squareup.wire.internal")
 }
 
-// https://github.com/vanniktech/gradle-maven-publish-plugin/issues/301
-val metadataJar by tasks.getting(Jar::class)
-configure<PublishingExtension> {
-  publications.withType<MavenPublication>().named("kotlinMultiplatform").configure {
-    artifact(metadataJar)
-  }
-}
-
 configure<MavenPublishBaseExtension> {
   configure(
     KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))

--- a/wire-library/wire-runtime/build.gradle.kts
+++ b/wire-library/wire-runtime/build.gradle.kts
@@ -130,14 +130,6 @@ configure<AnimalSnifferExtension> {
   ignore("com.squareup.wire.internal")
 }
 
-// https://github.com/vanniktech/gradle-maven-publish-plugin/issues/301
-val metadataJar by tasks.getting(Jar::class)
-configure<PublishingExtension> {
-  publications.withType<MavenPublication>().named("kotlinMultiplatform").configure {
-    artifact(metadataJar)
-  }
-}
-
 configure<MavenPublishBaseExtension> {
   configure(
     KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))

--- a/wire-library/wire-schema/build.gradle.kts
+++ b/wire-library/wire-schema/build.gradle.kts
@@ -61,14 +61,6 @@ kotlin {
   }
 }
 
-// https://github.com/vanniktech/gradle-maven-publish-plugin/issues/301
-val metadataJar by tasks.getting(Jar::class)
-configure<PublishingExtension> {
-  publications.withType<MavenPublication>().named("kotlinMultiplatform").configure {
-    artifact(metadataJar)
-  }
-}
-
 configure<MavenPublishBaseExtension> {
   configure(
     KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))


### PR DESCRIPTION
Also upgrade coroutines, dokka, and the vanniktech maven publish plugin.

This is great for Wire as kotlin.test is broken on 1.5.21 (multiplatform
packaging issue) and the compiler is broken on 1.5.30 (defaultfield verify
error). With 1.5.31 everything should work all on the same version.