### PR TITLE
Swift: Improve generated code for proto3 messages

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoCodable.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoCodable.swift
@@ -105,3 +105,18 @@ extension ProtoDecodable {
     }
 
 }
+
+extension ProtoEnum where Self : RawRepresentable, RawValue == UInt32 {
+
+    /**
+     A convenience function used with enum fields that throws an error if the field is null
+     and its default value can't be used instead.
+     */
+    public static func defaultIfMissing(_ value: Self?) throws -> Self {
+        guard let value = value ?? Self(rawValue: 0) else {
+            throw ProtoDecoder.Error.missingEnumDefaultValue(type: Self.self)
+        }
+        return value
+    }
+
+}

--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoDecoder.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoDecoder.swift
@@ -51,6 +51,7 @@ public final class ProtoDecoder {
         case mapEntryWithoutKey(value: Any?)
         case mapEntryWithoutValue(key: Any)
         case messageWithoutLength
+        case missingEnumDefaultValue(type: Any.Type)
         case missingRequiredField(typeName: String, fieldName: String)
         case recursionLimitExceeded
         case unexpectedEndOfData
@@ -80,6 +81,8 @@ public final class ProtoDecoder {
                 return "Map entry with \(key) did not include a value."
             case .messageWithoutLength:
                 return "Attempting to decode a message without first decoding the length of that message."
+            case let .missingEnumDefaultValue(type):
+                return "Could not assign a default value of 0 for enum type \(String(describing: type))"
             case let .missingRequiredField(typeName, fieldName):
                 return "Required field \(fieldName) for type \(typeName) is not included in the message data."
             case let .boxedValueMissingField(type):

--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoWriter.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoWriter.swift
@@ -145,6 +145,21 @@ public final class ProtoWriter {
         try value.encode(to: self)
     }
 
+    /** Encode a required `bool` field */
+    public func encode(tag: UInt32, value: Bool) throws {
+        if value == false && isProto3 { return }
+        try encode(tag: tag, value: value as Bool?)
+    }
+
+    /** Encode an optional `bool` field */
+    public func encode(tag: UInt32, value: Bool?) throws {
+        guard let value = value else { return }
+
+        let key = ProtoWriter.makeFieldKey(tag: tag, wireType: .varint)
+        writeVarint(key)
+        try value.encode(to: self)
+    }
+
     /** Encode a required `int32`, `sfixed32`, or `sint32` field */
     public func encode(tag: UInt32, value: Int32, encoding: ProtoIntEncoding = .variable) throws {
         // Don't encode default values if using proto3 syntax.

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
@@ -92,8 +92,8 @@ extension Duration : ProtoMessage {
 
 extension Duration : Proto3Codable {
     public init(from reader: ProtoReader) throws {
-        var seconds: Int64? = nil
-        var nanos: Int32? = nil
+        var seconds: Int64 = 0
+        var nanos: Int32 = 0
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
@@ -105,8 +105,8 @@ extension Duration : Proto3Codable {
         }
         self.unknownFields = try reader.endMessage(token: token)
 
-        self.seconds = try Duration.checkIfMissing(seconds, "seconds")
-        self.nanos = try Duration.checkIfMissing(nanos, "nanos")
+        self.seconds = seconds
+        self.nanos = nanos
     }
 
     public func encode(to writer: ProtoWriter) throws {

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
@@ -104,8 +104,8 @@ extension Timestamp : ProtoMessage {
 
 extension Timestamp : Proto3Codable {
     public init(from reader: ProtoReader) throws {
-        var seconds: Int64? = nil
-        var nanos: Int32? = nil
+        var seconds: Int64 = 0
+        var nanos: Int32 = 0
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
@@ -117,8 +117,8 @@ extension Timestamp : Proto3Codable {
         }
         self.unknownFields = try reader.endMessage(token: token)
 
-        self.seconds = try Timestamp.checkIfMissing(seconds, "seconds")
-        self.nanos = try Timestamp.checkIfMissing(nanos, "nanos")
+        self.seconds = seconds
+        self.nanos = nanos
     }
 
     public func encode(to writer: ProtoWriter) throws {

--- a/wire-runtime-swift/src/test/proto/empty.proto
+++ b/wire-runtime-swift/src/test/proto/empty.proto
@@ -20,5 +20,21 @@ message EmptyMessage {
 }
 
 message EmptyOmitted {
+    enum EmptyEnum {
+      UNKNOWN = 0;
+      OTHER = 1;
+    }
+
+    message EmptyNested {
+        int32 nested = 1;
+    }
+
     int32 numeric_value = 1;
+    string string_value = 2;
+    bytes bytes_value = 3;
+    bool bool_value = 4;
+    EmptyEnum enum_value = 5;
+    EmptyNested message_value = 6;
+    repeated string repeated_value = 7;
+    map<int32, string> map_value = 8;
 }

--- a/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
+++ b/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
@@ -29,7 +29,7 @@ final class ProtoEncoderTests: XCTestCase {
     }
 
     func testEncodeEmptyProtoMessageWithIdentityValues() throws {
-        let object = EmptyOmitted(numeric_value: 0)
+        let object = EmptyOmitted(numeric_value: 0, string_value: "", bytes_value: .init(), bool_value: false, enum_value: .UNKNOWN)
         let encoder = ProtoEncoder()
         let data = try encoder.encode(object)
 

--- a/wire-runtime-swift/src/test/swift/RoundTripTests.swift
+++ b/wire-runtime-swift/src/test/swift/RoundTripTests.swift
@@ -38,4 +38,26 @@ final class RoundTripTests: XCTestCase {
         XCTAssertEqual(decodedPerson, person)
     }
 
+    // ensure that fields set to their identity value survive a roundtrip when omitted over the wire
+    func testProto3IdentityValues() throws {
+        let empty = EmptyOmitted(
+            numeric_value: 0,
+            string_value: "",
+            bytes_value: Data(),
+            bool_value: false,
+            enum_value: .UNKNOWN,
+            message_value: nil,
+            repeated_value: [],
+            map_value: [:]
+        )
+
+        let encoder = ProtoEncoder()
+        let data = try encoder.encode(empty)
+
+        let decoder = ProtoDecoder()
+        let decodedEmpty = try decoder.decode(EmptyOmitted.self, from: data)
+
+        XCTAssertEqual(decodedEmpty, empty)
+    }
+
 }


### PR DESCRIPTION
- Inserts proto3 default values into generated Swift code where applicable
- Adds an `encode(tag:value:)` pair for `Bool` so that it can be correctly omitted when `false`

-------

```diff
@@ -88,7 +88,7 @@ extension Person3.PhoneNumber : ProtoMessage {
 
 extension Person3.PhoneNumber : Proto3Codable {
     public init(from reader: ProtoReader) throws {
-        var number: String? = nil
+        var number: String = ""
         var type: Person3.PhoneType? = nil
 
         let token = try reader.beginMessage()
@@ -101,8 +101,8 @@ extension Person3.PhoneNumber : Proto3Codable {
         }
         self.unknownFields = try reader.endMessage(token: token)
 
-        self.number = try Person3.PhoneNumber.checkIfMissing(number, "number")
-        self.type = try Person3.PhoneNumber.checkIfMissing(type, "type")
+        self.number = number
+        self.type = try Person3.PhoneType.defaultIfMissing(type)
     }
 
     public func encode(to writer: ProtoWriter) throws {
@@ -157,8 +157,8 @@ extension Person3 : ProtoMessage {
 
 extension Person3 : Proto3Codable {
     public init(from reader: ProtoReader) throws {
-        var name: String? = nil
-        var id: Int32? = nil
+        var name: String = ""
+        var id: Int32 = 0
         var email: String? = nil
         var phone: [Person3.PhoneNumber] = []
         var aliases: [String] = []
@@ -178,8 +178,8 @@ extension Person3 : Proto3Codable {
         }
         self.unknownFields = try reader.endMessage(token: token)
 
-        self.name = try Person3.checkIfMissing(name, "name")
-        self.id = try Person3.checkIfMissing(id, "id")
+        self.name = name
+        self.id = id
         self.email = email
         self.phone = phone
         self.aliases = aliases
```