### PR TITLE
Wire Runtime changes to enable protoc integration

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/WireRun.kt
@@ -260,8 +260,10 @@ data class WireRun(
             target.outDirectory.toPath() / moduleName
           }
         val context = SchemaHandler.Context(
-          fileSystem = fs,
-          outDirectory = outDirectory,
+          fileWriter = FileSystemWriter(
+            fs,
+            outDirectory,
+          ),
           logger = logger,
           errorCollector = errorCollector,
           emittingRules = targetToEmittingRules.getValue(target),
@@ -271,6 +273,8 @@ data class WireRun(
           module = module,
           profileLoader = schemaLoader,
         )
+        // Ensure the out directory is created.
+        fs.createDirectories(outDirectory)
         handler.handle(partition.schema, context)
       }
     }

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/MarkdownHandler.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/MarkdownHandler.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema
 
 import okio.Path
+import okio.Path.Companion.toPath
 
 class MarkdownHandlerFactory : SchemaHandler.Factory {
   override fun create(): SchemaHandler = MarkdownHandler()
@@ -23,24 +24,21 @@ class MarkdownHandlerFactory : SchemaHandler.Factory {
 
 /** This is a sample handler that writes text files that describe types. */
 private class MarkdownHandler : SchemaHandler() {
-  override fun handle(type: Type, context: SchemaHandler.Context): Path {
+  override fun handle(type: Type, context: Context): Path {
     return writeMarkdownFile(type.type, toMarkdown(type), context)
   }
 
-  override fun handle(service: Service, context: SchemaHandler.Context): List<Path> {
+  override fun handle(service: Service, context: Context): List<Path> {
     return listOf(writeMarkdownFile(service.type, toMarkdown(service), context))
   }
 
-  override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? {
+  override fun handle(extend: Extend, field: Field, context: Context): Path? {
     return null
   }
 
-  private fun writeMarkdownFile(protoType: ProtoType, markdown: String, context: SchemaHandler.Context): Path {
-    val outDirectory = context.outDirectory
-    val fileSystem = context.fileSystem
-    val path = outDirectory / toPath(protoType).joinToString(separator = "/")
-    fileSystem.createDirectories(path.parent!!)
-    fileSystem.write(path) { writeUtf8(markdown) }
+  private fun writeMarkdownFile(protoType: ProtoType, markdown: String, context: Context): Path {
+    val path = toPath(protoType).joinToString(separator = "/").toPath()
+    context.fileWriter.write(path, markdown)
     return path
   }
 

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -597,7 +597,7 @@ class WireRunTest {
   class ErrorReportingCustomHandler : SchemaHandler.Factory {
     override fun create(): SchemaHandler {
       return object : SchemaHandler() {
-        override fun handle(type: Type, context: SchemaHandler.Context): Path? {
+        override fun handle(type: Type, context: Context): Path? {
           val errorCollector = context.errorCollector
           if ("descriptor.proto" in type.location.path) return null // Don't report errors on built-in stuff.
           if (type is MessageType) {
@@ -610,9 +610,9 @@ class WireRunTest {
           return null
         }
 
-        override fun handle(service: Service, context: SchemaHandler.Context): List<Path> = listOf()
+        override fun handle(service: Service, context: Context): List<Path> = listOf()
 
-        override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? = null
+        override fun handle(extend: Extend, field: Field, context: Context): Path? = null
       }
     }
   }
@@ -654,8 +654,10 @@ class WireRunTest {
     schemaHandlerFactory.create().handle(
       schema = schema,
       context = SchemaHandler.Context(
-        fileSystem = fs,
-        outDirectory = "out".toPath(),
+        fileWriter = FileSystemWriter(
+          fileSystem = fs,
+          outDirectory = "out".toPath(),
+        ),
         logger = NULL_LOGGER,
         errorCollector = errorCollector,
         claimedPaths = ClaimedPaths(),

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/ErrorReportingSchemaHandler.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/ErrorReportingSchemaHandler.kt
@@ -25,7 +25,7 @@ import okio.Path
 
 /** Sample schema validator that enforces a field naming pattern. */
 class ErrorReportingSchemaHandler : SchemaHandler() {
-  override fun handle(type: Type, context: SchemaHandler.Context): Path? {
+  override fun handle(type: Type, context: Context): Path? {
     val errorCollector = context.errorCollector
 
     if ("descriptor.proto" in type.location.path) return null // Don't report errors on built-in stuff.
@@ -39,7 +39,7 @@ class ErrorReportingSchemaHandler : SchemaHandler() {
     return null
   }
 
-  override fun handle(service: Service, context: SchemaHandler.Context): List<Path> = emptyList()
+  override fun handle(service: Service, context: Context): List<Path> = emptyList()
 
-  override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? = null
+  override fun handle(extend: Extend, field: Field, context: Context): Path? = null
 }

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/ErrorReportingSchemaHandlerTest.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/ErrorReportingSchemaHandlerTest.kt
@@ -18,6 +18,7 @@ package com.squareup.wire.recipes
 import com.squareup.wire.WireTestLogger
 import com.squareup.wire.buildSchema
 import com.squareup.wire.schema.ErrorCollector
+import com.squareup.wire.schema.FileSystemWriter
 import com.squareup.wire.schema.SchemaException
 import com.squareup.wire.schema.SchemaHandler
 import okio.Path.Companion.toPath
@@ -55,8 +56,10 @@ class ErrorReportingSchemaHandlerTest {
 
     val errorCollector = ErrorCollector()
     val context = SchemaHandler.Context(
-      fileSystem = FakeFileSystem(),
-      outDirectory = "out".toPath(),
+      fileWriter = FileSystemWriter(
+        fileSystem = FakeFileSystem(),
+        outDirectory = "out".toPath(),
+      ),
       logger = WireTestLogger(),
       errorCollector = errorCollector,
     )

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToFileHandler.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToFileHandler.kt
@@ -20,35 +20,33 @@ import com.squareup.wire.schema.Field
 import com.squareup.wire.schema.SchemaHandler
 import com.squareup.wire.schema.Service
 import com.squareup.wire.schema.Type
+import okio.FileSystem
 import okio.Path
 import okio.Path.Companion.toPath
 import okio.buffer
 
 /** Sample schema handler which writes to disk generated artifacts. */
-class LogToFileHandler : SchemaHandler() {
+class LogToFileHandler(private val fileSystem: FileSystem) : SchemaHandler() {
   private val filePath = "log.txt".toPath()
 
-  override fun handle(type: Type, context: SchemaHandler.Context): Path? {
-    context.fileSystem.appendingSink(filePath).buffer().use {
+  override fun handle(type: Type, context: Context): Path? {
+    fileSystem.appendingSink(filePath).buffer().use {
       it.writeUtf8("Generating type: ${type.type}\n")
     }
-
     return null
   }
 
-  override fun handle(service: Service, context: SchemaHandler.Context): List<Path> {
-    context.fileSystem.appendingSink(filePath).buffer().use {
+  override fun handle(service: Service, context: Context): List<Path> {
+    fileSystem.appendingSink(filePath).buffer().use {
       it.writeUtf8("Generating service: ${service.type}\n")
     }
-
     return listOf()
   }
 
-  override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? {
-    context.fileSystem.appendingSink(filePath).buffer().use {
+  override fun handle(extend: Extend, field: Field, context: Context): Path? {
+    fileSystem.appendingSink(filePath).buffer().use {
       it.writeUtf8("Generating ${extend.type} on ${field.location}\n")
     }
-
     return null
   }
 }

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToFileHandlerTest.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToFileHandlerTest.kt
@@ -17,6 +17,7 @@ package com.squareup.wire.recipes
 
 import com.squareup.wire.WireTestLogger
 import com.squareup.wire.buildSchema
+import com.squareup.wire.schema.FileSystemWriter
 import com.squareup.wire.schema.SchemaHandler
 import okio.BufferedSource
 import okio.Path.Companion.toPath
@@ -56,15 +57,18 @@ class LogToFileHandlerTest {
       )
     }
 
+    val fileSystem = FakeFileSystem()
     val context = SchemaHandler.Context(
-      fileSystem = FakeFileSystem(),
-      outDirectory = "/".toPath(),
+      fileWriter = FileSystemWriter(
+        fileSystem = fileSystem,
+        outDirectory = "/".toPath(),
+      ),
       logger = WireTestLogger(),
       sourcePathPaths = setOf("test/message.proto", "test/service.proto"),
     )
-    LogToFileHandler().handle(schema, context)
+    LogToFileHandler(fileSystem).handle(schema, context)
 
-    val content = context.fileSystem.read("log.txt".toPath(), BufferedSource::readUtf8)
+    val content = fileSystem.read("log.txt".toPath(), BufferedSource::readUtf8)
     val expected = """
         |Generating type: test.Request
         |Generating type: test.Response

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandler.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandler.kt
@@ -21,26 +21,27 @@ import com.squareup.wire.schema.SchemaHandler
 import com.squareup.wire.schema.Service
 import com.squareup.wire.schema.Type
 import okio.Path
+import okio.Path.Companion.toPath
 
 /** Sample schema handler which logs handled types and services. */
 class LogToWireLoggerHandler : SchemaHandler() {
-  override fun handle(type: Type, context: SchemaHandler.Context): Path? {
+  override fun handle(type: Type, context: Context): Path? {
     context.logger.artifactHandled(
-      context.outDirectory, type.type.enclosingTypeOrPackage ?: "", type.type.simpleName
+      "".toPath(), type.type.enclosingTypeOrPackage ?: "", type.type.simpleName
     )
 
     return null
   }
 
-  override fun handle(service: Service, context: SchemaHandler.Context): List<Path> {
+  override fun handle(service: Service, context: Context): List<Path> {
     context.logger.artifactHandled(
-      context.outDirectory, service.type.enclosingTypeOrPackage ?: "", service.type.simpleName
+      "".toPath(), service.type.enclosingTypeOrPackage ?: "", service.type.simpleName
     )
 
     return listOf()
   }
 
-  override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? {
+  override fun handle(extend: Extend, field: Field, context: Context): Path? {
     return null
   }
 }

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandler.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandler.kt
@@ -24,10 +24,10 @@ import okio.Path
 import okio.Path.Companion.toPath
 
 /** Sample schema handler which logs handled types and services. */
-class LogToWireLoggerHandler : SchemaHandler() {
+class LogToWireLoggerHandler(private val outDirectory: Path) : SchemaHandler() {
   override fun handle(type: Type, context: Context): Path? {
     context.logger.artifactHandled(
-      "".toPath(), type.type.enclosingTypeOrPackage ?: "", type.type.simpleName
+      outDirectory, type.type.enclosingTypeOrPackage ?: "", type.type.simpleName
     )
 
     return null
@@ -35,7 +35,7 @@ class LogToWireLoggerHandler : SchemaHandler() {
 
   override fun handle(service: Service, context: Context): List<Path> {
     context.logger.artifactHandled(
-      "".toPath(), service.type.enclosingTypeOrPackage ?: "", service.type.simpleName
+      outDirectory, service.type.enclosingTypeOrPackage ?: "", service.type.simpleName
     )
 
     return listOf()

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandlerTest.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandlerTest.kt
@@ -66,7 +66,7 @@ class LogToWireLoggerHandlerTest {
       logger = logger,
       sourcePathPaths = setOf("test/message.proto", "test/service.proto"),
     )
-    LogToWireLoggerHandler().handle(schema, context)
+    LogToWireLoggerHandler("out".toPath()).handle(schema, context)
 
     assertThat(logger.artifactHandled.removeFirst()).isEqualTo(Triple("out".toPath(), "test", "Request"))
     assertThat(logger.artifactHandled.removeFirst()).isEqualTo(Triple("out".toPath(), "test", "Response"))

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandlerTest.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/LogToWireLoggerHandlerTest.kt
@@ -19,6 +19,7 @@ package com.squareup.wire.recipes
 
 import com.squareup.wire.WireTestLogger
 import com.squareup.wire.buildSchema
+import com.squareup.wire.schema.FileSystemWriter
 import com.squareup.wire.schema.SchemaHandler
 import okio.Path.Companion.toPath
 import okio.fakefilesystem.FakeFileSystem
@@ -58,8 +59,10 @@ class LogToWireLoggerHandlerTest {
     }
     val logger = WireTestLogger()
     val context = SchemaHandler.Context(
-      fileSystem = FakeFileSystem(),
-      outDirectory = "out".toPath(),
+      fileWriter = FileSystemWriter(
+        fileSystem = FakeFileSystem(),
+        outDirectory = "out".toPath(),
+      ),
       logger = logger,
       sourcePathPaths = setOf("test/message.proto", "test/service.proto"),
     )

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/MarkdownHandler.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/MarkdownHandler.kt
@@ -22,31 +22,29 @@ import com.squareup.wire.schema.SchemaHandler
 import com.squareup.wire.schema.Service
 import com.squareup.wire.schema.Type
 import okio.Path
+import okio.Path.Companion.toPath
 
 /** Sample schema handler which generate Markdown files for types and services. */
 class MarkdownHandler : SchemaHandler() {
-  override fun handle(type: Type, context: SchemaHandler.Context): Path {
+  override fun handle(type: Type, context: Context): Path {
     return writeMarkdownFile(type.type, toMarkdown(type), context)
   }
 
-  override fun handle(service: Service, context: SchemaHandler.Context): List<Path> {
+  override fun handle(service: Service, context: Context): List<Path> {
     return listOf(writeMarkdownFile(service.type, toMarkdown(service), context))
   }
 
-  override fun handle(extend: Extend, field: Field, context: SchemaHandler.Context): Path? {
+  override fun handle(extend: Extend, field: Field, context: Context): Path? {
     return null
   }
 
   private fun writeMarkdownFile(
     protoType: ProtoType,
     markdown: String,
-    context: SchemaHandler.Context
+    context: Context
   ): Path {
-    val path = context.outDirectory / toPath(protoType).joinToString(separator = "/")
-    context.fileSystem.createDirectories(path.parent!!)
-    context.fileSystem.write(path) {
-      writeUtf8(markdown)
-    }
+    val path = toPath(protoType).joinToString(separator = "/").toPath()
+    context.fileWriter.write(path, markdown)
     return path
   }
 

--- a/wire-schema-tests/src/test/java/com/squareup/wire/recipes/MarkdownHandlerTest.kt
+++ b/wire-schema-tests/src/test/java/com/squareup/wire/recipes/MarkdownHandlerTest.kt
@@ -17,6 +17,7 @@ package com.squareup.wire.recipes
 
 import com.squareup.wire.WireTestLogger
 import com.squareup.wire.buildSchema
+import com.squareup.wire.schema.FileSystemWriter
 import com.squareup.wire.schema.SchemaHandler
 import com.squareup.wire.testing.containsRelativePaths
 import com.squareup.wire.testing.findFiles
@@ -72,8 +73,10 @@ class MarkdownHandlerTest {
 
     val fileSystem = FakeFileSystem()
     val context = SchemaHandler.Context(
-      fileSystem = fileSystem,
-      outDirectory = "generated/markdown".toPath(),
+      fileWriter = FileSystemWriter(
+        fileSystem = fileSystem,
+        outDirectory = "generated/markdown".toPath(),
+      ),
       logger = WireTestLogger(),
       sourcePathPaths = setOf("squareup/colors/red.proto", "squareup/colors/blue.proto"),
     )

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileSystemWriter.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileSystemWriter.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import okio.FileSystem
+import okio.Path
+
+class FileSystemWriter constructor(
+  /** To be used by the [SchemaHandler] for reading/writing operations on disk. */
+  private val fileSystem: FileSystem,
+  /** Location on [fileSystem] where the [SchemaHandler] is to write files, if it needs to. */
+  private val outDirectory: Path,
+): FileWriter {
+
+  override fun write(file: Path, content: String): Path {
+    val output = outDirectory / file
+    fileSystem.createDirectories(outDirectory / file.parent!!)
+    fileSystem.write(output, false) {
+      writeUtf8(content)
+    }
+    return output
+  }
+}

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileWriter.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/FileWriter.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2019 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import okio.Path
+
+interface FileWriter {
+  /**
+   * Write contents to the file.
+   *
+   * @param file the file.
+   * @param content the contents.
+   *
+   * @return the Path of the written file.
+   */
+  fun write(file: Path, content: String): Path
+}

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Linker.kt
@@ -70,7 +70,6 @@ class Linker {
   internal fun getFileLinker(path: String): FileLinker {
     val existing = fileLinkers[path]
     if (existing != null) return existing
-
     val protoFile = loader.withErrors(errors).load(path)
     val result = FileLinker(protoFile, withContext(protoFile))
     fileLinkers[path] = result
@@ -84,11 +83,15 @@ class Linker {
    */
   fun link(sourceProtoFiles: Iterable<ProtoFile>): Schema {
     val sourceFiles = mutableListOf<FileLinker>()
-    sourceFiles += getFileLinker("google/protobuf/descriptor.proto")
     for (sourceFile in sourceProtoFiles) {
       val fileLinker = FileLinker(sourceFile, withContext(sourceFile))
       fileLinkers[sourceFile.location.path] = fileLinker
       sourceFiles += fileLinker
+    }
+
+    // Ensure linking the descriptor.proto, if not provided.
+    if (fileLinkers["google/protobuf/descriptor.proto"] == null) {
+      sourceFiles += getFileLinker("google/protobuf/descriptor.proto")
     }
 
     // When loading exhaustively, every import (and transitive import!) is a source file.

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
@@ -17,7 +17,6 @@ package com.squareup.wire.schema
 
 import com.squareup.wire.WireLogger
 import com.squareup.wire.internal.Serializable
-import okio.FileSystem
 import okio.Path
 
 /** A [SchemaHandler] [handle]s [Schema]! */
@@ -65,11 +64,9 @@ abstract class SchemaHandler {
    * A [Context] holds the information necessary for a [SchemaHandler] to do its job. It contains
    * both helping objects such as [logger], and constraining objects such as [emittingRules].
    */
-  data class Context(
-    /** To be used by the [SchemaHandler] for reading/writing operations on disk. */
-    val fileSystem: FileSystem,
-    /** Location on [fileSystem] where the [SchemaHandler] is to write files, if it needs to. */
-    val outDirectory: Path,
+  data class Context constructor(
+    /** File writer which the [SchemaHandler] will use to write generated files. **/
+    val fileWriter: FileWriter,
     /** Event-listener like logger with which [SchemaHandler] can notify handled artifacts. */
     val logger: WireLogger,
     /**


### PR DESCRIPTION
Protoc integration requires overriding the file writing logic in the `SchemaHandler.Context` object. The change here is to abstract out the file writing capabilities in the `SchemaHandler.Context` object into an interface called `FileWriter` which will have the file system based writer which is currently used called `FileSystemWriter`.

The intention here is to break up the protoc integration into two PRs and have a more focused review of changes:
1. Changes needed to make the protoc integration work
2. The additive changes for the protoc integration module

