### PR TITLE
feat: implement ProtoFileDescriptorSupplier in legacy adapter's schemaDescriptor

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ junit = { module = "junit:junit", version.ref = "junit" }
 kaml = { module = "com.charleskorn.kaml:kaml", version = "0.20.0" }
 kotlin-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "coroutines" }
 kotlin-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
+kotlin-jsr223 = { module = "org.jetbrains.kotlin:kotlin-scripting-jsr223", version.ref = "kotlin" }
 kotlin-reflect = { module = "org.jetbrains.kotlin:kotlin-reflect", version.ref = "kotlin" }
 kotlin-serialization = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version = "1.0.1" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }

--- a/samples/wire-grpc-sample/server-plain/build.gradle.kts
+++ b/samples/wire-grpc-sample/server-plain/build.gradle.kts
@@ -26,4 +26,5 @@ dependencies {
   implementation(libs.wire.runtime)
   implementation(libs.grpc.netty)
   implementation(libs.grpc.stub)
+  implementation(libs.grpc.protobuf)
 }

--- a/wire-library/wire-grpc-server-generator/build.gradle.kts
+++ b/wire-library/wire-grpc-server-generator/build.gradle.kts
@@ -16,10 +16,12 @@ dependencies {
   implementation(projects.wireGrpcClient)
   implementation(libs.okio.core)
   api(libs.kotlinpoet)
+  api(libs.protobuf.java)
   testImplementation(projects.wireTestUtils)
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.truth)
   testImplementation(libs.assertj)
