### PR TITLE
fix: do not fail with grpc adapter generation when using single method services on services with multiple methods

### DIFF
--- a/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-library/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -304,6 +304,13 @@ data class KotlinTarget(
           }
         }
 
+        if (grpcServerCompatible) {
+          val map = kotlinGenerator.generateGrpcServerAdapter(service)
+          for ((className, typeSpec) in map) {
+            generatedPaths.add(write(className, typeSpec, service.type, service.location, context))
+          }
+        }
+
         return generatedPaths
       }
 

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -238,12 +238,21 @@ class KotlinGenerator private constructor(
       result[implementationName] = implementationSpec
     }
 
-    if (grpcServerCompatible) {
-      val protoFile: ProtoFile? = schema.protoFile(service.location.path)
-      val (grpcClassName, grpcSpec) = KotlinGrpcGenerator(typeToKotlinName, singleMethodServices)
-        .generateGrpcServer(service, protoFile, schema)
-      result[grpcClassName] = grpcSpec
-    }
+    return result
+  }
+
+  /**
+   * Generates [TypeSpec]s for gRPC adapter for the given [service].
+   *
+   * These adapters allow us to use Wire based gRPC as io.grpc.BindableService
+   */
+  fun generateGrpcServerAdapter(service: Service): Map<ClassName, TypeSpec> {
+    val result = mutableMapOf<ClassName, TypeSpec>()
+
+    val protoFile: ProtoFile? = schema.protoFile(service.location.path)
+    val (grpcClassName, grpcSpec) = KotlinGrpcGenerator(typeToKotlinName, singleMethodServices)
+      .generateGrpcServer(service, protoFile, schema)
+    result[grpcClassName] = grpcSpec
 
     return result
   }


### PR DESCRIPTION
Previously, we tried to generate the adapter classes for each RPC method, failing the code generation. After this, generate the class for each service instead of each RPC