### PR TITLE
Fix enum constant name conflict with kotlin.Enum

### DIFF
--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
@@ -81,20 +81,23 @@ public class GsonTest {
                 KeywordKotlinEnum.when_,
                 KeywordKotlinEnum.fun_,
                 KeywordKotlinEnum.return_,
-                KeywordKotlinEnum.open_
+                KeywordKotlinEnum.open_,
+                KeywordKotlinEnum.name_,
+                KeywordKotlinEnum.ordinal_
             )
         )
         .build();
     String json = gson.toJson(keyword);
     assertJsonEquals(
         "{\"object\":\"object\",\"when\":1, \"fun\":{}, \"return\":[], \"enums\":[\"object\", "
-            + "\"when\", \"fun\", \"return\", \"open\"]}",
+            + "\"when\", \"fun\", \"return\", \"open\", \"name\", \"ordinal\"]}",
         json);
     KeywordKotlin parseKeyword = gson.fromJson(json, KeywordKotlin.class);
     assertThat(parseKeyword).isEqualTo(keyword);
 
     String generatedNamedJson = "{\"object_\":\"object\",\"when_\":1, \"fun_\":{}, \"return_\":[], "
-        + "\"enums\":[\"object_\", \"when_\", \"fun_\", \"return_\", \"open_\"]}";
+        + "\"enums\":[\"object_\", \"when_\", \"fun_\", \"return_\", \"open_\", \"name_\", "
+        + "\"ordinal_\"]}";
     assertThat(gson.fromJson(generatedNamedJson, KeywordKotlin.class)).isEqualTo(keyword);
   }
 

