### PR TITLE
generateSwiftTests dependsOn(:wire-runtime-swift:generateTestProtos)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
             path: "wire-runtime-swift/src/main/swift"
         ),
         // The tests depend on valid protos via gradle
-        // ./gradlew :wire-runtime-swift:generateTestProtos
+        // ./gradlew generateSwiftProtos generateSwiftTests
         .testTarget(
             name: "WireRuntimeTests",
             dependencies: ["Wire"],

--- a/gen-tests.gradle.kts
+++ b/gen-tests.gradle.kts
@@ -430,7 +430,8 @@ val generateSwiftTests by tasks.creating {
   description = "Generates Swift classes from the test protos"
   dependsOn(
     generateSwiftProto2Tests,
-    generateSwiftProto3Tests
+    generateSwiftProto3Tests,
+    ":wire-runtime-swift:generateTestProtos"
   )
 }
 

--- a/wire-runtime-swift/README.md
+++ b/wire-runtime-swift/README.md
@@ -25,9 +25,7 @@ You can also just `open Package.swift`.
 To generate all swift protos, there are three different invocations:
 
 ```
-./gradlew :wire-runtime-swift:generateTestProtos
-./gradlew :wire-runtime-swift:generateSampleProtos
-./gradlew generateSwiftProto
+./gradlew generateSwiftProtos
 ./gradlew generateSwiftTests
 ```
 

--- a/wire-runtime-swift/README.md
+++ b/wire-runtime-swift/README.md
@@ -22,12 +22,13 @@ You can also just `open Package.swift`.
 
 ### Codegen
 
-To generate all swift protos, there are three different invocations:
+To generate all swift protos, there are a few different gradle jobs:
 
 ```
-./gradlew generateSwiftProtos
-./gradlew generateSwiftTests
+./gradlew generateSwiftProtos generateSwiftTests
 ```
+
+This implicitly will happen as part of the `Running Tests On the Command Line`
 
 ### Running Tests On the Command Line
 


### PR DESCRIPTION
This simplifies invocations / expectations when it comes to Swift development

```sh
./gradlew generateTests
# implicitly does generateSwiftTests (existing)
# implicitly does :wire-runtime-swift:generateTestProtos (new)
```