### PR TITLE
MPP'ed SchemaLoader with CommonSchemaLoader to avoid too much duplication

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2018 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import okio.IOException
+
+/**
+ * Load proto files and their transitive dependencies and parse them. Keep track of which files were
+ * loaded from where so that we can use that information later when deciding what to generate.
+ */
+expect class SchemaLoader : Loader, ProfileLoader {
+  /** Strict by default. Note that golang cannot build protos with package cycles. */
+  var permitPackageCycles: Boolean
+
+  /**
+   * If true, the schema loader will load the whole graph, including files and types not used by
+   * anything in the source path.
+   */
+  var loadExhaustively: Boolean
+
+  /** Subset of the schema that was loaded from the source path. */
+  val sourcePathFiles: List<ProtoFile>
+
+  /** Initialize the [WireRun.sourcePath] and [WireRun.protoPath] from which files are loaded. */
+  fun initRoots(
+    sourcePath: List<Location>,
+    protoPath: List<Location> = listOf()
+  )
+
+  @Throws(IOException::class)
+  fun loadSchema(): Schema
+}

--- a/wire-library/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Block Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.wire.schema
 
 import com.squareup.wire.schema.internal.CommonSchemaLoader

--- a/wire-library/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -1,0 +1,53 @@
+package com.squareup.wire.schema
+
+import com.squareup.wire.schema.internal.CommonSchemaLoader
+import okio.FileSystem
+
+actual class SchemaLoader : Loader, ProfileLoader {
+  private val delegate: CommonSchemaLoader
+
+  constructor(fileSystem: FileSystem) {
+    delegate = CommonSchemaLoader(fileSystem)
+  }
+
+  private constructor(enclosing: CommonSchemaLoader, errors: ErrorCollector) {
+    delegate = CommonSchemaLoader(enclosing, errors)
+  }
+
+  override fun withErrors(errors: ErrorCollector) = SchemaLoader(delegate, errors)
+
+  /** Strict by default. Note that golang cannot build protos with package cycles. */
+  actual var permitPackageCycles: Boolean
+    get() = delegate.permitPackageCycles
+    set(value) {
+      delegate.permitPackageCycles = value
+    }
+
+  /**
+   * If true, the schema loader will load the whole graph, including files and types not used by
+   * anything in the source path.
+   */
+  actual var loadExhaustively: Boolean
+    get() = delegate.loadExhaustively
+    set(value) {
+      delegate.loadExhaustively = value
+    }
+
+  /** Subset of the schema that was loaded from the source path. */
+  actual val sourcePathFiles: List<ProtoFile>
+    get() = delegate.sourcePathFiles
+
+  /** Initialize the [WireRun.sourcePath] and [WireRun.protoPath] from which files are loaded. */
+  actual fun initRoots(
+    sourcePath: List<Location>,
+    protoPath: List<Location>
+  ) {
+    delegate.initRoots(sourcePath, protoPath)
+  }
+
+  override fun loadProfile(name: String, schema: Schema) = delegate.loadProfile(name, schema)
+
+  override fun load(path: String) = delegate.load(path)
+
+  actual fun loadSchema(): Schema = delegate.loadSchema()
+}

--- a/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2022 Block Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.wire.schema
 
 import com.squareup.wire.schema.internal.CommonSchemaLoader

--- a/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-library/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -1,0 +1,57 @@
+package com.squareup.wire.schema
+
+import com.squareup.wire.schema.internal.CommonSchemaLoader
+import com.squareup.wire.schema.internal.toOkioFileSystem
+import java.nio.file.FileSystem as NioFileSystem
+import okio.FileSystem
+
+actual class SchemaLoader : Loader, ProfileLoader {
+  private val delegate: CommonSchemaLoader
+
+  constructor(fileSystem: NioFileSystem) : this(fileSystem.toOkioFileSystem())
+
+  constructor(fileSystem: FileSystem) {
+    delegate = CommonSchemaLoader(fileSystem)
+  }
+
+  private constructor(enclosing: CommonSchemaLoader, errors: ErrorCollector) {
+    delegate = CommonSchemaLoader(enclosing, errors)
+  }
+
+  override fun withErrors(errors: ErrorCollector) = SchemaLoader(delegate, errors)
+
+  /** Strict by default. Note that golang cannot build protos with package cycles. */
+  actual var permitPackageCycles: Boolean
+    get() = delegate.permitPackageCycles
+    set(value) {
+      delegate.permitPackageCycles = value
+    }
+
+  /**
+   * If true, the schema loader will load the whole graph, including files and types not used by
+   * anything in the source path.
+   */
+  actual var loadExhaustively: Boolean
+    get() = delegate.loadExhaustively
+    set(value) {
+      delegate.loadExhaustively = value
+    }
+
+  /** Subset of the schema that was loaded from the source path. */
+  actual val sourcePathFiles: List<ProtoFile>
+    get() = delegate.sourcePathFiles
+
+  /** Initialize the [WireRun.sourcePath] and [WireRun.protoPath] from which files are loaded. */
+  actual fun initRoots(
+    sourcePath: List<Location>,
+    protoPath: List<Location>
+  ) {
+    delegate.initRoots(sourcePath, protoPath)
+  }
+
+  override fun loadProfile(name: String, schema: Schema) = delegate.loadProfile(name, schema)
+
+  override fun load(path: String) = delegate.load(path)
+
+  actual fun loadSchema(): Schema = delegate.loadSchema()
+}

