### PR TITLE
Fixup test protobuf option usage to be protoc compatible

### DIFF
--- a/wire-library/wire-tests/src/commonTest/proto/java/all_types.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/java/all_types.proto
@@ -114,8 +114,8 @@ message AllTypes {
   optional float default_float = 412 [default = 123.456e7 ];
   optional double default_double = 413 [default = 123.456e78 ];
   // Note: protoc doesn't allow some characters of the default value.
-  optional string default_string = 414 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\X1\X01\X11güzel" ];
-  optional bytes default_bytes = 415 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\X1\X01\X11güzel" ];
+  optional string default_string = 414 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\x01\x01\x11güzel" ];
+  optional bytes default_bytes = 415 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\x1\x01\x11güzel" ];
   optional NestedEnum default_nested_enum = 416 [default = A ];
 
   map<int32, int32> map_int32_int32 = 501;

--- a/wire-library/wire-tests/src/commonTest/proto/java/custom_options.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/java/custom_options.proto
@@ -30,8 +30,10 @@ message FooBar {
   optional uint64 qux = 4 [(squareup.protos.custom_options.my_field_option_one) = 18,
                            (squareup.protos.custom_options.my_field_option_two) = 34.5,
                            (squareup.protos.custom_options.my_field_option_five) = 3,
-                           (squareup.protos.custom_options.my_field_option_six) = ["a", "b"],
-                           (squareup.protos.custom_options.my_field_option_seven) = [BAV, BAX]
+                           (squareup.protos.custom_options.my_field_option_six) = "a",
+                           (squareup.protos.custom_options.my_field_option_six) = "b",
+                           (squareup.protos.custom_options.my_field_option_seven) = BAV,
+                           (squareup.protos.custom_options.my_field_option_seven) = BAX
                            ];
   repeated float fred = 5 [(squareup.protos.custom_options.my_field_option_four) = {
       foo: 11, bar: "22", baz: { value: BAR }, fred : [444.0, 555.0],
@@ -57,7 +59,9 @@ message FooBar {
              (repeated_enum_value_option_one)=3];
     BAZ = 3 [(squareup.protos.custom_options.enum_value_option)=18,
             (squareup.protos.foreign.foreign_enum_value_option)=false,
-            (repeated_enum_value_option_two) = ["c", "d"]];
+            (repeated_enum_value_option_two) = "c",
+            (repeated_enum_value_option_two) = "d"
+    ];
   }
 }
 
@@ -115,8 +119,8 @@ extend FooBar {
 
 message MessageWithOptions {
   option (my_message_option_one).foo = 1234;
-  option (my_message_option_one.bar) = "5678";
-  option (my_message_option_one.baz.value) = BAZ;
+  option (my_message_option_one).bar = "5678";
+  option (my_message_option_one).baz.value = BAZ;
   option (my_message_option_one).qux = 18446744073709551615;
   option (my_message_option_one).fred = 123.0;
   option (my_message_option_one).fred = 321.0;
@@ -139,8 +143,9 @@ message MessageWithOptions {
     nested: { foo: 55 }
   };
   option (my_message_option_seven) = 33;
-  option (my_message_option_eight) = [ "g", "h" ];
-  option (my_message_option_nine) = [ BAV ];
+  option (my_message_option_eight) = "g";
+  option (my_message_option_eight) = "h";
+  option (my_message_option_nine) = BAV;
 }
 
 service ServiceWithOptions {

--- a/wire-library/wire-tests/src/commonTest/proto/kotlin/all_types.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/kotlin/all_types.proto
@@ -113,8 +113,8 @@ message AllTypes {
   optional bool default_bool = 411 [default = true ];
   optional float default_float = 412 [default = 123.456e7 ];
   optional double default_double = 413 [default = 123.456e78 ];
-  optional string default_string = 414 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\X1\X01\X11güzel" ];
-  optional bytes default_bytes = 415 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\X1\X01\X11güzel" ];
+  optional string default_string = 414 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\x01\x01\x11güzel" ];
+  optional bytes default_bytes = 415 [default = "çok\a\b\f\n\r\t\v\1\01\001\17\017\176\x1\x01\x11\x1\x01\x11güzel" ];
   optional NestedEnum default_nested_enum = 416 [default = A ];
 
   map<int32, int32> map_int32_int32 = 501;

--- a/wire-library/wire-tests/src/commonTest/proto/kotlin/custom_options.proto
+++ b/wire-library/wire-tests/src/commonTest/proto/kotlin/custom_options.proto
@@ -30,8 +30,10 @@ message FooBar {
   optional uint64 qux = 4 [(squareup.protos.custom_options.my_field_option_one) = 18,
                            (squareup.protos.custom_options.my_field_option_two) = 34.5,
                            (squareup.protos.custom_options.my_field_option_five) = 3,
-                           (squareup.protos.custom_options.my_field_option_six) = ["a", "b"],
-                           (squareup.protos.custom_options.my_field_option_seven) = [BAV, BAX]
+                           (squareup.protos.custom_options.my_field_option_six) = "a",
+                           (squareup.protos.custom_options.my_field_option_six) = "b",
+                           (squareup.protos.custom_options.my_field_option_seven) = BAV,
+                           (squareup.protos.custom_options.my_field_option_seven) = BAX
                            ];
   repeated float fred = 5 [(squareup.protos.custom_options.my_field_option_four) = {
       foo: 11, bar: "22", baz: { value: BAR }, fred : [444.0, 555.0],
@@ -57,7 +59,9 @@ message FooBar {
              (repeated_enum_value_option_one)=3];
     BAZ = 3 [(squareup.protos.custom_options.enum_value_option)=18,
             (squareup.protos.kotlin.foreign.foreign_enum_value_option)=false,
-            (repeated_enum_value_option_two) = ["c", "d"]];
+            (repeated_enum_value_option_two) = "c",
+            (repeated_enum_value_option_two) = "d"
+    ];
   }
 }
 
@@ -115,8 +119,8 @@ extend FooBar {
 
 message MessageWithOptions {
   option (my_message_option_one).foo = 1234;
-  option (my_message_option_one.bar) = "5678";
-  option (my_message_option_one.baz.value) = BAZ;
+  option (my_message_option_one).bar = "5678";
+  option (my_message_option_one).baz.value = BAZ;
   option (my_message_option_one).qux = 18446744073709551615;
   option (my_message_option_one).fred = 123.0;
   option (my_message_option_one).fred = 321.0;
@@ -139,8 +143,9 @@ message MessageWithOptions {
     nested: { foo: 55 }
   };
   option (my_message_option_seven) = 33;
-  option (my_message_option_eight) = [ "g", "h" ];
-  option (my_message_option_nine) = [ BAV ];
+  option (my_message_option_eight) = "g";
+  option (my_message_option_eight) = "h";
+  option (my_message_option_nine) = BAV;
 }
 
 service ServiceWithOptions {

--- a/wire-library/wire-tests/src/commonTest/proto3/java/all_types.proto
+++ b/wire-library/wire-tests/src/commonTest/proto3/java/all_types.proto
@@ -141,7 +141,7 @@ message AllTypes {
     google.protobuf.Duration oneof_duration = 619;
     google.protobuf.Struct oneof_struct = 620;
     google.protobuf.ListValue oneof_list_value = 621;
-//     google.protobuf.Value oneof_value = 622;
+    // google.protobuf.Value oneof_value = 622;
     // google.protobuf.NullValue oneof_null_value = 623;
     google.protobuf.Empty oneof_empty = 624;
     google.protobuf.Timestamp oneof_timestamp = 625;

--- a/wire-library/wire-tests/src/commonTest/proto3/java/all_types.proto
+++ b/wire-library/wire-tests/src/commonTest/proto3/java/all_types.proto
@@ -141,7 +141,7 @@ message AllTypes {
     google.protobuf.Duration oneof_duration = 619;
     google.protobuf.Struct oneof_struct = 620;
     google.protobuf.ListValue oneof_list_value = 621;
-    // google.protobuf.Value oneof_value = 622;
+//     google.protobuf.Value oneof_value = 622;
     // google.protobuf.NullValue oneof_null_value = 623;
     google.protobuf.Empty oneof_empty = 624;
     google.protobuf.Timestamp oneof_timestamp = 625;


### PR DESCRIPTION
Fixed some protobuf syntax by running `protoc *.proto -o /dev/null`

Some violations:
 - String values can't be `/X`
 - Repeated values needs to be multiple assignments rather than a list
 - Options need to be surrounded with `()` before accessing it's fields