### PR TITLE
Modernize WireTask APIs to use more modern Gradle APIs and be configuration caching friendly

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -191,20 +191,23 @@ class WirePlugin : Plugin<Project> {
           protoSourceInput.debug(task.logger)
           protoPathInput.debug(task.logger)
         }
-        task.outputDirectories = targets.map { target -> project.file(target.outDirectory) }
+        task.outputDirectories.setFrom(targets.map { it.outDirectory })
         task.sourceInput.set(protoSourceInput.toLocations(project))
         task.protoInput.set(protoPathInput.toLocations(project))
-        task.roots = extension.roots.toList()
-        task.prunes = extension.prunes.toList()
-        task.moves = extension.moves.toList()
-        task.sinceVersion = extension.sinceVersion
-        task.untilVersion = extension.untilVersion
-        task.onlyVersion = extension.onlyVersion
-        task.rules = extension.rules
-        task.targets = targets
-        task.permitPackageCycles = extension.permitPackageCycles
+        task.roots.set(extension.roots.toList())
+        task.prunes.set(extension.prunes.toList())
+        task.moves.set(extension.moves.toList())
+        task.sinceVersion.set(extension.sinceVersion)
+        task.untilVersion.set(extension.untilVersion)
+        task.onlyVersion.set(extension.onlyVersion)
+        task.rules.set(extension.rules)
+        task.targets.set(targets)
+        task.permitPackageCycles.set(extension.permitPackageCycles)
 
-        task.inputFiles = inputFiles
+        task.inputFiles.setFrom(inputFiles)
+
+        task.projectDirProperty.set(project.layout.projectDirectory)
+        task.buildDirProperty.set(project.layout.buildDirectory)
 
         for (projectDependency in projectDependencies) {
           task.dependsOn(projectDependency)

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -167,7 +167,7 @@ private fun BaseExtension.sourceRoots(project: Project, kotlin: Boolean): List<S
       sourceSets = variant.sourceSets.map { it.name },
       registerTaskDependency = { task ->
         // TODO: Lazy task configuration!!!
-        variant.registerJavaGeneratingTask(task.get(), task.get().outputDirectories)
+        variant.registerJavaGeneratingTask(task.get(), task.get().outputDirectories.files)
         val compileTaskName =
           if (kotlin) """compile${variant.name.capitalize()}Kotlin"""
           else """compile${variant.name.capitalize()}Sources"""

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -8,8 +8,9 @@ import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.After
 import org.junit.Assert.fail
-import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
+import org.junit.rules.TemporaryFolder
 import java.io.File
 import java.io.IOException
 import java.util.zip.ZipFile
@@ -17,15 +18,25 @@ import kotlin.text.RegexOption.DOT_MATCHES_ALL
 import kotlin.text.RegexOption.MULTILINE
 
 class WirePluginTest {
-  private lateinit var gradleRunner: GradleRunner
 
-  @Before
-  fun setUp() {
-    gradleRunner = GradleRunner.create()
-        .withPluginClasspath()
-        .withArguments("generateProtos", "--stacktrace", "--info")
-        .withDebug(true)
-  }
+  @JvmField
+  @Rule
+  val tmpFolder = TemporaryFolder()
+
+  private val gradleRunner: GradleRunner = GradleRunner.create()
+    .withPluginClasspath()
+    // Ensure individual tests are isolated and not reusing each other's previous outputs
+    // by setting project dir and gradle home directly.
+    .withProjectDir(tmpFolder.newFolder("project-dir"))
+    .withArguments(
+      "-g",
+      tmpFolder.newFolder("gradle-home").absolutePath,
+      "generateProtos",
+      "--stacktrace",
+      "--info",
+      "--configuration-cache",
+    )
+    .withDebug(true)
 
   @After
   fun clearOutputs() {


### PR DESCRIPTION
This leans heavily on [managed properties](https://docs.gradle.org/current/userguide/custom_gradle_types.html#managed_properties), proper `Property` types, and fixes `project` accessor issues that break configuration caching in the `WireTask`. It's a breaking change but since 4.0 is in alpha it seemed like now is a good time, and it would be hard to do this without breaking anything.

Breaking in the following ways:
- Binary breaking change (obviously)
- Kotlin source breaking change (also obviously)
- _not_ a Groovy source breaking change (possibly not obvious)

Resolves #2086

This also cleans up `WirePluginTest` a bit and enables configuration caching on it.

This ensures individual tests are properly isolated from each other by defining and clearing their project and gradle home dirs between runs. Before, they would reuse caches and possibly return false positives on caches. This also adds `--configuration-cache` to the test arguments to catch any regressions to that support in the future. It does run more slowly, but that's the cost of full isolation.

Note that this also inlines the test runner initializer to the property, because it's needless to put it directly in the setup method here unless you're expecting it to possibly throw an exception and want a cleaner error message.