--- a/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaLoaderTest.kt
+++ b/wire-library/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaLoaderTest.kt
@@ -29,7 +29,9 @@ import kotlin.text.Charsets.UTF_16LE
 import kotlin.text.Charsets.UTF_32BE
 import kotlin.text.Charsets.UTF_32LE
 import kotlin.text.Charsets.UTF_8
+import com.squareup.wire.schema.internal.CommonSchemaLoader
 
+// TODO(Benoit) Move this class to commonTest, and test `SchemaLoader` instead of `CommonSchemaLoader`.
 class SchemaLoaderTest {
   private val fs = FakeFileSystem().apply {
     if (Path.DIRECTORY_SEPARATOR == "\\") emulateWindows() else emulateUnix()
@@ -101,7 +103,7 @@ class SchemaLoaderTest {
         """.trimMargin()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.initRoots(
       sourcePath = listOf(
         Location.get("colors/src/main/proto")
@@ -130,7 +132,7 @@ class SchemaLoaderTest {
   @Test
   fun noSourcesFound() {
     val exception = assertFailsWith<SchemaException> {
-      val loader = SchemaLoader(fs)
+      val loader = CommonSchemaLoader(fs)
       loader.initRoots(sourcePath = listOf())
       loader.loadSourcePathFiles()
     }
@@ -149,7 +151,7 @@ class SchemaLoaderTest {
         """.trimMargin()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.initRoots(
       sourcePath = listOf(Location.get("colors/src/main/proto", "squareup/shapes/blue.proto"))
     )
@@ -171,7 +173,7 @@ class SchemaLoaderTest {
     )
 
     val exception = assertFailsWith<SchemaException> {
-      val loader = SchemaLoader(fs)
+      val loader = CommonSchemaLoader(fs)
       loader.initRoots(
         sourcePath = listOf(Location.get("colors/src/main/proto/squareup/shapes/blue.proto"))
       )
@@ -205,7 +207,7 @@ class SchemaLoaderTest {
         """.trimMargin()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.initRoots(
       sourcePath = listOf(Location.get("colors/src/main/proto")),
       protoPath = listOf(Location.get("curves/src/main/proto", "squareup/curves/circle.proto"))
@@ -249,7 +251,7 @@ class SchemaLoaderTest {
       |}""".trimMargin()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.initRoots(
       sourcePath = listOf(Location.get(fs.workingDirectory.toString())),
       protoPath = listOf(Location.get(fs.workingDirectory.toString())),
@@ -312,7 +314,7 @@ class SchemaLoaderTest {
       charset = UTF_32LE, bom = "ffff0000".decodeHex()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.initRoots(sourcePath = listOf(Location.get("colors")))
     val sourcePathFiles = loader.loadSourcePathFiles()
     assertThat(sourcePathFiles.map { it.location.path }).containsExactlyInAnyOrder(
@@ -343,7 +345,7 @@ class SchemaLoaderTest {
       "../../../secret/proto".toPath()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.initRoots(
       sourcePath = listOf(Location.get("colors/src/main/proto"))
     )
@@ -372,7 +374,7 @@ class SchemaLoaderTest {
       "../../../../../../secret/proto/squareup/colors/blue.proto".toPath()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.initRoots(
       sourcePath = listOf(Location.get("colors/src/main/proto"))
     )
@@ -415,7 +417,7 @@ class SchemaLoaderTest {
     )
 
     val exception = assertFailsWith<SchemaException> {
-      val loader = SchemaLoader(fs)
+      val loader = CommonSchemaLoader(fs)
       loader.initRoots(
         sourcePath = listOf(
           Location.get("colors/src/main/proto")
@@ -476,7 +478,7 @@ class SchemaLoaderTest {
     )
 
     val exception = assertFailsWith<SchemaException> {
-      val loader = SchemaLoader(fs)
+      val loader = CommonSchemaLoader(fs)
       loader.initRoots(
         sourcePath = listOf(
           Location.get("colors/src/main/proto")
@@ -501,7 +503,7 @@ class SchemaLoaderTest {
 
   @Test
   fun locationsToCheck() {
-    val newSchemaLoader = SchemaLoader(fs)
+    val newSchemaLoader = CommonSchemaLoader(fs)
     val result = newSchemaLoader.locationsToCheck(
       "java",
       listOf(
@@ -526,7 +528,7 @@ class SchemaLoaderTest {
 
   @Test
   fun pathsToAttempt() {
-    val newSchemaLoader = SchemaLoader(fs)
+    val newSchemaLoader = CommonSchemaLoader(fs)
     val result = newSchemaLoader.locationsToCheck(
       "android",
       listOf(
@@ -542,7 +544,7 @@ class SchemaLoaderTest {
 
   @Test
   fun pathsToAttemptMultipleRoots() {
-    val newSchemaLoader = SchemaLoader(fs)
+    val newSchemaLoader = CommonSchemaLoader(fs)
     val result = newSchemaLoader.locationsToCheck(
       "android",
       listOf(
@@ -601,7 +603,7 @@ class SchemaLoaderTest {
         """.trimMargin()
     )
 
-    val loader = SchemaLoader(fs)
+    val loader = CommonSchemaLoader(fs)
     loader.loadExhaustively = true
     loader.initRoots(
       sourcePath = listOf(


### PR DESCRIPTION
The only diff between JS and JVM is 

`constructor(fileSystem: NioFileSystem) : this(fileSystem.toOkioFileSystem())`