### PR TITLE
Add interfaces to legacy adapter Service and Marshaller

### DIFF
--- a/wire-library/wire-grpc-server-generator/build.gradle.kts
+++ b/wire-library/wire-grpc-server-generator/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
   implementation(libs.okio.core)
   api(libs.kotlinpoet)
   api(libs.protobuf.java)
+  implementation(projects.wireGrpcServer)
   testImplementation(projects.wireTestUtils)
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.truth)

--- a/wire-library/wire-grpc-server-generator/src/test/golden/ImplBase.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/ImplBase.kt
@@ -1,7 +1,7 @@
 package routeguide
 
-import io.grpc.BindableService
-import io.grpc.MethodDescriptor
+import com.squareup.wire.kotlin.grpcserver.WireBindableService
+import com.squareup.wire.kotlin.grpcserver.WireMethodMarshaller
 import io.grpc.ServerServiceDefinition
 import io.grpc.stub.ServerCalls.asyncBidiStreamingCall
 import io.grpc.stub.ServerCalls.asyncClientStreamingCall
@@ -9,11 +9,12 @@ import io.grpc.stub.ServerCalls.asyncServerStreamingCall
 import io.grpc.stub.ServerCalls.asyncUnaryCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
+import java.lang.Class
 import java.lang.UnsupportedOperationException
 import kotlin.Unit
 
 public class RouteGuideWireGrpc {
-  public abstract class RouteGuideImplBase : BindableService {
+  public abstract class RouteGuideImplBase : WireBindableService {
     public open fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit = throw
         UnsupportedOperationException()
 
@@ -41,38 +42,48 @@ public class RouteGuideWireGrpc {
               asyncBidiStreamingCall(this@RouteGuideImplBase::RouteChat)
             ).build()
 
-    public class PointMarshaller : MethodDescriptor.Marshaller<Point> {
+    public class PointMarshaller : WireMethodMarshaller<Point> {
       public override fun stream(`value`: Point): InputStream =
           Point.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Point> = Point::class.java
 
       public override fun parse(stream: InputStream): Point = Point.ADAPTER.decode(stream)
     }
 
-    public class FeatureMarshaller : MethodDescriptor.Marshaller<Feature> {
+    public class FeatureMarshaller : WireMethodMarshaller<Feature> {
       public override fun stream(`value`: Feature): InputStream =
           Feature.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Feature> = Feature::class.java
 
       public override fun parse(stream: InputStream): Feature = Feature.ADAPTER.decode(stream)
     }
 
-    public class RectangleMarshaller : MethodDescriptor.Marshaller<Rectangle> {
+    public class RectangleMarshaller : WireMethodMarshaller<Rectangle> {
       public override fun stream(`value`: Rectangle): InputStream =
           Rectangle.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Rectangle> = Rectangle::class.java
 
       public override fun parse(stream: InputStream): Rectangle = Rectangle.ADAPTER.decode(stream)
     }
 
-    public class RouteSummaryMarshaller : MethodDescriptor.Marshaller<RouteSummary> {
+    public class RouteSummaryMarshaller : WireMethodMarshaller<RouteSummary> {
       public override fun stream(`value`: RouteSummary): InputStream =
           RouteSummary.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<RouteSummary> = RouteSummary::class.java
 
       public override fun parse(stream: InputStream): RouteSummary =
           RouteSummary.ADAPTER.decode(stream)
     }
 
-    public class RouteNoteMarshaller : MethodDescriptor.Marshaller<RouteNote> {
+    public class RouteNoteMarshaller : WireMethodMarshaller<RouteNote> {
       public override fun stream(`value`: RouteNote): InputStream =
           RouteNote.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<RouteNote> = RouteNote::class.java
 
       public override fun parse(stream: InputStream): RouteNote = RouteNote.ADAPTER.decode(stream)
     }

--- a/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -4,7 +4,8 @@ import com.google.protobuf.DescriptorProtos
 import com.google.protobuf.Descriptors
 import com.squareup.wire.kotlin.grpcserver.MessageSinkAdapter
 import com.squareup.wire.kotlin.grpcserver.MessageSourceAdapter
-import io.grpc.BindableService
+import com.squareup.wire.kotlin.grpcserver.WireBindableService
+import com.squareup.wire.kotlin.grpcserver.WireMethodMarshaller
 import io.grpc.CallOptions
 import io.grpc.Channel
 import io.grpc.MethodDescriptor
@@ -21,6 +22,7 @@ import io.grpc.stub.ServerCalls.asyncServerStreamingCall
 import io.grpc.stub.ServerCalls.asyncUnaryCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
+import java.lang.Class
 import java.lang.UnsupportedOperationException
 import java.util.concurrent.ExecutorService
 import kotlin.Array
@@ -199,7 +201,7 @@ public object RouteGuideWireGrpc {
   public fun newBlockingStub(channel: Channel): RouteGuideBlockingStub =
       RouteGuideBlockingStub(channel)
 
-  public abstract class RouteGuideImplBase : BindableService {
+  public abstract class RouteGuideImplBase : WireBindableService {
     public open fun GetFeature(request: Point, response: StreamObserver<Feature>): Unit = throw
         UnsupportedOperationException()
 
@@ -227,38 +229,48 @@ public object RouteGuideWireGrpc {
               asyncBidiStreamingCall(this@RouteGuideImplBase::RouteChat)
             ).build()
 
-    public class PointMarshaller : MethodDescriptor.Marshaller<Point> {
+    public class PointMarshaller : WireMethodMarshaller<Point> {
       public override fun stream(`value`: Point): InputStream =
           Point.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Point> = Point::class.java
 
       public override fun parse(stream: InputStream): Point = Point.ADAPTER.decode(stream)
     }
 
-    public class FeatureMarshaller : MethodDescriptor.Marshaller<Feature> {
+    public class FeatureMarshaller : WireMethodMarshaller<Feature> {
       public override fun stream(`value`: Feature): InputStream =
           Feature.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Feature> = Feature::class.java
 
       public override fun parse(stream: InputStream): Feature = Feature.ADAPTER.decode(stream)
     }
 
-    public class RectangleMarshaller : MethodDescriptor.Marshaller<Rectangle> {
+    public class RectangleMarshaller : WireMethodMarshaller<Rectangle> {
       public override fun stream(`value`: Rectangle): InputStream =
           Rectangle.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Rectangle> = Rectangle::class.java
 
       public override fun parse(stream: InputStream): Rectangle = Rectangle.ADAPTER.decode(stream)
     }
 
-    public class RouteSummaryMarshaller : MethodDescriptor.Marshaller<RouteSummary> {
+    public class RouteSummaryMarshaller : WireMethodMarshaller<RouteSummary> {
       public override fun stream(`value`: RouteSummary): InputStream =
           RouteSummary.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<RouteSummary> = RouteSummary::class.java
 
       public override fun parse(stream: InputStream): RouteSummary =
           RouteSummary.ADAPTER.decode(stream)
     }
 
-    public class RouteNoteMarshaller : MethodDescriptor.Marshaller<RouteNote> {
+    public class RouteNoteMarshaller : WireMethodMarshaller<RouteNote> {
       public override fun stream(`value`: RouteNote): InputStream =
           RouteNote.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<RouteNote> = RouteNote::class.java
 
       public override fun parse(stream: InputStream): RouteNote = RouteNote.ADAPTER.decode(stream)
     }

--- a/wire-library/wire-grpc-server-generator/src/test/golden/nonSingleMethodService.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/nonSingleMethodService.kt
@@ -2,7 +2,8 @@ package com.foo.bar
 
 import com.google.protobuf.DescriptorProtos
 import com.google.protobuf.Descriptors
-import io.grpc.BindableService
+import com.squareup.wire.kotlin.grpcserver.WireBindableService
+import com.squareup.wire.kotlin.grpcserver.WireMethodMarshaller
 import io.grpc.CallOptions
 import io.grpc.Channel
 import io.grpc.MethodDescriptor
@@ -16,6 +17,7 @@ import io.grpc.stub.ServerCalls
 import io.grpc.stub.ServerCalls.asyncUnaryCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
+import java.lang.Class
 import java.lang.UnsupportedOperationException
 import java.util.concurrent.ExecutorService
 import kotlin.Array
@@ -130,7 +132,7 @@ public object FooServiceWireGrpc {
   public fun newBlockingStub(channel: Channel): FooServiceBlockingStub =
       FooServiceBlockingStub(channel)
 
-  public abstract class FooServiceImplBase : BindableService {
+  public abstract class FooServiceImplBase : WireBindableService {
     public open fun Call1(request: Request, response: StreamObserver<Response>): Unit = throw
         UnsupportedOperationException()
 
@@ -146,16 +148,20 @@ public object FooServiceWireGrpc {
               asyncUnaryCall(this@FooServiceImplBase::Call2)
             ).build()
 
-    public class RequestMarshaller : MethodDescriptor.Marshaller<Request> {
+    public class RequestMarshaller : WireMethodMarshaller<Request> {
       public override fun stream(`value`: Request): InputStream =
           Request.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Request> = Request::class.java
 
       public override fun parse(stream: InputStream): Request = Request.ADAPTER.decode(stream)
     }
 
-    public class ResponseMarshaller : MethodDescriptor.Marshaller<Response> {
+    public class ResponseMarshaller : WireMethodMarshaller<Response> {
       public override fun stream(`value`: Response): InputStream =
           Response.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Response> = Response::class.java
 
       public override fun parse(stream: InputStream): Response = Response.ADAPTER.decode(stream)
     }

--- a/wire-library/wire-grpc-server-generator/src/test/golden/singleMethodService.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/singleMethodService.kt
@@ -2,7 +2,8 @@ package com.foo.bar
 
 import com.google.protobuf.DescriptorProtos
 import com.google.protobuf.Descriptors
-import io.grpc.BindableService
+import com.squareup.wire.kotlin.grpcserver.WireBindableService
+import com.squareup.wire.kotlin.grpcserver.WireMethodMarshaller
 import io.grpc.CallOptions
 import io.grpc.Channel
 import io.grpc.MethodDescriptor
@@ -16,6 +17,7 @@ import io.grpc.stub.ServerCalls
 import io.grpc.stub.ServerCalls.asyncUnaryCall
 import io.grpc.stub.StreamObserver
 import java.io.InputStream
+import java.lang.Class
 import java.lang.UnsupportedOperationException
 import java.util.concurrent.ExecutorService
 import kotlin.Array
@@ -130,7 +132,7 @@ public object FooServiceWireGrpc {
   public fun newBlockingStub(channel: Channel): FooServiceBlockingStub =
       FooServiceBlockingStub(channel)
 
-  public abstract class FooServiceImplBase : BindableService {
+  public abstract class FooServiceImplBase : WireBindableService {
     public open fun Call1(request: Request, response: StreamObserver<Response>): Unit = throw
         UnsupportedOperationException()
 
@@ -146,16 +148,20 @@ public object FooServiceWireGrpc {
               asyncUnaryCall(this@FooServiceImplBase::Call2)
             ).build()
 
-    public class RequestMarshaller : MethodDescriptor.Marshaller<Request> {
+    public class RequestMarshaller : WireMethodMarshaller<Request> {
       public override fun stream(`value`: Request): InputStream =
           Request.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Request> = Request::class.java
 
       public override fun parse(stream: InputStream): Request = Request.ADAPTER.decode(stream)
     }
 
-    public class ResponseMarshaller : MethodDescriptor.Marshaller<Response> {
+    public class ResponseMarshaller : WireMethodMarshaller<Response> {
       public override fun stream(`value`: Response): InputStream =
           Response.ADAPTER.encode(value).inputStream()
+
+      public override fun marshalledClass(): Class<Response> = Response::class.java
 
       public override fun parse(stream: InputStream): Response = Response.ADAPTER.decode(stream)
     }

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/ImplBaseTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/ImplBaseTest.kt
@@ -47,7 +47,6 @@ class ImplBaseTest {
       .build()
       .toString()
 
-    println(code)
     Assertions.assertThat(code)
       .isEqualTo(File("src/test/golden/ImplBase.kt").source().buffer().readUtf8())
   }

--- a/wire-library/wire-grpc-server/src/main/java/com/squareup/wire/kotlin/grpcserver/WireBindableService.kt
+++ b/wire-library/wire-grpc-server/src/main/java/com/squareup/wire/kotlin/grpcserver/WireBindableService.kt
@@ -1,0 +1,10 @@
+package com.squareup.wire.kotlin.grpcserver
+
+import io.grpc.BindableService
+
+/**
+ * Wire specific interface for BindableService.
+ *
+ * This allows us to detect if the service is a Wire service at runtime, if needed.
+ */
+interface WireBindableService : BindableService

--- a/wire-library/wire-grpc-server/src/main/java/com/squareup/wire/kotlin/grpcserver/WireMethodMarshaller.kt
+++ b/wire-library/wire-grpc-server/src/main/java/com/squareup/wire/kotlin/grpcserver/WireMethodMarshaller.kt
@@ -1,0 +1,14 @@
+package com.squareup.wire.kotlin.grpcserver
+
+import io.grpc.MethodDescriptor
+
+/**
+ * Interface for generated method marshallers used in Google style grpc stubs.
+ *
+ * Adds a method for fetching the underlying class at run time to support
+ * generating other marshallers (like JSON encoding) from an instance of
+ * this class.
+ */
+interface WireMethodMarshaller<T>: MethodDescriptor.Marshaller<T> {
+  fun marshalledClass(): Class<T>
+}


### PR DESCRIPTION
So that we can detect at runtime we are using Wire implementations.

This will be useful in projects like Armeria, where we can use Wire specific JSON transcoder with Wire services