### PR TITLE
bump gradle-maven-publish-plugin to 0.20.0

### DIFF
--- a/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/wire-library/buildSrc/src/main/kotlin/Dependencies.kt
@@ -121,7 +121,7 @@ object deps {
   }
 
   val truth = "com.google.truth:truth:1.1.3"
-  val vanniktechPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.18.0"
+  val vanniktechPublishPlugin = "com.vanniktech:gradle-maven-publish-plugin:0.20.0"
 
   object wire {
     val compiler = "com.squareup.wire:wire-compiler"


### PR DESCRIPTION
https://github.com/vanniktech/gradle-maven-publish-plugin/blob/master/CHANGELOG.md#version-0200-2022-06-02