### PR TITLE
feat: support suspending APIs in the protoc adapter

### DIFF
--- a/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
+++ b/wire-library/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/ImplBaseGenerator.kt
@@ -22,6 +22,7 @@ import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.MemberName
 import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
+import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.kotlinpoet.UNIT
 import com.squareup.kotlinpoet.asClassName
@@ -29,57 +30,100 @@ import com.squareup.wire.schema.Rpc
 import com.squareup.wire.schema.Service
 import java.io.InputStream
 import java.lang.UnsupportedOperationException
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.flow.Flow
 
 object ImplBaseGenerator {
   internal fun addImplBase(
     generator: ClassNameGenerator,
     builder: TypeSpec.Builder,
-    service: Service
+    service: Service,
+    options: KotlinGrpcGenerator.Companion.Options
   ) = builder
     .addType(
       TypeSpec.classBuilder("${service.name}ImplBase")
         .addModifiers(KModifier.ABSTRACT)
         .addSuperinterface(WireBindableService::class)
-        .apply { addImplBaseBody(generator, this, service) }
+        .apply { addImplBaseConstructor(options) }
+        .apply { addImplBaseBody(generator, this, service, options) }
         .build()
     )
+
+  private fun TypeSpec.Builder.addImplBaseConstructor(options: KotlinGrpcGenerator.Companion.Options) {
+    if (options.suspendingCalls) {
+      this.primaryConstructor(
+        FunSpec.constructorBuilder()
+          .addParameter(
+            ParameterSpec.builder("context", CoroutineContext::class)
+              .defaultValue(
+                CodeBlock.builder()
+                  .addStatement("kotlin.coroutines.EmptyCoroutineContext")
+                  .build()
+              ).build()
+          )
+          .build()
+      ).addProperty(
+        PropertySpec.builder("context", CoroutineContext::class, KModifier.PROTECTED)
+          .initializer("context")
+          .build()
+      )
+    }
+  }
 
   internal fun addImplBaseRpcSignature(
     generator: ClassNameGenerator,
     builder: FunSpec.Builder,
-    rpc: Rpc
+    rpc: Rpc,
+    options: KotlinGrpcGenerator.Companion.Options
   ): FunSpec.Builder {
-    val requestType = generator.classNameFor(rpc.requestType!!)
-    val responseType = generator.classNameFor(rpc.responseType!!)
-    return when {
-      rpc.requestStreaming ->
-        builder
-          .addParameter(
-            "response", ClassName("io.grpc.stub", "StreamObserver").parameterizedBy(responseType)
-          )
-          .returns(
-            ClassName("io.grpc.stub", "StreamObserver").parameterizedBy(requestType)
-          )
-      else ->
-        builder
-          .addParameter("request", requestType)
-          .addParameter(
-            "response", ClassName("io.grpc.stub", "StreamObserver").parameterizedBy(responseType)
-          )
-          .returns(UNIT)
+    val rpcRequestType = generator.classNameFor(rpc.requestType!!)
+    val rpcResponseType = generator.classNameFor(rpc.responseType!!)
+    return if (options.suspendingCalls) {
+      val requestType = if (rpc.requestStreaming) {
+        Flow::class.asClassName().parameterizedBy(rpcRequestType)
+      } else { rpcRequestType }
+
+      val responseType = if (rpc.responseStreaming) {
+        Flow::class.asClassName().parameterizedBy(rpcResponseType)
+      } else { rpcResponseType }
+
+      builder
+        .addParameter("request", requestType)
+        .returns(responseType)
+    } else {
+      when {
+        rpc.requestStreaming ->
+          builder
+            .addParameter(
+              "response", ClassName("io.grpc.stub", "StreamObserver").parameterizedBy(rpcResponseType)
+            )
+            .returns(
+              ClassName("io.grpc.stub", "StreamObserver").parameterizedBy(rpcRequestType)
+            )
+
+        else ->
+          builder
+            .addParameter("request", rpcRequestType)
+            .addParameter(
+              "response", ClassName("io.grpc.stub", "StreamObserver").parameterizedBy(rpcResponseType)
+            )
+            .returns(UNIT)
+      }
     }
   }
 
   private fun addImplBaseBody(
     generator: ClassNameGenerator,
     builder: TypeSpec.Builder,
-    service: Service
+    service: Service,
+    options: KotlinGrpcGenerator.Companion.Options
   ): TypeSpec.Builder {
     service.rpcs.forEach { rpc ->
       builder.addFunction(
         FunSpec.builder(rpc.name)
           .addModifiers(KModifier.OPEN)
-          .apply { addImplBaseRpcSignature(generator, this, rpc) }
+          .apply { addImplBaseRpcSignature(generator, this, rpc, options) }
+          .apply { if (options.suspendingCalls && !rpc.responseStreaming) { addModifiers(KModifier.SUSPEND) } }
           .addCode(CodeBlock.of("throw %T()", UnsupportedOperationException::class.java))
           .build()
       )
@@ -89,7 +133,7 @@ object ImplBaseGenerator {
       FunSpec.builder("bindService")
         .addModifiers(KModifier.OVERRIDE)
         .returns(ClassName("io.grpc", "ServerServiceDefinition"))
-        .addCode(bindServiceCodeBlock(service))
+        .addCode(bindServiceCodeBlock(service, options))
         .build()
     )
 
@@ -131,18 +175,38 @@ object ImplBaseGenerator {
     return builder
   }
 
-  private fun bindServiceCodeBlock(service: Service): CodeBlock {
-    val codeBlock =
-      CodeBlock.Builder().add("return ServerServiceDefinition.builder(getServiceDescriptor())")
+  private fun bindServiceCodeBlock(service: Service, options: KotlinGrpcGenerator.Companion.Options): CodeBlock {
+    val codeBlock = CodeBlock.Builder().add("return ServerServiceDefinition.builder(getServiceDescriptor())")
     service.rpcs.forEach {
-      codeBlock.add(
-        """.addMethod(
+      if (options.suspendingCalls) {
+        val methodDefinition = when {
+          it.requestStreaming && it.responseStreaming -> "bidiStreaming"
+          it.requestStreaming -> "clientStreaming"
+          it.responseStreaming -> "serverStreaming"
+          else -> "unary"
+        }
+
+        codeBlock.add(
+          """.addMethod(
+           io.grpc.kotlin.ServerCalls.${methodDefinition}ServerMethodDefinition(
+             context = context,
+             descriptor = get${it.name}Method(),
+             implementation = this@${service.name}ImplBase::${it.name},
+           )
+         )
+      """.trimIndent(),
+          MemberName(ClassName("io.grpc.stub", "ServerCalls"), bindServiceCallType(it))
+        )
+      } else {
+        codeBlock.add(
+          """.addMethod(
           get${it.name}Method(),
           %M(this@${service.name}ImplBase::${it.name})
         )
         """.trimIndent(),
-        MemberName(ClassName("io.grpc.stub", "ServerCalls"), bindServiceCallType(it))
-      )
+          MemberName(ClassName("io.grpc.stub", "ServerCalls"), bindServiceCallType(it))
+        )
+      }
     }
     codeBlock.add(".build()")
     return codeBlock.build()

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/ImplBaseTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/ImplBaseTest.kt
@@ -39,7 +39,11 @@ class ImplBaseTest {
             ImplBaseGenerator.addImplBase(
               generator = ClassNameGenerator(buildClassMap(schema, service!!)),
               builder = this,
-              service = service
+              service = service,
+              options = KotlinGrpcGenerator.Companion.Options(
+                singleMethodServices = false,
+                suspendingCalls = false
+              )
             )
           }
           .build()

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
@@ -15,7 +15,9 @@
  */
 package com.squareup.wire.kotlin.grpcserver
 
+import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.buildSchema
 import com.squareup.wire.schema.addLocal
 import okio.Path.Companion.toPath
@@ -24,6 +26,7 @@ import okio.source
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Test
 import java.io.File
+import javax.script.ScriptEngineManager
 
 internal class KotlinGrpcGeneratorTest {
   @Test
@@ -32,8 +35,11 @@ internal class KotlinGrpcGeneratorTest {
     val schema = buildSchema { addLocal(path) }
     val service = schema.getService("routeguide.RouteGuide")
 
-    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = true)
-      .generateGrpcServer(service, schema.protoFile(path), schema)
+    val (_, typeSpec) = KotlinGrpcGenerator(
+      buildClassMap(schema, service!!),
+      singleMethodServices = true,
+      suspendingCalls = false
+    ).generateGrpcServer(service, schema.protoFile(path), schema)
     val output = FileSpec.get("routeguide", typeSpec)
 
     assertThat(output.toString())
@@ -60,8 +66,11 @@ internal class KotlinGrpcGeneratorTest {
     val path = "service.proto".toPath()
     val schema = buildSchema { add(path, twoMethodSchema) }
     val service = schema.getService("foo.FooService")
-    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = false)
-      .generateGrpcServer(service, schema.protoFile(path), schema)
+    val (_, typeSpec) = KotlinGrpcGenerator(
+      buildClassMap(schema, service!!),
+      singleMethodServices = false,
+      suspendingCalls = false
+    ).generateGrpcServer(service, schema.protoFile(path), schema)
     val output = FileSpec.get("com.foo.bar", typeSpec)
 
     assertThat(output.toString())
@@ -73,8 +82,11 @@ internal class KotlinGrpcGeneratorTest {
     val path = "service.proto".toPath()
     val schema = buildSchema { add(path, twoMethodSchema) }
     val service = schema.getService("foo.FooService")
-    val (_, typeSpec) = KotlinGrpcGenerator(buildClassMap(schema, service!!), singleMethodServices = true)
-      .generateGrpcServer(service, schema.protoFile(path), schema)
+    val (_, typeSpec) = KotlinGrpcGenerator(
+      buildClassMap(schema, service!!),
+      singleMethodServices = true,
+      suspendingCalls = false
+    ).generateGrpcServer(service, schema.protoFile(path), schema)
     val output = FileSpec.get("com.foo.bar", typeSpec)
 
     assertThat(output.toString())

--- a/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/StubTest.kt
+++ b/wire-library/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/StubTest.kt
@@ -39,7 +39,11 @@ class StubTest {
             StubGenerator.addStub(
               generator = ClassNameGenerator(buildClassMap(schema, service!!)),
               builder = this,
-              service
+              service,
+              options = KotlinGrpcGenerator.Companion.Options(
+                singleMethodServices = false,
+                suspendingCalls = false
+              )
             )
           }
           .build()

--- a/wire-library/wire-grpc-server/build.gradle.kts
+++ b/wire-library/wire-grpc-server/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     exclude(group = "com.google.guava", module = "guava")
   }
   implementation("com.google.guava:guava:21.0")
+  implementation(libs.kotlin.coroutines.core)
   testImplementation(projects.wireTestUtils)
   testImplementation(libs.kotlin.test.junit)
   testImplementation(libs.truth)

--- a/wire-library/wire-grpc-server/src/main/java/com/squareup/wire/kotlin/grpcserver/FlowAdapter.kt
+++ b/wire-library/wire-grpc-server/src/main/java/com/squareup/wire/kotlin/grpcserver/FlowAdapter.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2022 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.kotlin.grpcserver
+
+import kotlin.coroutines.CoroutineContext
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.consumeAsFlow
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+
+/**
+ * This is an adapter class to convert Wire generated Channel based routines to
+ * flow based functions compatible with io.grpc:protoc-gen-grpc-kotlin.
+ */
+object FlowAdapter {
+
+  fun <I: Any, O: Any>serverStream(
+    context: CoroutineContext,
+    request: I,
+    f: suspend (I, SendChannel<O>) -> Unit)
+  : Flow<O> {
+    val sendChannel = Channel<O>()
+
+    CoroutineScope(context).launch { f(request, sendChannel) }
+    return sendChannel.consumeAsFlow()
+  }
+
+  suspend fun <I: Any, O: Any>clientStream(
+    context: CoroutineContext,
+    request: Flow<I>,
+    f: suspend (ReceiveChannel<I>) -> O)
+  : O {
+    val receiveChannel = Channel<I>()
+
+    CoroutineScope(context).launch { request
+      .onCompletion { receiveChannel.close() }
+      .collect { receiveChannel.send(it) }
+    }
+    return f(receiveChannel)
+  }
+
+  fun <I: Any, O: Any>bidiStream(
+    context: CoroutineContext,
+    request: Flow<I>,
+    f: suspend (ReceiveChannel<I>, SendChannel<O>) -> Unit)
+  : Flow<O> {
+    val sendChannel = Channel<O>()
+    val receiveChannel = Channel<I>()
+
+    CoroutineScope(context).launch { request
+      .onCompletion { receiveChannel.close() }
+      .collect { receiveChannel.send(it) }
+    }
+    CoroutineScope(context).launch { f(receiveChannel, sendChannel) }
+
+    return sendChannel.consumeAsFlow()
+  }
+}

--- a/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-library/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -250,7 +250,7 @@ class KotlinGenerator private constructor(
     val result = mutableMapOf<ClassName, TypeSpec>()
 
     val protoFile: ProtoFile? = schema.protoFile(service.location.path)
-    val (grpcClassName, grpcSpec) = KotlinGrpcGenerator(typeToKotlinName, singleMethodServices)
+    val (grpcClassName, grpcSpec) = KotlinGrpcGenerator(typeToKotlinName, singleMethodServices, rpcCallStyle == RpcCallStyle.SUSPENDING)
       .generateGrpcServer(service, protoFile, schema)
     result[grpcClassName] = grpcSpec
 


### PR DESCRIPTION
Adds support for 
```
rpcCallStyle = "suspending"
```
servers in the protoc adapter, making it possible to use Wire generated suspending services with Armeria.

Does not yet support generating stubs for the coroutine based services, this will be a further PR
