### PR TITLE
Add gradle.plugin-publish back

### DIFF
--- a/wire-library/wire-gradle-plugin/build.gradle.kts
+++ b/wire-library/wire-gradle-plugin/build.gradle.kts
@@ -3,6 +3,7 @@ import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
+  id("com.gradle.plugin-publish") version "0.16.0"
   kotlin("jvm")
   id("java-gradle-plugin")
   id("org.jetbrains.dokka")


### PR DESCRIPTION
I think it was removed when we migrated to kts

related to #1944