### PR TITLE
Add *.DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ wire-library/docs/changelog.md
 wire-library/docs/contributing.md
 wire-library/docs/index.md
 
+*.DS_Store
 local.properties
 
 # for dependency watching with https://github.com/JakeWharton/dependency-watch/


### PR DESCRIPTION
These files appear quite often when developing for iOS on macOS.