### PR TITLE
Properly deal with identity values for wrapper types

### DIFF
--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -1326,7 +1326,12 @@ public final class JavaGenerator {
         wireFieldLabel = WireField.Label.REQUIRED;
         break;
       case OMIT_IDENTITY:
-        wireFieldLabel = WireField.Label.OMIT_IDENTITY;
+        // Wrapper types don't omit identity values on JSON as other proto3 messages would.
+        if (field.getType().isWrapper()) {
+          wireFieldLabel = null;
+        } else {
+          wireFieldLabel =  WireField.Label.OMIT_IDENTITY;
+        }
         break;
       case REPEATED:
         wireFieldLabel = WireField.Label.REPEATED;

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1093,7 +1093,11 @@ class KotlinGenerator private constructor(
           val wireFieldLabel: WireField.Label? =
             when (field.encodeMode!!) {
               EncodeMode.REQUIRED -> WireField.Label.REQUIRED
-              EncodeMode.OMIT_IDENTITY -> WireField.Label.OMIT_IDENTITY
+              EncodeMode.OMIT_IDENTITY -> {
+                // Wrapper types don't omit identity values on JSON as other proto3 messages would.
+                if (field.type!!.isWrapper) null
+                else WireField.Label.OMIT_IDENTITY
+              }
               EncodeMode.REPEATED -> WireField.Label.REPEATED
               EncodeMode.PACKED -> WireField.Label.PACKED
               EncodeMode.MAP,

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
@@ -73,7 +73,7 @@ annotation class WireField(
     /** Implies [REPEATED]. */
     PACKED,
     /**
-     * Special label to defines proto3 fields which should not be emitted if their value is equal
+     * Special label to define proto3 fields which should not be emitted if their value is equal
      * to their type's respective identity value. E.g.: a field of type `int32` will not get emitted
      * if its value is `0`.
      */

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -200,7 +200,7 @@ data class Field(
     /** Required from proto2. */
     REQUIRED,
 
-    /** Non-repeated fields in proto3. Identify can be `0`, `false`, `""`, or `null`. */
+    /** Non-repeated fields in proto3. Identity can be `0`, `false`, `""`, or `null`. */
     OMIT_IDENTITY,
 
     /** List. */

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoType.kt
@@ -61,6 +61,10 @@ class ProtoType {
       }
     }
 
+  /** True if this type is defined in `google/protobuf/wrappers.proto`. */
+  val isWrapper: Boolean
+    get() = this in WRAPPER_TYPES
+
   /** Creates a scalar or message type.  */
   private constructor(isScalar: Boolean, string: String) {
     this.isScalar = isScalar
@@ -130,36 +134,49 @@ class ProtoType {
     @JvmField val BYTES_VALUE = ProtoType(false, "google.protobuf.BytesValue")
 
     private val SCALAR_TYPES: Map<String, ProtoType> = listOf(
-        BOOL,
-        BYTES,
-        DOUBLE,
-        FLOAT,
-        FIXED32,
-        FIXED64,
-        INT32,
-        INT64,
-        SFIXED32,
-        SFIXED64,
-        SINT32,
-        SINT64,
-        STRING,
-        UINT32,
-        UINT64
+      BOOL,
+      BYTES,
+      DOUBLE,
+      FLOAT,
+      FIXED32,
+      FIXED64,
+      INT32,
+      INT64,
+      SFIXED32,
+      SFIXED64,
+      SINT32,
+      SINT64,
+      STRING,
+      UINT32,
+      UINT64
     ).associateBy { it.string }
 
     internal val NUMERIC_SCALAR_TYPES = listOf(
-        DOUBLE,
-        FLOAT,
-        FIXED32,
-        FIXED64,
-        INT32,
-        INT64,
-        SFIXED32,
-        SFIXED64,
-        SINT32,
-        SINT64,
-        UINT32,
-        UINT64
+      DOUBLE,
+      FLOAT,
+      FIXED32,
+      FIXED64,
+      INT32,
+      INT64,
+      SFIXED32,
+      SFIXED64,
+      SINT32,
+      SINT64,
+      UINT32,
+      UINT64
+    )
+
+    /** All types defined in `google/protobuf/wrappers.proto`. */
+    internal val WRAPPER_TYPES = listOf(
+      DOUBLE_VALUE,
+      FLOAT_VALUE,
+      INT64_VALUE,
+      UINT64_VALUE,
+      INT32_VALUE,
+      UINT32_VALUE,
+      BOOL_VALUE,
+      STRING_VALUE,
+      BYTES_VALUE,
     )
 
     @JvmStatic
@@ -189,6 +206,6 @@ class ProtoType {
     }
 
     @JvmStatic fun get(keyType: ProtoType, valueType: ProtoType, name: String) =
-        ProtoType(keyType, valueType, name)
+      ProtoType(keyType, valueType, name)
   }
 }

--- a/wire-library/wire-tests/src/jvmJavaTest/kotlin/com/squareup/wire/ProtoAdapterIdentityTest.kt
+++ b/wire-library/wire-tests/src/jvmJavaTest/kotlin/com/squareup/wire/ProtoAdapterIdentityTest.kt
@@ -46,9 +46,35 @@ class ProtoAdapterIdentityTest {
         protoAdapter.type == String::class && protoAdapter.syntax === Syntax.PROTO_2 -> {
           assertThat(protoAdapter.identity).isEqualTo("")
         }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.DoubleValue" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.DOUBLE.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.FloatValue" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.FLOAT.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.Int64Value" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.INT64.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.UInt64Value" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.UINT64.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.Int32Value" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.INT32.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.UInt32Value" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.UINT32.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.BoolValue" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.BOOL.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.StringValue" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.STRING.identity)
+        }
+        protoAdapter.typeUrl == "type.googleapis.com/google.protobuf.BytesValue" -> {
+          assertThat(protoAdapter.identity).isEqualTo(ProtoAdapter.BYTES.identity)
+        }
         else -> {
-          // All other types are messages or wrappers (nullable primitives) and must have null as
-          // their identity value.
+          // All other types are messages and must have null as their identity value.
           assertThat(protoAdapter.identity).isNull()
         }
       }
@@ -70,21 +96,21 @@ class ProtoAdapterIdentityTest {
   @Test fun runtimeMessageAdaptersHaveNullIdentities() {
     val protoAdapter =
       ProtoAdapter.newMessageAdapter(
-          Person::class.java
+        Person::class.java
       )
     assertThat(protoAdapter.identity).isNull()
   }
 
   @Test fun runtimeEnumAdaptersHaveZeroIdentities() {
     val protoAdapter = ProtoAdapter.newEnumAdapter(
-        PhoneType::class.java
+      PhoneType::class.java
     )
     assertThat(protoAdapter.identity).isEqualTo(PhoneType.MOBILE) // value = 0.
   }
 
   @Test fun runtimeEnumAdaptersHaveNullIdentitiesWhenThereIsNoZero() {
     val protoAdapter = ProtoAdapter.newEnumAdapter(
-        NestedEnum::class.java
+      NestedEnum::class.java
     )
     assertThat(protoAdapter.identity).isNull()
   }
@@ -121,11 +147,12 @@ class ProtoAdapterIdentityTest {
 
   @Test fun mapIdentityIsEmptyMap() {
     assertThat(
-        ProtoAdapter.newMapAdapter(
-            ProtoAdapter.STRING,
-            ProtoAdapter.STRING
-        ).identity)
-        .isEqualTo(mapOf<String, String>())
+      ProtoAdapter.newMapAdapter(
+        ProtoAdapter.STRING,
+        ProtoAdapter.STRING
+      ).identity
+    )
+      .isEqualTo(mapOf<String, String>())
   }
 
   private val KClass<*>?.isPrimitive

--- a/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllWrappers.java
+++ b/wire-library/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllWrappers.java
@@ -27,7 +27,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "doubleValue"
   )
   public final Double double_value;
@@ -35,7 +34,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "floatValue"
   )
   public final Float float_value;
@@ -43,7 +41,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#INT64_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "int64Value"
   )
   public final Long int64_value;
