### PR TITLE
Inline WireLogger#warn into each scenarios

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/ConsoleWireLogger.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/ConsoleWireLogger.kt
@@ -21,10 +21,44 @@ import okio.Path
 internal class ConsoleWireLogger : WireLogger {
   var quiet: Boolean = false
 
-  override fun warn(message: String) {
-    if (!quiet) {
-      println(message)
-    }
+  override fun unusedRoots(unusedRoots: Set<String>) {
+    if (quiet) return
+
+    println(
+      """Unused element in treeShakingRoots:
+      |  ${unusedRoots.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  override fun unusedPrunes(unusedPrunes: Set<String>) {
+    if (quiet) return
+
+    println(
+      """Unused element in treeShakingRubbish:
+      |  ${unusedPrunes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  override fun unusedIncludesInTarget(unusedIncludes: Set<String>) {
+    if (quiet) return
+
+    println(
+      """Unused includes in targets:
+      |  ${unusedIncludes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  override fun unusedExcludesInTarget(unusedExcludes: Set<String>) {
+    if (quiet) return
+
+    println(
+      """Unused excludes in targets:
+      |  ${unusedExcludes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
   }
 
   override fun artifactHandled(outputPath: Path, qualifiedName: String) {

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireLogger.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/WireLogger.kt
@@ -43,8 +43,44 @@ interface WireLogger {
   fun artifactSkipped(type: ProtoType)
 
   /**
-   * This is called when [WireRun][com.squareup.wire.schema.WireRun] found unusual configurations.
-   * For instance when types marked as roots or prunes are not used.
+   * This is called if some `root` values have not been used when Wire pruned the schema model.
+   * Note that `root` should contain package names (suffixed with `.*`), type names, and member
+   * names only. It should not contain file paths. Unused roots can happen if the referenced type
+   * or service isn't part of any `.proto` files defined in either
+   * [sourcePath][com.squareup.wire.schema.WireRun.sourcePath] or
+   * [protoPath][com.squareup.wire.schema.WireRun.protoPath], or if a broader root value is already
+   * defined.
    */
-  fun warn(message: String)
+  fun unusedRoots(unusedRoots: Set<String>)
+
+  /**
+   * This is called if some `prune` values have not been used when Wire pruned the schema model.
+   * Note that `prune` should contain package names (suffixed with `.*`), type names, and member
+   * names only. It should not contain file paths. Unused prunes can happen if the referenced type
+   * or service isn't part of any `.proto` files defined in either
+   * [sourcePath][com.squareup.wire.schema.WireRun.sourcePath] or
+   * [protoPath][com.squareup.wire.schema.WireRun.protoPath], or if a broader prune value is
+   * already defined.
+   */
+  fun unusedPrunes(unusedPrunes: Set<String>)
+
+  /**
+   * This is called if some `includes` values have not been used by the target they were defined in.
+   * Note that `includes` should contain package names (suffixed with `.*`) and type names only. It
+   * should not contain member names, nor file paths. Unused includes can happen if the referenced
+   * type or service isn't part of the parsed and pruned schema model, or has already been consumed
+   * by another preceding target.
+   */
+  // TODO(Benoit) We could pass the target name or something which makes it identifiable.
+  fun unusedIncludesInTarget(unusedIncludes: Set<String>)
+
+  /**
+   * This is called if some `excludes` values have not been used by the target they were defined in.
+   * Note that `excludes` should contain package names (suffixed with `.*`) and type names only. It
+   * should not contain member names, nor file paths. Unused excludes can happen if the referenced
+   * type or service isn't part of the parsed and pruned schema model, or has already been consumed
+   * by another preceding target.
+   */
+  // TODO(Benoit) We could pass the target name or something which makes it identifiable.
+  fun unusedExcludesInTarget(unusedExcludes: Set<String>)
 }

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/StringWireLogger.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/StringWireLogger.kt
@@ -32,9 +32,43 @@ internal class StringWireLogger : WireLogger {
     buffer.append("skipped $type\n")
   }
 
-  @Synchronized override fun warn(message: String) {
-    if (!quiet) {
-      buffer.append("$message\n")
-    }
+  @Synchronized override fun unusedRoots(unusedRoots: Set<String>) {
+    if (quiet) return
+
+    buffer.append(
+      """Unused element in treeShakingRoots:
+      |  ${unusedRoots.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  @Synchronized override fun unusedPrunes(unusedPrunes: Set<String>) {
+    if (quiet) return
+
+    buffer.append(
+      """Unused element in treeShakingRubbish:
+      |  ${unusedPrunes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  @Synchronized override fun unusedIncludesInTarget(unusedIncludes: Set<String>) {
+    if (quiet) return
+
+    buffer.append(
+      """Unused includes in targets:
+      |  ${unusedIncludes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  @Synchronized override fun unusedExcludesInTarget(unusedExcludes: Set<String>) {
+    if (quiet) return
+
+    buffer.append(
+      """Unused excludes in targets:
+      |  ${unusedExcludes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
   }
 }

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/internal/GradleWireLogger.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/internal/GradleWireLogger.kt
@@ -24,8 +24,36 @@ import org.slf4j.LoggerFactory
 internal object GradleWireLogger : WireLogger {
   private val slf4jLogger = LoggerFactory.getLogger(WirePlugin::class.java)
 
-  override fun warn(message: String) {
-    slf4jLogger.warn(message)
+  override fun unusedRoots(unusedRoots: Set<String>) {
+    slf4jLogger.warn(
+      """Unused element in treeShakingRoots:
+      |  ${unusedRoots.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  override fun unusedPrunes(unusedPrunes: Set<String>) {
+    slf4jLogger.warn(
+      """Unused element in treeShakingRubbish:
+      |  ${unusedPrunes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  override fun unusedIncludesInTarget(unusedIncludes: Set<String>) {
+    slf4jLogger.warn(
+      """Unused includes in targets:
+      |  ${unusedIncludes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
+  }
+
+  override fun unusedExcludesInTarget(unusedExcludes: Set<String>) {
+    slf4jLogger.warn(
+      """Unused excludes in targets:
+      |  ${unusedExcludes.joinToString(separator = "\n  ")}
+      """.trimMargin()
+    )
   }
 
   override fun artifactHandled(outputPath: Path, qualifiedName: String) {


### PR DESCRIPTION
`skippedForSyntax` wasn't ever used anymore so I removed it.

I don't really like reference to `treeShakingRoots` and `treeShakingPrunes` in the logger.