### PR TITLE
3.7.1: Properly load schema located at root without packages.

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaLoader.kt
@@ -271,5 +271,8 @@ internal fun ProtoFile.importPath(location: Location): String {
 
 internal fun ProtoFile.canonicalImportPath(location: Location): String {
   val filename = location.path.substringAfterLast('/')
-  return packageName!!.replace('.', '/') + "/" + filename
+  return when (val packageName = packageName) {
+    null -> filename
+    else -> packageName.replace('.', '/') + "/" + filename
+  }
 }


### PR DESCRIPTION
Manually cherry-picked from https://github.com/square/wire/pull/2043