### PR TITLE
Swift: Sendable conformance

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/AnyMessage.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/AnyMessage.swift
@@ -73,7 +73,7 @@ extension AnyMessage: Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension AnyMessage: Sendable {
 }
 #endif

--- a/wire-library/wire-runtime-swift/src/main/swift/AnyMessage.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/AnyMessage.swift
@@ -73,7 +73,7 @@ extension AnyMessage: Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension AnyMessage: Sendable {
 }
 #endif

--- a/wire-library/wire-runtime-swift/src/main/swift/AnyMessage.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/AnyMessage.swift
@@ -64,11 +64,18 @@ public struct AnyMessage {
 }
 
 #if !WIRE_REMOVE_EQUATABLE
-extension AnyMessage: Equatable {}
+extension AnyMessage: Equatable {
+}
 #endif
 
 #if !WIRE_REMOVE_HASHABLE
-extension AnyMessage: Hashable {}
+extension AnyMessage: Hashable {
+}
+#endif
+
+#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
+extension AnyMessage: Sendable {
+}
 #endif
 
 extension AnyMessage: Proto3Codable {

--- a/wire-library/wire-runtime-swift/src/main/swift/Heap.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/Heap.swift
@@ -66,8 +66,3 @@ extension Heap : Hashable where T : Hashable {
     }
 
 }
-
-// MARK: - Sendable
-
-extension Heap : Sendable where T : Sendable {
-}

--- a/wire-library/wire-runtime-swift/src/main/swift/Heap.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/Heap.swift
@@ -66,3 +66,8 @@ extension Heap : Hashable where T : Hashable {
     }
 
 }
+
+// MARK: - Sendable
+
+extension Heap : Sendable where T : Sendable {
+}

