### PR TITLE
Working on generating plain gRPC server code

### DIFF
--- a/wire-library/docs/wire_grpc.md
+++ b/wire-library/docs/wire_grpc.md
@@ -214,6 +214,22 @@ public class FakeRouteGuideClient implements RouteGuideClient {
 
 These similarly interact nicely with Java lambdas.
 
+Plain gRPC Server Support
+------
+
+**Note: Plain gRPC server support is currently experimental.**
+
+By configuring `grpcServerCompatible` as `true`, wire would generate classes for plain gRPC server and client.
+```groovy
+wire{
+ rpcRole = "server"
+ rpcCallStyle = "blocking"
+ grpcServerCompatible = true
+}
+```
+Currently, wire does not support `rpcCallStyle = "suspending`. Only blocking stubs are generated.
+
+For every service defined, wire will generate a corresponding `${serviceName}WireGrpc` class. It provides abstract `${serviceName}ImplBase` class for servers and `newStub` method for client side.
 
 Sample
 ------

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ClassNameGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ClassNameGenerator.kt
@@ -3,7 +3,6 @@ package com.squareup.wire.kotlin.grpcserver
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.TypeName
 import com.squareup.wire.schema.ProtoType
-import com.squareup.wire.schema.Type
 
 internal class ClassNameGenerator(private val typeToKotlinName: Map<ProtoType, TypeName>) {
   fun classNameFor(type: ProtoType, suffix: String = ""): ClassName {

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterGenerator.kt
@@ -28,6 +28,7 @@ import com.squareup.wire.schema.Service
 import java.util.concurrent.ExecutorService
 
 object LegacyAdapterGenerator {
+  private const val SERVER_PACKAGE_NAME: String = "com.squareup.wire.kotlin.grpcserver"
   internal fun addLegacyAdapter(
     generator: ClassNameGenerator,
     builder: TypeSpec.Builder,
@@ -124,9 +125,9 @@ object LegacyAdapterGenerator {
           |}
           |return requestStream
           |""".trimMargin(),
-          ClassName("com.squareup.wire.kotlin.grpcserver", "MessageSourceAdapter")
+          ClassName(SERVER_PACKAGE_NAME, "MessageSourceAdapter")
             .parameterizedBy(generator.classNameFor(rpc.requestType!!)),
-          ClassName("com.squareup.wire.kotlin.grpcserver", "MessageSinkAdapter")
+          ClassName(SERVER_PACKAGE_NAME, "MessageSinkAdapter")
         )
         rpc.requestStreaming -> CodeBlock.of(
           """
@@ -137,14 +138,14 @@ object LegacyAdapterGenerator {
           |}
           |return requestStream
           |""".trimMargin(),
-          ClassName("com.squareup.wire.kotlin.grpcserver", "MessageSourceAdapter")
+          ClassName(SERVER_PACKAGE_NAME, "MessageSourceAdapter")
             .parameterizedBy(generator.classNameFor(rpc.requestType!!))
         )
         rpc.responseStreaming -> CodeBlock.of(
           """
           |${rpc.name}().${rpc.name}(request, %T(response))
           |""".trimMargin(),
-          ClassName("com.squareup.wire.kotlin.grpcserver", "MessageSinkAdapter")
+          ClassName(SERVER_PACKAGE_NAME, "MessageSinkAdapter")
         )
         else -> CodeBlock.of(
           """

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterGenerator.kt
@@ -77,7 +77,7 @@ object LegacyAdapterGenerator {
         type = LambdaTypeName.get(
           returnType = ClassName(
             generator.classNameFor(service.type).packageName,
-            "${service.name}${rpc.name}BlockingServer"
+            "${service.name}BlockingServer"
           )
         )
       )
@@ -97,7 +97,7 @@ object LegacyAdapterGenerator {
           type = LambdaTypeName.get(
             returnType = ClassName(
               generator.classNameFor(service.type).packageName,
-              "${service.name}${rpc.name}BlockingServer"
+              "${service.name}BlockingServer"
             )
           )
         )

--- a/wire-library/wire-grpc-server-generator/src/test/golden/LegacyAdapter.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/LegacyAdapter.kt
@@ -9,10 +9,10 @@ import kotlin.Unit
 public class RouteGuideWireGrpc {
   public class RouteGuideImplLegacyAdapter(
     private val streamExecutor: ExecutorService,
-    private val GetFeature: () -> RouteGuideGetFeatureBlockingServer,
-    private val ListFeatures: () -> RouteGuideListFeaturesBlockingServer,
-    private val RecordRoute: () -> RouteGuideRecordRouteBlockingServer,
-    private val RouteChat: () -> RouteGuideRouteChatBlockingServer
+    private val GetFeature: () -> RouteGuideBlockingServer,
+    private val ListFeatures: () -> RouteGuideBlockingServer,
+    private val RecordRoute: () -> RouteGuideBlockingServer,
+    private val RouteChat: () -> RouteGuideBlockingServer
   ) : RouteGuideWireGrpc.RouteGuideImplBase() {
     public override fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit {
       response.onNext(GetFeature().GetFeature(request))

--- a/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -227,10 +227,10 @@ public object RouteGuideWireGrpc {
 
   public class RouteGuideImplLegacyAdapter(
     private val streamExecutor: ExecutorService,
-    private val GetFeature: () -> RouteGuideGetFeatureBlockingServer,
-    private val ListFeatures: () -> RouteGuideListFeaturesBlockingServer,
-    private val RecordRoute: () -> RouteGuideRecordRouteBlockingServer,
-    private val RouteChat: () -> RouteGuideRouteChatBlockingServer
+    private val GetFeature: () -> RouteGuideBlockingServer,
+    private val ListFeatures: () -> RouteGuideBlockingServer,
+    private val RecordRoute: () -> RouteGuideRouteBlockingServer,
+    private val RouteChat: () -> RouteGuideBlockingServer
   ) : RouteGuideImplBase() {
     public override fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit {
       response.onNext(GetFeature().GetFeature(request))


### PR DESCRIPTION
 This PR addresses #2089.
 LegacyAdapterGenerator name would better be `${packageName}${serviceName}BlockingServer`, but only when `singleMethodServices` is configured as `false`. I have to confess I have no idea how LegacyAdapterGenerator could read this configuration item as condition. Do tell me how in code review.
 I add a short paragraph of this experimental feature too. Since English is not my native language, there could be grammar mistakes or implicit expressions. Feel free to point them out.