### PR TITLE
Wire builds on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,44 @@ jobs:
           ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
 
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - name: Set git to use LF and not automatically replace them with CRLF.
+        run: |
+          git config --global core.autocrlf false
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Validate Gradle Wrapper
+        uses: gradle/wrapper-validation-action@v1
+
+      - name: Configure JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: 14
+
+      - name: Check test files
+        run: |
+          ./gradlew clean generateTests
+          if [ ! -z "$(git status --porcelain)" ]; then git diff; echo -e "\nTest files changed. Did you run ./gradlew generateTests?"; exit 1; fi
+        shell: bash
+
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@latest
+
+      - name: Test
+        run: |
+          .\gradlew.bat -p wire-library build -Pswift=false
+          .\gradlew.bat build
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
+          ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
+
   swift:
     runs-on: macos-latest
 

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Root.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Root.kt
@@ -19,6 +19,7 @@ import com.squareup.wire.java.internal.ProfileFileElement
 import com.squareup.wire.java.internal.ProfileParser
 import com.squareup.wire.schema.CoreLoader.isWireRuntimeProto
 import com.squareup.wire.schema.internal.parser.ProtoParser
+import com.squareup.wire.schema.internal.withUnixSlashes
 import okio.FileSystem
 import okio.IOException
 import okio.Path
