### PR TITLE
Deserialize missing map scalar key/value as identity

### DIFF
--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -488,8 +488,11 @@ internal class MapProtoAdapter<K, V> internal constructor(
 
   @Throws(IOException::class)
   override fun decode(reader: ProtoReader): Map<K, V> {
-    var key: K? = null
-    var value: V? = null
+    var (key: K?, value: V?) = when (syntax){
+      Syntax.PROTO_2 -> null to null
+      // Default to identity for the sake of scalars.
+      Syntax.PROTO_3 -> entryAdapter.keyAdapter.identity to entryAdapter.valueAdapter.identity
+    }
 
     val token = reader.beginMessage()
     while (true) {
@@ -502,10 +505,6 @@ internal class MapProtoAdapter<K, V> internal constructor(
       }
     }
     reader.endMessageAndGetUnknownFields(token)
-
-    // Default to identity for the sake of scalars.
-    key = key ?: entryAdapter.keyAdapter.identity
-    value = value ?: entryAdapter.valueAdapter.identity
 
     check(key != null) { "Map entry with null key" }
     check(value != null) { "Map entry with null value" }

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -488,11 +488,8 @@ internal class MapProtoAdapter<K, V> internal constructor(
 
   @Throws(IOException::class)
   override fun decode(reader: ProtoReader): Map<K, V> {
-    var (key: K?, value: V?) = when (syntax) {
-      Syntax.PROTO_2 -> null to null
-      // Default to identity for the sake of scalars.
-      Syntax.PROTO_3 -> entryAdapter.keyAdapter.identity to entryAdapter.valueAdapter.identity
-    }
+    var key: K? = entryAdapter.keyAdapter.identity
+    var value: V? = entryAdapter.valueAdapter.identity
 
     val token = reader.beginMessage()
     while (true) {

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -503,6 +503,10 @@ internal class MapProtoAdapter<K, V> internal constructor(
     }
     reader.endMessageAndGetUnknownFields(token)
 
+    // Default to identity for the sake of scalars.
+    key = key ?: entryAdapter.keyAdapter.identity
+    value = value ?: entryAdapter.valueAdapter.identity
+
     check(key != null) { "Map entry with null key" }
     check(value != null) { "Map entry with null value" }
     return mapOf(key to value)

--- a/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
+++ b/wire-library/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoAdapter.kt
@@ -488,7 +488,7 @@ internal class MapProtoAdapter<K, V> internal constructor(
 
   @Throws(IOException::class)
   override fun decode(reader: ProtoReader): Map<K, V> {
-    var (key: K?, value: V?) = when (syntax){
+    var (key: K?, value: V?) = when (syntax) {
       Syntax.PROTO_2 -> null to null
       // Default to identity for the sake of scalars.
       Syntax.PROTO_3 -> entryAdapter.keyAdapter.identity to entryAdapter.valueAdapter.identity

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/map_types.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto2/kotlin/map_types.proto
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2022 Block Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+package squareup.proto2.kotlin;
+
+message MapTypes {
+  map<string, string> map_string_string = 1;
+  map<int32, int32> map_int32_int32 = 2;
+  map<sint32, sint32> map_sint32_sint32 = 3;
+  map<sfixed32, sfixed32> map_sfixed32_sfixed32 = 4;
+  map<fixed32, fixed32> map_fixed32_fixed32 = 5;
+  map<uint32, uint32> map_uint32_uint32 = 6;
+  map<int64, int64> map_int64_int64 = 7;
+  map<sfixed64, sfixed64> map_sfixed64_sfixed64 = 8;
+  map<sint64, sint64> map_sint64_sint64 = 9;
+  map<fixed64, fixed64> map_fixed64_fixed64 = 10;
+  map<uint64, uint64> map_uint64_uint64 = 11;
+}

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
@@ -131,14 +131,14 @@ class Proto2WireProtocCompatibilityTests {
     // first one has a key but not value, the second one has a value without key. Those are manually
     // generated because Protoc and Wire don't write maps this way but can decode them though.
     val bytes = listOf(
-      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
+      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> x0a
       0x04, // length
-      0x0a, // map key tag 1 -> 1|010 -> 10 -> 0a
+      0x0a, // map key tag 1 -> 1|010 -> 10 -> x0a
       0x02, // length
       0x64, 0x65, // de
-      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
+      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> x0a
       0x04, // length
-      0x12, // map key tag 1 -> 1|010 -> 10 -> 0a
+      0x12, // map value tag 2 -> 10|010 -> 18 -> x12
       0x02, // length
       0x65, 0x64, // ed
     ).map { it.toByte() }.toByteArray()

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto2WireProtocCompatibilityTests.kt
@@ -49,6 +49,8 @@ import squareup.proto2.kotlin.interop.type.EnumProto2 as EnumProto2K
 import squareup.proto2.kotlin.interop.type.MessageProto2 as MessageProto2K
 import squareup.proto3.java.interop.type.EnumProto3 as EnumProto3J
 import squareup.proto3.java.interop.type.MessageProto3 as MessageProto3J
+import squareup.proto2.kotlin.MapTypes
+import squareup.proto2.kotlin.MapTypesOuterClass
 import squareup.proto3.kotlin.interop.type.EnumProto3 as EnumProto3K
 import squareup.proto3.kotlin.interop.type.MessageProto3 as MessageProto3K
 
@@ -122,6 +124,36 @@ class Proto2WireProtocCompatibilityTests {
     assertThat(InteropMessageK.ADAPTER.decode(byteArrayProtoc)).isEqualTo(interopWireK)
     assertThat(InteropMessageOuterClass.InteropMessage.parseFrom(byteArrayWireK, interopRegistry))
       .isEqualTo(interopProtoc)
+  }
+
+  @Test fun mapKeysAndValuesDefaultsToTheirRespectiveIdentityValue() {
+    // Bytes for the message `MapType` message with 2 entries on the field `map_string_string`. The
+    // first one has a key but not value, the second one has a value without key. Those are manually
+    // generated because Protoc and Wire don't write maps this way but can decode them though.
+    val bytes = listOf(
+      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
+      0x04, // length
+      0x0a, // map key tag 1 -> 1|010 -> 10 -> 0a
+      0x02, // length
+      0x64, 0x65, // de
+      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
+      0x04, // length
+      0x12, // map key tag 1 -> 1|010 -> 10 -> 0a
+      0x02, // length
+      0x65, 0x64, // ed
+    ).map { it.toByte() }.toByteArray()
+
+    val mapTypeProtoc = MapTypesOuterClass.MapTypes.parseFrom(bytes)
+
+    assertThat(mapTypeProtoc.mapStringStringCount).isEqualTo(2)
+    assertThat(mapTypeProtoc.mapStringStringMap["de"]).isEqualTo("")
+    assertThat(mapTypeProtoc.mapStringStringMap[""]).isEqualTo("ed")
+
+    val mapTypeWire = MapTypes.ADAPTER.decode(bytes)
+
+    assertThat(mapTypeWire.map_string_string.size).isEqualTo(2)
+    assertThat(mapTypeWire.map_string_string["de"]).isEqualTo("")
+    assertThat(mapTypeWire.map_string_string[""]).isEqualTo("ed")
   }
 
   companion object {

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -579,14 +579,14 @@ class Proto3WireProtocCompatibilityTests {
     // first one has a key but not value, the second one has a value without key. Those are manually
     // generated because Protoc and Wire don't write maps this way but can decode them though.
     val bytes = listOf(
-      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
+      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0x0a
       0x04, // length
-      0x0a, // map key tag 1 -> 1|010 -> 10 -> 0a
+      0x0a, // map key tag 1 -> 1|010 -> 10 -> 0x0a
       0x02, // length
       0x64, 0x65, // de
-      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
+      0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0x0a
       0x04, // length
-      0x12, // map key tag 1 -> 1|010 -> 10 -> 0a
+      0x12, // map value tag 2 -> 10|010 -> 18 -> 0x12
       0x02, // length
       0x65, 0x64, // ed
     ).map { it.toByte() }.toByteArray()

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -574,7 +574,9 @@ class Proto3WireProtocCompatibilityTests {
     assertThat(parsed).isEqualTo(value)
   }
 
-  @Test fun validateMapTypesWithScalarKeyValueDeserializeOmittedKeyValue() {
+  @Test fun mapKeysAndValuesDefaultsToTheirRespectiveIdentityValue() {
+    // Build a MapType message with map_string_string field only, 2 entries, first one with key only, than value only.
+    // Both protoc and Wire encodes such with explicit zero-length fields, so had to be hand-crafted.
     val bytes = listOf(
       0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
       0x04, // length

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/Proto3WireProtocCompatibilityTests.kt
@@ -575,8 +575,9 @@ class Proto3WireProtocCompatibilityTests {
   }
 
   @Test fun mapKeysAndValuesDefaultsToTheirRespectiveIdentityValue() {
-    // Build a MapType message with map_string_string field only, 2 entries, first one with key only, than value only.
-    // Both protoc and Wire encodes such with explicit zero-length fields, so had to be hand-crafted.
+    // Bytes for the message `MapType` message with 2 entries on the field `map_string_string`. The
+    // first one has a key but not value, the second one has a value without key. Those are manually
+    // generated because Protoc and Wire don't write maps this way but can decode them though.
     val bytes = listOf(
       0x0a, // MapType.map_string_string tag -> 1|010 -> 10 -> 0a
       0x04, // length


### PR DESCRIPTION
Properly deal with maps of scalar types, deserializing missing scala key/value into identity.

For https://github.com/square/wire/issues/2231