--- a/wire-library/wire-runtime-swift/src/main/swift/Indirect.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/Indirect.swift
@@ -63,3 +63,6 @@ extension Indirect : Equatable where T : Equatable {
 
 extension Indirect : Hashable where T : Hashable {
 }
+
+extension Indirect : Sendable where T : Sendable {
+}

--- a/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/JSONString.swift
@@ -82,6 +82,9 @@ public struct JSONString<T : Hashable> : Hashable, Codable {
 
 }
 
+extension JSONString : Sendable where T : Sendable {
+}
+
 private extension Decoder {
     func decodeStringIfPresentToInt64() throws -> Int64? {
         let container = try singleValueContainer()

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
@@ -80,6 +80,11 @@ extension Duration : Hashable {
 }
 #endif
 
+#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
+extension Duration: Sendable {
+}
+#endif
+
 extension Duration : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/google.protobuf.Duration"

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
@@ -80,8 +80,8 @@ extension Duration : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
-extension Duration: Sendable {
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension Duration : Sendable {
 }
 #endif
 

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
@@ -80,7 +80,7 @@ extension Duration : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Duration : Sendable {
 }
 #endif

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -21,6 +21,11 @@ extension OneofOptions : Hashable {
 }
 #endif
 
+#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
+extension OneofOptions: Sendable {
+}
+#endif
+
 extension OneofOptions : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/google.protobuf.OneofOptions"

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -21,8 +21,8 @@ extension OneofOptions : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
-extension OneofOptions: Sendable {
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension OneofOptions : Sendable {
 }
 #endif
 

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -21,7 +21,7 @@ extension OneofOptions : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OneofOptions : Sendable {
 }
 #endif

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
@@ -92,6 +92,11 @@ extension Timestamp : Hashable {
 }
 #endif
 
+#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
+extension Timestamp: Sendable {
+}
+#endif
+
 extension Timestamp : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/google.protobuf.Timestamp"

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
@@ -92,8 +92,8 @@ extension Timestamp : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_HASHABLE
-extension Timestamp: Sendable {
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension Timestamp : Sendable {
 }
 #endif
 

--- a/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
@@ -92,7 +92,7 @@ extension Timestamp : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Timestamp : Sendable {
 }
 #endif

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -42,6 +42,7 @@ import io.outfoxx.swiftpoet.STRING
 import io.outfoxx.swiftpoet.TypeAliasSpec
 import io.outfoxx.swiftpoet.TypeName
 import io.outfoxx.swiftpoet.TypeSpec
+import io.outfoxx.swiftpoet.TypeVariableName
 import io.outfoxx.swiftpoet.UINT32
 import io.outfoxx.swiftpoet.UINT64
 import io.outfoxx.swiftpoet.joinToCode
@@ -65,6 +66,7 @@ class SwiftGenerator private constructor(
   private val equatable = DeclaredTypeName.typeName("Swift.Equatable")
   private val hashable = DeclaredTypeName.typeName("Swift.Hashable")
   private val sendable = DeclaredTypeName.typeName("Swift.Sendable")
+  private val uncheckedSendable = TypeVariableName.typeVariable("@unchecked Sendable")
   private val codable = DeclaredTypeName.typeName("Swift.Codable")
   private val codingKey = DeclaredTypeName.typeName("Swift.CodingKey")
   private val encoder = DeclaredTypeName.typeName("Swift.Encoder")
@@ -233,8 +235,13 @@ class SwiftGenerator private constructor(
       .addGuard("!$FLAG_REMOVE_HASHABLE")
       .build()
 
+    val structSendableType = if (type.isHeapAllocated) {
+      uncheckedSendable
+    } else {
+      sendable
+    }
     val structSendableExtension = ExtensionSpec.builder(structType)
-      .addSuperType(sendable)
+      .addSuperType(structSendableType)
       .build()
     fileMembers += FileMemberSpec.builder(structSendableExtension)
       .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -64,6 +64,7 @@ class SwiftGenerator private constructor(
   private val redactedKey = DeclaredTypeName.typeName("Wire.RedactedKey")
   private val equatable = DeclaredTypeName.typeName("Swift.Equatable")
   private val hashable = DeclaredTypeName.typeName("Swift.Hashable")
+  private val sendable = DeclaredTypeName.typeName("Swift.Sendable")
   private val codable = DeclaredTypeName.typeName("Swift.Codable")
   private val codingKey = DeclaredTypeName.typeName("Swift.CodingKey")
   private val encoder = DeclaredTypeName.typeName("Swift.Encoder")
@@ -232,6 +233,13 @@ class SwiftGenerator private constructor(
       .addGuard("!$FLAG_REMOVE_HASHABLE")
       .build()
 
+    val structSendableExtension = ExtensionSpec.builder(structType)
+      .addSuperType(sendable)
+      .build()
+    fileMembers += FileMemberSpec.builder(structSendableExtension)
+      .addGuard("!$FLAG_REMOVE_SENDABLE")
+      .build()
+
     val redactionExtension = if (type.fields.any { it.isRedacted }) {
       ExtensionSpec.builder(structType)
         .addSuperType(redactable)
@@ -317,6 +325,13 @@ class SwiftGenerator private constructor(
         .build()
       fileMembers += FileMemberSpec.builder(storageHashableExtension)
         .addGuard("!$FLAG_REMOVE_HASHABLE")
+        .build()
+
+      val storageSendableExtension = ExtensionSpec.builder(structType)
+        .addSuperType(sendable)
+        .build()
+      fileMembers += FileMemberSpec.builder(storageSendableExtension)
+        .addGuard("!$FLAG_REMOVE_SENDABLE")
         .build()
 
       if (redactionExtension != null) {
@@ -876,6 +891,13 @@ class SwiftGenerator private constructor(
         .addGuard("!$FLAG_REMOVE_HASHABLE")
         .build()
 
+      val sendableExtension = ExtensionSpec.builder(enumName)
+        .addSuperType(sendable)
+        .build()
+      fileMembers += FileMemberSpec.builder(sendableExtension)
+        .addGuard("!$FLAG_REMOVE_SENDABLE")
+        .build()
+
       if (oneOf.fields.any { it.isRedacted }) {
         val redactableExtension = ExtensionSpec.builder(enumName)
           .addSuperType(redactable)
@@ -1027,6 +1049,7 @@ class SwiftGenerator private constructor(
     private const val FLAG_REMOVE_CODABLE = "WIRE_REMOVE_CODABLE"
     private const val FLAG_REMOVE_EQUATABLE = "WIRE_REMOVE_EQUATABLE"
     private const val FLAG_REMOVE_HASHABLE = "WIRE_REMOVE_HASHABLE"
+    private const val FLAG_REMOVE_SENDABLE = "WIRE_REMOVE_SENDABLE"
     private const val FLAG_REMOVE_REDACTABLE = "WIRE_REMOVE_REDACTABLE"
 
     @JvmStatic @JvmName("get")

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -334,7 +334,7 @@ class SwiftGenerator private constructor(
         .addGuard("!$FLAG_REMOVE_HASHABLE")
         .build()
 
-      val storageSendableExtension = ExtensionSpec.builder(structType)
+      val storageSendableExtension = ExtensionSpec.builder(storageType)
         .addSuperType(sendable)
         .build()
       fileMembers += FileMemberSpec.builder(storageSendableExtension)

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -244,7 +244,7 @@ class SwiftGenerator private constructor(
       .addSuperType(structSendableType)
       .build()
     fileMembers += FileMemberSpec.builder(structSendableExtension)
-      .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
+      .addGuard("swift(>=5.5)")
       .build()
 
     val redactionExtension = if (type.fields.any { it.isRedacted }) {
@@ -338,7 +338,7 @@ class SwiftGenerator private constructor(
         .addSuperType(sendable)
         .build()
       fileMembers += FileMemberSpec.builder(storageSendableExtension)
-        .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
+        .addGuard("swift(>=5.5)")
         .build()
 
       if (redactionExtension != null) {
@@ -902,7 +902,7 @@ class SwiftGenerator private constructor(
         .addSuperType(sendable)
         .build()
       fileMembers += FileMemberSpec.builder(sendableExtension)
-        .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
+        .addGuard("swift(>=5.5)")
         .build()
 
       if (oneOf.fields.any { it.isRedacted }) {
@@ -967,7 +967,7 @@ class SwiftGenerator private constructor(
           .addSuperType(sendable)
           .build()
         fileMembers += FileMemberSpec.builder(sendableExtension)
-          .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
+          .addGuard("swift(>=5.5)")
           .build()
 
         if (type.documentation.isNotBlank()) {
@@ -1063,7 +1063,6 @@ class SwiftGenerator private constructor(
     private const val FLAG_REMOVE_CODABLE = "WIRE_REMOVE_CODABLE"
     private const val FLAG_REMOVE_EQUATABLE = "WIRE_REMOVE_EQUATABLE"
     private const val FLAG_REMOVE_HASHABLE = "WIRE_REMOVE_HASHABLE"
-    private const val FLAG_REMOVE_SENDABLE = "WIRE_REMOVE_SENDABLE"
     private const val FLAG_REMOVE_REDACTABLE = "WIRE_REMOVE_REDACTABLE"
 
     @JvmStatic @JvmName("get")

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -963,6 +963,13 @@ class SwiftGenerator private constructor(
       .addSuperType(CASE_ITERABLE)
       .addSuperType(codable)
       .apply {
+        val sendableExtension = ExtensionSpec.builder(enumName)
+          .addSuperType(sendable)
+          .build()
+        fileMembers += FileMemberSpec.builder(sendableExtension)
+          .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
+          .build()
+
         if (type.documentation.isNotBlank()) {
           addDoc("%L\n", type.documentation.sanitizeDoc())
         }

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -237,7 +237,7 @@ class SwiftGenerator private constructor(
       .addSuperType(sendable)
       .build()
     fileMembers += FileMemberSpec.builder(structSendableExtension)
-      .addGuard("!$FLAG_REMOVE_SENDABLE")
+      .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
       .build()
 
     val redactionExtension = if (type.fields.any { it.isRedacted }) {
@@ -331,7 +331,7 @@ class SwiftGenerator private constructor(
         .addSuperType(sendable)
         .build()
       fileMembers += FileMemberSpec.builder(storageSendableExtension)
-        .addGuard("!$FLAG_REMOVE_SENDABLE")
+        .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
         .build()
 
       if (redactionExtension != null) {
@@ -895,7 +895,7 @@ class SwiftGenerator private constructor(
         .addSuperType(sendable)
         .build()
       fileMembers += FileMemberSpec.builder(sendableExtension)
-        .addGuard("!$FLAG_REMOVE_SENDABLE")
+        .addGuard("swift(>=5.5) && !$FLAG_REMOVE_SENDABLE")
         .build()
 
       if (oneOf.fields.any { it.isRedacted }) {

--- a/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
+++ b/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
@@ -24,7 +24,7 @@ extension ContainsDuration : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension ContainsDuration : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
+++ b/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
@@ -24,6 +24,11 @@ extension ContainsDuration : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension ContainsDuration : Sendable {
+}
+#endif
+
 extension ContainsDuration : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos3.kotlin.contains_duration.ContainsDuration"

--- a/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
+++ b/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
@@ -24,7 +24,7 @@ extension ContainsDuration : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension ContainsDuration : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
+++ b/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
@@ -24,7 +24,7 @@ extension ContainsTimestamp : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension ContainsTimestamp : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
+++ b/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
@@ -24,6 +24,11 @@ extension ContainsTimestamp : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension ContainsTimestamp : Sendable {
+}
+#endif
+
 extension ContainsTimestamp : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos3.kotlin.contains_timestamp.ContainsTimestamp"

--- a/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
+++ b/wire-library/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
@@ -24,7 +24,7 @@ extension ContainsTimestamp : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension ContainsTimestamp : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1895,7 +1895,7 @@ extension AllTypes.NestedMessage : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension AllTypes.NestedMessage : Sendable {
 }
 #endif
@@ -1948,7 +1948,7 @@ extension AllTypes : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension AllTypes : Sendable {
 }
 #endif
@@ -2676,7 +2676,7 @@ extension _AllTypes : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension AllTypes : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1949,7 +1949,7 @@ extension AllTypes : Hashable {
 #endif
 
 #if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
-extension AllTypes : Sendable {
+extension AllTypes : @unchecked Sendable {
 }
 #endif
 

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1895,6 +1895,11 @@ extension AllTypes.NestedMessage : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension AllTypes.NestedMessage : Sendable {
+}
+#endif
+
 extension AllTypes.NestedMessage : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes.NestedMessage"
@@ -1940,6 +1945,11 @@ extension AllTypes : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension AllTypes : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension AllTypes : Sendable {
 }
 #endif
 
@@ -2663,5 +2673,10 @@ extension _AllTypes : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension _AllTypes : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension AllTypes : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1885,6 +1885,11 @@ fileprivate struct _AllTypes {
 
 }
 
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension AllTypes.NestedEnum : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension AllTypes.NestedMessage : Equatable {
 }

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1885,7 +1885,7 @@ fileprivate struct _AllTypes {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension AllTypes.NestedEnum : Sendable {
 }
 #endif
@@ -1900,7 +1900,7 @@ extension AllTypes.NestedMessage : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension AllTypes.NestedMessage : Sendable {
 }
 #endif
@@ -1953,7 +1953,7 @@ extension AllTypes : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension AllTypes : @unchecked Sendable {
 }
 #endif
@@ -2681,7 +2681,7 @@ extension _AllTypes : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension _AllTypes : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -2677,6 +2677,6 @@ extension _AllTypes : Hashable {
 #endif
 
 #if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
-extension AllTypes : Sendable {
+extension _AllTypes : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
@@ -15,7 +15,7 @@ public enum DeprecatedEnum : UInt32, CaseIterable, Codable {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension DeprecatedEnum : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedEnum.swift
@@ -14,3 +14,8 @@ public enum DeprecatedEnum : UInt32, CaseIterable, Codable {
     }
 
 }
+
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension DeprecatedEnum : Sendable {
+}
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
@@ -25,7 +25,7 @@ extension DeprecatedProto : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension DeprecatedProto : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
@@ -25,7 +25,7 @@ extension DeprecatedProto : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension DeprecatedProto : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/DeprecatedProto.swift
@@ -25,6 +25,11 @@ extension DeprecatedProto : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension DeprecatedProto : Sendable {
+}
+#endif
+
 extension DeprecatedProto : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.DeprecatedProto"

--- a/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -26,7 +26,7 @@ extension EmbeddedMessage : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension EmbeddedMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -26,7 +26,7 @@ extension EmbeddedMessage : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension EmbeddedMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -26,6 +26,11 @@ extension EmbeddedMessage : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension EmbeddedMessage : Sendable {
+}
+#endif
+
 extension EmbeddedMessage : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage"

--- a/wire-library/wire-tests-swift/src/main/swift/EnumVersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EnumVersionOne.swift
@@ -7,3 +7,8 @@ public enum EnumVersionOne : UInt32, CaseIterable, Codable {
     case FIONA_V1 = 3
 
 }
+
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension EnumVersionOne : Sendable {
+}
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/EnumVersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EnumVersionOne.swift
@@ -8,7 +8,7 @@ public enum EnumVersionOne : UInt32, CaseIterable, Codable {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension EnumVersionOne : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/EnumVersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EnumVersionTwo.swift
@@ -8,3 +8,8 @@ public enum EnumVersionTwo : UInt32, CaseIterable, Codable {
     case PUSS_IN_BOOTS_V2 = 4
 
 }
+
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension EnumVersionTwo : Sendable {
+}
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/EnumVersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EnumVersionTwo.swift
@@ -9,7 +9,7 @@ public enum EnumVersionTwo : UInt32, CaseIterable, Codable {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension EnumVersionTwo : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
@@ -24,7 +24,7 @@ extension ExternalMessage : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension ExternalMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
@@ -24,7 +24,7 @@ extension ExternalMessage : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension ExternalMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ExternalMessage.swift
@@ -24,6 +24,11 @@ extension ExternalMessage : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension ExternalMessage : Sendable {
+}
+#endif
+
 extension ExternalMessage : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.simple.ExternalMessage"

--- a/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
@@ -180,6 +180,11 @@ extension FooBar.More : Codable {
 }
 #endif
 
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension FooBar.FooBarBazEnum : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension FooBar : Equatable {
 }

--- a/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
@@ -84,7 +84,7 @@ extension FooBar.Nested : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension FooBar.Nested : Sendable {
 }
 #endif
@@ -137,7 +137,7 @@ extension FooBar.More : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension FooBar.More : Sendable {
 }
 #endif
@@ -180,7 +180,7 @@ extension FooBar.More : Codable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension FooBar.FooBarBazEnum : Sendable {
 }
 #endif
@@ -195,7 +195,7 @@ extension FooBar : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension FooBar : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
@@ -84,6 +84,11 @@ extension FooBar.Nested : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension FooBar.Nested : Sendable {
+}
+#endif
+
 extension FooBar.Nested : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested"
@@ -132,6 +137,11 @@ extension FooBar.More : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension FooBar.More : Sendable {
+}
+#endif
+
 extension FooBar.More : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.custom_options.FooBar.More"
@@ -177,6 +187,11 @@ extension FooBar : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension FooBar : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension FooBar : Sendable {
 }
 #endif
 

--- a/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
@@ -84,7 +84,7 @@ extension FooBar.Nested : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension FooBar.Nested : Sendable {
 }
 #endif
@@ -137,7 +137,7 @@ extension FooBar.More : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension FooBar.More : Sendable {
 }
 #endif
@@ -190,7 +190,7 @@ extension FooBar : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension FooBar : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ForeignEnum.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ForeignEnum.swift
@@ -6,3 +6,8 @@ public enum ForeignEnum : UInt32, CaseIterable, Codable {
     case BAX = 1
 
 }
+
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension ForeignEnum : Sendable {
+}
+#endif

--- a/wire-library/wire-tests-swift/src/main/swift/ForeignEnum.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ForeignEnum.swift
@@ -7,7 +7,7 @@ public enum ForeignEnum : UInt32, CaseIterable, Codable {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension ForeignEnum : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
@@ -24,7 +24,7 @@ extension ForeignMessage : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension ForeignMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
@@ -24,7 +24,7 @@ extension ForeignMessage : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension ForeignMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ForeignMessage.swift
@@ -24,6 +24,11 @@ extension ForeignMessage : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension ForeignMessage : Sendable {
+}
+#endif
+
 extension ForeignMessage : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.foreign.ForeignMessage"

--- a/wire-library/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Form.swift
@@ -197,6 +197,11 @@ extension Form.Choice : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.Choice : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension Form.Decision : Equatable {
 }
@@ -204,6 +209,11 @@ extension Form.Decision : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Form.Decision : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Form.Decision : Sendable {
 }
 #endif
 
@@ -224,6 +234,11 @@ extension Form.ButtonElement : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Form.ButtonElement : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Form.ButtonElement : Sendable {
 }
 #endif
 
@@ -267,6 +282,11 @@ extension Form.LocalImageElement : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.LocalImageElement : Sendable {
+}
+#endif
+
 extension Form.LocalImageElement : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.LocalImageElement"
@@ -304,6 +324,11 @@ extension Form.RemoteImageElement : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Form.RemoteImageElement : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Form.RemoteImageElement : Sendable {
 }
 #endif
 
@@ -347,6 +372,11 @@ extension Form.MoneyElement : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.MoneyElement : Sendable {
+}
+#endif
+
 extension Form.MoneyElement : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.MoneyElement"
@@ -387,6 +417,11 @@ extension Form.SpacerElement : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.SpacerElement : Sendable {
+}
+#endif
+
 extension Form.SpacerElement : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.SpacerElement"
@@ -424,6 +459,11 @@ extension Form.TextElement : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Form.TextElement : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Form.TextElement : Sendable {
 }
 #endif
 
@@ -475,6 +515,11 @@ extension Form.CustomizedCardElement : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.CustomizedCardElement : Sendable {
+}
+#endif
+
 extension Form.CustomizedCardElement : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CustomizedCardElement"
@@ -512,6 +557,11 @@ extension Form.AddressElement : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Form.AddressElement : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Form.AddressElement : Sendable {
 }
 #endif
 
@@ -555,6 +605,11 @@ extension Form.TextInputElement : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.TextInputElement : Sendable {
+}
+#endif
+
 extension Form.TextInputElement : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextInputElement"
@@ -592,6 +647,11 @@ extension Form.OptionPickerElement : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Form.OptionPickerElement : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Form.OptionPickerElement : Sendable {
 }
 #endif
 
@@ -635,6 +695,11 @@ extension Form.DetailRowElement : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.DetailRowElement : Sendable {
+}
+#endif
+
 extension Form.DetailRowElement : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.DetailRowElement"
@@ -675,6 +740,11 @@ extension Form.CurrencyConversionFlagsElement : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Form.CurrencyConversionFlagsElement : Sendable {
+}
+#endif
+
 extension Form.CurrencyConversionFlagsElement : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CurrencyConversionFlagsElement"
@@ -712,6 +782,11 @@ extension Form : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Form : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Form : Sendable {
 }
 #endif
 

--- a/wire-library/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Form.swift
@@ -197,7 +197,7 @@ extension Form.Choice : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.Choice : Sendable {
 }
 #endif
@@ -212,7 +212,7 @@ extension Form.Decision : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.Decision : Sendable {
 }
 #endif
@@ -237,7 +237,7 @@ extension Form.ButtonElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.ButtonElement : Sendable {
 }
 #endif
@@ -282,7 +282,7 @@ extension Form.LocalImageElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.LocalImageElement : Sendable {
 }
 #endif
@@ -327,7 +327,7 @@ extension Form.RemoteImageElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.RemoteImageElement : Sendable {
 }
 #endif
@@ -372,7 +372,7 @@ extension Form.MoneyElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.MoneyElement : Sendable {
 }
 #endif
@@ -417,7 +417,7 @@ extension Form.SpacerElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.SpacerElement : Sendable {
 }
 #endif
@@ -462,7 +462,7 @@ extension Form.TextElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.TextElement : Sendable {
 }
 #endif
@@ -515,7 +515,7 @@ extension Form.CustomizedCardElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.CustomizedCardElement : Sendable {
 }
 #endif
@@ -560,7 +560,7 @@ extension Form.AddressElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.AddressElement : Sendable {
 }
 #endif
@@ -605,7 +605,7 @@ extension Form.TextInputElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.TextInputElement : Sendable {
 }
 #endif
@@ -650,7 +650,7 @@ extension Form.OptionPickerElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.OptionPickerElement : Sendable {
 }
 #endif
@@ -695,7 +695,7 @@ extension Form.DetailRowElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.DetailRowElement : Sendable {
 }
 #endif
@@ -740,7 +740,7 @@ extension Form.CurrencyConversionFlagsElement : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form.CurrencyConversionFlagsElement : Sendable {
 }
 #endif
@@ -785,7 +785,7 @@ extension Form : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Form : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Form.swift
@@ -197,7 +197,7 @@ extension Form.Choice : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.Choice : Sendable {
 }
 #endif
@@ -212,7 +212,7 @@ extension Form.Decision : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.Decision : Sendable {
 }
 #endif
@@ -237,7 +237,7 @@ extension Form.ButtonElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.ButtonElement : Sendable {
 }
 #endif
@@ -282,7 +282,7 @@ extension Form.LocalImageElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.LocalImageElement : Sendable {
 }
 #endif
@@ -327,7 +327,7 @@ extension Form.RemoteImageElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.RemoteImageElement : Sendable {
 }
 #endif
@@ -372,7 +372,7 @@ extension Form.MoneyElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.MoneyElement : Sendable {
 }
 #endif
@@ -417,7 +417,7 @@ extension Form.SpacerElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.SpacerElement : Sendable {
 }
 #endif
@@ -462,7 +462,7 @@ extension Form.TextElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.TextElement : Sendable {
 }
 #endif
@@ -515,7 +515,7 @@ extension Form.CustomizedCardElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.CustomizedCardElement : Sendable {
 }
 #endif
@@ -560,7 +560,7 @@ extension Form.AddressElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.AddressElement : Sendable {
 }
 #endif
@@ -605,7 +605,7 @@ extension Form.TextInputElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.TextInputElement : Sendable {
 }
 #endif
@@ -650,7 +650,7 @@ extension Form.OptionPickerElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.OptionPickerElement : Sendable {
 }
 #endif
@@ -695,7 +695,7 @@ extension Form.DetailRowElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.DetailRowElement : Sendable {
 }
 #endif
@@ -740,7 +740,7 @@ extension Form.CurrencyConversionFlagsElement : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form.CurrencyConversionFlagsElement : Sendable {
 }
 #endif
@@ -785,7 +785,7 @@ extension Form : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Form : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
@@ -24,7 +24,7 @@ extension Mappy : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Mappy : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
@@ -24,6 +24,11 @@ extension Mappy : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Mappy : Sendable {
+}
+#endif
+
 extension Mappy : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Mappy"

--- a/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
@@ -24,7 +24,7 @@ extension Mappy : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Mappy : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
@@ -29,7 +29,7 @@ extension MessageUsingMultipleEnums : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension MessageUsingMultipleEnums : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
@@ -29,7 +29,7 @@ extension MessageUsingMultipleEnums : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension MessageUsingMultipleEnums : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
@@ -29,6 +29,11 @@ extension MessageUsingMultipleEnums : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension MessageUsingMultipleEnums : Sendable {
+}
+#endif
+
 extension MessageUsingMultipleEnums : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.MessageUsingMultipleEnums"

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
@@ -22,6 +22,11 @@ extension MessageWithOptions : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension MessageWithOptions : Sendable {
+}
+#endif
+
 extension MessageWithOptions : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions"

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
@@ -22,7 +22,7 @@ extension MessageWithOptions : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension MessageWithOptions : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithOptions.swift
@@ -22,7 +22,7 @@ extension MessageWithOptions : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension MessageWithOptions : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -28,7 +28,7 @@ extension MessageWithStatus : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension MessageWithStatus : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -18,6 +18,11 @@ public struct MessageWithStatus {
 
 }
 
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension MessageWithStatus.Status : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension MessageWithStatus : Equatable {
 }

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -28,6 +28,11 @@ extension MessageWithStatus : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension MessageWithStatus : Sendable {
+}
+#endif
+
 extension MessageWithStatus : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.MessageWithStatus"

--- a/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -18,7 +18,7 @@ public struct MessageWithStatus {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension MessageWithStatus.Status : Sendable {
 }
 #endif
@@ -33,7 +33,7 @@ extension MessageWithStatus : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension MessageWithStatus : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -47,7 +47,7 @@ extension ModelEvaluation : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension ModelEvaluation : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -47,7 +47,7 @@ extension ModelEvaluation : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension ModelEvaluation : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -47,6 +47,11 @@ extension ModelEvaluation : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension ModelEvaluation : Sendable {
+}
+#endif
+
 extension ModelEvaluation : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/ModelEvaluation"

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
@@ -24,7 +24,7 @@ extension NestedVersionOne : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension NestedVersionOne : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
@@ -24,7 +24,7 @@ extension NestedVersionOne : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension NestedVersionOne : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionOne.swift
@@ -24,6 +24,11 @@ extension NestedVersionOne : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension NestedVersionOne : Sendable {
+}
+#endif
+
 extension NestedVersionOne : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionOne"

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -42,7 +42,7 @@ extension NestedVersionTwo : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension NestedVersionTwo : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -42,7 +42,7 @@ extension NestedVersionTwo : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension NestedVersionTwo : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -42,6 +42,11 @@ extension NestedVersionTwo : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension NestedVersionTwo : Sendable {
+}
+#endif
+
 extension NestedVersionTwo : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionTwo"

--- a/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
@@ -22,7 +22,7 @@ extension NoFields : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension NoFields : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
@@ -22,7 +22,7 @@ extension NoFields : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension NoFields : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NoFields.swift
@@ -22,6 +22,11 @@ extension NoFields : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension NoFields : Sendable {
+}
+#endif
+
 extension NoFields : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.NoFields"

--- a/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -55,7 +55,7 @@ extension OneOfMessage.Choice : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension OneOfMessage.Choice : Sendable {
 }
 #endif
@@ -70,7 +70,7 @@ extension OneOfMessage : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension OneOfMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -55,7 +55,7 @@ extension OneOfMessage.Choice : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OneOfMessage.Choice : Sendable {
 }
 #endif
@@ -70,7 +70,7 @@ extension OneOfMessage : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OneOfMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -55,6 +55,11 @@ extension OneOfMessage.Choice : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension OneOfMessage.Choice : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension OneOfMessage : Equatable {
 }
@@ -62,6 +67,11 @@ extension OneOfMessage : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension OneOfMessage : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension OneOfMessage : Sendable {
 }
 #endif
 

--- a/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -21,7 +21,7 @@ public struct OptionalEnumUser {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OptionalEnumUser.OptionalEnum : Sendable {
 }
 #endif
@@ -36,7 +36,7 @@ extension OptionalEnumUser : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OptionalEnumUser : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -21,6 +21,11 @@ public struct OptionalEnumUser {
 
 }
 
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension OptionalEnumUser.OptionalEnum : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension OptionalEnumUser : Equatable {
 }

--- a/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -31,6 +31,11 @@ extension OptionalEnumUser : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension OptionalEnumUser : Sendable {
+}
+#endif
+
 extension OptionalEnumUser : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.OptionalEnumUser"

--- a/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -31,7 +31,7 @@ extension OptionalEnumUser : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension OptionalEnumUser : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -18,7 +18,7 @@ public struct OtherMessageWithStatus {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OtherMessageWithStatus.Status : Sendable {
 }
 #endif
@@ -33,7 +33,7 @@ extension OtherMessageWithStatus : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OtherMessageWithStatus : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -28,7 +28,7 @@ extension OtherMessageWithStatus : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension OtherMessageWithStatus : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -28,6 +28,11 @@ extension OtherMessageWithStatus : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension OtherMessageWithStatus : Sendable {
+}
+#endif
+
 extension OtherMessageWithStatus : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.OtherMessageWithStatus"

--- a/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -18,6 +18,11 @@ public struct OtherMessageWithStatus {
 
 }
 
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension OtherMessageWithStatus.Status : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension OtherMessageWithStatus : Equatable {
 }

--- a/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
@@ -26,7 +26,7 @@ extension OuterMessage : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension OuterMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
@@ -26,7 +26,7 @@ extension OuterMessage : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension OuterMessage : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/OuterMessage.swift
@@ -26,6 +26,11 @@ extension OuterMessage : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension OuterMessage : Sendable {
+}
+#endif
+
 extension OuterMessage : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage"

--- a/wire-library/wire-tests-swift/src/main/swift/Percents.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Percents.swift
@@ -27,7 +27,7 @@ extension Percents : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Percents : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/Percents.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Percents.swift
@@ -27,6 +27,11 @@ extension Percents : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Percents : Sendable {
+}
+#endif
+
 extension Percents : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.Percents"

--- a/wire-library/wire-tests-swift/src/main/swift/Percents.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Percents.swift
@@ -27,7 +27,7 @@ extension Percents : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Percents : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Person.swift
@@ -86,6 +86,11 @@ extension Person.PhoneNumber : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Person.PhoneNumber : Sendable {
+}
+#endif
+
 extension Person.PhoneNumber : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
@@ -136,6 +141,11 @@ extension Person : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension Person : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension Person : Sendable {
 }
 #endif
 

--- a/wire-library/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Person.swift
@@ -76,6 +76,11 @@ public struct Person {
 
 }
 
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+extension Person.PhoneType : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_EQUATABLE
 extension Person.PhoneNumber : Equatable {
 }

--- a/wire-library/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Person.swift
@@ -76,7 +76,7 @@ public struct Person {
 
 }
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Person.PhoneType : Sendable {
 }
 #endif
@@ -91,7 +91,7 @@ extension Person.PhoneNumber : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Person.PhoneNumber : Sendable {
 }
 #endif
@@ -149,7 +149,7 @@ extension Person : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Person : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Person.swift
@@ -86,7 +86,7 @@ extension Person.PhoneNumber : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Person.PhoneNumber : Sendable {
 }
 #endif
@@ -144,7 +144,7 @@ extension Person : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Person : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -38,7 +38,7 @@ extension RedactedOneOf.A : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension RedactedOneOf.A : Sendable {
 }
 #endif
@@ -63,7 +63,7 @@ extension RedactedOneOf : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension RedactedOneOf : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -38,7 +38,7 @@ extension RedactedOneOf.A : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension RedactedOneOf.A : Sendable {
 }
 #endif
@@ -63,7 +63,7 @@ extension RedactedOneOf : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension RedactedOneOf : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -38,6 +38,11 @@ extension RedactedOneOf.A : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension RedactedOneOf.A : Sendable {
+}
+#endif
+
 #if !WIRE_REMOVE_REDACTABLE
 extension RedactedOneOf.A : Redactable {
     public enum RedactedKeys : String, RedactedKey {
@@ -55,6 +60,11 @@ extension RedactedOneOf : Equatable {
 
 #if !WIRE_REMOVE_HASHABLE
 extension RedactedOneOf : Hashable {
+}
+#endif
+
+#if !WIRE_REMOVE_SENDABLE
+extension RedactedOneOf : Sendable {
 }
 #endif
 

--- a/wire-library/wire-tests-swift/src/main/swift/Thing.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Thing.swift
@@ -24,7 +24,7 @@ extension Thing : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension Thing : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/Thing.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Thing.swift
@@ -24,6 +24,11 @@ extension Thing : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension Thing : Sendable {
+}
+#endif
+
 extension Thing : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Thing"

--- a/wire-library/wire-tests-swift/src/main/swift/Thing.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Thing.swift
@@ -24,7 +24,7 @@ extension Thing : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension Thing : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
@@ -32,7 +32,7 @@ extension VersionOne : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension VersionOne : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
@@ -32,7 +32,7 @@ extension VersionOne : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension VersionOne : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionOne.swift
@@ -32,6 +32,11 @@ extension VersionOne : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension VersionOne : Sendable {
+}
+#endif
+
 extension VersionOne : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionOne"

--- a/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -48,6 +48,11 @@ extension VersionTwo : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension VersionTwo : Sendable {
+}
+#endif
+
 extension VersionTwo : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionTwo"

--- a/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -48,7 +48,7 @@ extension VersionTwo : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension VersionTwo : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -48,7 +48,7 @@ extension VersionTwo : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension VersionTwo : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -27,6 +27,11 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Hashable {
 }
 #endif
 
+#if !WIRE_REMOVE_SENDABLE
+extension VeryLongProtoNameCausingBrokenLineBreaks : Sendable {
+}
+#endif
+
 extension VeryLongProtoNameCausingBrokenLineBreaks : ProtoMessage {
     public static func protoMessageTypeURL() -> String {
         return "type.googleapis.com/squareup.protos.tostring.VeryLongProtoNameCausingBrokenLineBreaks"

--- a/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -27,7 +27,7 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Hashable {
 }
 #endif
 
-#if !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
 extension VeryLongProtoNameCausingBrokenLineBreaks : Sendable {
 }
 #endif

--- a/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -27,7 +27,7 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Hashable {
 }
 #endif
 
-#if swift(>=5.5) && !WIRE_REMOVE_SENDABLE
+#if swift(>=5.5)
 extension VeryLongProtoNameCausingBrokenLineBreaks : Sendable {
 }
 #endif


### PR DESCRIPTION
This adds `Sendable` conformance to all codegened types.
Structs that need to use `@Heap` are `@unchecked`. 
All other types are checked.

This follows the existing patterns of guarding with `#if` checks as well as checking for `swift(>=5.5)`