@@ -51,7 +48,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "uint64Value"
   )
   public final Long uint64_value;
@@ -59,7 +55,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#INT32_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "int32Value"
   )
   public final Integer int32_value;
@@ -67,7 +62,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 6,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "uint32Value"
   )
   public final Integer uint32_value;
@@ -75,7 +69,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 7,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "boolValue"
   )
   public final Boolean bool_value;
@@ -83,7 +76,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 8,
       adapter = "com.squareup.wire.ProtoAdapter#STRING_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "stringValue"
   )
   public final String string_value;
@@ -91,7 +83,6 @@ public final class AllWrappers extends Message<AllWrappers, AllWrappers.Builder>
   @WireField(
       tag = 9,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES_VALUE",
-      label = WireField.Label.OMIT_IDENTITY,
       jsonName = "bytesValue"
   )
   public final ByteString bytes_value;

--- a/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
+++ b/wire-library/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
@@ -31,7 +31,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "doubleValue"
   )
   @JvmField
@@ -39,7 +38,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "floatValue"
   )
   @JvmField
@@ -47,7 +45,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#INT64_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "int64Value"
   )
   @JvmField
@@ -55,7 +52,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "uint64Value"
   )
   @JvmField
@@ -63,7 +59,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#INT32_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "int32Value"
   )
   @JvmField
