### PR TITLE
fix: options entries can be null for files imported from external jars

### DIFF
--- a/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
+++ b/wire-library/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Options.kt
@@ -38,7 +38,7 @@ class Options(
     }
 
   val map: Map<ProtoMember, Any?>
-    get() = entries!!.toMap()
+    get() = entries?.toMap() ?: emptyMap()
 
   fun retainLinked() = Options(optionType, emptyList())
 


### PR DESCRIPTION
Return empty map on `map` in this case instead of failing with NPE.

This was crashing FDS generation when using external files.