### PR TITLE
Swift: Don't throw when decoding structs with missing arrays/maps

### DIFF
--- a/wire-library/wire-runtime-swift/src/main/swift/propertyWrappers/DefaultEmpty.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/propertyWrappers/DefaultEmpty.swift
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Allow creation of an instance with an empty `init()`
+public protocol EmptyInitializable {
+    init()
+}
+
+extension Array: EmptyInitializable {
+}
+
+extension Dictionary: EmptyInitializable {
+}
+
+extension Set: EmptyInitializable {
+}
+
+@propertyWrapper
+public struct DefaultEmpty<T: EmptyInitializable> {
+    public var wrappedValue: T
+
+    public init(wrappedValue: T) {
+        self.wrappedValue = wrappedValue
+    }
+}
+
+extension DefaultEmpty : EmptyInitializable {
+    public init() {
+        self.init(wrappedValue: T())
+    }
+}
+
+extension DefaultEmpty : Equatable where T : Equatable {
+}
+
+extension DefaultEmpty : Hashable where T : Hashable {
+}
+
+extension DefaultEmpty : Encodable where T : Encodable {
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(wrappedValue)
+    }
+}
+
+extension DefaultEmpty : Decodable where T : Decodable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        wrappedValue = try container.decode(T.self)
+    }
+}
+
+#if swift(>=5.5)
+extension DefaultEmpty : Sendable where T : Sendable {
+}
+#endif
+
+
+public extension KeyedDecodingContainer {
+    func decode<T: EmptyInitializable & Decodable>(
+        _: DefaultEmpty<T>.Type,
+        forKey key: Key
+    ) throws -> DefaultEmpty<T> {
+        if let value = try decodeIfPresent(DefaultEmpty<T>.self, forKey: key) {
+            return value
+        } else {
+            return DefaultEmpty()
+        }
+    }
+}

--- a/wire-library/wire-runtime-swift/src/main/swift/propertyWrappers/JSONEnumArray.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/propertyWrappers/JSONEnumArray.swift
@@ -53,6 +53,12 @@ public struct JSONEnumArray<T : CaseIterable & Hashable & RawRepresentable> : Co
     }
 }
 
+extension JSONEnumArray: EmptyInitializable {
+    public init() {
+        self.init(wrappedValue: [])
+    }
+}
+
 #if swift(>=5.5)
 extension JSONEnumArray : Sendable where T : Sendable {
 }

--- a/wire-library/wire-runtime-swift/src/main/swift/propertyWrappers/JSONOptionalEnum.swift
+++ b/wire-library/wire-runtime-swift/src/main/swift/propertyWrappers/JSONOptionalEnum.swift
@@ -63,6 +63,12 @@ extension JSONOptionalEnum : Sendable where T : Sendable {
 }
 #endif
 
