### PR TITLE
feat: Keeping schema format when options are defined as list of enums

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OptionReader.kt
@@ -170,8 +170,13 @@ class OptionReader(internal val reader: SyntaxReader) {
     while (true) {
       // If we see the close brace, finish immediately. This handles [] and ,] cases.
       if (reader.peekChar(']')) return result
-
-      result.add(readKindAndValue().value)
+      val option = readKindAndValue()
+      val value = if (option.kind == BOOLEAN || option.kind == ENUM || option.kind == NUMBER) {
+        OptionElement.OptionPrimitive(option.kind, option.value)
+      } else {
+        option.value
+      }
+      result.add(value)
 
       if (reader.peekChar(',')) continue
       reader.expect(reader.peekChar() == ']') { "expected ',' or ']'" }

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/OptionsTest.kt
@@ -97,10 +97,16 @@ class OptionsTest {
             |   NUMBER = 1;
             |   STRING = 2;
             |}
+            |enum Scheme {
+            |  UNKNOWN = 0;
+            |  HTTP = 1;
+            |  HTTPS = 2;
+            |}
             | 
             |message FooOptions {
             |  optional string name = 1;
-            |  optional FooParameterType type = 2; 
+            |  optional FooParameterType type = 2;
+            |  repeated Scheme schemes = 3;
             |} 
             |extend google.protobuf.MessageOptions {
             |  repeated FooOptions foo = 12345;
@@ -110,11 +116,14 @@ class OptionsTest {
             |  option (foo) = {
             |    name: "test"
             |    type: STRING
+            |    schemes: HTTP
+            |    schemes: HTTPS
             |  };
             |  
             |  option (foo) = {
             |    name: "test2"
             |    type: NUMBER
+            |    schemes: [HTTP, HTTPS]
             |  };
             |  
             |  optional int32 b = 2;
@@ -131,21 +140,26 @@ class OptionsTest {
     assertThat(optionElements[0].toSchema())
         .isEqualTo("""|(foo) = {
                       |  name: "test",
-                      |  type: STRING
+                      |  type: STRING,
+                      |  schemes: [
+                      |    HTTP,
+                      |    HTTPS
+                      |  ]
                       |}""".trimMargin())
 
     val foo = ProtoMember.get(Options.MESSAGE_OPTIONS, "foo")
 
     val name = ProtoMember.get(ProtoType.get("FooOptions"), "name")
     val type = ProtoMember.get(ProtoType.get("FooOptions"), "type")
+    val schemes = ProtoMember.get(ProtoType.get("FooOptions"), "schemes")
 
     val message = schema.getType("Message") as MessageType
     message.toElement().name
 
     assertThat(message.options.map)
         .isEqualTo(mapOf( foo to
-            arrayListOf(mapOf(name to "test", type to "STRING" ),
-            mapOf ( name to "test2", type to "NUMBER" ) )))
+            arrayListOf(mapOf(name to "test", type to "STRING", schemes to listOf("HTTP","HTTPS")),
+            mapOf (name to "test2", type to "NUMBER", schemes to listOf("HTTP","HTTPS")))))
   }
 
   @Test

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -1796,7 +1796,7 @@ class ProtoParserTest {
                             OptionElement.create(
                                 "squareup.a.b",
                                 Kind.MAP,
-                                mapOf("value" to listOf("FOO", "BAR")),
+                                mapOf("value" to listOf(OptionElement.OptionPrimitive(Kind.ENUM,"FOO"), OptionElement.OptionPrimitive(Kind.ENUM,"BAR"))),
                                 true
                             )
                         )


### PR DESCRIPTION
This PR is related to this one https://github.com/square/wire/pull/2019, when using lists on Message options was always outputting them as strings.

```proto
import "google/protobuf/descriptor.proto";

enum Scheme {
    UNKNOWN = 0;
    HTTP = 1;
    HTTPS = 2;
}
 
message FooOptions {
  repeated Scheme schemes = 1;
} 
extend google.protobuf.MessageOptions {
  repeated FooOptions foo = 12345;
}

message Message {
  option (foo) = {
    schemes: HTTP
    schemes: HTTPS
  };
  
  option (foo) = {
    schemes: [HTTP, HTTPS]
  };
  
  optional int32 b = 2;
}
```

After it's parsed if you get the string representation of the schema using ProtoFileElement.toSchema() the result is

```proto
// Proto schema formatted by Wire, do not edit.
// Source: foo.proto

import "google/protobuf/descriptor.proto";

enum Scheme {
  UNKNOWN = 0;
  HTTP = 1;
  HTTPS = 2;
}

message FooOptions {
  repeated Scheme schemes = 1;
}

message Message {
  option (foo) = {
      "HTTP",
      "HTTPS"
    ]
  };
  option (foo) = {
    schemes: [
      "HTTP",
      "HTTPS"
    ]
  };

  optional int32 b = 2;
}

extend google.protobuf.MessageOptions {
  repeated FooOptions foo = 12345;
}
```

Which is malformed, the resulting schema should use `schemes: [HTTP, HTTPS]` instead of `schemes: ["HTTP", "HTTPS"]`