### PR TITLE
Require a target to be set.

### DIFF
--- a/samples/simple-sample/build.gradle.kts
+++ b/samples/simple-sample/build.gradle.kts
@@ -11,11 +11,13 @@ dependencies {
   implementation(deps.wire.runtime)
 }
 
+wire{
+  java{}
+}
 /**
  * Default settings:
  * 1) all proto definitions located in "${projectDir}/src/main/proto"
- * 2) all protos generated in Java
- * 3) all generated protos written to "${projectDir}/build/generated/source/wire"
+ * 2) all generated protos written to "${projectDir}/build/generated/source/wire"
  *
  * If all of the above suffice, no additional configuration is needed!
  */

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -109,7 +109,10 @@ class WirePlugin : Plugin<Project> {
       }
     }
 
-    val outputs = extension.outputs.ifEmpty { listOf(JavaOutput()) }
+    val outputs = extension.outputs
+    check(outputs.isNotEmpty()) {
+      "At least one target must be provided for project '${project.path}"
+    }
     val hasJavaOutput = outputs.any { it is JavaOutput }
     val hasKotlinOutput = outputs.any { it is KotlinOutput }
     check(!hasKotlinOutput || kotlin.get()) {

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -111,7 +111,8 @@ class WirePlugin : Plugin<Project> {
 
     val outputs = extension.outputs
     check(outputs.isNotEmpty()) {
-      "At least one target must be provided for project '${project.path}"
+      "At least one target must be provided for project '${project.path}\n" +
+          "See our documentation for details: https://square.github.io/wire/wire_compiler/#customizing-output"
     }
     val hasJavaOutput = outputs.any { it is JavaOutput }
     val hasKotlinOutput = outputs.any { it is KotlinOutput }

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -104,6 +104,18 @@ class WirePluginTest {
   }
 
   @Test
+  fun requireTarget() {
+    val fixtureRoot = File("src/test/projects/require-target")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { buildAndFail() }
+
+    val task = result.task(":generateProtos")
+    assertThat(task).isNull()
+    assertThat(result.output)
+      .contains("At least one target must be provided for project")
+  }
+
+  @Test
   fun useDefaultSourcePath() {
     val fixtureRoot = File("src/test/projects/sourcepath-default")
 

--- a/wire-library/wire-gradle-plugin/src/test/projects/java-project-java-protos/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/java-project-java-protos/build.gradle
@@ -15,3 +15,8 @@ repositories {
 dependencies {
   implementation "com.squareup.wire:wire-runtime:$VERSION_NAME"
 }
+
+wire{
+  java{
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/kotlin-project-java-protos/build.gradle
@@ -18,3 +18,8 @@ dependencies {
 
   compileOnly "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.20"
 }
+
+wire{
+  java{
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/missing-plugin/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/missing-plugin/build.gradle
@@ -1,3 +1,8 @@
 plugins {
   id 'com.squareup.wire'
 }
+
+wire{
+  java{
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/protopath-maven/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/protopath-maven/build.gradle
@@ -17,4 +17,6 @@ wire {
   sourcePath {
     srcDir 'src/main/proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/require-target/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/require-target/build.gradle
@@ -2,8 +2,3 @@ plugins {
   id 'application'
   id 'com.squareup.wire'
 }
-
-wire{
-  java{
-  }
-}

--- a/wire-library/wire-gradle-plugin/src/test/projects/require-target/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/require-target/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/require-target/src/main/proto/squareup/geology/period.proto
+++ b/wire-library/wire-gradle-plugin/src/test/projects/require-target/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-local-many-files/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-local-many-files/build.gradle
@@ -8,4 +8,6 @@ wire {
     srcJar 'src/main/proto/protos.jar'
     include 'squareup/geology/period.proto', 'squareup/dinosaurs/dinosaur.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-local-nonproto-file/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-local-nonproto-file/build.gradle
@@ -7,4 +7,6 @@ wire {
   sourcePath {
     srcJar 'src/main/proto/protos-plus-nonprotos.jar'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-local-single-file/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-local-single-file/build.gradle
@@ -8,4 +8,6 @@ wire {
     srcJar 'src/main/proto/protos.jar'
     include 'squareup/geology/period.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-mixed-conflicts/build.gradle
@@ -20,4 +20,6 @@ wire {
     include 'squareup/**/*.proto'
     exclude 'squareup/geology/period.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-remote-many-files/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-remote-many-files/build.gradle
@@ -15,4 +15,6 @@ wire {
     srcJar 'com.squareup.wire.dinosaur:all-protos:+'
     include 'squareup/geology/period.proto', 'squareup/dinosaurs/dinosaur.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-remote-protopath/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-remote-protopath/build.gradle
@@ -19,4 +19,6 @@ wire {
     srcDir 'src/main/proto'
     include 'squareup/geology/period.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-remote-wildcards/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcejar-remote-wildcards/build.gradle
@@ -15,4 +15,6 @@ wire {
     srcJar 'com.squareup.wire.dinosaur:all-protos-plus-martians:+'
     include 'squareup/geology/*.proto', '**/dinosaur.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-and-protopath-intersect/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-and-protopath-intersect/build.gradle
@@ -19,4 +19,6 @@ wire {
     srcJar 'com.squareup.wire.dinosaur:all-protos:+'
     include 'squareup/dinosaurs/dinosaur.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-build-dir/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-build-dir/build.gradle
@@ -23,4 +23,6 @@ wire {
   sourcePath {
     srcDir OUTPUT_REPO_DIR
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-dir/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-dir/build.gradle
@@ -5,4 +5,6 @@ plugins {
 
 wire {
   sourcePath 'src/main/proto'
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-file/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-file/build.gradle
@@ -5,4 +5,6 @@ plugins {
 
 wire {
   sourcePath 'src/main/proto/squareup/geology/period.proto'
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-maven-single-file/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-maven-single-file/build.gradle
@@ -15,4 +15,6 @@ wire {
     srcJar 'com.squareup.wire.dinosaur:all-protos:+'
     include 'squareup/geology/period.proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-maven/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-maven/build.gradle
@@ -12,4 +12,6 @@ repositories {
 
 wire {
   sourcePath 'com.squareup.wire.dinosaur:all-protos:+'
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-no-sources/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-no-sources/build.gradle
@@ -2,3 +2,8 @@ plugins {
   id 'application'
   id 'com.squareup.wire'
 }
+
+wire{
+  java{
+  }
+}

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-nonexistent-dir/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-nonexistent-dir/build.gradle
@@ -5,4 +5,6 @@ plugins {
 
 wire {
   sourcePath 'src/main/proto'
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-nonexistent-srcdir/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-nonexistent-srcdir/build.gradle
@@ -7,4 +7,6 @@ wire {
   sourcePath {
     srcDir 'src/main/proto'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-uri/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcepath-uri/build.gradle
@@ -5,4 +5,6 @@ plugins {
 
 wire {
   sourcePath 'http://www.squareup.com'
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcetree-many-srcdirs/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcetree-many-srcdirs/build.gradle
@@ -8,4 +8,6 @@ wire {
     srcDirs 'src/main/proto', 'src/main/proto2'
     include 'squareup/**'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcetree-one-srcdir-many-files/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcetree-one-srcdir-many-files/build.gradle
@@ -8,4 +8,6 @@ wire {
     srcDir 'src/main/proto'
     include 'squareup/**'
   }
+  java{
+  }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/sourcetree-one-srcdir-one-file/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/sourcetree-one-srcdir-one-file/build.gradle
@@ -8,4 +8,6 @@ wire {
     srcDir 'src/main/proto'
     include 'squareup/**'
   }
+  java{
+  }
 }


### PR DESCRIPTION
Force a target to be specified instead of defaulting to using java.