### PR TITLE
Swift: encode & decode size-delimited messages

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/WriteBuffer.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/WriteBuffer.swift
@@ -49,6 +49,8 @@ final class WriteBuffer {
     // MARK: - Public Methods
 
     func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+
         expandIfNeeded(adding: data.count)
 
         data.copyBytes(to: storage.advanced(by: count), count: data.count)
@@ -63,6 +65,8 @@ final class WriteBuffer {
     }
 
     func append(_ value: [UInt8]) {
+        guard !value.isEmpty else { return }
+
         expandIfNeeded(adding: value.count)
 
         for byte in value {
@@ -73,6 +77,8 @@ final class WriteBuffer {
 
     func append(_ value: WriteBuffer) {
         precondition(value !== self)
+        guard value.count > 0 else { return }
+
         expandIfNeeded(adding: value.count)
 
         memcpy(storage.advanced(by: count), value.storage, value.count)
@@ -80,6 +86,8 @@ final class WriteBuffer {
     }
 
     func append(_ value: UnsafeRawBufferPointer) {
+        guard value.count > 0 else { return }
+        
         expandIfNeeded(adding: value.count)
 
         memcpy(storage.advanced(by: count), value.baseAddress, value.count)

--- a/wire-runtime-swift/src/test/swift/ProtoDecoderTests.swift
+++ b/wire-runtime-swift/src/test/swift/ProtoDecoderTests.swift
@@ -25,6 +25,13 @@ final class ProtoDecoderTests: XCTestCase {
         XCTAssertEqual(object, SimpleOptional2())
     }
 
+    func testDecodeEmptySizeDelimitedData() throws {
+        let decoder = ProtoDecoder()
+        let object = try decoder.decodeSizeDelimited(SimpleOptional2.self, from: Foundation.Data())
+
+        XCTAssertEqual(object, [])
+    }
+
     func testDecodeEmptyDataTwice() throws {
         let decoder = ProtoDecoder()
         // The empty message case is optimized to reuse objects, so make sure

--- a/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
+++ b/wire-runtime-swift/src/test/swift/ProtoEncoderTests.swift
@@ -43,4 +43,12 @@ final class ProtoEncoderTests: XCTestCase {
 
         XCTAssertEqual(jsonString, "{}")
     }
+
+    func testEncodeEmptySizeDelimitedMessage() throws {
+        let object = EmptyMessage()
+        let encoder = ProtoEncoder()
+        let data = try encoder.encodeSizeDelimited([object])
+
+        XCTAssertEqual(data, Foundation.Data())
+    }
 }

--- a/wire-runtime-swift/src/test/swift/RoundTripTests.swift
+++ b/wire-runtime-swift/src/test/swift/RoundTripTests.swift
@@ -61,4 +61,20 @@ final class RoundTripTests: XCTestCase {
         XCTAssertEqual(decodedEmpty, empty)
     }
 
+    func testSizeDelimited() throws {
+        let values = [
+            Person3(name: "John Doe", id: 123),
+            Person3(name: "Jane Doe", id: 456) {
+                $0.email = "jdoe@example.com"
+            }
+        ]
+
+        let encoder = ProtoEncoder()
+        let data = try encoder.encodeSizeDelimited(values)
+
+        let decoder = ProtoDecoder()
+        let decodedValues = try decoder.decodeSizeDelimited(Person3.self, from: data)
+
+        XCTAssertEqual(decodedValues, values)
+    }
 }

--- a/wire-runtime-swift/src/test/swift/WriteBufferTests.swift
+++ b/wire-runtime-swift/src/test/swift/WriteBufferTests.swift
@@ -59,4 +59,11 @@ final class WriteBufferTests: XCTestCase {
         XCTAssertEqual(Foundation.Data(buffer, copyBytes: true), Foundation.Data(hexEncoded: "0011"))
     }
 
+    func testAppendEmptyFirst() {
+        let buffer = WriteBuffer()
+        buffer.append(Foundation.Data())
+
+        XCTAssertEqual(Foundation.Data(buffer, copyBytes: true), Foundation.Data())
+    }
+
 }


### PR DESCRIPTION
Adds the ability to encode and decode a size-delimited message collection in Swift.  

The intended use case is to decode a stream of messages recorded to disk (e.g., [Bazel's Build Event Protocol](https://bazel.build/remote/bep#consuming-bep-binary)). Similar implementations exist in Java ([writeDelimitedTo](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/MessageLite.html#writeDelimitedTo-java.io.OutputStream-) and [parseDelimitedFrom](https://developers.google.com/protocol-buffers/docs/reference/java/com/google/protobuf/AbstractParser.html#parseDelimitedFrom-java.io.InputStream-)) and other languages in https://github.com/protocolbuffers/protobuf/issues/10229.