@@ -157,7 +158,9 @@ internal class DirectoryRoot(
     return fileSystem.listRecursively(rootDirectory)
         .filter { it.toString().endsWith(".proto") }
         .map { descendant ->
-          val location = Location.get(base, descendant.relativeTo(rootDirectory).toString())
+          val location = Location.get(
+              base = base,
+              path = descendant.relativeTo(rootDirectory).withUnixSlashes().toString())
           ProtoFilePath(location, fileSystem, descendant)
         }
         .toSet()
@@ -166,7 +169,11 @@ internal class DirectoryRoot(
   override fun resolve(import: String): ProtoFilePath? {
     val resolved = rootDirectory / import
     if (!fileSystem.exists(resolved)) return null
-    return ProtoFilePath(Location.get(base, import), fileSystem, resolved)
+    return ProtoFilePath(
+        location = Location.get(base, import.toPath().withUnixSlashes().toString()),
+        fileSystem = fileSystem,
+        path = resolved
+    )
   }
 
   override fun toString(): String = base

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/CommandLineOptionsTest.kt
@@ -21,7 +21,6 @@ import org.junit.Test
 import java.io.File
 import java.io.FileOutputStream
 import java.io.PrintWriter
-import java.util.ArrayList
 import kotlin.test.assertFailsWith
 
 class CommandLineOptionsTest {

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/StringWireLogger.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/StringWireLogger.kt
@@ -19,8 +19,8 @@ import com.squareup.javapoet.JavaFile
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.schema.ProtoType
-import io.outfoxx.swiftpoet.FileSpec as SwiftFileSpec
 import okio.Path
+import io.outfoxx.swiftpoet.FileSpec as SwiftFileSpec
 
 internal class StringWireLogger : WireLogger {
   private var quiet: Boolean = false

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerErrorTest.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire
 
 import com.squareup.wire.schema.SchemaException
+import okio.Path
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import org.assertj.core.api.Assertions.assertThat
@@ -23,7 +24,9 @@ import org.junit.Test
 import kotlin.test.assertFailsWith
 
 class WireCompilerErrorTest {
-  private var fileSystem = FakeFileSystem()
+  private var fileSystem = FakeFileSystem().apply {
+    if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
+  }
   private var nextFileIndex = 1
 
   /**

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/CycleCheckerTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/CycleCheckerTest.kt
@@ -17,14 +17,17 @@
 
 package com.squareup.wire.schema
 
-import okio.fakefilesystem.FakeFileSystem
 import com.squareup.wire.testing.add
+import okio.Path
+import okio.fakefilesystem.FakeFileSystem
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
 class CycleCheckerTest {
-  private val fs = FakeFileSystem()
+  private val fs = FakeFileSystem().apply {
+    if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
+  }
 
   @Test
   fun singleFileImportCycle() {

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/LinkerTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/LinkerTest.kt
@@ -18,12 +18,15 @@
 package com.squareup.wire.schema
 
 import com.squareup.wire.testing.add
+import okio.Path
 import okio.fakefilesystem.FakeFileSystem
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class LinkerTest {
-  private val fs = FakeFileSystem()
+  private val fs = FakeFileSystem().apply {
+    if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
+  }
 
   @Test
   fun usedProtoPathFileIncludedInSchema() {

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/OptionsLinkingTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/OptionsLinkingTest.kt
@@ -18,13 +18,16 @@
 package com.squareup.wire.schema
 
 import com.squareup.wire.testing.add
+import okio.Path
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 
 class OptionsLinkingTest {
-  private val fs = FakeFileSystem()
+  private val fs = FakeFileSystem().apply {
+    if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
+  }
 
   @Test
   fun extensionOnTheSourcePathIsApplied() {

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/ProfileLoaderTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/ProfileLoaderTest.kt
@@ -15,19 +15,22 @@
  */
 package com.squareup.wire.schema
 
-import okio.fakefilesystem.FakeFileSystem
 import com.squareup.javapoet.ClassName
 import com.squareup.wire.java.AdapterConstant
 import com.squareup.wire.java.Profile
 import com.squareup.wire.testing.add
 import com.squareup.wire.testing.addZip
-import java.io.IOException
+import okio.Path
+import okio.fakefilesystem.FakeFileSystem
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
 import org.junit.Test
+import java.io.IOException
 
 class ProfileLoaderTest {
-  private val fs = FakeFileSystem()
+  private val fs = FakeFileSystem().apply {
+    if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
+  }
 
   @Test @Throws(IOException::class)
   fun test() {

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/RootTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/RootTest.kt
@@ -15,17 +15,18 @@
  */
 package com.squareup.wire.schema
 
-import com.google.common.io.Closer
-import okio.fakefilesystem.FakeFileSystem
 import com.squareup.wire.testing.add
 import com.squareup.wire.testing.addZip
+import okio.Path
+import okio.fakefilesystem.FakeFileSystem
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.After
 import org.junit.Test
 import kotlin.test.assertFailsWith
 
 class RootTest {
-  private val fs = FakeFileSystem()
+  private val fs = FakeFileSystem().apply {
+    if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
+  }
 
   @Test fun standaloneFile() {
     fs.add("sample/src/main/proto/squareup/dinosaurs/dinosaur.proto", "/* dinosaur.proto */")

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -22,6 +22,7 @@ import com.squareup.wire.kotlin.RpcRole
 import com.squareup.wire.schema.Target.SchemaHandler
 import com.squareup.wire.schema.WireRun.Module
 import com.squareup.wire.testing.add
+import com.squareup.wire.testing.containsRelativePaths
 import com.squareup.wire.testing.findFiles
 import com.squareup.wire.testing.readUtf8
 import okio.Buffer
@@ -36,7 +37,9 @@ import java.io.ObjectOutputStream
 import kotlin.test.assertFailsWith
 
 class WireRunTest {
-  private val fs = FakeFileSystem()
+  private val fs = FakeFileSystem().apply {
+    if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
+  }
   private val logger = StringWireLogger()
 
   @Test
@@ -52,7 +55,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/colors/Blue.java",
         "generated/java/squareup/colors/Red.java")
     assertThat(fs.readUtf8("generated/java/squareup/colors/Blue.java"))
@@ -74,7 +77,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Blue.kt",
         "generated/kt/squareup/colors/Red.kt")
     assertThat(fs.readUtf8("generated/kt/squareup/colors/Blue.kt"))
@@ -98,7 +101,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/routes/RouteClient.kt",
         "generated/kt/squareup/routes/GrpcRouteClient.kt")
     assertThat(fs.readUtf8("generated/kt/squareup/routes/RouteClient.kt"))
@@ -134,7 +137,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/routes/RouteBlockingServer.kt")
     assertThat(fs.readUtf8("generated/kt/squareup/routes/RouteBlockingServer.kt"))
         .contains(
@@ -159,7 +162,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/routes/RouteGetUpdatedBlueClient.kt",
         "generated/kt/squareup/routes/RouteGetUpdatedRedClient.kt",
         "generated/kt/squareup/routes/GrpcRouteGetUpdatedBlueClient.kt",
@@ -191,7 +194,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/proto/squareup/colors/blue.proto",
         "generated/proto/squareup/colors/red.proto")
     assertThat(fs.readUtf8("generated/proto/squareup/colors/blue.proto"))
@@ -219,7 +222,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/colors/Red.java",
         "generated/kt/squareup/colors/Blue.kt")
     assertThat(fs.readUtf8("generated/kt/squareup/colors/Blue.kt"))
@@ -247,7 +250,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/colors/Blue.java",
         "generated/kt/squareup/colors/Red.kt")
     assertThat(fs.readUtf8("generated/java/squareup/colors/Blue.java"))
@@ -277,7 +280,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Blue.kt",
         "generated/java/squareup/colors/Red.java",
         "generated/kt/squareup/polygons/Triangle.kt")
@@ -310,7 +313,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/colors/Blue.java",
         "generated/java/squareup/colors/Red.java",
         "generated/kt/squareup/polygons/Triangle.kt")
@@ -336,7 +339,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Blue.kt")
   }
 
@@ -354,7 +357,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Blue.kt")
   }
 
@@ -374,7 +377,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Blue.kt")
   }
 
