### PR TITLE
Introduce new SchemaHandler APIs

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ include(":samples:wire-grpc-sample:protos")
 include(":samples:wire-grpc-sample:server")
 include(":samples:wire-grpc-sample:server-plain")
 include(":wire-benchmarks")
+include(":wire-gradle-plugin-playground")
 include(":wire-grpc-tests")
 include(":wire-protoc-compatibility-tests")
 

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/AbstractSchemaHandler.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/AbstractSchemaHandler.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2022 Block Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import okio.Path
+
+/**
+ * [SchemaHandler] with default logic on handling [Schema]'s [ProtoFile]s respecting the
+ * [SchemaHandler.Context].
+ */
+abstract class AbstractSchemaHandler : SchemaHandler {
+  /**
+   * This will handle all [ProtoFile]s which are part of the `sourcePath`. If a
+   * [Module][SchemaHandler.Context.Module] is set in the [context], it will handle only [Type]s
+   * and [Service]s the module defines.
+   */
+  override fun handle(schema: Schema, context: SchemaHandler.Context) {
+    val moduleTypes = context.module?.types
+    for (protoFile in schema.protoFiles) {
+      if (!context.inSourcePath(protoFile)) continue
+
+      // Remove types from the file which are not owned by this partition.
+      val filteredProtoFile = protoFile.copy(
+        types = protoFile.types.filter { if (moduleTypes != null) it.type in moduleTypes else true },
+        services = protoFile.services.filter { if (moduleTypes != null) it.type in moduleTypes else true }
+      )
+
+      handle(filteredProtoFile, context)
+    }
+  }
+
+  /**
+   * This will handle all [Type]s and [Service]s of the [protoFile] in respect to the emitting
+   * rules defined by the [context]. If exclusive, the handled [Type]s and [Service]s should be
+   * added to the [ClaimedDefinitions]. Already consumed types and services themselves will be
+   * omitted by this handler.
+   */
+  private fun handle(
+    protoFile: ProtoFile,
+    context: SchemaHandler.Context,
+  ) {
+    val claimedDefinitions = context.claimedDefinitions
+    val emittingRules = context.emittingRules
+    val claimedPaths = context.claimedPaths
+    val types = protoFile.types
+      .filter { if (claimedDefinitions != null) it !in claimedDefinitions else true }
+      .filter { emittingRules.includes(it.type) }
+
+    for (type in types) {
+      val generatedFilePath = handle(type, context)
+
+      if (generatedFilePath != null) {
+        claimedPaths.claim(generatedFilePath, type)
+      }
+
+      // We don't let other targets handle this one.
+      claimedDefinitions?.claim(type)
+    }
+
+    val services = protoFile.services
+      .filter { if (claimedDefinitions != null) it !in claimedDefinitions else true }
+      .filter { emittingRules.includes(it.type) }
+
+    for (service in services) {
+      val generatedFilePaths = handle(service, context)
+
+      for (generatedFilePath in generatedFilePaths) {
+        claimedPaths.claim(generatedFilePath, service)
+      }
+
+      // We don't let other targets handle this one.
+      claimedDefinitions?.claim(service)
+    }
+
+    // TODO(jwilson): extend emitting rules to support include/exclude of extension fields.
+    protoFile.extendList
+      .flatMap { extend -> extend.fields.map { field -> extend to field } }
+      .filter { if (claimedDefinitions != null) it.second !in claimedDefinitions else true }
+      .forEach { extendToField ->
+        val (extend, field) = extendToField
+        // TODO(Benoît) claim path.
+        handle(extend, field, context)
+
+        // We don't let other targets handle this one.
+        claimedDefinitions?.claim(field)
+      }
+  }
+
+  /**
+   * Returns the [Path] of the file which [type] will have been generated into. Null if nothing has
+   * been generated.
+   */
+  abstract fun handle(type: Type, context: SchemaHandler.Context): Path?
+
+  /**
+   * Returns the [Path]s of the files which [service] will have been generated into. Null if
+   * nothing has been generated.
+   */
+  abstract fun handle(service: Service, context: SchemaHandler.Context): List<Path>
+
+  /**
+   * Returns the [Path] of the files which [field] will have been generated into. Null if nothing
+   * has been generated.
+   */
+  abstract fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path?
+}

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaHandler.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaHandler.kt
@@ -1,0 +1,112 @@
+/*
+ * Copyright 2022 Block Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.squareup.wire.WireLogger
+import com.squareup.wire.internal.Serializable
+import okio.FileSystem
+import okio.Path
+
+/**
+ * A [SchemaHandler] [handle]s [Schema]!
+ * Implementations of this interface must have a no-arguments public constructor. TODO(Benoit) Is it still true?
+ *
+ * Consider using [AbstractSchemaHandler] for default logic around handling [Schema] and delegating
+ * individual calls on [Type]s and [Service]s.
+ */
+interface SchemaHandler {
+  /**
+   * Entry point for the [SchemaHandler] to handle [schema]. It is the responsibility of the
+   * [SchemaHandler] to respect the [context].
+   *
+   * This function is invoked at most once per [SchemaHandler] instance. When a single type can
+   * handle multiple schemas, a new handler should be created for each schema.
+   */
+  fun handle(schema: Schema, context: Context)
+
+  interface Factory : Serializable {
+    fun create(): SchemaHandler
+  }
+
+  /**
+   * A [Context] holds the information necessary for a [SchemaHandler] to do its job. It contains
+   * both helping objects such as [logger], and constraining objects such as [emittingRules].
+   */
+  data class Context(
+    /** To be used by the [SchemaHandler] for reading/writing operations on disk. */
+    val fileSystem: FileSystem,
+    /** Location on [fileSystem] where the [SchemaHandler] is to write files, if it needs to. */
+    val outDirectory: Path,
+    /** Event-listener like logger with which [SchemaHandler] can notify handled artifacts. */
+    val logger: WireLogger,
+    /**
+     * Object to be used by the [SchemaHandler] to store errors. After all [SchemaHandler]s are
+     * finished, Wire will throw an exception if any error are present inside the collector.
+     */
+    val errorCollector: ErrorCollector = ErrorCollector(),
+    /**
+     * Set of rules letting the [SchemaHandler] know what [ProtoType] to include or exclude in its
+     * logic. This object represents the `includes` and `excludes` values which were associated
+     * with its [Target].
+     */
+    val emittingRules: EmittingRules = EmittingRules(),
+    /**
+     * If set, the [SchemaHandler] is to handle only types which are not claimed yet, and claim
+     * itself types it has handled. If null, the [SchemaHandler] is to handle all types.
+     */
+    val claimedDefinitions: ClaimedDefinitions? = null,
+    /** If the [SchemaHandler] writes files, it is to claim [Path]s of files it created. */
+    val claimedPaths: ClaimedPaths = ClaimedPaths(),
+    /**
+     * A [Module] dictates how the loaded types are partitioned and how they are to be handled.
+     * If null, there are no partition and all types are to be handled.
+     */
+    val module: Module? = null,
+    /**
+     * Contains [Location.path] values of all `sourcePath` roots. The [SchemaHandler] is to ignore
+     * [ProtoFile]s not part of this set; this verification can be executed via the [inSourcePath]
+     * method.
+     */
+    val sourcePathPaths: Set<String>? = null,
+    /**
+     * To be used by the [SchemaHandler] if it supports [Profile] files. Please note that this API
+     * is unstable and can change at anytime.
+     */
+    val profileLoader: ProfileLoader? = null,
+  ) {
+    /** True if this [protoFile] ia part of a `sourcePath` root. */
+    fun inSourcePath(protoFile: ProtoFile): Boolean {
+      return inSourcePath(protoFile.location)
+    }
+
+    /** True if this [location] ia part of a `sourcePath` root. */
+    fun inSourcePath(location: Location): Boolean {
+      return sourcePathPaths == null || location.path in sourcePathPaths
+    }
+  }
+
+  /**
+   * A [Module] dictates how the loaded types are to be partitioned and handled.
+   */
+  data class Module(
+    /** The name of the [Module]. */
+    val name: String,
+    /** The types that this module is to handle. */
+    val types: Set<ProtoType>,
+    /** These are the types depended upon by [types] associated with their module name. */
+    val upstreamTypes: Map<ProtoType, String> = mapOf(),
+  )
+}

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/SchemaLoader.kt
@@ -107,7 +107,7 @@ class SchemaLoader : Loader, ProfileLoader {
     val result = mutableListOf<ProtoFile>()
     for (sourceRoot in sourcePathRoots!!) {
       for (locationAndPath in sourceRoot.allProtoFiles()) {
-        result += load(locationAndPath, loadedOnSourcePath = true)
+        result += load(locationAndPath)
       }
     }
 
@@ -133,7 +133,7 @@ class SchemaLoader : Loader, ProfileLoader {
     }
 
     if (loadFrom != null) {
-      return load(loadFrom, loadedOnSourcePath = false)
+      return load(loadFrom)
     }
 
     if (isWireRuntimeProto(path)) {
@@ -148,7 +148,7 @@ class SchemaLoader : Loader, ProfileLoader {
     return ProtoFile.get(ProtoFileElement.empty(path))
   }
 
-  private fun load(protoFilePath: ProtoFilePath, loadedOnSourcePath: Boolean): ProtoFile {
+  private fun load(protoFilePath: ProtoFilePath): ProtoFile {
     if (isWireRuntimeProto(protoFilePath.location)) {
       return CoreLoader.load(protoFilePath.location.path)
     }
@@ -165,7 +165,6 @@ class SchemaLoader : Loader, ProfileLoader {
       errors += "expected ${protoFilePath.location.path} to have a path ending with $importPath"
     }
 
-    protoFile.loadedOnSourcePath = loadedOnSourcePath
     return protoFile
   }
 

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/WireCompilerTest.kt
@@ -17,7 +17,6 @@
 
 package com.squareup.wire
 
-import java.util.Collections
 import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toOkioPath
@@ -27,6 +26,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
+import java.util.Collections
 
 class WireCompilerTest {
   @Rule @JvmField val temp = TemporaryFolder()

--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -17,13 +17,13 @@ package com.squareup.wire.gradle
 
 import com.squareup.wire.kotlin.RpcCallStyle
 import com.squareup.wire.kotlin.RpcRole
-import com.squareup.wire.schema.CustomHandlerBeta
-import com.squareup.wire.schema.CustomTargetBeta
+import com.squareup.wire.schema.CustomTarget
 import com.squareup.wire.schema.JavaTarget
 import com.squareup.wire.schema.KotlinTarget
 import com.squareup.wire.schema.ProtoTarget
+import com.squareup.wire.schema.SchemaHandler
 import com.squareup.wire.schema.Target
-import com.squareup.wire.schema.newCustomHandler
+import com.squareup.wire.schema.newSchemaHandler
 import javax.inject.Inject
 
 /**
@@ -123,27 +123,26 @@ open class CustomOutput @Inject constructor() : WireOutput() {
   var includes: List<String>? = null
   var excludes: List<String>? = null
   var exclusive: Boolean = true
-  /**
-   * Assign the custom handler instance. If you use this, your custom handler should implement
-   * [java.io.Serializable] (which Gradle uses as a cache key).
-   */
-  var customHandler: CustomHandlerBeta? = null
-  /**
-   * Assign the custom handler by name. If you use a class name, that class must have a no-arguments
-   * constructor.
-   */
-  var customHandlerClass: String? = null
 
-  override fun toTarget(outputDirectory: String): CustomTargetBeta {
-    check((customHandlerClass == null) != (customHandler == null)) {
-      "customHandlerClass or customHandler required"
+  /** Assign the schema handler factory instance. */
+  var schemaHandlerFactory: SchemaHandler.Factory? = null
+
+  /**
+   * Assign the schema handler factory by name. If you use a class name, that class must have a
+   * no-arguments constructor.
+   */
+  var schemaHandlerFactoryClass: String? = null
+
+  override fun toTarget(outputDirectory: String): CustomTarget {
+    check((schemaHandlerFactory != null) || (schemaHandlerFactoryClass != null)) {
+      "schemaHandlerFactory or schemaHandlerFactoryClass required"
     }
-    return CustomTargetBeta(
+    return CustomTarget(
       includes = includes ?: listOf("*"),
       excludes = excludes ?: listOf(),
       exclusive = exclusive,
       outDirectory = outputDirectory,
-      customHandler = customHandler ?: newCustomHandler(customHandlerClass!!)
+      schemaHandlerFactory = schemaHandlerFactory ?: newSchemaHandler(schemaHandlerFactoryClass!!),
     )
   }
 }

--- a/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-library/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -933,7 +933,7 @@ class WirePluginTest {
 
     val result = gradleRunner.runFixture(fixtureRoot) { buildAndFail() }
     assertThat(result.output)
-      .contains("Couldn't find CustomHandlerClass 'NoSuchClass'")
+      .contains("Couldn't find SchemaHandlerClass 'NoSuchClass'")
   }
 
   @Test

--- a/wire-library/wire-gradle-plugin/src/test/projects/custom-output-no-such-class/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/custom-output-no-such-class/build.gradle
@@ -7,6 +7,6 @@ wire {
   sourcePath 'src/main/proto'
 
   custom {
-    customHandlerClass = "NoSuchClass"
+    schemaHandlerFactoryClass = "NoSuchClass"
   }
 }

--- a/wire-library/wire-gradle-plugin/src/test/projects/custom-output/build.gradle
+++ b/wire-library/wire-gradle-plugin/src/test/projects/custom-output/build.gradle
@@ -1,26 +1,13 @@
-import java.io.Serializable
-import com.squareup.wire.WireLogger
-import com.squareup.wire.schema.CustomHandlerBeta
-import com.squareup.wire.schema.ErrorCollector
-import com.squareup.wire.schema.ProfileLoader
-import com.squareup.wire.schema.Schema
-import com.squareup.wire.schema.Target
-import okio.FileSystem
+import com.squareup.wire.schema.SchemaHandler
 
 plugins {
   id 'application'
   id 'com.squareup.wire'
 }
 
-class MyCustomHandler implements CustomHandlerBeta, Serializable {
-  public Target.SchemaHandler newHandler(Schema schema, FileSystem fs,
-          String outDirectory, WireLogger logger, ProfileLoader profileLoader) {
-    throw new RuntimeException("custom handler is running!!")
-  }
-  public Target.SchemaHandler newHandler(Schema schema, FileSystem fs,
-          String outDirectory, WireLogger logger, ProfileLoader profileLoader,
-          ErrorCollector errorCollector) {
-    throw new RuntimeException("custom handler is running!!")
+class MyCustomHandlerFactory implements SchemaHandler.Factory {
+  @Override public SchemaHandler create() {
+    throw new RuntimeException("custom handler is running!!");
   }
 }
 
@@ -28,6 +15,6 @@ wire {
   sourcePath 'src/main/proto'
 
   custom {
-    customHandler = new MyCustomHandler()
+    schemaHandlerFactory = new MyCustomHandlerFactory()
   }
 }

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -380,12 +380,6 @@ class Options(
     }
   }
 
-  /** Returns true if these options assigns a value to [protoMember].  */
-  fun assignsMember(protoMember: ProtoMember?): Boolean {
-    // TODO(jwilson): remove the null check; this shouldn't be called until linking completes.
-    return entries?.any { it.protoMember == protoMember } ?: false
-  }
-
   companion object {
     @JvmField val FILE_OPTIONS = ProtoType.get("google.protobuf.FileOptions")
     @JvmField val MESSAGE_OPTIONS = ProtoType.get("google.protobuf.MessageOptions")

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -32,11 +32,6 @@ data class ProtoFile(
   val options: Options,
   val syntax: Syntax?,
 ) {
-  /**
-   * True if this [ProtoFile] has been loaded on the `sourcePath`, in opposition to the `protoPath`.
-   */
-  var loadedOnSourcePath: Boolean = false
-
   private var javaPackage: Any? = null
 
   fun toElement(): ProtoFileElement {
@@ -109,7 +104,6 @@ data class ProtoFile(
       location, imports, publicImports, packageName, retainedTypes,
       retainedServices, retainedExtends, retainedOptions, syntax
     )
-    result.loadedOnSourcePath = loadedOnSourcePath
     result.javaPackage = javaPackage
     return result
   }
@@ -128,7 +122,6 @@ data class ProtoFile(
       location, imports, publicImports, packageName, retainedTypes,
       retainedServices, retainedExtends, retainedOptions, syntax
     )
-    result.loadedOnSourcePath = loadedOnSourcePath
     result.javaPackage = javaPackage
     return result
   }
@@ -157,7 +150,6 @@ data class ProtoFile(
         location, retainedImports, publicImports, packageName, types, services,
         extendList, options, syntax
       )
-      result.loadedOnSourcePath = loadedOnSourcePath
       result.javaPackage = javaPackage
       result
     } else {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Type.kt
@@ -23,7 +23,7 @@ import com.squareup.wire.schema.internal.parser.MessageElement
 import com.squareup.wire.schema.internal.parser.TypeElement
 import kotlin.jvm.JvmStatic
 
-abstract class Type {
+sealed class Type {
   abstract val location: Location
   abstract val type: ProtoType
   abstract val documentation: String

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/TypeMover.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/TypeMover.kt
@@ -70,12 +70,10 @@ class TypeMover(
       val movedType = sourceTypes.removeAt(typeIndex)
 
       pathToFile[sourcePath] = oldSourceProtoFile.copy(types = sourceTypes)
-        .apply { this.loadedOnSourcePath = oldSourceProtoFile.loadedOnSourcePath }
 
       val targetProtoFile = pathToFile[targetPath]
         ?: oldSourceProtoFile.emptyCopy(targetPath)
       pathToFile[targetPath] = targetProtoFile.copy(types = targetProtoFile.types + movedType)
-        .apply { this.loadedOnSourcePath = targetProtoFile.loadedOnSourcePath }
 
       sourceAndTargetPaths += sourcePath
       sourceAndTargetPaths += targetPath
@@ -161,7 +159,7 @@ class TypeMover(
     return copy(
       imports = newImports,
       publicImports = newPublicImports
-    ).apply { this.loadedOnSourcePath = this@fixImports.loadedOnSourcePath }
+    )
   }
 
   /** Returns the type that moved. */
@@ -224,8 +222,8 @@ class TypeMover(
       publicImports = listOf(),
       types = listOf(),
       services = listOf(),
-      extendList = listOf()
-    ).apply { this.loadedOnSourcePath = this@emptyCopy.loadedOnSourcePath }
+      extendList = listOf(),
+    )
   }
 
   private fun checkForErrors() {

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/Util.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/Util.kt
@@ -119,7 +119,6 @@ fun Schema.withStubs(typesToStub: Set<ProtoType>): Schema {
           if (service.type in typesToStub) service.asStub() else service
         }
       )
-      result.loadedOnSourcePath = protoFile.loadedOnSourcePath
       return@map result
     }
   )


### PR DESCRIPTION
Part of #2077

TL;DR

```kotlin
interface SchemaHandler {
  fun handle(schema: Schema, context: Context)

  data class Context(
    val fileSystem: FileSystem,
    val outDirectory: Path,
    val logger: WireLogger,
    val errorCollector: ErrorCollector = ErrorCollector(),
    val emittingRules: EmittingRules = EmittingRules(),
    val claimedDefinitions: ClaimedDefinitions? = null,
    val claimedPaths: ClaimedPaths = ClaimedPaths(),
    val module: Module? = null,
    val sourcePathPaths: Set<String>? = null,
    val profileLoader: ProfileLoader? = null,
  ) {
    fun inSourcePath(protoFile: ProtoFile): Boolean {
      return inSourcePath(protoFile.location)
    }

    fun inSourcePath(location: Location): Boolean {
      return sourcePathPaths == null || location.path in sourcePathPaths
    }

    data class Module(
      val name: String,
      val types: Set<ProtoType>,
      val upstreamTypes: Map<ProtoType, String> = mapOf(),
    )
  }
}
```