### PR TITLE
Fix input locations sorting inconsistency (#2294)

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
@@ -155,7 +155,8 @@ internal class WireInput(var configuration: Configuration) {
     // configuration time.
     return project.provider {
       configuration.dependencies.flatMap { dep ->
-        configuration.files(dep).flatMap { file -> file.toLocations(project, dep) }
+        val sortedFiles = configuration.files(dep).sortedWith(compareBy { it.name })
+        sortedFiles.flatMap { file -> file.toLocations(project, dep) }
       }
     }
   }


### PR DESCRIPTION
This will ensure consistent ordering on WireTask sourceInput and protoInputs, avoiding cache misses on different OS.
The tests are kindof "whitebox" approach as it's difficult to run those kind of cross platforms tests.

Fixes #2294