### PR TITLE
Add loadedOnSourcePath field to ProtoFile

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaLoader.kt
@@ -107,7 +107,7 @@ class SchemaLoader : Loader, ProfileLoader {
     val result = mutableListOf<ProtoFile>()
     for (sourceRoot in sourcePathRoots!!) {
       for (locationAndPath in sourceRoot.allProtoFiles()) {
-        result += load(locationAndPath)
+        result += load(locationAndPath, loadedOnSourcePath = true)
       }
     }
 
@@ -133,7 +133,7 @@ class SchemaLoader : Loader, ProfileLoader {
     }
 
     if (loadFrom != null) {
-      return load(loadFrom)
+      return load(loadFrom, loadedOnSourcePath = false)
     }
 
     if (isWireRuntimeProto(path)) {
@@ -148,7 +148,7 @@ class SchemaLoader : Loader, ProfileLoader {
     return ProtoFile.get(ProtoFileElement.empty(path))
   }
 
-  private fun load(protoFilePath: ProtoFilePath): ProtoFile {
+  private fun load(protoFilePath: ProtoFilePath, loadedOnSourcePath: Boolean): ProtoFile {
     if (isWireRuntimeProto(protoFilePath.location)) {
       return CoreLoader.load(protoFilePath.location.path)
     }
@@ -165,6 +165,7 @@ class SchemaLoader : Loader, ProfileLoader {
       errors += "expected ${protoFilePath.location.path} to have a path ending with $importPath"
     }
 
+    protoFile.loadedOnSourcePath = loadedOnSourcePath
     return protoFile
   }
 

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -217,7 +217,6 @@ data class WireRun(
 
     // Validate the schema and resolve references
     val fullSchema = schemaLoader.loadSchema()
-    val sourceLocationPaths = schemaLoader.sourcePathFiles.map { it.location.path }
     val moveTargetPaths = moves.map { it.targetPath }
 
     // Refactor the schema.
@@ -252,9 +251,7 @@ data class WireRun(
 
       // Call each target.
       for (protoFile in partition.schema.protoFiles) {
-        if (protoFile.location.path !in sourceLocationPaths &&
-          protoFile.location.path !in moveTargetPaths
-        ) {
+        if (!protoFile.loadedOnSourcePath && protoFile.location.path !in moveTargetPaths) {
           continue
         }
 

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -217,7 +217,6 @@ data class WireRun(
 
     // Validate the schema and resolve references
     val fullSchema = schemaLoader.loadSchema()
-    val moveTargetPaths = moves.map { it.targetPath }
 
     // Refactor the schema.
     val schema = refactorSchema(fullSchema, logger)
@@ -251,15 +250,13 @@ data class WireRun(
 
       // Call each target.
       for (protoFile in partition.schema.protoFiles) {
-        if (!protoFile.loadedOnSourcePath && protoFile.location.path !in moveTargetPaths) {
-          continue
-        }
+        if (!protoFile.loadedOnSourcePath) continue
 
         // Remove types from the file which are not owned by this partition.
         val filteredProtoFile = protoFile.copy(
           types = protoFile.types.filter { it.type in partition.types },
           services = protoFile.services.filter { it.type in partition.types }
-        )
+        ).apply { this.loadedOnSourcePath = true }
 
         val claimedDefinitions = ClaimedDefinitions()
         claimedDefinitions.claim(ProtoType.ANY)

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -30,8 +30,13 @@ data class ProtoFile(
   val services: List<Service>,
   val extendList: List<Extend>,
   val options: Options,
-  val syntax: Syntax?
+  val syntax: Syntax?,
 ) {
+  /**
+   * True if this [ProtoFile] has been loaded on the `sourcePath`, in opposition to the `protoPath`.
+   */
+  var loadedOnSourcePath: Boolean = false
+
   private var javaPackage: Any? = null
 
   fun toElement(): ProtoFileElement {
@@ -104,6 +109,7 @@ data class ProtoFile(
       location, imports, publicImports, packageName, retainedTypes,
       retainedServices, retainedExtends, retainedOptions, syntax
     )
+    result.loadedOnSourcePath = loadedOnSourcePath
     result.javaPackage = javaPackage
     return result
   }
@@ -122,6 +128,7 @@ data class ProtoFile(
       location, imports, publicImports, packageName, retainedTypes,
       retainedServices, retainedExtends, retainedOptions, syntax
     )
+    result.loadedOnSourcePath = loadedOnSourcePath
     result.javaPackage = javaPackage
     return result
   }
@@ -150,6 +157,7 @@ data class ProtoFile(
         location, retainedImports, publicImports, packageName, types, services,
         extendList, options, syntax
       )
+      result.loadedOnSourcePath = loadedOnSourcePath
       result.javaPackage = javaPackage
       result
     } else {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/TypeMover.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/TypeMover.kt
@@ -70,10 +70,12 @@ class TypeMover(
       val movedType = sourceTypes.removeAt(typeIndex)
 
       pathToFile[sourcePath] = oldSourceProtoFile.copy(types = sourceTypes)
+        .apply { this.loadedOnSourcePath = oldSourceProtoFile.loadedOnSourcePath }
 
       val targetProtoFile = pathToFile[targetPath]
         ?: oldSourceProtoFile.emptyCopy(targetPath)
       pathToFile[targetPath] = targetProtoFile.copy(types = targetProtoFile.types + movedType)
+        .apply { this.loadedOnSourcePath = targetProtoFile.loadedOnSourcePath }
 
       sourceAndTargetPaths += sourcePath
       sourceAndTargetPaths += targetPath
@@ -159,7 +161,7 @@ class TypeMover(
     return copy(
       imports = newImports,
       publicImports = newPublicImports
-    )
+    ).apply { this.loadedOnSourcePath = this@fixImports.loadedOnSourcePath }
   }
 
   /** Returns the type that moved. */
@@ -223,7 +225,7 @@ class TypeMover(
       types = listOf(),
       services = listOf(),
       extendList = listOf()
-    )
+    ).apply { this.loadedOnSourcePath = this@emptyCopy.loadedOnSourcePath }
   }
 
   private fun checkForErrors() {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/Util.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/Util.kt
@@ -111,7 +111,7 @@ fun Schema.withStubs(typesToStub: Set<ProtoType>): Schema {
   }
   return Schema(
     protoFiles.map { protoFile ->
-      protoFile.copy(
+      val result = protoFile.copy(
         types = protoFile.types.map { type ->
           if (type.type in typesToStub) type.asStub() else type
         },
@@ -119,6 +119,8 @@ fun Schema.withStubs(typesToStub: Set<ProtoType>): Schema {
           if (service.type in typesToStub) service.asStub() else service
         }
       )
+      result.loadedOnSourcePath = protoFile.loadedOnSourcePath
+      return@map result
     }
   )
 }


### PR DESCRIPTION
Right now, only the `SchemaLoader` which file is on `sourcePath` or `protoPath`. Using `SchemaLoader`, `WireRun` is able to pass only files loaded on `sourcePath` to targets but I think there's value in proto files being tagged as being part of `sourcePath` or not. Otherwise, any target (including custom ones) being passed a Schema isn't able to differentiate between those proto files.