--- a/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -279,6 +279,10 @@ public class KeywordKotlin(
     return_(3),
     @WireEnumConstant(declaredName = "open")
     open_(4),
+    @WireEnumConstant(declaredName = "name")
+    name_(5),
+    @WireEnumConstant(declaredName = "ordinal")
+    ordinal_(6),
     ;
 
     public companion object {
@@ -299,6 +303,8 @@ public class KeywordKotlin(
         2 -> fun_
         3 -> return_
         4 -> open_
+        5 -> name_
+        6 -> ordinal_
         else -> null
       }
     }

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -73,6 +73,7 @@ import com.squareup.wire.internal.boxedOneOfClassName
 import com.squareup.wire.internal.boxedOneOfKeyFieldName
 import com.squareup.wire.internal.boxedOneOfKeysFieldName
 import com.squareup.wire.internal.camelCase
+import com.squareup.wire.internal.safeEnumConstantName
 import com.squareup.wire.java.Profile
 import com.squareup.wire.kotlin.grpcserver.KotlinGrpcGenerator
 import com.squareup.wire.schema.EnclosingType
@@ -404,7 +405,7 @@ class KotlinGenerator private constructor(
             newName("ADAPTER", "ADAPTER")
             newName("ENUM_OPTIONS", "ENUM_OPTIONS")
             message.constants.forEach { constant ->
-              newName(constant.name, constant)
+              newName(safeEnumConstantName(constant.name), constant)
             }
           }
           is MessageType -> {

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -73,7 +73,6 @@ import com.squareup.wire.internal.boxedOneOfClassName
 import com.squareup.wire.internal.boxedOneOfKeyFieldName
 import com.squareup.wire.internal.boxedOneOfKeysFieldName
 import com.squareup.wire.internal.camelCase
-import com.squareup.wire.internal.safeEnumConstantName
 import com.squareup.wire.java.Profile
 import com.squareup.wire.kotlin.grpcserver.KotlinGrpcGenerator
 import com.squareup.wire.schema.EnclosingType
@@ -405,7 +404,13 @@ class KotlinGenerator private constructor(
             newName("ADAPTER", "ADAPTER")
             newName("ENUM_OPTIONS", "ENUM_OPTIONS")
             message.constants.forEach { constant ->
-              newName(safeEnumConstantName(constant.name), constant)
+              val constantName = when (constant.name) {
+                // `name` and `ordinal` are private fields of all Kotlin enums. We are escaping them
+                // manually because KotlinPoet does not escape them.
+                "name", "ordinal" -> constant.name + "_"
+                else -> constant.name
+              }
+              newName(constantName, constant)
             }
           }
           is MessageType -> {

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/MoshiTest.java
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/MoshiTest.java
@@ -128,19 +128,22 @@ public class MoshiTest {
                 KeywordKotlinEnum.when_,
                 KeywordKotlinEnum.fun_,
                 KeywordKotlinEnum.return_,
-                KeywordKotlinEnum.open_
+                KeywordKotlinEnum.open_,
+                KeywordKotlinEnum.name_,
+                KeywordKotlinEnum.ordinal_
             )
         )
         .build();
     String json = adapter.toJson(keyword);
     JsonUtils.assertJsonEquals(
         "{\"object\":\"object\",\"when\":1, \"fun\":{}, \"return\":[], \"enums\":[\"object\", "
-            + "\"when\", \"fun\", \"return\", \"open\"]}",
+            + "\"when\", \"fun\", \"return\", \"open\", \"name\", \"ordinal\"]}",
         json);
     assertThat(adapter.fromJson(json)).isEqualTo(keyword);
 
     String generatedNamedJson = "{\"object_\":\"object\",\"when_\":1, \"fun_\":{}, \"return_\":[], "
-        + "\"enums\":[\"object_\", \"when_\", \"fun_\", \"return_\", \"open_\"]}";
+        + "\"enums\":[\"object_\", \"when_\", \"fun_\", \"return_\", \"open_\", \"name_\", "
+        + "\"ordinal_\"]}";
     assertThat(adapter.fromJson(generatedNamedJson)).isEqualTo(keyword);
   }
 

--- a/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -279,6 +279,10 @@ public class KeywordKotlin(
     return_(3),
     @WireEnumConstant(declaredName = "open")
     open_(4),
+    @WireEnumConstant(declaredName = "name")
+    name_(5),
+    @WireEnumConstant(declaredName = "ordinal")
+    ordinal_(6),
     ;
 
     public companion object {
@@ -299,6 +303,8 @@ public class KeywordKotlin(
         2 -> fun_
         3 -> return_
         4 -> open_
+        5 -> name_
+        6 -> ordinal_
         else -> null
       }
     }

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Internal.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Internal.kt
@@ -221,3 +221,14 @@ fun boxedOneOfKeyFieldName(oneOfName: String, fieldName: String): String {
 fun boxedOneOfKeysFieldName(oneOfName: String): String {
   return "${oneOfName}_keys".toUpperCase()
 }
+
+/**
+ * Returns a name for [enumConstantName] which avoids conflicting with the `final val` declarations
+ * in [kotlin.Enum].
+ * */
+fun safeEnumConstantName(enumConstantName: String): String {
+  return when (enumConstantName) {
+    "name", "ordinal" -> enumConstantName + "_"
+    else -> enumConstantName
+  }
+}

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Internal.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/Internal.kt
@@ -221,14 +221,3 @@ fun boxedOneOfKeyFieldName(oneOfName: String, fieldName: String): String {
 fun boxedOneOfKeysFieldName(oneOfName: String): String {
   return "${oneOfName}_keys".toUpperCase()
 }
-
-/**
- * Returns a name for [enumConstantName] which avoids conflicting with the `final val` declarations
- * in [kotlin.Enum].
- * */
-fun safeEnumConstantName(enumConstantName: String): String {
-  return when (enumConstantName) {
-    "name", "ordinal" -> enumConstantName + "_"
-    else -> enumConstantName
-  }
-}

--- a/wire-library/wire-tests/src/commonTest/shared/proto/proto2/keyword_kotlin.proto
+++ b/wire-library/wire-tests/src/commonTest/shared/proto/proto2/keyword_kotlin.proto
@@ -30,5 +30,7 @@ message KeywordKotlin {
     fun = 2;
     return = 3;
     open = 4;
+    name = 5;
+    ordinal = 6;
   }
 }


### PR DESCRIPTION
Given an enum such as
```proto
enum ConflictingEnumConstants {
  hello = 0;
  name = 1;
  ordinal = 2;
  open = 3;
}
```
currently the resulting generated class looks like:
```kotlin
public enum class ConflictingEnumConstants(
  public override val `value`: Int
) : WireEnum {
  hello(0),
  name(1),
  ordinal(2),
  @WireEnumConstant(declaredName = "open")
  open_(3),
  ;
// ...
```
which fails to compile with:
```
Conflicting declarations: public final val name: String, enum entry name
Conflicting declarations: public final val ordinal: Int, enum entry ordinal
```
This is a similar issue to square/kotlinpoet#991 (which resulted in the fix for `open` seen above), and I'm not sure if it would be better fixed here or in that repository. Additionally, I'm not sure where to put/how to name `safeEnumConstantName`.