### PR TITLE
Fix Swift test build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           ./gradlew build
 
   multiplatform:
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -59,6 +59,9 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: 14
+
+      - name: Setup Xcode
+        run: sudo xcode-select -switch "/Applications/Xcode_12.app"
 
       - name: Check test files
         run: |
@@ -76,7 +79,7 @@ jobs:
           ./gradlew build
 
   swift:
-    runs-on: macOS-latest
+    runs-on: macos-latest
 
     steps:
       - name: Checkout
@@ -113,7 +116,7 @@ jobs:
           ./gradlew -p wire-library :wire-tests-swift:build
 
   publish:
-    runs-on: macOS-latest
+    runs-on: macos-latest
     if: github.repository == 'square/wire' && github.ref == 'refs/heads/master'
     needs: [jvm, multiplatform]
 

--- a/wire-library/wire-runtime-swift/build.gradle.kts
+++ b/wire-library/wire-runtime-swift/build.gradle.kts
@@ -99,4 +99,27 @@ afterEvaluate {
   tasks.named("compileTestSwift").configure {
     dependsOn(generateTestProtos)
   }
+
+  tasks.withType(SwiftCompile::class).all {
+    // Include the ${DEVELOPER_DIR}/usr/lib as we also need to use libXCTestSwiftSupport.dylib as of
+    // Xcode 12.5:
+    // https://forums.swift.org/t/why-xcode-12-5b-cannot-find-xctassertequal-in-scope-in-playground/44411
+    val developerDir = compilerArgs.get().extractDeveloperDir() ?: return@all
+    compilerArgs.add("-I$developerDir/usr/lib")
+  }
+
+  tasks.withType(LinkMachOBundle::class).all {
+    // Include the ${DEVELOPER_DIR}/usr/lib as we also need to use libXCTestSwiftSupport.dylib as of
+    // Xcode 12.5:
+    // https://forums.swift.org/t/why-xcode-12-5b-cannot-find-xctassertequal-in-scope-in-playground/44411
+    val developerDir = linkerArgs.get().extractDeveloperDir() ?: return@all
+    linkerArgs.add("-L$developerDir/usr/lib")
+  }
 }
+
+fun List<String>.extractDeveloperDir(): String? = this
+  .firstOrNull {
+    it.startsWith("-F") && it.endsWith("/Developer/Library/Frameworks")
+  }
+  ?.removePrefix("-F")
+  ?.removeSuffix("/Library/Frameworks")

--- a/wire-library/wire-tests-swift/build.gradle.kts
+++ b/wire-library/wire-tests-swift/build.gradle.kts
@@ -11,3 +11,28 @@ library {
 
   module.set("WireTests")
 }
+
+afterEvaluate {
+  tasks.withType(SwiftCompile::class).all {
+    // Include the ${DEVELOPER_DIR}/usr/lib as we also need to use libXCTestSwiftSupport.dylib as of
+    // Xcode 12.5:
+    // https://forums.swift.org/t/why-xcode-12-5b-cannot-find-xctassertequal-in-scope-in-playground/44411
+    val developerDir = compilerArgs.get().extractDeveloperDir() ?: return@all
+    compilerArgs.add("-I$developerDir/usr/lib")
+  }
+
+  tasks.withType(LinkMachOBundle::class).all {
+    // Include the ${DEVELOPER_DIR}/usr/lib as we also need to use libXCTestSwiftSupport.dylib as of
+    // Xcode 12.5:
+    // https://forums.swift.org/t/why-xcode-12-5b-cannot-find-xctassertequal-in-scope-in-playground/44411
+    val developerDir = linkerArgs.get().extractDeveloperDir() ?: return@all
+    linkerArgs.add("-L$developerDir/usr/lib")
+  }
+}
+
+fun List<String>.extractDeveloperDir(): String? = this
+  .firstOrNull {
+    it.startsWith("-F") && it.endsWith("/Developer/Library/Frameworks")
+  }
+  ?.removePrefix("-F")
+  ?.removeSuffix("/Library/Frameworks")


### PR DESCRIPTION
The build requirements changed in Xcode 12.5 such that we need to include a new framework. This change adds the /usr/lib directory that contains that framework into the build arguments so that the Swift build can find it.