### PR TITLE
Define Swift library in SPM

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -6,8 +6,8 @@ let package = Package(
     name: "Wire",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v11),
-        .watchOS(.v4),
+        .iOS(.v10),
+        .watchOS(.v3),
         .macOS(.v10_15)
     ],
     products: [

--- a/Wire.podspec
+++ b/Wire.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target  = '10.0'
   s.osx.deployment_target  = '10.15'
-  s.watchos.deployment_target = '4.0'
+  s.watchos.deployment_target = '3.0'
 
   s.source_files  = 'wire-library/wire-runtime-swift/src/main/swift/**/*.swift'
 


### PR DESCRIPTION
This exposes a Swift Package Manager library for libWire.
It does not attempt to build the Wire compiler.