@@ -71,7 +66,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "uint32Value"
   )
   @JvmField
@@ -79,7 +73,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "boolValue"
   )
   @JvmField
@@ -87,7 +80,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.ProtoAdapter#STRING_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "stringValue"
   )
   @JvmField
@@ -95,7 +87,6 @@ public class AllWrappers(
   @field:WireField(
     tag = 9,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES_VALUE",
-    label = WireField.Label.OMIT_IDENTITY,
     jsonName = "bytesValue"
   )
   @JvmField

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/java/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/java/interop/interop_test.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 package squareup.proto3.java.interop;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
 
 message InteropDuration {
   google.protobuf.Duration value = 1;
@@ -56,3 +57,14 @@ message InteropBoxOneOf {
   }
 }
 
+message InteropWrappers {
+  google.protobuf.DoubleValue double_value = 1;
+  google.protobuf.FloatValue float_value = 2;
+  google.protobuf.Int64Value int64_value = 3;
+  google.protobuf.UInt64Value uint64_value = 4;
+  google.protobuf.Int32Value int32_value = 5;
+  google.protobuf.UInt32Value uint32_value = 6;
+  google.protobuf.BoolValue bool_value = 7;
+  google.protobuf.StringValue string_value = 8;
+  google.protobuf.BytesValue bytes_value = 9;
+}

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/interop/interop_test.proto
@@ -18,6 +18,7 @@ syntax = "proto3";
 package squareup.proto3.kotlin.interop;
 
 import "google/protobuf/duration.proto";
+import "google/protobuf/wrappers.proto";
 
 message InteropDuration {
   google.protobuf.Duration value = 1;
@@ -54,4 +55,16 @@ message InteropBoxOneOf {
     bytes e = 5;
     sint32 f = 6;
   }
+}
+
+message InteropWrappers {
+  google.protobuf.DoubleValue double_value = 1;
+  google.protobuf.FloatValue float_value = 2;
+  google.protobuf.Int64Value int64_value = 3;
+  google.protobuf.UInt64Value uint64_value = 4;
+  google.protobuf.Int32Value int32_value = 5;
+  google.protobuf.UInt32Value uint32_value = 6;
+  google.protobuf.BoolValue bool_value = 7;
+  google.protobuf.StringValue string_value = 8;
+  google.protobuf.BytesValue bytes_value = 9;
 }

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropChecker.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropChecker.kt
@@ -97,6 +97,7 @@ class InteropChecker(
     val wireBytes = (adapter as ProtoAdapter<Any>).encodeByteString(message)
     assertThat(wireBytes).isEqualTo(protocBytes)
     assertThat(adapter.encodeByteString(message)).isEqualTo(protocBytes)
+    assertThat(adapter.decode(protocBytes!!)).isEqualTo(message)
   }
 
   private fun roundtripGson(message: Any) {

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropTest.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropTest.kt
@@ -16,8 +16,10 @@
 package com.squareup.wire
 
 import com.google.protobuf.Duration
+import okio.ByteString
 import org.junit.Ignore
 import org.junit.Test
+import squareup.proto3.java.interop.InteropTest.InteropWrappers
 import squareup.proto2.java.interop.InteropBoxOneOf as InteropBoxOneOfJ2
 import squareup.proto2.java.interop.InteropCamelCase as InteropCamelCaseJ2
 import squareup.proto2.java.interop.InteropDuration as InteropDurationJ2
@@ -42,12 +44,14 @@ import squareup.proto3.java.interop.InteropTest.InteropDuration as InteropDurati
 import squareup.proto3.java.interop.InteropTest.InteropJsonName as InteropJsonNameP3
 import squareup.proto3.java.interop.InteropTest.InteropUint64 as InteropUint64P3
 import squareup.proto3.java.interop.InteropUint64 as InteropUint64J3
+import squareup.proto3.java.interop.InteropWrappers as InteropWrappersJ3
 import squareup.proto3.kotlin.interop.InteropBoxOneOf as InteropBoxOneOfK3
 import squareup.proto3.kotlin.interop.InteropCamelCase as InteropCamelCaseK3
 import squareup.proto3.kotlin.interop.InteropDuration as InteropDurationK3
 import squareup.proto3.kotlin.interop.InteropJsonName as InteropJsonNameK3
 import squareup.proto3.kotlin.interop.InteropOptional as InteropOptionalK3
 import squareup.proto3.kotlin.interop.InteropUint64 as InteropUint64K3
+import squareup.proto3.kotlin.interop.InteropWrappers as InteropWrappersK3
 import squareup.proto3.kotlin.interop.TestProto3Optional.InteropOptional as InteropOptionalP3
 
 class InteropTest {
@@ -270,6 +274,101 @@ class InteropTest {
     )
     checker.check(InteropBoxOneOfJ2.Builder().a("Hello").build())
     checker.check(InteropBoxOneOfJ3.Builder().a("Hello").build())
+  }
+
+  @Test fun wrappersDoesNotOmitWrappedIdentityValues() {
+    val checker = InteropChecker(
+      protocMessage = InteropWrappers.newBuilder()
+        .setDoubleValue(0.0.toDoubleValue())
+        .setFloatValue(0f.toFloatValue())
+        .setInt64Value(0L.toInt64Value())
+        .setUint64Value(0L.toUInt64Value())
+        .setInt32Value(0.toInt32Value())
+        .setUint32Value(0.toUInt32Value())
+        .setBoolValue(false.toBoolValue())
+        .setStringValue("".toStringValue())
+        .setBytesValue(ByteString.EMPTY.toBytesValue())
+        .build(),
+      canonicalJson = """{"doubleValue":0.0,"floatValue":0.0,"int64Value":"0","uint64Value":"0","int32Value":0,"uint32Value":0,"boolValue":false,"stringValue":"","bytesValue":""}""",
+    )
+    checker.check(
+      InteropWrappersJ3.Builder()
+        .double_value(0.0)
+        .float_value(0f)
+        .int64_value(0L)
+        .uint64_value(0L)
+        .int32_value(0)
+        .uint32_value(0)
+        .bool_value(false)
+        .string_value("")
+        .bytes_value(ByteString.EMPTY)
+        .build()
+    )
+    checker.check(
+      InteropWrappersK3.Builder()
+        .double_value(0.0)
+        .float_value(0f)
+        .int64_value(0L)
+        .uint64_value(0L)
+        .int32_value(0)
+        .uint32_value(0)
+        .bool_value(false)
+        .string_value("")
+        .bytes_value(ByteString.EMPTY)
+        .build()
+    )
+  }
+
+  @Test fun wrappersWithNulls() {
+    val checker = InteropChecker(
+      protocMessage = InteropWrappers.newBuilder().build(),
+      canonicalJson = """{}""",
+    )
+    checker.check(InteropWrappersJ3.Builder().build())
+    checker.check(InteropWrappersK3.Builder().build())
+  }
+
+  @Test fun wrappers() {
+    val checker = InteropChecker(
+      protocMessage = InteropWrappers.newBuilder()
+        .setDoubleValue(1.0.toDoubleValue())
+        .setFloatValue(2f.toFloatValue())
+        .setInt64Value(3L.toInt64Value())
+        .setUint64Value(4L.toUInt64Value())
+        .setInt32Value(5.toInt32Value())
+        .setUint32Value(6.toUInt32Value())
+        .setBoolValue(true.toBoolValue())
+        .setStringValue("string".toStringValue())
+        .setBytesValue(ByteString.of(1).toBytesValue())
+        .build(),
+      canonicalJson = """{"doubleValue":1.0,"floatValue":2.0,"int64Value":"3","uint64Value":"4","int32Value":5,"uint32Value":6,"boolValue":true,"stringValue":"string","bytesValue":"AQ=="}""",
+    )
+    checker.check(
+      InteropWrappersJ3.Builder()
+        .double_value(1.0)
+        .float_value(2f)
+        .int64_value(3L)
+        .uint64_value(4L)
+        .int32_value(5)
+        .uint32_value(6)
+        .bool_value(true)
+        .string_value("string")
+        .bytes_value(ByteString.of(1))
+        .build()
+    )
+    checker.check(
+      InteropWrappersK3.Builder()
+        .double_value(1.0)
+        .float_value(2f)
+        .int64_value(3L)
+        .uint64_value(4L)
+        .int32_value(5)
+        .uint32_value(6)
+        .bool_value(true)
+        .string_value("string")
+        .bytes_value(ByteString.of(1))
+        .build()
+    )
   }
 }
 

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -32,7 +32,6 @@ import okio.buffer
 import okio.source
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Assert.fail
-import org.junit.Ignore
 import org.junit.Test
 import squareup.proto2.kotlin.interop.type.InteropTypes.MessageProto2
 import squareup.proto3.kotlin.MapTypesOuterClass


### PR DESCRIPTION
Protoc isn't making it easy for us. It would *not* omit identities on JSON but would when writing bytes. Moreover, it would omit writing bytes in two cases, 1) when the wrapper is null, and 2) when the wrapped value is identity.

fixes #2222
