### PR TITLE
Avoid NPEs with kotlin 1.7.20

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -83,7 +83,8 @@ internal fun WirePlugin.sourceRoots(kotlin: Boolean, java: Boolean): List<Source
   return listOf(
     Source(
       type = KotlinPlatformType.jvm,
-      kotlinSourceDirectorySet = WireSourceDirectorySet.of(main.kotlin!!),
+      kotlinSourceDirectorySet = WireSourceDirectorySet.of(main.kotlin
+        ?: project.objects.sourceDirectorySet("empty", "Empty kotlin source set")),
       javaSourceDirectorySet = WireSourceDirectorySet.of(main.java),
       name = "main",
       sourceSets = listOf("main"),
@@ -146,7 +147,7 @@ private fun BaseExtension.sourceRoots(project: Project, kotlin: Boolean): List<S
     val kotlinSourceDirectSet = when {
       kotlin -> {
         val sourceDirectorySet = sourceSets!![variant.name]
-          ?: throw IllegalStateException("Couldn't find ${variant.name} in $sourceSets")
+          ?: project.objects.sourceDirectorySet(variant.name, "Empty kotlin source set")
         WireSourceDirectorySet.of(sourceDirectorySet)
       }
       else -> null


### PR DESCRIPTION
With kotlin 1.7.20, some of the source sets (that are nullable properties)
are actually null. The wire gradle plugin code was treating these cases as
exceptional and was throwing exceptions. With this fix, the cases are handled
more gracefully by creating an empty source set and using that instead.

No test is added, since the wire build itself suffers from this problem if
kotlin 1.7.20 is used to build, and so a successful build with 1.7.20 is itself
a test of this code.