### PR TITLE
[Swift] Fix JSON incorrectly encoding `unknownFields`

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -46,5 +46,7 @@ extension OneofOptions : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension OneofOptions : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif

--- a/wire-library/wire-runtime-swift/src/test/proto/empty.proto
+++ b/wire-library/wire-runtime-swift/src/test/proto/empty.proto
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2022 Block Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto3";
+
+message EmptyMessage {
+}

--- a/wire-library/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
+++ b/wire-library/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
@@ -14,17 +14,26 @@
  * limitations under the License.
  */
 
+import Foundation
 import Wire
 import XCTest
 
 final class ProtoEncoderTests: XCTestCase {
 
-    func testEncodeEmptyMessage() throws {
-        let object = SimpleOptional2()
+    func testEncodeEmptyProtoMessage() throws {
+        let object = EmptyMessage()
         let encoder = ProtoEncoder()
         let data = try encoder.encode(object)
 
         XCTAssertEqual(data, Data())
     }
 
+    func testEncodeEmptyJSONMessage() throws {
+        let object = EmptyMessage()
+        let encoder = JSONEncoder()
+        let data = try encoder.encode(object)
+        let jsonString = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertEqual(jsonString, "{}")
+    }
 }

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -569,6 +569,15 @@ class SwiftGenerator private constructor(
               }
               .build()
           )
+        } else {
+          // Coding keys still need to be specified in order to prevent `unknownFields` from getting serialized
+          // in the JSON/Codable scenario.
+          addType(
+            TypeSpec.enumBuilder(codingKeys)
+              .addModifiers(PUBLIC)
+              .addSuperType(codingKey)
+              .build()
+          )
         }
 
         // If there are any oneofs we cannot rely on the built-in Codable support since the

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -553,32 +553,25 @@ class SwiftGenerator private constructor(
       .addSuperType(codable)
       .apply {
         val codingKeys = structType.nestedType("CodingKeys")
-
-        if (type.fieldsAndOneOfFields.isNotEmpty()) {
-          // Define the keys which are the set of all direct properties and the properties within
-          // each oneof.
-          addType(
-            TypeSpec.enumBuilder(codingKeys)
-              .addModifiers(PUBLIC)
-              .addSuperType(STRING)
-              .addSuperType(codingKey)
-              .apply {
-                type.fieldsAndOneOfFields.forEach { field ->
-                  addEnumCase(field.name)
-                }
+        // Define the keys which are the set of all direct properties and the properties within
+        // each oneof.
+        addType(
+          TypeSpec.enumBuilder(codingKeys)
+            .addModifiers(PUBLIC)
+            .apply {
+              // Coding keys still need to be specified on empty messages in order to prevent `unknownFields` from
+              // getting serialized via JSON/Codable. In this case, the keys cannot conform to `RawRepresentable`
+              // in order to compile.
+              if (type.fieldsAndOneOfFields.isNotEmpty()) {
+                addSuperType(STRING)
               }
-              .build()
-          )
-        } else {
-          // Coding keys still need to be specified in order to prevent `unknownFields` from getting serialized
-          // in the JSON/Codable scenario.
-          addType(
-            TypeSpec.enumBuilder(codingKeys)
-              .addModifiers(PUBLIC)
-              .addSuperType(codingKey)
-              .build()
-          )
-        }
+              addSuperType(codingKey)
+              type.fieldsAndOneOfFields.forEach { field ->
+                addEnumCase(field.name)
+              }
+            }
+            .build()
+        )
 
         // If there are any oneofs we cannot rely on the built-in Codable support since the
         // keys of the nested associated enum are flattened into the enclosing parent.

--- a/wire-library/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Form.swift
@@ -252,6 +252,8 @@ extension Form.ButtonElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.ButtonElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -290,6 +292,8 @@ extension Form.LocalImageElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.LocalImageElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -328,6 +332,8 @@ extension Form.RemoteImageElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.RemoteImageElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -366,6 +372,8 @@ extension Form.MoneyElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.MoneyElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -404,6 +412,8 @@ extension Form.SpacerElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.SpacerElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -490,6 +500,8 @@ extension Form.CustomizedCardElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.CustomizedCardElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -528,6 +540,8 @@ extension Form.AddressElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.AddressElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -566,6 +580,8 @@ extension Form.TextInputElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.TextInputElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -604,6 +620,8 @@ extension Form.OptionPickerElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.OptionPickerElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -642,6 +660,8 @@ extension Form.DetailRowElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.DetailRowElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 
@@ -680,6 +700,8 @@ extension Form.CurrencyConversionFlagsElement : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.CurrencyConversionFlagsElement : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif
 

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
@@ -47,5 +47,7 @@ extension MessageWithOptions : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension MessageWithOptions : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -53,5 +53,7 @@ extension MessageWithStatus : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension MessageWithStatus : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
@@ -47,5 +47,7 @@ extension NoFields : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension NoFields : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -53,5 +53,7 @@ extension OtherMessageWithStatus : Proto2Codable {
 
 #if !WIRE_REMOVE_CODABLE
 extension OtherMessageWithStatus : Codable {
+    public enum CodingKeys : CodingKey {
+    }
 }
 #endif


### PR DESCRIPTION
For empty messages, the current implementation encodes `{"unknownFields":""}` as the JSON representation instead of `{}`.

This is because `CodingKeys` are not generated at all for empty messages, and iOS instead synthesizes the `unknownFields` key.

To fix the issue, we should generate empty `CodingKeys` for empty messages.