### PR TITLE
Decode grpc-status-details-bin and add it to GrpcException

### DIFF
--- a/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcException.kt
+++ b/wire-library/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcException.kt
@@ -21,4 +21,5 @@ import okio.IOException
 class GrpcException(
   val grpcStatus: GrpcStatus,
   val grpcMessage: String?
+  val grpcStatusDetails: ByteArray? = null,
 ) : IOException("grpc-status=${grpcStatus.code}, grpc-status-name=${grpcStatus.name}, grpc-message=$grpcMessage")


### PR DESCRIPTION
Only attempt to base64-decode it when there's no transport error. An invalid base64 value will be treated as IOException.

It is up to the user to unmarshal it into a string if desired.

This is a de-facto standard used by grpc:
https://groups.google.com/g/grpc-io/c/p_gCk1bn2JE

Note that this is *not* included into `responseMetadata` because gRPC metadata must not include reserved names `grpc-*` per spec: https://grpc.io/docs/what-is-grpc/core-concepts/#metadata In other words, by definition this is not "metadata".

Fixes #2343.