### PR TITLE
Fix a crash where ProtoMember was populated with the wrong data

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/AbstractSchemaHandler.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/AbstractSchemaHandler.kt
@@ -88,14 +88,15 @@ abstract class AbstractSchemaHandler : SchemaHandler {
     // TODO(jwilson): extend emitting rules to support include/exclude of extension fields.
     protoFile.extendList
       .flatMap { extend -> extend.fields.map { field -> extend to field } }
-      .filter { if (claimedDefinitions != null) it.second !in claimedDefinitions else true }
-      .forEach { extendToField ->
-        val (extend, field) = extendToField
+      .filter { (extend, field) ->
+        claimedDefinitions == null || extend.member(field) !in claimedDefinitions
+      }
+      .forEach { (extend, field) ->
         // TODO(Benoît) claim path.
         handle(extend, field, context)
 
         // We don't let other targets handle this one.
-        claimedDefinitions?.claim(field)
+        claimedDefinitions?.claim(extend.member(field))
       }
   }
 

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/ClaimedDefinitions.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/ClaimedDefinitions.kt
@@ -45,11 +45,6 @@ class ClaimedDefinitions {
     claim(service.type)
   }
 
-  /** Tracks that [field] has been handled. */
-  fun claim(field: Field) {
-    claim(field.member)
-  }
-
   /** Returns true if [type] has already been handled. */
   operator fun contains(type: ProtoType) = type in types
 
@@ -61,7 +56,4 @@ class ClaimedDefinitions {
 
   /** Returns true if [service] has already been handled. */
   operator fun contains(service: Service) = contains(service.type)
-
-  /** Returns true if [field] has already been handled. */
-  operator fun contains(field: Field) = contains(field.member)
 }

--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -140,7 +140,7 @@ data class JavaTarget(
 
       override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? {
         val typeSpec = javaGenerator.generateOptionType(extend, field) ?: return null
-        val javaTypeName = javaGenerator.generatedTypeName(field)
+        val javaTypeName = javaGenerator.generatedTypeName(extend.member(field))
         return write(javaTypeName, typeSpec, field.qualifiedName, field.location, context)
       }
 
@@ -297,7 +297,7 @@ data class KotlinTarget(
 
       override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? {
         val typeSpec = kotlinGenerator.generateOptionType(extend, field) ?: return null
-        val name = kotlinGenerator.generatedTypeName(field)
+        val name = kotlinGenerator.generatedTypeName(extend.member(field))
         return write(name, typeSpec, field.qualifiedName, field.location, context)
       }
 

--- a/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-library/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -1135,13 +1135,7 @@ class WireRunTest {
     )
     val wireRun = WireRun(
       sourcePath = listOf(Location.get("polygons/src/main/proto")),
-      targets = listOf(
-        KotlinTarget(
-          outDirectory = "generated/kt",
-          emitAppliedOptions = false,
-          exclusive = false
-        )
-      )
+      targets = listOf(KotlinTarget(outDirectory = "generated/kt"))
     )
     wireRun.execute(fs, logger)
     assertThat(fs.findFiles("generated")).containsRelativePaths(

--- a/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
+++ b/wire-library/wire-java-generator/src/main/java/com/squareup/wire/java/JavaGenerator.java
@@ -80,7 +80,6 @@ import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import okio.ByteString;
-
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.squareup.wire.internal._PlatformKt.camelCase;
 import static com.squareup.wire.schema.internal.JvmLanguages.annotationTargetType;
@@ -311,7 +310,7 @@ public final class JavaGenerator {
         for (Field field : extend.getFields()) {
           if (!eligibleAsAnnotationMember(schema, field)) continue;
 
-          ProtoMember protoMember = field.getMember();
+          ProtoMember protoMember = extend.member(field);
           String simpleName = camelCase(protoMember.getSimpleName(), true) + "Option";
           ClassName className = ClassName.get(javaPackage, simpleName);
           memberToJavaName.put(protoMember, className);
@@ -2074,9 +2073,9 @@ public final class JavaGenerator {
         nameAllocators.getUnchecked(enumType).get(constantZero));
   }
 
-  /** Returns the full name of the class generated for {@code field}. */
-  public ClassName generatedTypeName(Field field) {
-    return (ClassName) memberToJavaName.get(field.getMember());
+  /** Returns the full name of the class generated for {@code member}. */
+  public ClassName generatedTypeName(ProtoMember member) {
+    return (ClassName) memberToJavaName.get(member);
   }
 
   // Example:
@@ -2113,7 +2112,7 @@ public final class JavaGenerator {
       returnType = typeName(field.getType());
     }
 
-    ClassName javaType = generatedTypeName(field);
+    ClassName javaType = generatedTypeName(extend.member(field));
 
     TypeSpec.Builder builder = TypeSpec.annotationBuilder(javaType.simpleName())
         .addModifiers(PUBLIC)

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -102,11 +102,11 @@ import com.squareup.wire.schema.internal.eligibleAsAnnotationMember
 import com.squareup.wire.schema.internal.javaPackage
 import com.squareup.wire.schema.internal.optionValueToInt
 import com.squareup.wire.schema.internal.optionValueToLong
+import java.util.Locale
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 import okio.ByteString
 import okio.ByteString.Companion.encode
-import java.util.Locale
 
 class KotlinGenerator private constructor(
   val schema: Schema,
@@ -153,8 +153,8 @@ class KotlinGenerator private constructor(
   /** Returns the full name of the class generated for [type].  */
   fun generatedTypeName(type: Type) = type.typeName as ClassName
 
-  /** Returns the full name of the class generated for [field].  */
-  fun generatedTypeName(field: Field) = memberToKotlinName[field.member] as ClassName
+  /** Returns the full name of the class generated for [member].  */
+  fun generatedTypeName(member: ProtoMember) = memberToKotlinName[member] as ClassName
 
   /**
    * Returns the full name of the class generated for [service]#[rpc]. This returns a name like
@@ -2077,7 +2077,7 @@ class KotlinGenerator private constructor(
       else -> field.type!!.typeName
     }
 
-    val kotlinType = generatedTypeName(field)
+    val kotlinType = generatedTypeName(extend.member(field))
 
     val builder = TypeSpec.annotationBuilder(kotlinType)
       .addModifiers(PUBLIC)
@@ -2527,7 +2527,7 @@ class KotlinGenerator private constructor(
           if (extend.annotationTargets.isEmpty()) continue
           for (field in extend.fields) {
             if (!eligibleAsAnnotationMember(schema, field)) continue
-            val protoMember = field.member
+            val protoMember = extend.member(field)
             val simpleName = camelCase(protoMember.simpleName, upperCamel = true) + "Option"
             val className = ClassName(kotlinPackage, simpleName)
             memberToKotlinName[protoMember] = className

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Extend.kt
@@ -29,6 +29,8 @@ data class Extend(
   var type: ProtoType? = null
     private set
 
+  fun member(field: Field): ProtoMember = ProtoMember.get(type!!, field)
+
   fun link(linker: Linker) {
     val linker = linker.withContext(this)
     type = linker.resolveMessageType(name)

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -90,9 +90,6 @@ data class Field(
   var jsonName: String? = null
     private set
 
-  val member: ProtoMember
-    get() = ProtoMember.get(type!!, this)
-
   private fun isPackable(linker: Linker, type: ProtoType): Boolean {
     return type != ProtoType.STRING &&
       type != ProtoType.BYTES &&

--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoMember.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoMember.kt
@@ -32,6 +32,10 @@ class ProtoMember private constructor(
   val simpleName: String
     get() = member.substringAfterLast('.') // Strip package prefix for extension fields.
 
+  init {
+    require(!type.isScalar) { "scalars cannot have members" }
+  }
+
   override fun equals(other: Any?) =
     other is ProtoMember && type == other.type && member == other.member
 


### PR DESCRIPTION
We were mixing up the declaring class with the value class. This only
caused harm in tracking double claims.