### PR TITLE
Fix publication for jar-with-dependencies

### DIFF
--- a/wire-library/wire-compiler/build.gradle.kts
+++ b/wire-library/wire-compiler/build.gradle.kts
@@ -37,8 +37,10 @@ val shadowJar by tasks.getting(ShadowJar::class) {
   classifier = "jar-with-dependencies"
 }
 
-artifacts {
-  archives(shadowJar)
+publishing {
+  publications.withType<MavenPublication>().configureEach {
+    artifact(shadowJar)
+  }
 }
 
 // The `shadow` plugin internally applies the `distribution` plugin and


### PR DESCRIPTION
We publish it via as a `WireCompiler` Pod so cannot really remove it just yet.