### PR TITLE
Add macosArm64 support to the KMP projects supporting mac.

### DIFF
--- a/wire-library/wire-grpc-client/build.gradle.kts
+++ b/wire-library/wire-grpc-client/build.gradle.kts
@@ -37,6 +37,7 @@ kotlin {
     // Required to generate tests tasks: https://youtrack.jetbrains.com/issue/KT-26547
     linuxX64()
     macosX64()
+    macosArm64()
   }
   sourceSets {
     val commonMain by getting {
@@ -60,7 +61,8 @@ kotlin {
       val iosSimulatorArm64Main by getting
       val linuxX64Main by getting
       val macosX64Main by getting
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main)) {
+      val macosArm64Main by getting
+      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main)) {
         it.dependsOn(nativeMain)
       }
     }

--- a/wire-library/wire-runtime/build.gradle.kts
+++ b/wire-library/wire-runtime/build.gradle.kts
@@ -99,7 +99,6 @@ kotlin {
       val macosX64Test by getting
       val macosArm64Test by getting
 
-
       for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main)) {
         it.dependsOn(nativeMain)
       }

--- a/wire-library/wire-runtime/build.gradle.kts
+++ b/wire-library/wire-runtime/build.gradle.kts
@@ -39,6 +39,7 @@ kotlin {
     // Required to generate tests tasks: https://youtrack.jetbrains.com/issue/KT-26547
     linuxX64()
     macosX64()
+    macosArm64()
   }
   sourceSets {
     all {
@@ -90,21 +91,24 @@ kotlin {
       val iosSimulatorArm64Main by getting
       val linuxX64Main by getting
       val macosX64Main by getting
+      val macosArm64Main by getting
       val iosX64Test by getting
       val iosArm64Test by getting
       val iosSimulatorArm64Test by getting
       val linuxX64Test by getting
       val macosX64Test by getting
+      val macosArm64Test by getting
 
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main)) {
+
+      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main)) {
         it.dependsOn(nativeMain)
       }
 
-      for (it in listOf(iosX64Test, iosArm64Test, iosSimulatorArm64Test, linuxX64Test, macosX64Test)) {
+      for (it in listOf(iosX64Test, iosArm64Test, iosSimulatorArm64Test, linuxX64Test, macosX64Test, macosArm64Test)) {
         it.dependsOn(nativeTest)
       }
 
-      for (it in listOf(iosX64Main, iosArm64Main, macosX64Main)) {
+      for (it in listOf(iosX64Main, iosArm64Main, macosX64Main, macosArm64Main)) {
         it.dependsOn(darwinMain)
       }
     }

--- a/wire-library/wire-tests/build.gradle.kts
+++ b/wire-library/wire-tests/build.gradle.kts
@@ -69,6 +69,7 @@ kotlin {
     // Required to generate tests tasks: https://youtrack.jetbrains.com/issue/KT-26547
     linuxX64()
     macosX64()
+    macosArm64()
   }
   sourceSets {
     val commonMain by getting {
@@ -117,18 +118,20 @@ kotlin {
       val iosSimulatorArm64Main by getting
       val linuxX64Main by getting
       val macosX64Main by getting
+      val macosArm64Main by getting
       val iosX64Test by getting
       val iosArm64Test by getting
       val iosSimulatorArm64Test by getting
       val linuxX64Test by getting
       val macosX64Test by getting
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main)) {
+      val macosArm64Test by getting
+      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main)) {
         it.dependsOn(nativeMain)
       }
-      for (it in listOf(iosX64Test, iosArm64Test, iosSimulatorArm64Test, linuxX64Test, macosX64Test)) {
+      for (it in listOf(iosX64Test, iosArm64Test, iosSimulatorArm64Test, linuxX64Test, macosX64Test, macosArm64Test)) {
         it.dependsOn(nativeTest)
       }
-      for (it in listOf(iosX64Test, iosArm64Test, macosX64Test)) {
+      for (it in listOf(iosX64Test, iosArm64Test, macosX64Test, macosArm64Test)) {
         it.dependsOn(darwinTest)
       }
     }


### PR DESCRIPTION
Need this to be able to develop and test on the new M1 Macs.

Ran `./gradlew clean check` and all tests passed.