### PR TITLE
Add WatchOS support to the Swift tests

### DIFF
--- a/Wire.podspec
+++ b/Wire.podspec
@@ -22,6 +22,7 @@ Pod::Spec.new do |s|
   s.test_spec do |test_spec|
     test_spec.ios.deployment_target  = '11.0'
     test_spec.osx.deployment_target  = '10.15'
+    test_spec.watchos.deployment_target = '3.0'
 
     test_spec.script_phase = {
       :name => 'Compile Test Protos',


### PR DESCRIPTION
This fixes the ability to use `pod gen`.

Fixes #2170