### PR TITLE
Update syntax to fetch sourceSets on kotlin codebases

### DIFF
--- a/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-library/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -135,13 +135,15 @@ private fun BaseExtension.sourceRoots(project: Project, kotlin: Boolean): List<S
           sourceSet.name to sourceSet.java
         }
     }
-  val sourceSets: Map<String, SourceDirectorySet?>? =
+  val sourceSets: Map<String, SourceDirectorySet?>? = run {
     if (kotlin) {
+      val kotlinSourceSets = (project.extensions.getByName("kotlin") as KotlinProjectExtension).sourceSets
       sourceSets
         .associate { sourceSet ->
-          sourceSet.name to sourceSet.kotlinSourceDirectorySet
+          sourceSet.name to kotlinSourceSets.getByName(sourceSet.name).kotlin
         }
     } else null
+  }
 
   return variants.map { variant ->
     val kotlinSourceDirectSet = when {


### PR DESCRIPTION
Using CI to check that this doesn't break old implementations before the follow-up PR to update to Kotlin 1.7.20.

Should fix #2339