+extension JSONOptionalEnum: EmptyInitializable {
+    public init() {
+        self.init(wrappedValue: nil)
+    }
+}
+
 public extension KeyedDecodingContainer {
     func decode<T: CaseIterable & Hashable & RawRepresentable>(
         _: JSONOptionalEnum<T>.Type,

--- a/wire-library/wire-runtime-swift/src/test/swift/DefaultEmptyTests.swift
+++ b/wire-library/wire-runtime-swift/src/test/swift/DefaultEmptyTests.swift
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+import XCTest
+@testable import Wire
+
+final class DefaultEmptyTests: XCTestCase {
+    private struct CodableType : Equatable, Codable {
+        @DefaultEmpty
+        var emptyResults: [Int]
+        var nonemptyResults: [Int]
+    }
+}
+
+extension DefaultEmptyTests {
+    func testEncodingEmptyArrays() {
+        let expectedStruct = CodableType(emptyResults: [], nonemptyResults: [])
+        let expectedJson = """
+        {\
+        "emptyResults":[],\
+        "nonemptyResults":[]\
+        }
+        """
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys // For deterministic output.
+
+        // Encode our struct
+        let jsonData = try! encoder.encode(expectedStruct)
+        let actualJson = String(data: jsonData, encoding: .utf8)!
+        XCTAssertEqual(expectedJson, actualJson)
+
+        // Verify decoding round trip results
+        let actualStruct = try! JSONDecoder().decode(CodableType.self, from: jsonData)
+        XCTAssertEqual(expectedStruct, actualStruct)
+    }
+
+    func testEncodingValues() {
+        let expectedStruct = CodableType(emptyResults: [1, 2], nonemptyResults: [1, 2])
+        let expectedJson = """
+        {\
+        "emptyResults":[1,2],\
+        "nonemptyResults":[1,2]\
+        }
+        """
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = .sortedKeys // For deterministic output.
+
+        // Encode our struct
+        let jsonData = try! encoder.encode(expectedStruct)
+        let actualJson = String(data: jsonData, encoding: .utf8)!
+        XCTAssertEqual(expectedJson, actualJson)
+
+        // Verify decoding round trip results
+        let actualStruct = try! JSONDecoder().decode(CodableType.self, from: jsonData)
+        XCTAssertEqual(expectedStruct, actualStruct)
+    }
+
+    func testDecodingMissingArrays() {
+        let expectedStruct = CodableType(emptyResults: [], nonemptyResults: [])
+
+        let json = """
+        {\
+        "nonemptyResults":[]\
+        }
+        """
+
+        let jsonData = json.data(using: .utf8)!
+        let actualStruct = try! JSONDecoder().decode(CodableType.self, from: jsonData)
+        XCTAssertEqual(expectedStruct, actualStruct)
+    }
+
+    func testDecodingMissingArrayFails() {
+        let json = "{}"
+
+        let jsonData = json.data(using: .utf8)!
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(CodableType.self, from: jsonData)
+        ) { error in
+            guard let error = error as? DecodingError else {
+                XCTFail("Invalid error type for \(error)")
+                return
+            }
+
+            guard case let .keyNotFound(codingKey, _) = error else {
+                XCTFail("Invalid error case for \(error)")
+                return
+            }
+
+            XCTAssertEqual(codingKey.stringValue, "nonemptyResults")
+        }
+    }
+}

--- a/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-library/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -732,6 +732,10 @@ class SwiftGenerator private constructor(
       if (!forStorageType && field.isDeprecated) {
         property.addAttribute(deprecated)
       }
+      if (field.needsDefaultEmpty()) {
+        property.addAttribute("DefaultEmpty")
+      }
+
       val prototype = field.type
       if (prototype != null && schema.getType(prototype) is EnumType) {
         if (field.isRepeated) {
@@ -946,6 +950,15 @@ class SwiftGenerator private constructor(
       ProtoType.FIXED32, ProtoType.FIXED64 -> "fixed"
       else -> null
     }
+
+  private fun Field.needsDefaultEmpty(): Boolean {
+    // This is a temporary thing
+    if (typeName.needsJsonString()) {
+      return false
+    }
+
+    return isRepeated || isMap
+  }
 
   private fun TypeName.needsJsonString(): Boolean {
     val self = makeNonOptional()

--- a/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -1484,10 +1484,15 @@ fileprivate struct _AllTypes {
     @JSONEnum
     public var req_nested_enum: AllTypes.NestedEnum
     public var req_nested_message: AllTypes.NestedMessage
+    @DefaultEmpty
     public var rep_int32: [Int32]
+    @DefaultEmpty
     public var rep_uint32: [UInt32]
+    @DefaultEmpty
     public var rep_sint32: [Int32]
+    @DefaultEmpty
     public var rep_fixed32: [UInt32]
+    @DefaultEmpty
     public var rep_sfixed32: [Int32]
     @JSONString
     public var rep_int64: [Int64]
@@ -1499,18 +1504,30 @@ fileprivate struct _AllTypes {
     public var rep_fixed64: [UInt64]
     @JSONString
     public var rep_sfixed64: [Int64]
+    @DefaultEmpty
     public var rep_bool: [Bool]
+    @DefaultEmpty
     public var rep_float: [Float]
+    @DefaultEmpty
     public var rep_double: [Double]
+    @DefaultEmpty
     public var rep_string: [String]
+    @DefaultEmpty
     public var rep_bytes: [Data]
+    @DefaultEmpty
     @JSONEnumArray
     public var rep_nested_enum: [AllTypes.NestedEnum]
+    @DefaultEmpty
     public var rep_nested_message: [AllTypes.NestedMessage]
+    @DefaultEmpty
     public var pack_int32: [Int32]
+    @DefaultEmpty
     public var pack_uint32: [UInt32]
+    @DefaultEmpty
     public var pack_sint32: [Int32]
+    @DefaultEmpty
     public var pack_fixed32: [UInt32]
+    @DefaultEmpty
     public var pack_sfixed32: [Int32]
     @JSONString
     public var pack_int64: [Int64]
@@ -1522,9 +1539,13 @@ fileprivate struct _AllTypes {
     public var pack_fixed64: [UInt64]
     @JSONString
     public var pack_sfixed64: [Int64]
+    @DefaultEmpty
     public var pack_bool: [Bool]
+    @DefaultEmpty
     public var pack_float: [Float]
+    @DefaultEmpty
     public var pack_double: [Double]
+    @DefaultEmpty
     @JSONEnumArray
     public var pack_nested_enum: [AllTypes.NestedEnum]
     public var default_int32: Int32?
@@ -1549,9 +1570,13 @@ fileprivate struct _AllTypes {
     public var default_bytes: Data?
     @JSONOptionalEnum
     public var default_nested_enum: AllTypes.NestedEnum?
+    @DefaultEmpty
     public var map_int32_int32: [Int32 : Int32]
+    @DefaultEmpty
     public var map_string_string: [String : String]
+    @DefaultEmpty
     public var map_string_message: [String : AllTypes.NestedMessage]
+    @DefaultEmpty
     public var map_string_enum: [String : AllTypes.NestedEnum]
     public var ext_opt_int32: Int32?
     public var ext_opt_uint32: UInt32?
@@ -1576,10 +1601,15 @@ fileprivate struct _AllTypes {
     @JSONOptionalEnum
     public var ext_opt_nested_enum: AllTypes.NestedEnum?
     public var ext_opt_nested_message: AllTypes.NestedMessage?
+    @DefaultEmpty
     public var ext_rep_int32: [Int32]
+    @DefaultEmpty
     public var ext_rep_uint32: [UInt32]
+    @DefaultEmpty
     public var ext_rep_sint32: [Int32]
+    @DefaultEmpty
     public var ext_rep_fixed32: [UInt32]
+    @DefaultEmpty
     public var ext_rep_sfixed32: [Int32]
     @JSONString
     public var ext_rep_int64: [Int64]
@@ -1591,18 +1621,30 @@ fileprivate struct _AllTypes {
     public var ext_rep_fixed64: [UInt64]
     @JSONString
     public var ext_rep_sfixed64: [Int64]
+    @DefaultEmpty
     public var ext_rep_bool: [Bool]
+    @DefaultEmpty
     public var ext_rep_float: [Float]
+    @DefaultEmpty
     public var ext_rep_double: [Double]
+    @DefaultEmpty
     public var ext_rep_string: [String]
+    @DefaultEmpty
     public var ext_rep_bytes: [Data]
+    @DefaultEmpty
     @JSONEnumArray
     public var ext_rep_nested_enum: [AllTypes.NestedEnum]
+    @DefaultEmpty
     public var ext_rep_nested_message: [AllTypes.NestedMessage]
+    @DefaultEmpty
     public var ext_pack_int32: [Int32]
+    @DefaultEmpty
     public var ext_pack_uint32: [UInt32]
+    @DefaultEmpty
     public var ext_pack_sint32: [Int32]
+    @DefaultEmpty
     public var ext_pack_fixed32: [UInt32]
+    @DefaultEmpty
     public var ext_pack_sfixed32: [Int32]
     @JSONString
     public var ext_pack_int64: [Int64]
@@ -1614,9 +1656,13 @@ fileprivate struct _AllTypes {
     public var ext_pack_fixed64: [UInt64]
     @JSONString
     public var ext_pack_sfixed64: [Int64]
+    @DefaultEmpty
     public var ext_pack_bool: [Bool]
+    @DefaultEmpty
     public var ext_pack_float: [Float]
+    @DefaultEmpty
     public var ext_pack_double: [Double]
+    @DefaultEmpty
     @JSONEnumArray
     public var ext_pack_nested_enum: [AllTypes.NestedEnum]
     public var unknownFields: Data = .init()

--- a/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -5,6 +5,7 @@ import Wire
 
 public struct EmbeddedMessage {
 
+    @DefaultEmpty
     public var inner_repeated_number: [Int32]
     public var inner_number_after: Int32?
     public var unknownFields: Data = .init()

--- a/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/FooBar.swift
@@ -10,11 +10,14 @@ public struct FooBar {
     public var baz: Nested?
     @JSONString
     public var qux: UInt64?
+    @DefaultEmpty
     public var fred: [Float]
     public var daisy: Double?
+    @DefaultEmpty
     public var nested: [FooBar]
     @JSONOptionalEnum
     public var ext: FooBarBazEnum?
+    @DefaultEmpty
     @JSONEnumArray
     public var rep: [FooBarBazEnum]
     public var more_string: String?
@@ -58,6 +61,7 @@ public struct FooBar {
 
     public struct More {
 
+        @DefaultEmpty
         public var serial: [Int32]
         public var unknownFields: Data = .init()
 

--- a/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Mappy.swift
@@ -5,6 +5,7 @@ import Wire
 
 public struct Mappy {
 
+    @DefaultEmpty
     public var things: [String : Thing]
     public var unknownFields: Data = .init()
 

--- a/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -22,6 +22,7 @@ public struct ModelEvaluation {
 
     public var name: String?
     public var score: Double?
+    @DefaultEmpty
     public var models: [String : ModelEvaluation]
     public var unknownFields: Data = .init()
 

--- a/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -11,6 +11,7 @@ public struct NestedVersionTwo {
     public var v2_f32: UInt32?
     @JSONString
     public var v2_f64: UInt64?
+    @DefaultEmpty
     public var v2_rs: [String]
     public var unknownFields: Data = .init()
 

--- a/wire-library/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/Person.swift
@@ -23,7 +23,9 @@ public struct Person {
     /**
      * A list of the customer's phone numbers.
      */
+    @DefaultEmpty
     public var phone: [PhoneNumber]
+    @DefaultEmpty
     public var aliases: [String]
     public var unknownFields: Data = .init()
 

--- a/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-library/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -11,6 +11,7 @@ public struct VersionTwo {
     public var v2_f32: UInt32?
     @JSONString
     public var v2_f64: UInt64?
+    @DefaultEmpty
     public var v2_rs: [String]
     public var obj: NestedVersionTwo?
     @JSONOptionalEnum


### PR DESCRIPTION
Builds upon https://github.com/square/wire/pull/2371

This creates a new propertyWrapper of `@DefaultEmpty`. 
It will automatically init a value via `init()` and (more importantly) will decode a nonexistent value with that same `.init()`