### PR TITLE
gRPC Adapter Fixes

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -269,6 +269,7 @@ data class KotlinTarget(
           grpcServerCompatible = grpcServerCompatible,
           nameSuffix = nameSuffix,
           buildersOnly = buildersOnly,
+          singleMethodServices = singleMethodServices,
         )
         context.fileSystem.createDirectories(context.outDirectory)
         super.handle(schema, context)

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
@@ -27,7 +27,10 @@ import com.squareup.wire.kotlin.grpcserver.StubGenerator.addStub
 import com.squareup.wire.schema.ProtoType
 import com.squareup.wire.schema.Service
 
-class KotlinGrpcGenerator(private val typeToKotlinName: Map<ProtoType, TypeName>) {
+class KotlinGrpcGenerator(
+  private val typeToKotlinName: Map<ProtoType, TypeName>,
+  private val singleMethodServices: Boolean,
+  ) {
   fun generateGrpcServer(service: Service): Pair<ClassName, TypeSpec> {
     val classNameGenerator = ClassNameGenerator(typeToKotlinName)
     val grpcClassName = classNameGenerator.classNameFor(service.type, "WireGrpc")
@@ -36,7 +39,9 @@ class KotlinGrpcGenerator(private val typeToKotlinName: Map<ProtoType, TypeName>
     addServiceDescriptor(builder, service)
     service.rpcs.forEach { rpc -> addMethodDescriptor(classNameGenerator, builder, service, rpc) }
     addImplBase(classNameGenerator, builder, service)
-    addLegacyAdapter(classNameGenerator, builder, service)
+    addLegacyAdapter(classNameGenerator, builder, service, LegacyAdapterGenerator.Options(
+      singleMethodServices = singleMethodServices,
+    ))
     addStub(classNameGenerator, builder, service)
     addBlockingStub(classNameGenerator, builder, service)
 

--- a/wire-library/wire-grpc-server-generator/src/test/golden/JavaPackage.java
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/JavaPackage.java
@@ -1,0 +1,134 @@
+package com.foo.bar
+
+import io.grpc.BindableService
+import io.grpc.CallOptions
+import io.grpc.Channel
+import io.grpc.MethodDescriptor
+import io.grpc.ServerServiceDefinition
+import io.grpc.ServiceDescriptor
+import io.grpc.ServiceDescriptor.newBuilder
+import io.grpc.stub.AbstractStub
+import io.grpc.stub.ClientCalls
+import io.grpc.stub.ClientCalls.blockingUnaryCall
+import io.grpc.stub.ServerCalls.asyncUnaryCall
+import io.grpc.stub.StreamObserver
+import java.io.InputStream
+import java.lang.UnsupportedOperationException
+import java.util.concurrent.ExecutorService
+import kotlin.String
+import kotlin.Unit
+import kotlin.jvm.Volatile
+
+public object FooServiceWireGrpc {
+  public val SERVICE_NAME: String = "foo.FooService"
+
+  @Volatile
+  private var serviceDescriptor: ServiceDescriptor? = null
+
+  @Volatile
+  private var getCallMethod: MethodDescriptor<Request, Response>? = null
+
+  public fun getServiceDescriptor(): ServiceDescriptor? {
+    var result = serviceDescriptor
+    if (result == null) {
+      synchronized(FooServiceWireGrpc::class) {
+        result = serviceDescriptor
+        if (result == null) {
+          result = newBuilder(SERVICE_NAME)
+          .addMethod(getCallMethod())
+          .build()
+          serviceDescriptor = result
+        }
+      }
+    }
+    return result
+  }
+
+  public fun getCallMethod(): MethodDescriptor<Request, Response> {
+    var result: MethodDescriptor<Request, Response>? = getCallMethod
+    if (result == null) {
+      synchronized(FooServiceWireGrpc::class) {
+        result = getCallMethod
+        if (result == null) {
+          getCallMethod = MethodDescriptor.newBuilder<Request, Response>()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(
+              MethodDescriptor.generateFullMethodName(
+                "foo.FooService", "Call"
+              )
+            )
+            .setSampledToLocalTracing(true)
+            .setRequestMarshaller(FooServiceImplBase.RequestMarshaller())
+            .setResponseMarshaller(FooServiceImplBase.ResponseMarshaller())
+            .build()
+        }
+      }
+    }
+    return getCallMethod!!
+  }
+
+  public fun newStub(channel: Channel): FooServiceStub = FooServiceStub(channel)
+
+  public fun newBlockingStub(channel: Channel): FooServiceBlockingStub =
+      FooServiceBlockingStub(channel)
+
+  public abstract class FooServiceImplBase : BindableService {
+    public open fun Call(request: Request, response: StreamObserver<Response>): Unit = throw
+        UnsupportedOperationException()
+
+    public override fun bindService(): ServerServiceDefinition =
+        ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
+              getCallMethod(),
+              asyncUnaryCall(this@FooServiceImplBase::Call)
+            ).build()
+
+    public class RequestMarshaller : MethodDescriptor.Marshaller<Request> {
+      public override fun stream(`value`: Request): InputStream =
+          Request.ADAPTER.encode(value).inputStream()
+
+      public override fun parse(stream: InputStream): Request = Request.ADAPTER.decode(stream)
+    }
+
+    public class ResponseMarshaller : MethodDescriptor.Marshaller<Response> {
+      public override fun stream(`value`: Response): InputStream =
+          Response.ADAPTER.encode(value).inputStream()
+
+      public override fun parse(stream: InputStream): Response = Response.ADAPTER.decode(stream)
+    }
+  }
+
+  public class FooServiceImplLegacyAdapter(
+    private val streamExecutor: ExecutorService,
+    private val Call: () -> FooServiceCallBlockingServer,
+  ) : FooServiceImplBase() {
+    public override fun Call(request: Request, response: StreamObserver<Response>): Unit {
+      response.onNext(Call().Call(request))
+      response.onCompleted()
+    }
+  }
+
+  public class FooServiceStub : AbstractStub<FooServiceStub> {
+    internal constructor(channel: Channel) : super(channel)
+
+    internal constructor(channel: Channel, callOptions: CallOptions) : super(channel, callOptions)
+
+    public override fun build(channel: Channel, callOptions: CallOptions) = FooServiceStub(channel,
+        callOptions)
+
+    public fun Call(request: Request, response: StreamObserver<Response>): Unit {
+      ClientCalls.asyncUnaryCall(channel.newCall(getCallMethod(), callOptions), request, response)
+    }
+  }
+
+  public class FooServiceBlockingStub : AbstractStub<FooServiceStub> {
+    internal constructor(channel: Channel) : super(channel)
+
+    internal constructor(channel: Channel, callOptions: CallOptions) : super(channel, callOptions)
+
+    public override fun build(channel: Channel, callOptions: CallOptions) = FooServiceStub(channel,
+        callOptions)
+
+    public fun Call(request: Request): Response = blockingUnaryCall(channel, getCallMethod(),
+        callOptions, request)
+  }
+}

--- a/wire-library/wire-grpc-server-generator/src/test/golden/singleMethodService.java
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/singleMethodService.java
@@ -1,0 +1,181 @@
+package com.foo.bar
+
+import io.grpc.BindableService
+import io.grpc.CallOptions
+import io.grpc.Channel
+import io.grpc.MethodDescriptor
+import io.grpc.ServerServiceDefinition
+import io.grpc.ServiceDescriptor
+import io.grpc.ServiceDescriptor.newBuilder
+import io.grpc.stub.AbstractStub
+import io.grpc.stub.ClientCalls
+import io.grpc.stub.ClientCalls.blockingUnaryCall
+import io.grpc.stub.ServerCalls
+import io.grpc.stub.ServerCalls.asyncUnaryCall
+import io.grpc.stub.StreamObserver
+import java.io.InputStream
+import java.lang.UnsupportedOperationException
+import java.util.concurrent.ExecutorService
+import kotlin.String
+import kotlin.Unit
+import kotlin.jvm.Volatile
+
+public object FooServiceWireGrpc {
+  public val SERVICE_NAME: String = "foo.FooService"
+
+  @Volatile
+  private var serviceDescriptor: ServiceDescriptor? = null
+
+  @Volatile
+  private var getCall1Method: MethodDescriptor<Request, Response>? = null
+
+  @Volatile
+  private var getCall2Method: MethodDescriptor<Request, Response>? = null
+
+  public fun getServiceDescriptor(): ServiceDescriptor? {
+    var result = serviceDescriptor
+    if (result == null) {
+      synchronized(FooServiceWireGrpc::class) {
+        result = serviceDescriptor
+        if (result == null) {
+          result = newBuilder(SERVICE_NAME)
+          .addMethod(getCall1Method())
+          .addMethod(getCall2Method())
+          .build()
+          serviceDescriptor = result
+        }
+      }
+    }
+    return result
+  }
+
+  public fun getCall1Method(): MethodDescriptor<Request, Response> {
+    var result: MethodDescriptor<Request, Response>? = getCall1Method
+    if (result == null) {
+      synchronized(FooServiceWireGrpc::class) {
+        result = getCall1Method
+        if (result == null) {
+          getCall1Method = MethodDescriptor.newBuilder<Request, Response>()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(
+              MethodDescriptor.generateFullMethodName(
+                "foo.FooService", "Call1"
+              )
+            )
+            .setSampledToLocalTracing(true)
+            .setRequestMarshaller(FooServiceImplBase.RequestMarshaller())
+            .setResponseMarshaller(FooServiceImplBase.ResponseMarshaller())
+            .build()
+        }
+      }
+    }
+    return getCall1Method!!
+  }
+
+  public fun getCall2Method(): MethodDescriptor<Request, Response> {
+    var result: MethodDescriptor<Request, Response>? = getCall2Method
+    if (result == null) {
+      synchronized(FooServiceWireGrpc::class) {
+        result = getCall2Method
+        if (result == null) {
+          getCall2Method = MethodDescriptor.newBuilder<Request, Response>()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(
+              MethodDescriptor.generateFullMethodName(
+                "foo.FooService", "Call2"
+              )
+            )
+            .setSampledToLocalTracing(true)
+            .setRequestMarshaller(FooServiceImplBase.RequestMarshaller())
+            .setResponseMarshaller(FooServiceImplBase.ResponseMarshaller())
+            .build()
+        }
+      }
+    }
+    return getCall2Method!!
+  }
+
+  public fun newStub(channel: Channel): FooServiceStub = FooServiceStub(channel)
+
+  public fun newBlockingStub(channel: Channel): FooServiceBlockingStub =
+      FooServiceBlockingStub(channel)
+
+  public abstract class FooServiceImplBase : BindableService {
+    public open fun Call1(request: Request, response: StreamObserver<Response>): Unit = throw
+        UnsupportedOperationException()
+
+    public open fun Call2(request: Request, response: StreamObserver<Response>): Unit = throw
+        UnsupportedOperationException()
+
+    public override fun bindService(): ServerServiceDefinition =
+        ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
+              getCall1Method(),
+              asyncUnaryCall(this@FooServiceImplBase::Call1)
+            ).addMethod(
+              getCall2Method(),
+              asyncUnaryCall(this@FooServiceImplBase::Call2)
+            ).build()
+
+    public class RequestMarshaller : MethodDescriptor.Marshaller<Request> {
+      public override fun stream(`value`: Request): InputStream =
+          Request.ADAPTER.encode(value).inputStream()
+
+      public override fun parse(stream: InputStream): Request = Request.ADAPTER.decode(stream)
+    }
+
+    public class ResponseMarshaller : MethodDescriptor.Marshaller<Response> {
+      public override fun stream(`value`: Response): InputStream =
+          Response.ADAPTER.encode(value).inputStream()
+
+      public override fun parse(stream: InputStream): Response = Response.ADAPTER.decode(stream)
+    }
+  }
+
+  public class FooServiceImplLegacyAdapter(
+    private val streamExecutor: ExecutorService,
+    private val Call1: () -> FooServiceCall1BlockingServer,
+    private val Call2: () -> FooServiceCall2BlockingServer,
+  ) : FooServiceImplBase() {
+    public override fun Call1(request: Request, response: StreamObserver<Response>): Unit {
+      response.onNext(Call1().Call1(request))
+      response.onCompleted()
+    }
+
+    public override fun Call2(request: Request, response: StreamObserver<Response>): Unit {
+      response.onNext(Call2().Call2(request))
+      response.onCompleted()
+    }
+  }
+
+  public class FooServiceStub : AbstractStub<FooServiceStub> {
+    internal constructor(channel: Channel) : super(channel)
+
+    internal constructor(channel: Channel, callOptions: CallOptions) : super(channel, callOptions)
+
+    public override fun build(channel: Channel, callOptions: CallOptions) = FooServiceStub(channel,
+        callOptions)
+
+    public fun Call1(request: Request, response: StreamObserver<Response>): Unit {
+      ClientCalls.asyncUnaryCall(channel.newCall(getCall1Method(), callOptions), request, response)
+    }
+
+    public fun Call2(request: Request, response: StreamObserver<Response>): Unit {
+      ClientCalls.asyncUnaryCall(channel.newCall(getCall2Method(), callOptions), request, response)
+    }
+  }
+
+  public class FooServiceBlockingStub : AbstractStub<FooServiceStub> {
+    internal constructor(channel: Channel) : super(channel)
+
+    internal constructor(channel: Channel, callOptions: CallOptions) : super(channel, callOptions)
+
+    public override fun build(channel: Channel, callOptions: CallOptions) = FooServiceStub(channel,
+        callOptions)
+
+    public fun Call1(request: Request): Response = blockingUnaryCall(channel, getCall1Method(),
+        callOptions, request)
+
+    public fun Call2(request: Request): Response = blockingUnaryCall(channel, getCall2Method(),
+        callOptions, request)
+  }
+}

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
@@ -38,4 +38,30 @@ internal class KotlinGrpcGeneratorTest {
     assertThat(output.toString())
       .isEqualTo(File("src/test/golden/RouteGuideWireGrpc.kt").source().buffer().readUtf8())
   }
+
+  @Test
+  fun `java_package option is respected`() {
+    val schema = buildSchema { add(
+      "service.proto".toPath(),
+      """
+      |syntax = "proto2";
+      |
+      |package foo;
+      |option java_package = "com.foo.bar";
+      |
+      |message Request {}
+      |message Response {}
+      |
+      |service FooService {
+      |  rpc Call(Request) returns (Response) {}
+      |}
+      |""".trimMargin()
+    ) }
+    val service = schema.getService("foo.FooService")
+    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!)).generateGrpcServer(service)
+    val output = FileSpec.get("com.foo.bar", typeSpec)
+
+    assertThat(output.toString())
+      .isEqualTo(File("src/test/golden/JavaPackage.java").source().buffer().readUtf8())
+  }
 }

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
@@ -31,7 +31,7 @@ internal class KotlinGrpcGeneratorTest {
     val schema = buildSchema { addLocal("src/test/proto/RouteGuideProto.proto".toPath()) }
     val service = schema.getService("routeguide.RouteGuide")
 
-    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!))
+    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = true)
       .generateGrpcServer(service)
     val output = FileSpec.get("routeguide", typeSpec)
 
