### PR TITLE
Restrict building the Swift WireCompiler to Mac only

### DIFF
--- a/WireCompiler.podspec
+++ b/WireCompiler.podspec
@@ -12,6 +12,8 @@ Pod::Spec.new do |s|
   s.source        = { :git => 'https://github.com/square/wire.git', :tag => version }
   s.module_name   = 'WireCompiler'
 
+  s.osx.deployment_target  = '10.15'
+
   s.prepare_command = <<-CMD
     curl https://repo.maven.apache.org/maven2/com/squareup/wire/wire-compiler/#{version}/wire-compiler-#{version}-jar-with-dependencies.jar --output compiler.jar
   CMD


### PR DESCRIPTION
Without a platform definition CocoaPods assumes you want to build for macOS, iOS, watchOS, and tvOS. It really only makes sense to run the Wire compiler on macOS, so restrict to that platform. This also makes the builds a little faster and the deployment process easier since you don't need all of the simulators to run the tests.