### PR TITLE
Swift: fix proto3 messages not always omitting fields with default values

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoEncoder.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoEncoder.swift
@@ -80,7 +80,11 @@ public final class ProtoEncoder {
         // Use the size of the struct as an initial estimate for the space needed.
         let structSize = MemoryLayout.size(ofValue: value)
 
-        let writer = ProtoWriter(data: .init(capacity: structSize))
+        let writer = ProtoWriter(
+            data: .init(capacity: structSize),
+            outputFormatting: [],
+            rootMessageProtoSyntax: T.self.protoSyntax ?? .proto2
+        )
         writer.outputFormatting = outputFormatting
         try value.encode(to: writer)
 

--- a/wire-runtime-swift/src/test/proto/empty.proto
+++ b/wire-runtime-swift/src/test/proto/empty.proto
@@ -18,3 +18,7 @@ syntax = "proto3";
 
 message EmptyMessage {
 }
+
+message EmptyOmitted {
+    int32 numeric_value = 1;
+}

--- a/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
+++ b/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
@@ -28,6 +28,14 @@ final class ProtoEncoderTests: XCTestCase {
         XCTAssertEqual(data, Data())
     }
 
+    func testEncodeEmptyProtoMessageWithIdentityValues() throws {
+        let object = EmptyOmitted(numeric_value: 0)
+        let encoder = ProtoEncoder()
+        let data = try encoder.encode(object)
+
+        XCTAssertEqual(data, Data())
+    }
+
     func testEncodeEmptyJSONMessage() throws {
         let object = EmptyMessage()
         let encoder = JSONEncoder()


### PR DESCRIPTION
Fix issue where proto3 messages with omitted values were still encoding those fields when at the top level of a message.

----

When encoding a message like: 
```
syntax = "proto3";

message EmptyOmitted {
    int32 numeric_value = 1;
}
``` 

`numeric_value` should be omitted when set to `0`.  In the current runtime however `isProto3` defaults to `false`, so the first pass through `encode(tag:value:encoding:)` would always fail the `if value == 0 && isProto3 { return }` test.

To fix that, I set the initial `isProto3` value to that syntax of the parent message.