+  testImplementation(libs.kotlin.jsr223)
 }
 
 sourceSets {

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.kotlin.grpcserver
+
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.Descriptors
+import com.squareup.kotlinpoet.CodeBlock
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.KModifier
+import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.withIndent
+import com.squareup.wire.schema.ProtoFile
+import com.squareup.wire.schema.Schema
+import com.squareup.wire.schema.internal.SchemaEncoder
+
+object FileDescriptorGenerator {
+  /**
+   * Adds properties to the given TypeSpec for storing com.google.protobuf.DescriptorProtos.FileDescriptorProto instances,
+   * and helper functions for getting full FileDescriptors with dependencies for any included schema file.
+   */
+  fun addDescriptorDataProperty(builder: TypeSpec.Builder, protoFile: ProtoFile?, schema: Schema) {
+    addDescriptorForFunction(builder)
+    addFileDescriptorFunction(builder)
+
+    if (protoFile != null) {
+      val encoded = encodeFileAndDependencies(protoFile, schema)
+      addDescriptorMapProperty(builder, encoded)
+    }
+  }
+
+  /**
+   * Encodes the given file from the schema as a string that can be embedded in a class.
+   * Also encodes all transitive dependencies of the file.
+   */
+  private fun encodeFileAndDependencies(protoFile: ProtoFile, schema: Schema): MutableMap<String, String> {
+    val encoded = mutableMapOf<String, String>()
+    val visited = mutableSetOf<String>()
+    val todo = mutableListOf(protoFile.location.path)
+
+    while (todo.isNotEmpty()) {
+      val path = todo.removeLast()
+
+      if (!visited.contains(path)) {
+        visited.add(path)
+        val file = schema.protoFile(path)
+        if (file != null) {
+          todo.addAll(file.imports)
+          encoded[file.location.path] = SchemaEncoder(schema).encode(file).base64()
+        }
+      }
+    }
+    return encoded
+  }
+
+  private fun addDescriptorMapProperty(builder: TypeSpec.Builder, encoded: MutableMap<String, String>) {
+    builder.addProperty(
+      PropertySpec
+        .builder("descriptorMap", Map::class.parameterizedBy(
+            String::class, DescriptorProtos.FileDescriptorProto::class
+          )
+        )
+        .addModifiers(KModifier.PRIVATE)
+        .initializer(
+          encoded.toList().fold(CodeBlock.builder().addStatement("mapOf(")) { b, (name, data) ->
+            b.withIndent {
+              this.addStatement("\"$name\" to descriptorFor(arrayOf(")
+                // Split the string to chunks because max string length in a class file is 64k bytes
+                .withIndent {
+                  data.chunked(FDS_CHUNK_SIZE).fold(this) { b, c ->
+                    b.addStatement("\"$c\",")
+                  }
+                }.addStatement(")),")
+            }
+          }.addStatement(")").build()
+        ).build()
+    )
+  }
+
+  private fun addFileDescriptorFunction(builder: TypeSpec.Builder) {
+    builder.addFunction(
+      FunSpec
+        .builder("fileDescriptor")
+        .addModifiers(KModifier.PRIVATE)
+        .addParameter("path", String::class)
+        .addParameter("visited", Set::class.parameterizedBy(String::class))
+        .returns(Descriptors.FileDescriptor::class)
+        .addCode(
+          """
+            val proto = descriptorMap[path]!!
+            val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it, visited + path) }
+            return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+          """.trimIndent()
+        ).build()
+    )
+  }
+
+  private fun addDescriptorForFunction(builder: TypeSpec.Builder) {
+    builder.addFunction(
+      FunSpec
+        .builder("descriptorFor")
+        .addModifiers(KModifier.PRIVATE)
+        .addParameter("data", Array::class.parameterizedBy(String::class))
+        .returns(DescriptorProtos.FileDescriptorProto::class)
+        .addCode(
+          """
+            val str = data.fold(java.lang.StringBuilder()) { b, s -> b.append(s) }.toString()
+            val bytes = java.util.Base64.getDecoder().decode(str)
+            return DescriptorProtos.FileDescriptorProto.parseFrom(bytes)
+          """.trimIndent()
+        ).build()
+    )
+  }
+
+  private const val FDS_CHUNK_SIZE = 80
+}

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
@@ -24,19 +24,21 @@ import com.squareup.wire.kotlin.grpcserver.LegacyAdapterGenerator.addLegacyAdapt
 import com.squareup.wire.kotlin.grpcserver.MethodDescriptorGenerator.addMethodDescriptor
 import com.squareup.wire.kotlin.grpcserver.ServiceDescriptorGenerator.addServiceDescriptor
 import com.squareup.wire.kotlin.grpcserver.StubGenerator.addStub
+import com.squareup.wire.schema.ProtoFile
 import com.squareup.wire.schema.ProtoType
+import com.squareup.wire.schema.Schema
 import com.squareup.wire.schema.Service
 
 class KotlinGrpcGenerator(
   private val typeToKotlinName: Map<ProtoType, TypeName>,
   private val singleMethodServices: Boolean,
   ) {
-  fun generateGrpcServer(service: Service): Pair<ClassName, TypeSpec> {
+  fun generateGrpcServer(service: Service, protoFile: ProtoFile?, schema: Schema): Pair<ClassName, TypeSpec> {
     val classNameGenerator = ClassNameGenerator(typeToKotlinName)
     val grpcClassName = classNameGenerator.classNameFor(service.type, "WireGrpc")
     val builder = TypeSpec.objectBuilder(grpcClassName)
 
-    addServiceDescriptor(builder, service)
+    addServiceDescriptor(builder, service, protoFile, schema)
     service.rpcs.forEach { rpc -> addMethodDescriptor(classNameGenerator, builder, service, rpc) }
     addImplBase(classNameGenerator, builder, service)
     addLegacyAdapter(classNameGenerator, builder, service, LegacyAdapterGenerator.Options(

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterGenerator.kt
@@ -15,14 +15,8 @@
  */
 package com.squareup.wire.kotlin.grpcserver
 
-import com.squareup.kotlinpoet.ClassName
-import com.squareup.kotlinpoet.CodeBlock
-import com.squareup.kotlinpoet.FunSpec
-import com.squareup.kotlinpoet.KModifier
-import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.*
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
-import com.squareup.kotlinpoet.PropertySpec
-import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.kotlin.grpcserver.ImplBaseGenerator.addImplBaseRpcSignature
 import com.squareup.wire.schema.Service
 import java.util.concurrent.ExecutorService

--- a/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -1,5 +1,7 @@
 package routeguide
 
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.Descriptors
 import com.squareup.wire.kotlin.grpcserver.MessageSinkAdapter
 import com.squareup.wire.kotlin.grpcserver.MessageSourceAdapter
 import io.grpc.BindableService
@@ -21,9 +23,12 @@ import io.grpc.stub.StreamObserver
 import java.io.InputStream
 import java.lang.UnsupportedOperationException
 import java.util.concurrent.ExecutorService
+import kotlin.Array
 import kotlin.String
 import kotlin.Unit
 import kotlin.collections.Iterator
+import kotlin.collections.Map
+import kotlin.collections.Set
 import kotlin.jvm.Volatile
 
 public object RouteGuideWireGrpc {
@@ -31,6 +36,24 @@ public object RouteGuideWireGrpc {
 
   @Volatile
   private var serviceDescriptor: ServiceDescriptor? = null
+
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
+    "src/test/proto/RouteGuideProto.proto" to descriptorFor(arrayOf(
+      "CiRzcmMvdGVzdC9wcm90by9Sb3V0ZUd1aWRlUHJvdG8ucHJvdG8SCnJvdXRlZ3VpZGUiLAoFUG9pbnQS",
+      "EAoIbGF0aXR1ZGUYASABKAUSEQoJbG9uZ2l0dWRlGAIgASgFIkkKCVJlY3RhbmdsZRIdCgJsbxgBIAEo",
+      "CzIRLnJvdXRlZ3VpZGUuUG9pbnQSHQoCaGkYAiABKAsyES5yb3V0ZWd1aWRlLlBvaW50IjwKB0ZlYXR1",
+      "cmUSDAoEbmFtZRgBIAEoCRIjCghsb2NhdGlvbhgCIAEoCzIRLnJvdXRlZ3VpZGUuUG9pbnQiNwoPRmVh",
+      "dHVyZURhdGFiYXNlEiQKB2ZlYXR1cmUYASADKAsyEy5yb3V0ZWd1aWRlLkZlYXR1cmUiQQoJUm91dGVO",
+      "b3RlEiMKCGxvY2F0aW9uGAEgASgLMhEucm91dGVndWlkZS5Qb2ludBIPCgdtZXNzYWdlGAIgASgJImIK",
+      "DFJvdXRlU3VtbWFyeRITCgtwb2ludF9jb3VudBgBIAEoBRIVCg1mZWF0dXJlX2NvdW50GAIgASgFEhAK",
+      "CGRpc3RhbmNlGAMgASgFEhQKDGVsYXBzZWRfdGltZRgEIAEoBTL9AQoKUm91dGVHdWlkZRI0CgpHZXRG",
+      "ZWF0dXJlEhEucm91dGVndWlkZS5Qb2ludBoTLnJvdXRlZ3VpZGUuRmVhdHVyZRI8CgxMaXN0RmVhdHVy",
+      "ZXMSFS5yb3V0ZWd1aWRlLlJlY3RhbmdsZRoTLnJvdXRlZ3VpZGUuRmVhdHVyZTABEjwKC1JlY29yZFJv",
+      "dXRlEhEucm91dGVndWlkZS5Qb2ludBoYLnJvdXRlZ3VpZGUuUm91dGVTdW1tYXJ5KAESPQoJUm91dGVD",
+      "aGF0EhUucm91dGVndWlkZS5Sb3V0ZU5vdGUaFS5yb3V0ZWd1aWRlLlJvdXRlTm90ZSgBMAE=",
+    )),
+  )
+
 
   @Volatile
   private var getGetFeatureMethod: MethodDescriptor<Point, Feature>? = null
@@ -44,6 +67,19 @@ public object RouteGuideWireGrpc {
   @Volatile
   private var getRouteChatMethod: MethodDescriptor<RouteNote, RouteNote>? = null
 
+  private fun descriptorFor(`data`: Array<String>): DescriptorProtos.FileDescriptorProto {
+    val str = data.fold(java.lang.StringBuilder()) { b, s -> b.append(s) }.toString()
+    val bytes = java.util.Base64.getDecoder().decode(str)
+    return DescriptorProtos.FileDescriptorProto.parseFrom(bytes)
+  }
+
+  private fun fileDescriptor(path: String, visited: Set<String>): Descriptors.FileDescriptor {
+    val proto = descriptorMap[path]!!
+    val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
+        visited + path) }
+    return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
+
   public fun getServiceDescriptor(): ServiceDescriptor? {
     var result = serviceDescriptor
     if (result == null) {
@@ -55,6 +91,9 @@ public object RouteGuideWireGrpc {
           .addMethod(getListFeaturesMethod())
           .addMethod(getRecordRouteMethod())
           .addMethod(getRouteChatMethod())
+          .setSchemaDescriptor(io.grpc.protobuf.ProtoFileDescriptorSupplier {
+                fileDescriptor("src/test/proto/RouteGuideProto.proto", emptySet())
+              })
           .build()
           serviceDescriptor = result
         }

--- a/wire-library/wire-grpc-server-generator/src/test/golden/ServiceDescriptor.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/ServiceDescriptor.kt
@@ -1,8 +1,13 @@
 package routeguide
 
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.Descriptors
 import io.grpc.ServiceDescriptor
 import io.grpc.ServiceDescriptor.newBuilder
+import kotlin.Array
 import kotlin.String
+import kotlin.collections.Map
+import kotlin.collections.Set
 import kotlin.jvm.Volatile
 
 public class RouteGuideWireGrpc {
@@ -10,6 +15,37 @@ public class RouteGuideWireGrpc {
 
   @Volatile
   private var serviceDescriptor: ServiceDescriptor? = null
+
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
+    "src/test/proto/RouteGuideProto.proto" to descriptorFor(arrayOf(
+      "CiRzcmMvdGVzdC9wcm90by9Sb3V0ZUd1aWRlUHJvdG8ucHJvdG8SCnJvdXRlZ3VpZGUiLAoFUG9pbnQS",
+      "EAoIbGF0aXR1ZGUYASABKAUSEQoJbG9uZ2l0dWRlGAIgASgFIkkKCVJlY3RhbmdsZRIdCgJsbxgBIAEo",
+      "CzIRLnJvdXRlZ3VpZGUuUG9pbnQSHQoCaGkYAiABKAsyES5yb3V0ZWd1aWRlLlBvaW50IjwKB0ZlYXR1",
+      "cmUSDAoEbmFtZRgBIAEoCRIjCghsb2NhdGlvbhgCIAEoCzIRLnJvdXRlZ3VpZGUuUG9pbnQiNwoPRmVh",
+      "dHVyZURhdGFiYXNlEiQKB2ZlYXR1cmUYASADKAsyEy5yb3V0ZWd1aWRlLkZlYXR1cmUiQQoJUm91dGVO",
+      "b3RlEiMKCGxvY2F0aW9uGAEgASgLMhEucm91dGVndWlkZS5Qb2ludBIPCgdtZXNzYWdlGAIgASgJImIK",
+      "DFJvdXRlU3VtbWFyeRITCgtwb2ludF9jb3VudBgBIAEoBRIVCg1mZWF0dXJlX2NvdW50GAIgASgFEhAK",
+      "CGRpc3RhbmNlGAMgASgFEhQKDGVsYXBzZWRfdGltZRgEIAEoBTL9AQoKUm91dGVHdWlkZRI0CgpHZXRG",
+      "ZWF0dXJlEhEucm91dGVndWlkZS5Qb2ludBoTLnJvdXRlZ3VpZGUuRmVhdHVyZRI8CgxMaXN0RmVhdHVy",
+      "ZXMSFS5yb3V0ZWd1aWRlLlJlY3RhbmdsZRoTLnJvdXRlZ3VpZGUuRmVhdHVyZTABEjwKC1JlY29yZFJv",
+      "dXRlEhEucm91dGVndWlkZS5Qb2ludBoYLnJvdXRlZ3VpZGUuUm91dGVTdW1tYXJ5KAESPQoJUm91dGVD",
+      "aGF0EhUucm91dGVndWlkZS5Sb3V0ZU5vdGUaFS5yb3V0ZWd1aWRlLlJvdXRlTm90ZSgBMAE=",
+    )),
+  )
+
+
+  private fun descriptorFor(`data`: Array<String>): DescriptorProtos.FileDescriptorProto {
+    val str = data.fold(java.lang.StringBuilder()) { b, s -> b.append(s) }.toString()
+    val bytes = java.util.Base64.getDecoder().decode(str)
+    return DescriptorProtos.FileDescriptorProto.parseFrom(bytes)
+  }
+
+  private fun fileDescriptor(path: String, visited: Set<String>): Descriptors.FileDescriptor {
+    val proto = descriptorMap[path]!!
+    val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
+        visited + path) }
+    return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
 
   public fun getServiceDescriptor(): ServiceDescriptor? {
     var result = serviceDescriptor
@@ -22,6 +58,9 @@ public class RouteGuideWireGrpc {
           .addMethod(getListFeaturesMethod())
           .addMethod(getRecordRouteMethod())
           .addMethod(getRouteChatMethod())
+          .setSchemaDescriptor(io.grpc.protobuf.ProtoFileDescriptorSupplier {
+                fileDescriptor("src/test/proto/RouteGuideProto.proto", emptySet())
+              })
           .build()
           serviceDescriptor = result
         }

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGeneratorTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGeneratorTest.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2021 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.kotlin.grpcserver
+
+import com.google.protobuf.Descriptors
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.wire.buildSchema
+import com.squareup.wire.schema.addLocal
+import okio.Path.Companion.toPath
+import okio.buffer
+import okio.source
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import java.io.File
+import javax.script.ScriptEngineManager
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+internal class FileDescriptorGeneratorTest {
+  @Test
+  fun `generated descriptor can be used correctly`() {
+    val protoSchema = """
+      |syntax = "proto2";
+      |
+      |package test;
+      |import "imported.proto";
+      |
+      |message Test {}
+      |""".trimMargin()
+
+    val importedSchema = """
+      |syntax = "proto2";
+      |
+      |package test;
+      |
+      |message Imported {}
+      |""".trimMargin()
+
+    val path = "test.proto".toPath()
+    val imported = "imported.proto".toPath()
+    val schema = buildSchema {
+      add(imported, importedSchema)
+      add(path, protoSchema)
+    }
+
+    val file = FileSpec.scriptBuilder("test", "test.kts")
+      .addType(TypeSpec.classBuilder("Test")
+        .apply { FileDescriptorGenerator.addDescriptorDataProperty(this, schema.protoFile(path), schema) }
+        .addFunction(FunSpec.builder("output")
+          .returns(Descriptors.FileDescriptor::class)
+          .addCode("return fileDescriptor(\"test.proto\", emptySet())")
+          .build())
+        .build()
+      ).addCode("Test().output()").build()
+
+    val engine = ScriptEngineManager().getEngineByExtension("kts")
+    val result = engine.eval(file.toString())
+    val descriptor = result as Descriptors.FileDescriptor
+
+    assertEquals("test", descriptor.`package`)
+    assertEquals("test.proto", descriptor.name)
+    assertEquals(descriptor.messageTypes.size, 1)
+    assertEquals("Test", descriptor.messageTypes.first().name)
+    assertEquals( 1, descriptor.dependencies.size)
+  }
+}

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
@@ -28,11 +28,12 @@ import java.io.File
 internal class KotlinGrpcGeneratorTest {
   @Test
   fun fullFile() {
-    val schema = buildSchema { addLocal("src/test/proto/RouteGuideProto.proto".toPath()) }
+    val path = "src/test/proto/RouteGuideProto.proto".toPath()
+    val schema = buildSchema { addLocal(path) }
     val service = schema.getService("routeguide.RouteGuide")
 
     val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = true)
-      .generateGrpcServer(service)
+      .generateGrpcServer(service, schema.protoFile(path), schema)
     val output = FileSpec.get("routeguide", typeSpec)
 
     assertThat(output.toString())
@@ -56,25 +57,27 @@ internal class KotlinGrpcGeneratorTest {
 
   @Test
   fun `correctly generates singleMethodService = false adapters`() {
-    val schema = buildSchema { add("service.proto".toPath(), twoMethodSchema) }
+    val path = "service.proto".toPath()
+    val schema = buildSchema { add(path, twoMethodSchema) }
     val service = schema.getService("foo.FooService")
     val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = false)
-      .generateGrpcServer(service)
+      .generateGrpcServer(service, schema.protoFile(path), schema)
     val output = FileSpec.get("com.foo.bar", typeSpec)
 
     assertThat(output.toString())
-      .isEqualTo(File("src/test/golden/nonSingleMethodService.java").source().buffer().readUtf8())
+      .isEqualTo(File("src/test/golden/nonSingleMethodService.kt").source().buffer().readUtf8())
   }
 
   @Test
   fun `correctly generates singleMethodService = true adapters`() {
-    val schema = buildSchema { add("service.proto".toPath(), twoMethodSchema) }
+    val path = "service.proto".toPath()
+    val schema = buildSchema { add(path, twoMethodSchema) }
     val service = schema.getService("foo.FooService")
     val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = true)
-      .generateGrpcServer(service)
+      .generateGrpcServer(service, schema.protoFile(path), schema)
     val output = FileSpec.get("com.foo.bar", typeSpec)
 
     assertThat(output.toString())
-      .isEqualTo(File("src/test/golden/singleMethodService.java").source().buffer().readUtf8())
+      .isEqualTo(File("src/test/golden/singleMethodService.kt").source().buffer().readUtf8())
   }
 }

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/LegacyAdapterTest.kt
@@ -30,7 +30,8 @@ import java.io.File
 class LegacyAdapterTest {
   @Test
   fun legacyAdapter() {
-    val schema = buildSchema { addLocal("src/test/proto/RouteGuideProto.proto".toPath()) }
+    val path = "src/test/proto/RouteGuideProto.proto".toPath()
+    val schema = buildSchema { addLocal(path) }
     val service = schema.getService("routeguide.RouteGuide")
 
     val code = FileSpec.builder("routeguide", "RouteGuide")

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/ServiceDescriptorTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/ServiceDescriptorTest.kt
@@ -29,19 +29,21 @@ import java.io.File
 class ServiceDescriptorTest {
   @Test
   fun addServiceDescriptor() {
-    val schema = buildSchema { addLocal("src/test/proto/RouteGuideProto.proto".toPath()) }
+    val path = "src/test/proto/RouteGuideProto.proto".toPath()
+    val schema = buildSchema { addLocal(path) }
     val service = schema.getService("routeguide.RouteGuide")
 
     val code = FileSpec.builder("routeguide", "RouteGuide")
       .addType(
         TypeSpec.classBuilder("RouteGuideWireGrpc")
-          .apply { ServiceDescriptorGenerator.addServiceDescriptor(this, service!!) }
+          .apply {
+            ServiceDescriptorGenerator.addServiceDescriptor(this, service!!, schema.protoFile(path), schema)
+          }
           .build()
       )
       .build()
       .toString()
 
-    println(code)
     assertThat(code).isEqualTo(File("src/test/golden/ServiceDescriptor.kt").source().buffer().readUtf8())
   }
 }

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -239,8 +239,9 @@ class KotlinGenerator private constructor(
     }
 
     if (grpcServerCompatible) {
+      val protoFile: ProtoFile? = schema.protoFile(service.location.path)
       val (grpcClassName, grpcSpec) = KotlinGrpcGenerator(typeToKotlinName, singleMethodServices)
-        .generateGrpcServer(service)
+        .generateGrpcServer(service, protoFile, schema)
       result[grpcClassName] = grpcSpec
     }
 


### PR DESCRIPTION
This adds a `schemaDescriptor` to the legacy gRPC adapter, implementing `io.grpc.protobuf.ProtoFileDescriptorSupplier`
This then returns the FileDescriptor for the file where the service is defined.

This is something expected by Armeria DocService to provide a dynamic interface to the gRPC service generated from these FileDescriptors.

For now, we insert the full base64 encoded FDS to each service adapter. This can lead to duplication if multiple services are referring to the same file, but for now this is done for simplicity.