### PR TITLE
gradle/wrapper-validation-action 1.0.4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Validate Gradle Wrapper
-        uses: gradle/wrapper-validation-action@v1
+        uses: gradle/wrapper-validation-action@v1.0.4
 
       - name: Configure JDK
         uses: actions/setup-java@v2


### PR DESCRIPTION
This action frequently fails with "connect ETIMEDOUT". v1.0.4
seems to address this issue:

https://github.com/gradle/wrapper-validation-action/releases/tag/v1.0.4