@@ -395,7 +398,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/com/squareup/polygons/Square.java",
         "generated/kt/com/squareup/polygons/Rhombus.kt")
   }
@@ -418,7 +421,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/com/squareup/polygons/Square.java",
         "generated/java/com/squareup/polygons/Rhombus.java",
         "generated/kt/com/squareup/polygons/Square.kt")
@@ -443,7 +446,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Blue.kt",
         "generated/kt/squareup/colors/Red.kt")
   }
@@ -471,7 +474,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/colors/Blue.java")
     assertThat(fs.readUtf8("generated/java/squareup/colors/Blue.java"))
         .contains("public final class Blue extends Message")
@@ -493,7 +496,7 @@ class WireRunTest {
         targets = listOf(JavaTarget(outDirectory = "generated/java"))
     )
     wireRun.execute(fs, logger)
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/colors/Blue.java")
     assertThat(fs.readUtf8("generated/java/squareup/colors/Blue.java"))
         .contains("public final class Blue extends Message")
@@ -515,7 +518,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/markdown/squareup/colors/Blue.md",
         "generated/markdown/squareup/colors/Red.md")
     assertThat(fs.readUtf8("generated/markdown/squareup/colors/Blue.md")).isEqualTo("""
@@ -680,7 +683,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Orange.kt")
     assertThat(fs.readUtf8("generated/kt/squareup/colors/Orange.kt"))
         .contains("class Orange")
@@ -699,7 +702,7 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/kt/squareup/colors/Orange.kt")
     assertThat(fs.readUtf8("generated/kt/squareup/colors/Orange.kt"))
         .contains("class Orange")
@@ -724,8 +727,8 @@ class WireRunTest {
     )
     wireRun.execute(fs, logger)
 
-    assertThat(fs.findFiles("gen/a")).containsExactlyInAnyOrder("gen/a/A.java")
-    assertThat(fs.findFiles("gen/b")).containsExactlyInAnyOrder("gen/b/B.java")
+    assertThat(fs.findFiles("gen/a")).containsRelativePaths("gen/a/A.java")
+    assertThat(fs.findFiles("gen/b")).containsRelativePaths("gen/b/B.java")
   }
 
   @Test
@@ -768,11 +771,11 @@ class WireRunTest {
     wireRun.execute(fs, logger)
 
     // TODO(jwilson): fix modules to treat extension fields as first-class objects.
-    assertThat(fs.findFiles("gen/a")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("gen/a")).containsRelativePaths(
         "gen/a/example/A.java",
         "gen/a/example/MapsToOption.java",
         "gen/a/example/TypeOption.java")
-    assertThat(fs.findFiles("gen/b")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("gen/b")).containsRelativePaths(
         "gen/b/example/B.java",
         "gen/b/example/MapsToOption.java",
         "gen/b/example/TypeOption.java")
@@ -933,7 +936,7 @@ class WireRunTest {
         )
     )
     wireRun.execute(fs, logger)
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/options/DocumentationUrlOption.java",
         "generated/kt/squareup/options/DocumentationUrlOption.kt")
     assertThat(fs.readUtf8("generated/java/squareup/options/DocumentationUrlOption.java"))
@@ -960,7 +963,7 @@ class WireRunTest {
             ))
     )
     wireRun.execute(fs, logger)
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder()
+    assertThat(fs.findFiles("generated")).containsRelativePaths()
   }
 
   @Test
@@ -984,7 +987,7 @@ class WireRunTest {
         )
     )
     wireRun.execute(fs, logger)
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/polygons/Octagon.java",
         "generated/kt/squareup/polygons/Octagon.kt")
     assertThat(fs.readUtf8("generated/java/squareup/polygons/Octagon.java"))
@@ -1014,7 +1017,7 @@ class WireRunTest {
         )
     )
     wireRun.execute(fs, logger)
-    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrder(
+    assertThat(fs.findFiles("generated")).containsRelativePaths(
         "generated/java/squareup/polygons/Octagon.java",
         "generated/kt/squareup/polygons/Octagon.kt")
     assertThat(fs.readUtf8("generated/java/squareup/polygons/Octagon.java"))

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -188,6 +188,8 @@ public final class JavaGenerator {
   private static final String URL_CHARS = "[-!#$%&'()*+,./0-9:;=?@A-Z\\[\\]_a-z~]";
   private static final int MAX_PARAMS_IN_CONSTRUCTOR = 16;
 
+  private static final String DOUBLE_FULL_BLOCK = "\u2588\u2588";
+
   /**
    * Preallocate all of the names we'll need for {@code type}. Names are allocated in precedence
    * order, so names we're stuck with (serialVersionUID etc.) occur before proto field names are
@@ -1715,7 +1717,8 @@ public final class JavaGenerator {
         result.addCode("if ($N != null) ", fieldName);
       }
       if (field.isRedacted()) {
-        result.addStatement("$N.append(\", $N=██\")", builderName, field.getName());
+        result.addStatement("$N.append(\", $N=$L\")", builderName, field.getName(),
+            DOUBLE_FULL_BLOCK);
       } else if (field.getType().equals(ProtoType.STRING)) {
         result.addStatement("$N.append(\", $N=\").append($T.sanitize($L))", builderName,
             field.getName(), Internal.class, fieldName);

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1159,7 +1159,7 @@ class KotlinGenerator private constructor(
               addStatement("%N += %P", resultName, buildCodeBlock {
                 add(fieldName)
                 if (fieldOrOneOf.isRedacted) {
-                  add("=██")
+                  add("=$DOUBLE_FULL_BLOCK")
                 } else {
                   if (fieldOrOneOf.type == ProtoType.STRING) {
                     add("=\${%M($fieldName)}", sanitizeMember)
@@ -1176,7 +1176,7 @@ class KotlinGenerator private constructor(
               addStatement("%N += %P", resultName, buildCodeBlock {
                 add(fieldName)
                 if (fieldOrOneOf.fields.any { it.isRedacted }) {
-                  add("=██")
+                  add("=$DOUBLE_FULL_BLOCK")
                 } else {
                   add("=\$")
                   add(fieldName)
@@ -2439,6 +2439,8 @@ class KotlinGenerator private constructor(
           .replace("""[""", """\[""")
           .replace("""]""", """\]""")
     }
+
+    private const val DOUBLE_FULL_BLOCK = "\u2588\u2588"
   }
 }
 

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/Util.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/Util.kt
@@ -24,6 +24,8 @@ import com.squareup.wire.schema.Schema
 import com.squareup.wire.schema.Service
 import com.squareup.wire.schema.Type
 import com.squareup.wire.schema.internal.parser.OptionElement
+import okio.Path
+import okio.Path.Companion.toPath
 
 // TODO internal and friend for wire-java-generator: https://youtrack.jetbrains.com/issue/KT-34102
 fun StringBuilder.appendDocumentation(
@@ -148,3 +150,7 @@ private fun Service.asStub() = copy(
     rpcs = emptyList(),
     options = Options(Options.SERVICE_OPTIONS, emptyList())
 )
+
+fun Path.withUnixSlashes(): Path {
+  return toString().replace('\\', '/').toPath()
+}

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
@@ -21,6 +21,8 @@ import com.squareup.wire.schema.Field
 import com.squareup.wire.schema.Field.Label.REQUIRED
 import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.internal.MAX_TAG_VALUE
+import com.squareup.wire.schema.internal.withUnixSlashes
+import okio.Path.Companion.toPath
 
 /** Basic parser for `.proto` schema declarations. */
 class ProtoParser internal constructor(
@@ -55,8 +57,8 @@ class ProtoParser internal constructor(
             location = location,
             packageName = packageName,
             syntax = syntax,
-            imports = imports,
-            publicImports = publicImports,
+            imports = imports.map { it.toPath().withUnixSlashes().toString() },
+            publicImports = publicImports.map { it.toPath().withUnixSlashes().toString() },
             types = nestedTypes,
             services = services,
             extendDeclarations = extendsList,

--- a/wire-library/wire-test-utils/src/main/java/com/squareup/wire/testing/files.kt
+++ b/wire-library/wire-test-utils/src/main/java/com/squareup/wire/testing/files.kt
@@ -15,15 +15,18 @@
  */
 package com.squareup.wire.testing
 
+import okio.ByteString
+import okio.FileSystem
+import okio.Path
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.sink
+import org.assertj.core.api.IterableAssert
+import org.assertj.core.api.ListAssert
 import java.nio.charset.Charset
 import java.util.zip.ZipEntry
 import java.util.zip.ZipOutputStream
 import kotlin.text.Charsets.UTF_8
-import okio.ByteString
-import okio.FileSystem
-import okio.Path.Companion.toPath
-import okio.buffer
-import okio.sink
 
 fun FileSystem.add(
   pathString: String,
@@ -48,7 +51,7 @@ fun FileSystem.readUtf8(pathString: String): String {
 }
 
 fun FileSystem.findFiles(path: String): Set<String> {
-  return listRecursively(path.toPath())
+  return listRecursively(path.withPlatformSlashes().toPath())
       .filter { !metadata(it).isDirectory }
       .map { it.toString() }
       .toSet()
@@ -70,4 +73,33 @@ fun FileSystem.addZip(pathString: String, vararg contents: Pair<String, String>)
       }
     }
   }
+}
+
+private val slash = Path.DIRECTORY_SEPARATOR
+private val otherSlash = if (slash == "/") "\\" else "/"
+
+/**
+ * This returns a string where all other slashes are replaced with the slash of the local platform.
+ * On Windows, `/` will be replaced with `\`. On other platforms, `\` will be replaced with `/`.
+ */
+fun String.withPlatformSlashes(): String {
+  return replace(otherSlash, slash)
+}
+
+/**
+ * This asserts that [this] contains exactly in any order all [values] regardless of the slash they
+ * may contain. This is useful to write one assertion which can be run on both macOS and Windows.
+ */
+fun IterableAssert<String>.containsRelativePaths(vararg values: String): IterableAssert<String> {
+  val values = values.map { it.withPlatformSlashes() }
+  return containsExactlyInAnyOrder(*values.toTypedArray())
+}
+
+/**
+ * This asserts that [this] contains exactly in any order all [values] regardless of the slash they
+ * may contain. This is useful to write one assertion which can be run on both macOS and Windows.
+ */
+fun ListAssert<String>.containsRelativePaths(vararg values: String): ListAssert<String> {
+  val values = values.map { it.withPlatformSlashes() }
+  return containsExactlyInAnyOrder(*values.toTypedArray())
 }


### PR DESCRIPTION
On parsing, I decided to replace all slashes to unix slashes. This means Wire doesn't need to change its internal behavior, doesn't need to change as well when it prints `.proto` files. Okio's filesystem works with any slashes so that's actually all we need to do.

Might fix #1325 