### PR TITLE
Handle out of order proto fields when initializing Kotlin constructor

### DIFF
--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/GsonTest.java
@@ -151,16 +151,20 @@ public class GsonTest {
   }
 
   @Test public void kotlinWithoutBuilderFromJson() {
-    Person person = gson.fromJson("{\"id\":1,\"name\":\"Jo\",\"email\":\"foo@square.com\"}", Person.class);
+    Person person = gson.fromJson(
+        "{\"id\":1,\"name\":\"Jo\",\"email\":\"foo@square.com\",\"is_canadian\":true}",
+        Person.class);
     assertThat(person).isEqualTo(
-        new Person("Jo", 1, "foo@square.com", Collections.emptyList(), ByteString.EMPTY));
+        new Person("Jo", 1, "foo@square.com", Collections.emptyList(), true, ByteString.EMPTY));
   }
 
   @Test public void kotlinWithoutBuilderToJson() {
     Person person =
-        new Person("Jo", 1, "foo@square.com", Collections.emptyList(), ByteString.EMPTY);
+        new Person("Jo", 1, "foo@square.com", Collections.emptyList(), false, ByteString.EMPTY);
     String json = gson.toJson(person);
-    assertJsonEquals("{\"id\":1,\"name\":\"Jo\",\"email\":\"foo@square.com\", \"phone\":[]}", json);
+    assertJsonEquals(
+        "{\"id\":1,\"name\":\"Jo\",\"email\":\"foo@square.com\", \"phone\":[],\"is_canadian\":false}",
+        json);
   }
 
   @Test public void kotlinGettersFromJson() {

--- a/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
+++ b/wire-library/wire-gson-support/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
@@ -63,6 +63,11 @@ public class Person(
   )
   public val email: String? = null,
   phone: List<PhoneNumber> = emptyList(),
+  @field:WireField(
+    tag = 5,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
+  public val is_canadian: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Person, Nothing>(ADAPTER, unknownFields) {
   /**
@@ -90,6 +95,7 @@ public class Person(
     if (id != other.id) return false
     if (email != other.email) return false
     if (phone != other.phone) return false
+    if (is_canadian != other.is_canadian) return false
     return true
   }
 
@@ -101,6 +107,7 @@ public class Person(
       result = result * 37 + id.hashCode()
       result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
+      result = result * 37 + (is_canadian?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -112,6 +119,7 @@ public class Person(
     result += """id=$id"""
     if (email != null) result += """email=${sanitize(email)}"""
     if (phone.isNotEmpty()) result += """phone=$phone"""
+    if (is_canadian != null) result += """is_canadian=$is_canadian"""
     return result.joinToString(prefix = "Person{", separator = ", ", postfix = "}")
   }
 
@@ -120,8 +128,9 @@ public class Person(
     id: Int = this.id,
     email: String? = this.email,
     phone: List<PhoneNumber> = this.phone,
+    is_canadian: Boolean? = this.is_canadian,
     unknownFields: ByteString = this.unknownFields
-  ): Person = Person(name, id, email, phone, unknownFields)
+  ): Person = Person(name, id, email, phone, is_canadian, unknownFields)
 
   public companion object {
     @JvmField
@@ -139,6 +148,7 @@ public class Person(
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
         size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
         size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(5, value.is_canadian)
         return size
       }
 
@@ -147,11 +157,13 @@ public class Person(
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
+        ProtoAdapter.BOOL.encodeWithTag(writer, 5, value.is_canadian)
         writer.writeBytes(value.unknownFields)
       }
 
       public override fun encode(writer: ReverseProtoWriter, `value`: Person): Unit {
         writer.writeBytes(value.unknownFields)
+        ProtoAdapter.BOOL.encodeWithTag(writer, 5, value.is_canadian)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
@@ -163,12 +175,14 @@ public class Person(
         var id: Int? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
+        var is_canadian: Boolean? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
+            5 -> is_canadian = ProtoAdapter.BOOL.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -177,6 +191,7 @@ public class Person(
           id = id ?: throw missingRequiredFields(id, "id"),
           email = email,
           phone = phone,
+          is_canadian = is_canadian,
           unknownFields = unknownFields
         )
       }

--- a/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
+++ b/wire-library/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
@@ -63,6 +63,11 @@ public class Person(
   )
   public val email: String? = null,
   phone: List<PhoneNumber> = emptyList(),
+  @field:WireField(
+    tag = 5,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+  )
+  public val is_canadian: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY
 ) : Message<Person, Nothing>(ADAPTER, unknownFields) {
   /**
@@ -90,6 +95,7 @@ public class Person(
     if (id != other.id) return false
     if (email != other.email) return false
     if (phone != other.phone) return false
+    if (is_canadian != other.is_canadian) return false
     return true
   }
 
@@ -101,6 +107,7 @@ public class Person(
       result = result * 37 + id.hashCode()
       result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
+      result = result * 37 + (is_canadian?.hashCode() ?: 0)
       super.hashCode = result
     }
     return result
@@ -112,6 +119,7 @@ public class Person(
     result += """id=$id"""
     if (email != null) result += """email=${sanitize(email)}"""
     if (phone.isNotEmpty()) result += """phone=$phone"""
+    if (is_canadian != null) result += """is_canadian=$is_canadian"""
     return result.joinToString(prefix = "Person{", separator = ", ", postfix = "}")
   }
 
@@ -120,8 +128,9 @@ public class Person(
     id: Int = this.id,
     email: String? = this.email,
     phone: List<PhoneNumber> = this.phone,
+    is_canadian: Boolean? = this.is_canadian,
     unknownFields: ByteString = this.unknownFields
-  ): Person = Person(name, id, email, phone, unknownFields)
+  ): Person = Person(name, id, email, phone, is_canadian, unknownFields)
 
   public companion object {
     @JvmField
@@ -139,6 +148,7 @@ public class Person(
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
         size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
         size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
+        size += ProtoAdapter.BOOL.encodedSizeWithTag(5, value.is_canadian)
         return size
       }
 
@@ -147,11 +157,13 @@ public class Person(
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
+        ProtoAdapter.BOOL.encodeWithTag(writer, 5, value.is_canadian)
         writer.writeBytes(value.unknownFields)
       }
 
       public override fun encode(writer: ReverseProtoWriter, `value`: Person): Unit {
         writer.writeBytes(value.unknownFields)
+        ProtoAdapter.BOOL.encodeWithTag(writer, 5, value.is_canadian)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
@@ -163,12 +175,14 @@ public class Person(
         var id: Int? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
+        var is_canadian: Boolean? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
+            5 -> is_canadian = ProtoAdapter.BOOL.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -177,6 +191,7 @@ public class Person(
           id = id ?: throw missingRequiredFields(id, "id"),
           email = email,
           phone = phone,
+          is_canadian = is_canadian,
           unknownFields = unknownFields
         )
       }

--- a/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/KotlinConstructorBuilder.kt
+++ b/wire-library/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/KotlinConstructorBuilder.kt
@@ -15,6 +15,8 @@
  */
 package com.squareup.wire
 
+import com.squareup.wire.WireField.Label.REPEATED
+
 internal class KotlinConstructorBuilder<M : Message<M, B>, B : Message.Builder<M, B>>(
   private val messageType: Class<M>,
 ) : Message.Builder<M, B>() {
@@ -61,17 +63,44 @@ internal class KotlinConstructorBuilder<M : Message<M, B>, B : Message.Builder<M
   @Suppress("UNCHECKED_CAST")
   override fun build(): M {
     val protoFields = messageType.declaredProtoFields()
-    val unknownFields = buildUnknownFields()
-    val args = protoFields.map { get(it.wireField) }
-        .plus(unknownFields)
-        .toTypedArray()
-    val fieldTypes = protoFields.map { it.type }
-        .plus(unknownFields::class.java)
-        .toTypedArray()
 
-    val constructor = messageType.getConstructor(*fieldTypes)
+    // KotlinGenerator emits different kinds of properties for various proto fields depending on
+    // their type:
+    //
+    // - For certain types (group A), a primary constructor property is created
+    // - For other types (group B), a primary constructor parameter and a simple property are
+    //   created
+    //
+    // This leads to a mismatch between the order in which proto fields annotated with WireField
+    // appear in generated code (which matches the order in which they appear in the proto file) and
+    // the order of matching constructor parameters (https://github.com/square/wire/issues/2153).
+    // Therefore, we'll partition fields from groups A and B separately, where fields in each group
+    // will appear in the right order. This will allow us to iterate over the constructor parameters
+    // and retrieve the matching proto field based on the parameter type.
+    val fieldsWithSimpleProperties = ArrayDeque<ProtoField>()
+    val fieldsWithPrimaryConstructorProperties = ArrayDeque<ProtoField>()
+    for (protoField in protoFields) {
+      // TODO(egor): Repeated fields aren't the only ones for which no primary constructor property
+      // is generated. Need to extend this solution to cover other types.
+      if (protoField.wireField.label == REPEATED) {
+        fieldsWithSimpleProperties += protoField
+      } else {
+        fieldsWithPrimaryConstructorProperties += protoField
+      }
+    }
 
-    return constructor.newInstance(*args) as M
+    // We'll assume there's only one constructor with this number of parameters.
+    val constructor = messageType.constructors.first {
+      it.parameterCount == protoFields.size + 1 // +1 for the unknown_fields.
+    }
+    val args = constructor.parameters.mapIndexed { index, param ->
+      when {
+        param.type == List::class.java -> get(fieldsWithSimpleProperties.removeFirst().wireField)
+        index == protoFields.size -> buildUnknownFields()
+        else -> get(fieldsWithPrimaryConstructorProperties.removeFirst().wireField)
+      }
+    }
+    return constructor.newInstance(*args.toTypedArray()) as M
   }
 
   private fun Class<M>.declaredProtoFields(): List<ProtoField> = declaredFields

--- a/wire-library/wire-tests/src/commonTest/shared/proto/proto2/person_kotlin.proto
+++ b/wire-library/wire-tests/src/commonTest/shared/proto/proto2/person_kotlin.proto
@@ -47,4 +47,6 @@ message Person {
 
   // A list of the customer's phone numbers.
   repeated PhoneNumber phone = 4;
+
+  optional bool is_canadian = 5;
 }


### PR DESCRIPTION
Fixes #2153 