### PR TITLE
Download WireCompiler jar in podspec instead of building from scratch

### DIFF
--- a/WireCompiler.podspec
+++ b/WireCompiler.podspec
@@ -13,10 +13,7 @@ Pod::Spec.new do |s|
   s.module_name   = 'WireCompiler'
 
   s.prepare_command = <<-CMD
-    JAVA_HOME="$(/usr/libexec/java_home -v 1.8)"
-    ./gradlew -p wire-library :wire-compiler:shadowJar
-    MOST_RECENT_ARTIFACT="$(ls -t ./wire-library/wire-compiler/build/libs/wire-compiler-*-jar-with-dependencies.jar | head -n1)"
-    cp "$MOST_RECENT_ARTIFACT" ./compiler.jar
+    curl https://repo.maven.apache.org/maven2/com/squareup/wire/wire-compiler/#{version}/wire-compiler-#{version}-jar-with-dependencies.jar --output compiler.jar
   CMD
 
   s.preserve_paths = 'compiler.jar'


### PR DESCRIPTION
We were previously building the compiler jar, which significantly slows
down `pod install` times and pollutes the dev machine environment with a
Gradle process. Instead, we'll now download the jar from Maven Central.

Used the Maven repo URL documented here, which uses a CDN for
distribution: https://maven.apache.org/guides/mini/guide-mirror-settings.html

For testing, I pointed the Cash iOS repo at the local version of the podspec, successfully
ran `pod install`, and then used the `WireCompiler` jar.

Fixes #2173