@@ -39,11 +39,7 @@ internal class KotlinGrpcGeneratorTest {
       .isEqualTo(File("src/test/golden/RouteGuideWireGrpc.kt").source().buffer().readUtf8())
   }
 
-  @Test
-  fun `java_package option is respected`() {
-    val schema = buildSchema { add(
-      "service.proto".toPath(),
-      """
+  private val twoMethodSchema = """
       |syntax = "proto2";
       |
       |package foo;
@@ -53,15 +49,32 @@ internal class KotlinGrpcGeneratorTest {
       |message Response {}
       |
       |service FooService {
-      |  rpc Call(Request) returns (Response) {}
+      |  rpc Call1(Request) returns (Response) {}
+      |  rpc Call2(Request) returns (Response) {}
       |}
       |""".trimMargin()
-    ) }
+
+  @Test
+  fun `correctly generates singleMethodService = false adapters`() {
+    val schema = buildSchema { add("service.proto".toPath(), twoMethodSchema) }
     val service = schema.getService("foo.FooService")
-    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!)).generateGrpcServer(service)
+    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = false)
+      .generateGrpcServer(service)
     val output = FileSpec.get("com.foo.bar", typeSpec)
 
     assertThat(output.toString())
-      .isEqualTo(File("src/test/golden/JavaPackage.java").source().buffer().readUtf8())
+      .isEqualTo(File("src/test/golden/nonSingleMethodService.java").source().buffer().readUtf8())
+  }
+
+  @Test
+  fun `correctly generates singleMethodService = true adapters`() {
+    val schema = buildSchema { add("service.proto".toPath(), twoMethodSchema) }
+    val service = schema.getService("foo.FooService")
+    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = true)
+      .generateGrpcServer(service)
+    val output = FileSpec.get("com.foo.bar", typeSpec)
+
+    assertThat(output.toString())
+      .isEqualTo(File("src/test/golden/singleMethodService.java").source().buffer().readUtf8())
   }
 }

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterTest.kt
@@ -40,7 +40,8 @@ class LegacyAdapterTest {
             addLegacyAdapter(
               generator = ClassNameGenerator(buildClassMap(schema, service!!)),
               builder = this,
-              service
+              service,
+              LegacyAdapterGenerator.Options(singleMethodServices = true),
             )
           }
           .build()

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -127,6 +127,7 @@ class KotlinGenerator private constructor(
   private val grpcServerCompatible: Boolean,
   private val nameSuffix: String?,
   private val buildersOnly: Boolean,
+  private val singleMethodServices: Boolean,
 ) {
   private val nameAllocatorStore = mutableMapOf<Type, NameAllocator>()
 
@@ -238,7 +239,7 @@ class KotlinGenerator private constructor(
     }
 
     if (grpcServerCompatible) {
-      val (grpcClassName, grpcSpec) = KotlinGrpcGenerator(typeToKotlinName)
+      val (grpcClassName, grpcSpec) = KotlinGrpcGenerator(typeToKotlinName, singleMethodServices)
         .generateGrpcServer(service)
       result[grpcClassName] = grpcSpec
     }
@@ -2518,6 +2519,7 @@ class KotlinGenerator private constructor(
       grpcServerCompatible: Boolean = false,
       nameSuffix: String? = null,
       buildersOnly: Boolean = false,
+      singleMethodServices: Boolean = false,
     ): KotlinGenerator {
       val typeToKotlinName = mutableMapOf<ProtoType, TypeName>()
       val memberToKotlinName = mutableMapOf<ProtoMember, TypeName>()
@@ -2562,6 +2564,7 @@ class KotlinGenerator private constructor(
         grpcServerCompatible = grpcServerCompatible,
         nameSuffix = nameSuffix,
         buildersOnly = buildersOnly,
+        singleMethodServices = singleMethodServices,
       )
     }
 


### PR DESCRIPTION
Fixes two issues in the `LegacyAdapterGenerator`:
- The generated code did not take `java_package` option into account when generating a references to the request and response classes. This means it worked when the proto and kotlin packages matched, but failed otherwise. Now, the kotlin package is correctly used
- Now supports services generated with `singleMethodServices = false`. Previously, only single method service with just one method was supported. Now multi method service works with multiple services. When using `singleMethodServices = true` only one method is still supported. This needs to be fixed later.

Added integration tests for `singleMethodServices = false` and `singleMethodServices = true` checking that the generated code is what is expected.