### PR TITLE
chore: rename <service>WireGrpc.<service>ImplLegacyAdapter to <service>WireGrpc.BindableAdapter

### DIFF
--- a/samples/wire-grpc-sample/server-plain/src/main/java/com/squareup/wire/whiteboard/WhiteboardCompatImpl.kt
+++ b/samples/wire-grpc-sample/server-plain/src/main/java/com/squareup/wire/whiteboard/WhiteboardCompatImpl.kt
@@ -22,7 +22,7 @@ import java.util.concurrent.Executors
 
 class WhiteboardCompatImpl() : WhiteboardWireGrpc.WhiteboardImplBase() {
   override fun Whiteboard(response: StreamObserver<WhiteboardUpdate>): StreamObserver<WhiteboardCommand> {
-    return WhiteboardWireGrpc.WhiteboardImplLegacyAdapter(
+    return WhiteboardWireGrpc.BindableAdapter(
       Whiteboard = { WhiteboardCompat() },
       streamExecutor = Executors.newSingleThreadExecutor()
     )

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
@@ -21,11 +21,11 @@ import com.squareup.wire.kotlin.grpcserver.ImplBaseGenerator.addImplBaseRpcSigna
 import com.squareup.wire.schema.Service
 import java.util.concurrent.ExecutorService
 
-object LegacyAdapterGenerator {
+object BindableAdapterGenerator {
 
   data class Options(val singleMethodServices: Boolean)
 
-  internal fun addLegacyAdapter(
+  internal fun addBindableAdapter(
     generator: ClassNameGenerator,
     builder: TypeSpec.Builder,
     service: Service,
@@ -39,7 +39,7 @@ object LegacyAdapterGenerator {
     )
     return builder
       .addType(
-        TypeSpec.classBuilder(generator.classNameFor(service.type, "ImplLegacyAdapter"))
+        TypeSpec.classBuilder("BindableAdapter")
           .superclass(implBaseClassName)
           .primaryConstructor(
             FunSpec.constructorBuilder()

--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGenerator.kt
@@ -20,7 +20,7 @@ import com.squareup.kotlinpoet.TypeName
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.kotlin.grpcserver.BlockingStubGenerator.addBlockingStub
 import com.squareup.wire.kotlin.grpcserver.ImplBaseGenerator.addImplBase
-import com.squareup.wire.kotlin.grpcserver.LegacyAdapterGenerator.addLegacyAdapter
+import com.squareup.wire.kotlin.grpcserver.BindableAdapterGenerator.addBindableAdapter
 import com.squareup.wire.kotlin.grpcserver.MethodDescriptorGenerator.addMethodDescriptor
 import com.squareup.wire.kotlin.grpcserver.ServiceDescriptorGenerator.addServiceDescriptor
 import com.squareup.wire.kotlin.grpcserver.StubGenerator.addStub
@@ -41,7 +41,7 @@ class KotlinGrpcGenerator(
     addServiceDescriptor(builder, service, protoFile, schema)
     service.rpcs.forEach { rpc -> addMethodDescriptor(classNameGenerator, builder, service, rpc) }
     addImplBase(classNameGenerator, builder, service)
-    addLegacyAdapter(classNameGenerator, builder, service, LegacyAdapterGenerator.Options(
+    addBindableAdapter(classNameGenerator, builder, service, BindableAdapterGenerator.Options(
       singleMethodServices = singleMethodServices,
     ))
     addStub(classNameGenerator, builder, service)

--- a/wire-library/wire-grpc-server-generator/src/test/golden/BindableAdapter.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/BindableAdapter.kt
@@ -7,7 +7,7 @@ import java.util.concurrent.ExecutorService
 import kotlin.Unit
 
 public class RouteGuideWireGrpc {
-  public class RouteGuideImplLegacyAdapter(
+  public class BindableAdapter(
     private val streamExecutor: ExecutorService,
     private val GetFeature: () -> RouteGuideGetFeatureBlockingServer,
     private val ListFeatures: () -> RouteGuideListFeaturesBlockingServer,

--- a/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -276,7 +276,7 @@ public object RouteGuideWireGrpc {
     }
   }
 
-  public class RouteGuideImplLegacyAdapter(
+  public class BindableAdapter(
     private val streamExecutor: ExecutorService,
     private val GetFeature: () -> RouteGuideGetFeatureBlockingServer,
     private val ListFeatures: () -> RouteGuideListFeaturesBlockingServer,

--- a/wire-library/wire-grpc-server-generator/src/test/golden/nonSingleMethodService.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/nonSingleMethodService.kt
@@ -167,7 +167,7 @@ public object FooServiceWireGrpc {
     }
   }
 
-  public class FooServiceImplLegacyAdapter(
+  public class BindableAdapter(
     private val streamExecutor: ExecutorService,
     private val service: () -> FooServiceBlockingServer,
   ) : FooServiceImplBase() {

--- a/wire-library/wire-grpc-server-generator/src/test/golden/singleMethodService.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/golden/singleMethodService.kt
@@ -167,7 +167,7 @@ public object FooServiceWireGrpc {
     }
   }
 
-  public class FooServiceImplLegacyAdapter(
+  public class BindableAdapter(
     private val streamExecutor: ExecutorService,
     private val Call1: () -> FooServiceCall1BlockingServer,
     private val Call2: () -> FooServiceCall2BlockingServer,

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterTest.kt
@@ -18,7 +18,7 @@ package com.squareup.wire.kotlin.grpcserver
 import com.squareup.kotlinpoet.FileSpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.buildSchema
-import com.squareup.wire.kotlin.grpcserver.LegacyAdapterGenerator.addLegacyAdapter
+import com.squareup.wire.kotlin.grpcserver.BindableAdapterGenerator.addBindableAdapter
 import com.squareup.wire.schema.addLocal
 import okio.Path.Companion.toPath
 import okio.buffer
@@ -27,7 +27,7 @@ import org.assertj.core.api.Assertions
 import org.junit.Test
 import java.io.File
 
-class LegacyAdapterTest {
+class BindableAdapterTest {
   @Test
   fun legacyAdapter() {
     val path = "src/test/proto/RouteGuideProto.proto".toPath()
@@ -38,11 +38,11 @@ class LegacyAdapterTest {
       .addType(
         TypeSpec.classBuilder("RouteGuideWireGrpc")
           .apply {
-            addLegacyAdapter(
+            addBindableAdapter(
               generator = ClassNameGenerator(buildClassMap(schema, service!!)),
               builder = this,
               service,
-              LegacyAdapterGenerator.Options(singleMethodServices = true),
+              BindableAdapterGenerator.Options(singleMethodServices = true),
             )
           }
           .build()
@@ -52,6 +52,6 @@ class LegacyAdapterTest {
 
     println(code)
     Assertions.assertThat(code)
-      .isEqualTo(File("src/test/golden/LegacyAdapter.kt").source().buffer().readUtf8())
+      .isEqualTo(File("src/test/golden/BindableAdapter.kt").source().buffer().readUtf8())
   }
 }


### PR DESCRIPTION
Legacy is misleading here. We are adapting to the standard io.grpc.BindableService