### PR TITLE
Adds schemaIndex to WireField

### DIFF
--- a/wire-compiler/build.gradle.kts
+++ b/wire-compiler/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
 }
 
 val shadowJar by tasks.getting(ShadowJar::class) {
-  classifier = "jar-with-dependencies"
+  archiveClassifier.set("jar-with-dependencies")
 }
 
 if (project.rootProject.name == "wire") {

--- a/wire-gson-support/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
@@ -160,563 +160,648 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   @WireField(
       tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 1
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 2
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 3
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 4
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 5
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 6
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 7
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 8
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 9
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 10
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 11
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 12
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 13
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 14
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 15
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 16
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 17
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 18
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 19
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 20
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 21
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 22
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 23
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 24
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 25
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 26
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 27
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 28
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 29
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 30
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 31
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 32
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 33
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 34
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 35
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 36
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 37
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 38
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 39
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 40
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 41
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 42
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 43
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 44
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 45
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 46
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 47
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 48
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 49
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 50
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 51
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 52
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 53
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 54
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 55
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 56
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 57
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 58
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 59
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 60
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 61
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 62
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 63
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 64
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 65
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 66
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 67
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 68
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 69
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 70
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 71
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 72
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 73
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 74
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 75
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 76
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 77
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 78
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 79
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 80
   )
   public final NestedEnum default_nested_enum;
 
   @WireField(
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 81
   )
   public final Map<Integer, Integer> map_int32_int32;
 
   @WireField(
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 82
   )
   public final Map<String, String> map_string_string;
 
   @WireField(
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 83
   )
   public final Map<String, NestedMessage> map_string_message;
 
   @WireField(
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 84
   )
   public final Map<String, NestedEnum> map_string_enum;
 
@@ -725,7 +810,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1001,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 85
   )
   public final Integer ext_opt_int32;
 
@@ -734,7 +820,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1002,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 86
   )
   public final Integer ext_opt_uint32;
 
@@ -743,7 +830,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1003,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 87
   )
   public final Integer ext_opt_sint32;
 
@@ -752,7 +840,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1004,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 88
   )
   public final Integer ext_opt_fixed32;
 
@@ -761,7 +850,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1005,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 89
   )
   public final Integer ext_opt_sfixed32;
 
@@ -770,7 +860,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1006,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 90
   )
   public final Long ext_opt_int64;
 
@@ -779,7 +870,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1007,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 91
   )
   public final Long ext_opt_uint64;
 
@@ -788,7 +880,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1008,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 92
   )
   public final Long ext_opt_sint64;
 
@@ -797,7 +890,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1009,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 93
   )
   public final Long ext_opt_fixed64;
 
@@ -806,7 +900,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1010,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 94
   )
   public final Long ext_opt_sfixed64;
 
@@ -815,7 +910,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1011,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 95
   )
   public final Boolean ext_opt_bool;
 
@@ -824,7 +920,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1012,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 96
   )
   public final Float ext_opt_float;
 
@@ -833,7 +930,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1013,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 97
   )
   public final Double ext_opt_double;
 
@@ -842,7 +940,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1014,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 98
   )
   public final String ext_opt_string;
 
@@ -851,7 +950,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1015,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 99
   )
   public final ByteString ext_opt_bytes;
 
@@ -860,7 +960,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1016,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 100
   )
   public final NestedEnum ext_opt_nested_enum;
 
@@ -869,7 +970,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1017,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 101
   )
   public final NestedMessage ext_opt_nested_message;
 
@@ -879,7 +981,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 102
   )
   public final List<Integer> ext_rep_int32;
 
@@ -889,7 +992,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 103
   )
   public final List<Integer> ext_rep_uint32;
 
@@ -899,7 +1003,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 104
   )
   public final List<Integer> ext_rep_sint32;
 
@@ -909,7 +1014,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 105
   )
   public final List<Integer> ext_rep_fixed32;
 
@@ -919,7 +1025,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 106
   )
   public final List<Integer> ext_rep_sfixed32;
 
@@ -929,7 +1036,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 107
   )
   public final List<Long> ext_rep_int64;
 
@@ -939,7 +1047,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 108
   )
   public final List<Long> ext_rep_uint64;
 
@@ -949,7 +1058,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 109
   )
   public final List<Long> ext_rep_sint64;
 
@@ -959,7 +1069,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 110
   )
   public final List<Long> ext_rep_fixed64;
 
@@ -969,7 +1080,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 111
   )
   public final List<Long> ext_rep_sfixed64;
 
@@ -979,7 +1091,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 112
   )
   public final List<Boolean> ext_rep_bool;
 
@@ -989,7 +1102,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 113
   )
   public final List<Float> ext_rep_float;
 
@@ -999,7 +1113,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 114
   )
   public final List<Double> ext_rep_double;
 
@@ -1009,7 +1124,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 115
   )
   public final List<String> ext_rep_string;
 
@@ -1019,7 +1135,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 116
   )
   public final List<ByteString> ext_rep_bytes;
 
@@ -1029,7 +1146,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 117
   )
   public final List<NestedEnum> ext_rep_nested_enum;
 
@@ -1039,7 +1157,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 118
   )
   public final List<NestedMessage> ext_rep_nested_message;
 
@@ -1049,7 +1168,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 119
   )
   public final List<Integer> ext_pack_int32;
 
@@ -1059,7 +1179,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 120
   )
   public final List<Integer> ext_pack_uint32;
 
@@ -1069,7 +1190,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 121
   )
   public final List<Integer> ext_pack_sint32;
 
@@ -1079,7 +1201,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 122
   )
   public final List<Integer> ext_pack_fixed32;
 
@@ -1089,7 +1212,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 123
   )
   public final List<Integer> ext_pack_sfixed32;
 
@@ -1099,7 +1223,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 124
   )
   public final List<Long> ext_pack_int64;
 
@@ -1109,7 +1234,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 125
   )
   public final List<Long> ext_pack_uint64;
 
@@ -1119,7 +1245,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 126
   )
   public final List<Long> ext_pack_sint64;
 
@@ -1129,7 +1256,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 127
   )
   public final List<Long> ext_pack_fixed64;
 
@@ -1139,7 +1267,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 128
   )
   public final List<Long> ext_pack_sfixed64;
 
@@ -1149,7 +1278,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 129
   )
   public final List<Boolean> ext_pack_bool;
 
@@ -1159,7 +1289,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 130
   )
   public final List<Float> ext_pack_float;
 
@@ -1169,7 +1300,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 131
   )
   public final List<Double> ext_pack_double;
 
@@ -1179,28 +1311,32 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 132
   )
   public final List<NestedEnum> ext_pack_nested_enum;
 
   @WireField(
       tag = 601,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 133
   )
   public final String oneof_string;
 
   @WireField(
       tag = 602,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 134
   )
   public final Integer oneof_int32;
 
   @WireField(
       tag = 603,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 135
   )
   public final NestedMessage oneof_nested_message;
 

--- a/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -449,6 +449,37 @@ public final class JavaGeneratorTest {
         + "    public final String c;");
   }
 
+  @Test public void unsortedTagsPrintSchemaIndex() throws IOException {
+    Schema schema = new SchemaBuilder()
+      .add(Path.get("message.proto"), ""
+        + "message A {\n"
+        + "  optional string two = 2;\n"
+        + "  optional string one = 1;\n"
+        + "}\n")
+      .build();
+    MessageType message = (MessageType) schema.getType("A");
+    JavaGenerator javaGenerator = JavaGenerator.get(schema).withAndroidAnnotations(true);
+    TypeSpec typeSpec = javaGenerator.generateType(message);
+    String javaOutput = JavaFile.builder("", typeSpec).build().toString();
+    System.out.println(javaOutput);
+    assertThat(javaOutput).contains(""
+      + "  @WireField(\n"
+      + "      tag = 2,\n"
+      + "      adapter = \"com.squareup.wire.ProtoAdapter#STRING\",\n"
+      + "      schemaIndex = 0\n"
+      + "  )\n"
+      + "  @Nullable\n"
+      + "  public final String two;");
+    assertThat(javaOutput).contains(""
+      + "  @WireField(\n"
+      + "      tag = 1,\n"
+      + "      adapter = \"com.squareup.wire.ProtoAdapter#STRING\",\n"
+      + "      schemaIndex = 1\n"
+      + "  )\n"
+      + "  @Nullable\n"
+      + "  public final String one;");
+  }
+
   @Test public void androidSupport() throws IOException {
     Schema schema = new SchemaBuilder()
         .add(Path.get("message.proto"), ""

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1954,50 +1954,59 @@ class KotlinGeneratorTest {
       |  @field:WireField(
       |    tag = 1,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    schemaIndex = 0,
       |  )
       |  public val a: String? = null,
       |  @field:WireField(
       |    tag = 2,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    schemaIndex = 1,
       |  )
       |  public val b: String? = null,
       |  @field:WireField(
       |    tag = 3,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
       |    oneofName = "choice",
+      |    schemaIndex = 2,
       |  )
       |  public val c: String? = null,
       |  @field:WireField(
       |    tag = 8,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
       |    oneofName = "choice",
+      |    schemaIndex = 3,
       |  )
       |  public val d: String? = null,
       |  @field:WireField(
       |    tag = 4,
       |    adapter = "SecretData#ADAPTER",
+      |    schemaIndex = 4,
       |  )
       |  public val secret_data: SecretData? = null,
       |  @field:WireField(
       |    tag = 5,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    schemaIndex = 5,
       |  )
       |  public val e: String? = null,
       |  public val decision: OneOf<Decision<*>, *>? = null,
       |  @field:WireField(
       |    tag = 10,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    schemaIndex = 6,
       |  )
       |  public val i: String? = null,
       |  @field:WireField(
       |    tag = 12,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
       |    oneofName = "unique",
+      |    schemaIndex = 7,
       |  )
       |  public val j: String? = null,
       |  @field:WireField(
       |    tag = 11,
       |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      |    schemaIndex = 8,
       |  )
       |  public val k: String? = null,
       |  unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
@@ -160,563 +160,648 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   @WireField(
       tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 1
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 2
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 3
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 4
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 5
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 6
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 7
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 8
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 9
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 10
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 11
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 12
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 13
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 14
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 15
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 16
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 17
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 18
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 19
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 20
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 21
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 22
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 23
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 24
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 25
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 26
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 27
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 28
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 29
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 30
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 31
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 32
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 33
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 34
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 35
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 36
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 37
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 38
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 39
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 40
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 41
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 42
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 43
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 44
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 45
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 46
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 47
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 48
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 49
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 50
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 51
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 52
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 53
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 54
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 55
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 56
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 57
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 58
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 59
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 60
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 61
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 62
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 63
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 64
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 65
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 66
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 67
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 68
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 69
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 70
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 71
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 72
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 73
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 74
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 75
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 76
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 77
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 78
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 79
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 80
   )
   public final NestedEnum default_nested_enum;
 
   @WireField(
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 81
   )
   public final Map<Integer, Integer> map_int32_int32;
 
   @WireField(
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 82
   )
   public final Map<String, String> map_string_string;
 
   @WireField(
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 83
   )
   public final Map<String, NestedMessage> map_string_message;
 
   @WireField(
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 84
   )
   public final Map<String, NestedEnum> map_string_enum;
 
@@ -725,7 +810,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1001,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 85
   )
   public final Integer ext_opt_int32;
 
@@ -734,7 +820,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1002,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 86
   )
   public final Integer ext_opt_uint32;
 
@@ -743,7 +830,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1003,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 87
   )
   public final Integer ext_opt_sint32;
 
@@ -752,7 +840,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1004,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 88
   )
   public final Integer ext_opt_fixed32;
 
@@ -761,7 +850,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1005,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 89
   )
   public final Integer ext_opt_sfixed32;
 
@@ -770,7 +860,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1006,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 90
   )
   public final Long ext_opt_int64;
 
@@ -779,7 +870,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1007,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 91
   )
   public final Long ext_opt_uint64;
 
@@ -788,7 +880,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1008,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 92
   )
   public final Long ext_opt_sint64;
 
@@ -797,7 +890,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1009,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 93
   )
   public final Long ext_opt_fixed64;
 
@@ -806,7 +900,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1010,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 94
   )
   public final Long ext_opt_sfixed64;
 
@@ -815,7 +910,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1011,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 95
   )
   public final Boolean ext_opt_bool;
 
@@ -824,7 +920,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1012,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 96
   )
   public final Float ext_opt_float;
 
@@ -833,7 +930,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1013,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 97
   )
   public final Double ext_opt_double;
 
@@ -842,7 +940,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1014,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 98
   )
   public final String ext_opt_string;
 
@@ -851,7 +950,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1015,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 99
   )
   public final ByteString ext_opt_bytes;
 
@@ -860,7 +960,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1016,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 100
   )
   public final NestedEnum ext_opt_nested_enum;
 
@@ -869,7 +970,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1017,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 101
   )
   public final NestedMessage ext_opt_nested_message;
 
@@ -879,7 +981,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 102
   )
   public final List<Integer> ext_rep_int32;
 
@@ -889,7 +992,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 103
   )
   public final List<Integer> ext_rep_uint32;
 
@@ -899,7 +1003,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 104
   )
   public final List<Integer> ext_rep_sint32;
 
@@ -909,7 +1014,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 105
   )
   public final List<Integer> ext_rep_fixed32;
 
@@ -919,7 +1025,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 106
   )
   public final List<Integer> ext_rep_sfixed32;
 
@@ -929,7 +1036,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 107
   )
   public final List<Long> ext_rep_int64;
 
@@ -939,7 +1047,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 108
   )
   public final List<Long> ext_rep_uint64;
 
@@ -949,7 +1058,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 109
   )
   public final List<Long> ext_rep_sint64;
 
@@ -959,7 +1069,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 110
   )
   public final List<Long> ext_rep_fixed64;
 
@@ -969,7 +1080,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 111
   )
   public final List<Long> ext_rep_sfixed64;
 
@@ -979,7 +1091,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 112
   )
   public final List<Boolean> ext_rep_bool;
 
@@ -989,7 +1102,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 113
   )
   public final List<Float> ext_rep_float;
 
@@ -999,7 +1113,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 114
   )
   public final List<Double> ext_rep_double;
 
@@ -1009,7 +1124,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 115
   )
   public final List<String> ext_rep_string;
 
@@ -1019,7 +1135,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 116
   )
   public final List<ByteString> ext_rep_bytes;
 
@@ -1029,7 +1146,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 117
   )
   public final List<NestedEnum> ext_rep_nested_enum;
 
@@ -1039,7 +1157,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 118
   )
   public final List<NestedMessage> ext_rep_nested_message;
 
@@ -1049,7 +1168,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 119
   )
   public final List<Integer> ext_pack_int32;
 
@@ -1059,7 +1179,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 120
   )
   public final List<Integer> ext_pack_uint32;
 
@@ -1069,7 +1190,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 121
   )
   public final List<Integer> ext_pack_sint32;
 
@@ -1079,7 +1201,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 122
   )
   public final List<Integer> ext_pack_fixed32;
 
@@ -1089,7 +1212,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 123
   )
   public final List<Integer> ext_pack_sfixed32;
 
@@ -1099,7 +1223,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 124
   )
   public final List<Long> ext_pack_int64;
 
@@ -1109,7 +1234,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 125
   )
   public final List<Long> ext_pack_uint64;
 
@@ -1119,7 +1245,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 126
   )
   public final List<Long> ext_pack_sint64;
 
@@ -1129,7 +1256,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 127
   )
   public final List<Long> ext_pack_fixed64;
 
@@ -1139,7 +1267,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 128
   )
   public final List<Long> ext_pack_sfixed64;
 
@@ -1149,7 +1278,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 129
   )
   public final List<Boolean> ext_pack_bool;
 
@@ -1159,7 +1289,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 130
   )
   public final List<Float> ext_pack_float;
 
@@ -1169,7 +1300,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 131
   )
   public final List<Double> ext_pack_double;
 
@@ -1179,28 +1311,32 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 132
   )
   public final List<NestedEnum> ext_pack_nested_enum;
 
   @WireField(
       tag = 601,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 133
   )
   public final String oneof_string;
 
   @WireField(
       tag = 602,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 134
   )
   public final Integer oneof_int32;
 
   @WireField(
       tag = 603,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 135
   )
   public final NestedMessage oneof_nested_message;
 

--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
@@ -62,6 +62,12 @@ annotation class WireField(
    * field is part of a oneof.
    */
   val oneofName: String = "",
+  /**
+   * This is the order that this field was declared in the `.proto` schema.
+   *
+   * It is -1 if their tags are declared in ascending order.
+   */
+  val schemaIndex: Int = -1,
 ) {
 
   /** A protocol buffer label.  */

--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/KotlinConstructorBuilder.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/KotlinConstructorBuilder.kt
@@ -125,6 +125,7 @@ internal class KotlinConstructorBuilder<M : Message<M, B>, B : Message.Builder<M
         .firstOrNull()
       return@mapNotNull wireField?.let { ProtoField(field.type, wireField) }
     }
+    .sortedBy { it.wireField.schemaIndex }
 
   private class ProtoField(
     // TODO(Benoit) Delete if unused?

--- a/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-tests-swift/src/main/swift/Person.swift
@@ -9,13 +9,13 @@ import Wire
 public struct Person {
 
     /**
-     * The customer's full name.
-     */
-    public var name: String
-    /**
      * The customer's ID number.
      */
     public var id: Int32
+    /**
+     * The customer's full name.
+     */
+    public var name: String
     /**
      * Email address for the customer.
      */
@@ -28,14 +28,14 @@ public struct Person {
     public var unknownFields: Data = .init()
 
     public init(
-        name: String,
         id: Int32,
+        name: String,
         email: String? = nil,
         phone: [PhoneNumber] = [],
         aliases: [String] = []
     ) {
-        self.name = name
         self.id = id
+        self.name = name
         self.email = email
         self.phone = phone
         self.aliases = aliases
@@ -179,8 +179,8 @@ extension Person : ProtoMessage {
 
 extension Person : Proto2Codable {
     public init(from reader: ProtoReader) throws {
-        var name: String? = nil
         var id: Int32? = nil
+        var name: String? = nil
         var email: String? = nil
         var phone: [Person.PhoneNumber] = []
         var aliases: [String] = []
@@ -188,8 +188,8 @@ extension Person : Proto2Codable {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: name = try reader.decode(String.self)
             case 2: id = try reader.decode(Int32.self)
+            case 1: name = try reader.decode(String.self)
             case 3: email = try reader.decode(String.self)
             case 4: try reader.decode(into: &phone)
             case 5: try reader.decode(into: &aliases)
@@ -198,16 +198,16 @@ extension Person : Proto2Codable {
         }
         self.unknownFields = try reader.endMessage(token: token)
 
-        self.name = try Person.checkIfMissing(name, "name")
         self.id = try Person.checkIfMissing(id, "id")
+        self.name = try Person.checkIfMissing(name, "name")
         self.email = email
         self.phone = phone
         self.aliases = aliases
     }
 
     public func encode(to writer: ProtoWriter) throws {
-        try writer.encode(tag: 1, value: self.name)
         try writer.encode(tag: 2, value: self.id)
+        try writer.encode(tag: 1, value: self.name)
         try writer.encode(tag: 3, value: self.email)
         try writer.encode(tag: 4, value: self.phone)
         try writer.encode(tag: 5, value: self.aliases)
@@ -219,8 +219,8 @@ extension Person : Proto2Codable {
 extension Person : Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.name = try container.decode(String.self, forKey: "name")
         self.id = try container.decode(Int32.self, forKey: "id")
+        self.name = try container.decode(String.self, forKey: "name")
         self.email = try container.decodeIfPresent(String.self, forKey: "email")
         self.phone = try container.decodeProtoArray(Person.PhoneNumber.self, forKey: "phone")
         self.aliases = try container.decodeProtoArray(String.self, forKey: "aliases")
@@ -230,11 +230,11 @@ extension Person : Codable {
         var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
-        if includeDefaults || !self.name.isEmpty {
-            try container.encode(self.name, forKey: "name")
-        }
         if includeDefaults || self.id != 0 {
             try container.encode(self.id, forKey: "id")
+        }
+        if includeDefaults || !self.name.isEmpty {
+            try container.encode(self.name, forKey: "name")
         }
         try container.encodeIfPresent(self.email, forKey: "email")
         if includeDefaults || !self.phone.isEmpty {

--- a/wire-tests-swift/src/test/swift/JsonLitmusTest.swift
+++ b/wire-tests-swift/src/test/swift/JsonLitmusTest.swift
@@ -21,8 +21,8 @@ import XCTest
 final class JsonLitmusTest : XCTestCase {
     func testSimpleRoundtrip() {
         let expectedPerson = Person(
-            name: "Luke Skywalker",
             id: 42,
+            name: "Luke Skywalker",
             email: "luke@skywalker.net",
             phone: [.init(number: "800-555-1234", type: .WORK)],
             aliases: ["Nerfherder"]

--- a/wire-tests/src/commonTest/kotlin/com/squareup/wire/WireTest.kt
+++ b/wire-tests/src/commonTest/kotlin/com/squareup/wire/WireTest.kt
@@ -76,8 +76,8 @@ class WireTest {
       aliases = listOf("B-lo,ved", "D{esperado}")
     )
     val expected = """Person{
-          |name=Such\, I mean it\, such \[a\] \{funny\} name.
-          |, id=1
+          |id=1
+          |, name=Such\, I mean it\, such \[a\] \{funny\} name.
           |, phone=[PhoneNumber{number=123\,456\,789}]
           |, aliases=[B-lo\,ved, D\{esperado\}]
           |}""".trimMargin().replace("\n", "")

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -37,29 +37,32 @@ import okio.ByteString
  */
 public class Person(
   /**
-   * The customer's full name.
-   */
-  @field:WireField(
-    tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REQUIRED,
-  )
-  public val name: String,
-  /**
    * The customer's ID number.
    */
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 0,
   )
   public val id: Int,
+  /**
+   * The customer's full name.
+   */
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REQUIRED,
+    schemaIndex = 1,
+  )
+  public val name: String,
   /**
    * Email address for the customer.
    */
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   public val email: String? = null,
   phone: List<PhoneNumber> = emptyList(),
@@ -73,6 +76,7 @@ public class Person(
     tag = 4,
     adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 3,
   )
   public val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
 
@@ -80,6 +84,7 @@ public class Person(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   public val aliases: List<String> = immutableCopyOf("aliases", aliases)
 
@@ -94,8 +99,8 @@ public class Person(
     if (other === this) return true
     if (other !is Person) return false
     if (unknownFields != other.unknownFields) return false
-    if (name != other.name) return false
     if (id != other.id) return false
+    if (name != other.name) return false
     if (email != other.email) return false
     if (phone != other.phone) return false
     if (aliases != other.aliases) return false
@@ -106,8 +111,8 @@ public class Person(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
+      result = result * 37 + name.hashCode()
       result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       result = result * 37 + aliases.hashCode()
@@ -118,8 +123,8 @@ public class Person(
 
   public override fun toString(): String {
     val result = mutableListOf<String>()
-    result += """name=${sanitize(name)}"""
     result += """id=$id"""
+    result += """name=${sanitize(name)}"""
     if (email != null) result += """email=${sanitize(email)}"""
     if (phone.isNotEmpty()) result += """phone=$phone"""
     if (aliases.isNotEmpty()) result += """aliases=${sanitize(aliases)}"""
@@ -127,13 +132,13 @@ public class Person(
   }
 
   public fun copy(
-    name: String = this.name,
     id: Int = this.id,
+    name: String = this.name,
     email: String? = this.email,
     phone: List<PhoneNumber> = this.phone,
     aliases: List<String> = this.aliases,
     unknownFields: ByteString = this.unknownFields,
-  ): Person = Person(name, id, email, phone, aliases, unknownFields)
+  ): Person = Person(id, name, email, phone, aliases, unknownFields)
 
   public companion object {
     @JvmField
@@ -147,8 +152,8 @@ public class Person(
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
-        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
         size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
@@ -156,8 +161,8 @@ public class Person(
       }
 
       public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
-        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
@@ -169,20 +174,20 @@ public class Person(
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
-        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
       }
 
       public override fun decode(reader: ProtoReader): Person {
-        var name: String? = null
         var id: Int? = null
+        var name: String? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
         val aliases = mutableListOf<String>()
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
-            1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
+            1 -> name = ProtoAdapter.STRING.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
             5 -> aliases.add(ProtoAdapter.STRING.decode(reader))
@@ -190,8 +195,8 @@ public class Person(
           }
         }
         return Person(
-          name = name ?: throw missingRequiredFields(name, "name"),
           id = id ?: throw missingRequiredFields(id, "id"),
+          name = name ?: throw missingRequiredFields(name, "name"),
           email = email,
           phone = phone,
           aliases = aliases,

--- a/wire-tests/src/commonTest/proto/java/person.proto
+++ b/wire-tests/src/commonTest/proto/java/person.proto
@@ -19,10 +19,10 @@ option java_package = "com.squareup.wire.protos.person";
 option java_outer_classname = "PersonProtos";
 
 message Person {
-  // The customer's full name.
-  required string name = 1;
   // The customer's ID number.
   required int32 id = 2;
+  // The customer's full name.
+  required string name = 1;
   // Email address for the customer.
   optional string email = 3;
 

--- a/wire-tests/src/commonTest/proto/kotlin/person.proto
+++ b/wire-tests/src/commonTest/proto/kotlin/person.proto
@@ -22,10 +22,10 @@ option java_outer_classname = "PersonProtos";
  * Message representing a person, includes their name, unique ID number, email and phone number.
  */
 message Person {
-  // The customer's full name.
-  required string name = 1;
   // The customer's ID number.
   required int32 id = 2;
+  // The customer's full name.
+  required string name = 1;
   // Email address for the customer.
   optional string email = 3;
 

--- a/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -36,7 +36,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 0
   )
   public final Integer id;
 
@@ -46,7 +47,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 1
   )
   public final String name;
 
@@ -55,7 +57,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 2
   )
   public final String email;
 
@@ -65,14 +68,16 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 3
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 4
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -24,21 +24,11 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
 
   private static final long serialVersionUID = 0L;
 
-  public static final String DEFAULT_NAME = "";
-
   public static final Integer DEFAULT_ID = 0;
 
-  public static final String DEFAULT_EMAIL = "";
+  public static final String DEFAULT_NAME = "";
 
-  /**
-   * The customer's full name.
-   */
-  @WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
-  )
-  public final String name;
+  public static final String DEFAULT_EMAIL = "";
 
   /**
    * The customer's ID number.
@@ -49,6 +39,16 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
       label = WireField.Label.REQUIRED
   )
   public final Integer id;
+
+  /**
+   * The customer's full name.
+   */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED
+  )
+  public final String name;
 
   /**
    * Email address for the customer.
@@ -76,16 +76,16 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   )
   public final List<String> aliases;
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases) {
-    this(name, id, email, phone, aliases, ByteString.EMPTY);
+    this(id, name, email, phone, aliases, ByteString.EMPTY);
   }
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
-    this.name = name;
     this.id = id;
+    this.name = name;
     this.email = email;
     this.phone = Internal.immutableCopyOf("phone", phone);
     this.aliases = Internal.immutableCopyOf("aliases", aliases);
@@ -94,8 +94,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.name = name;
     builder.id = id;
+    builder.name = name;
     builder.email = email;
     builder.phone = Internal.copyOf(phone);
     builder.aliases = Internal.copyOf(aliases);
@@ -109,8 +109,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
     return unknownFields().equals(o.unknownFields())
-        && name.equals(o.name)
         && id.equals(o.id)
+        && name.equals(o.name)
         && Internal.equals(email, o.email)
         && phone.equals(o.phone)
         && aliases.equals(o.aliases);
@@ -121,8 +121,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + name.hashCode();
       result = result * 37 + id.hashCode();
+      result = result * 37 + name.hashCode();
       result = result * 37 + (email != null ? email.hashCode() : 0);
       result = result * 37 + phone.hashCode();
       result = result * 37 + aliases.hashCode();
@@ -132,9 +132,9 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   }
 
   public static final class Builder extends Message.Builder<Person, Builder> {
-    public String name;
-
     public Integer id;
+
+    public String name;
 
     public String email;
 
@@ -148,18 +148,18 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     }
 
     /**
-     * The customer's full name.
-     */
-    public Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    /**
      * The customer's ID number.
      */
     public Builder id(Integer id) {
       this.id = id;
+      return this;
+    }
+
+    /**
+     * The customer's full name.
+     */
+    public Builder name(String name) {
+      this.name = name;
       return this;
     }
 
@@ -188,12 +188,12 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
 
     @Override
     public Person build() {
-      if (name == null
-          || id == null) {
-        throw Internal.missingRequiredFields(name, "name",
-            id, "id");
+      if (id == null
+          || name == null) {
+        throw Internal.missingRequiredFields(id, "id",
+            name, "name");
       }
-      return new Person(name, id, email, phone, aliases, super.buildUnknownFields());
+      return new Person(id, name, email, phone, aliases, super.buildUnknownFields());
     }
   }
 

--- a/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -31,21 +31,11 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
 
   private static final long serialVersionUID = 0L;
 
-  public static final String DEFAULT_NAME = "";
-
   public static final Integer DEFAULT_ID = 0;
 
-  public static final String DEFAULT_EMAIL = "";
+  public static final String DEFAULT_NAME = "";
 
-  /**
-   * The customer's full name.
-   */
-  @WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
-  )
-  public final String name;
+  public static final String DEFAULT_EMAIL = "";
 
   /**
    * The customer's ID number.
@@ -56,6 +46,16 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
       label = WireField.Label.REQUIRED
   )
   public final Integer id;
+
+  /**
+   * The customer's full name.
+   */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED
+  )
+  public final String name;
 
   /**
    * Email address for the customer.
@@ -83,16 +83,16 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   )
   public final List<String> aliases;
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases) {
-    this(name, id, email, phone, aliases, ByteString.EMPTY);
+    this(id, name, email, phone, aliases, ByteString.EMPTY);
   }
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
-    this.name = name;
     this.id = id;
+    this.name = name;
     this.email = email;
     this.phone = Internal.immutableCopyOf("phone", phone);
     this.aliases = Internal.immutableCopyOf("aliases", aliases);
@@ -101,8 +101,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.name = name;
     builder.id = id;
+    builder.name = name;
     builder.email = email;
     builder.phone = Internal.copyOf(phone);
     builder.aliases = Internal.copyOf(aliases);
@@ -116,8 +116,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
     return unknownFields().equals(o.unknownFields())
-        && name.equals(o.name)
         && id.equals(o.id)
+        && name.equals(o.name)
         && Internal.equals(email, o.email)
         && phone.equals(o.phone)
         && aliases.equals(o.aliases);
@@ -128,8 +128,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + name.hashCode();
       result = result * 37 + id.hashCode();
+      result = result * 37 + name.hashCode();
       result = result * 37 + (email != null ? email.hashCode() : 0);
       result = result * 37 + phone.hashCode();
       result = result * 37 + aliases.hashCode();
@@ -141,8 +141,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    builder.append(", name=").append(Internal.sanitize(name));
     builder.append(", id=").append(id);
+    builder.append(", name=").append(Internal.sanitize(name));
     if (email != null) builder.append(", email=").append(Internal.sanitize(email));
     if (!phone.isEmpty()) builder.append(", phone=").append(phone);
     if (!aliases.isEmpty()) builder.append(", aliases=").append(Internal.sanitize(aliases));
@@ -150,9 +150,9 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   }
 
   public static final class Builder extends Message.Builder<Person, Builder> {
-    public String name;
-
     public Integer id;
+
+    public String name;
 
     public String email;
 
@@ -166,18 +166,18 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     }
 
     /**
-     * The customer's full name.
-     */
-    public Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    /**
      * The customer's ID number.
      */
     public Builder id(Integer id) {
       this.id = id;
+      return this;
+    }
+
+    /**
+     * The customer's full name.
+     */
+    public Builder name(String name) {
+      this.name = name;
       return this;
     }
 
@@ -206,12 +206,12 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
 
     @Override
     public Person build() {
-      if (name == null
-          || id == null) {
-        throw Internal.missingRequiredFields(name, "name",
-            id, "id");
+      if (id == null
+          || name == null) {
+        throw Internal.missingRequiredFields(id, "id",
+            name, "name");
       }
-      return new Person(name, id, email, phone, aliases, super.buildUnknownFields());
+      return new Person(id, name, email, phone, aliases, super.buildUnknownFields());
     }
   }
 
@@ -443,8 +443,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
     @Override
     public int encodedSize(Person value) {
       int result = 0;
-      result += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name);
       result += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id);
+      result += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name);
       result += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email);
       result += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone);
       result += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases);
@@ -454,8 +454,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
 
     @Override
     public void encode(ProtoWriter writer, Person value) throws IOException {
-      ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
+      ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
       PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases);
@@ -468,8 +468,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
       ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases);
       PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
-      ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
       ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
+      ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
     }
 
     @Override

--- a/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -43,7 +43,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 0
   )
   public final Integer id;
 
@@ -53,7 +54,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 1
   )
   public final String name;
 
@@ -62,7 +64,8 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 2
   )
   public final String email;
 
@@ -72,14 +75,16 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 3
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 4
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -27,21 +27,11 @@ public final class Person extends Message<Person, Person.Builder> {
 
   private static final long serialVersionUID = 0L;
 
-  public static final String DEFAULT_NAME = "";
-
   public static final Integer DEFAULT_ID = 0;
 
-  public static final String DEFAULT_EMAIL = "";
+  public static final String DEFAULT_NAME = "";
 
-  /**
-   * The customer's full name.
-   */
-  @WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
-  )
-  public final String name;
+  public static final String DEFAULT_EMAIL = "";
 
   /**
    * The customer's ID number.
@@ -52,6 +42,16 @@ public final class Person extends Message<Person, Person.Builder> {
       label = WireField.Label.REQUIRED
   )
   public final Integer id;
+
+  /**
+   * The customer's full name.
+   */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED
+  )
+  public final String name;
 
   /**
    * Email address for the customer.
@@ -79,16 +79,16 @@ public final class Person extends Message<Person, Person.Builder> {
   )
   public final List<String> aliases;
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases) {
-    this(name, id, email, phone, aliases, ByteString.EMPTY);
+    this(id, name, email, phone, aliases, ByteString.EMPTY);
   }
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
-    this.name = name;
     this.id = id;
+    this.name = name;
     this.email = email;
     this.phone = Internal.immutableCopyOf("phone", phone);
     this.aliases = Internal.immutableCopyOf("aliases", aliases);
@@ -97,8 +97,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.name = name;
     builder.id = id;
+    builder.name = name;
     builder.email = email;
     builder.phone = Internal.copyOf(phone);
     builder.aliases = Internal.copyOf(aliases);
@@ -112,8 +112,8 @@ public final class Person extends Message<Person, Person.Builder> {
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
     return unknownFields().equals(o.unknownFields())
-        && name.equals(o.name)
         && id.equals(o.id)
+        && name.equals(o.name)
         && Internal.equals(email, o.email)
         && phone.equals(o.phone)
         && aliases.equals(o.aliases);
@@ -124,8 +124,8 @@ public final class Person extends Message<Person, Person.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + name.hashCode();
       result = result * 37 + id.hashCode();
+      result = result * 37 + name.hashCode();
       result = result * 37 + (email != null ? email.hashCode() : 0);
       result = result * 37 + phone.hashCode();
       result = result * 37 + aliases.hashCode();
@@ -137,8 +137,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    builder.append(", name=").append(Internal.sanitize(name));
     builder.append(", id=").append(id);
+    builder.append(", name=").append(Internal.sanitize(name));
     if (email != null) builder.append(", email=").append(Internal.sanitize(email));
     if (!phone.isEmpty()) builder.append(", phone=").append(phone);
     if (!aliases.isEmpty()) builder.append(", aliases=").append(Internal.sanitize(aliases));
@@ -146,9 +146,9 @@ public final class Person extends Message<Person, Person.Builder> {
   }
 
   public static final class Builder extends Message.Builder<Person, Builder> {
-    public String name;
-
     public Integer id;
+
+    public String name;
 
     public String email;
 
@@ -162,18 +162,18 @@ public final class Person extends Message<Person, Person.Builder> {
     }
 
     /**
-     * The customer's full name.
-     */
-    public Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    /**
      * The customer's ID number.
      */
     public Builder id(Integer id) {
       this.id = id;
+      return this;
+    }
+
+    /**
+     * The customer's full name.
+     */
+    public Builder name(String name) {
+      this.name = name;
       return this;
     }
 
@@ -202,12 +202,12 @@ public final class Person extends Message<Person, Person.Builder> {
 
     @Override
     public Person build() {
-      if (name == null
-          || id == null) {
-        throw Internal.missingRequiredFields(name, "name",
-            id, "id");
+      if (id == null
+          || name == null) {
+        throw Internal.missingRequiredFields(id, "id",
+            name, "name");
       }
-      return new Person(name, id, email, phone, aliases, super.buildUnknownFields());
+      return new Person(id, name, email, phone, aliases, super.buildUnknownFields());
     }
   }
 
@@ -437,8 +437,8 @@ public final class Person extends Message<Person, Person.Builder> {
     @Override
     public int encodedSize(Person value) {
       int result = 0;
-      result += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name);
       result += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id);
+      result += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name);
       result += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email);
       result += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone);
       result += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases);
@@ -448,8 +448,8 @@ public final class Person extends Message<Person, Person.Builder> {
 
     @Override
     public void encode(ProtoWriter writer, Person value) throws IOException {
-      ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
+      ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
       PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases);
@@ -462,8 +462,8 @@ public final class Person extends Message<Person, Person.Builder> {
       ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases);
       PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
-      ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
       ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
+      ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
     }
 
     @Override

--- a/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -39,7 +39,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 0
   )
   public final Integer id;
 
@@ -49,7 +50,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 1
   )
   public final String name;
 
@@ -58,7 +60,8 @@ public final class Person extends Message<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 2
   )
   public final String email;
 
@@ -68,14 +71,16 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 3
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 4
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJavaTest/java/com/squareup/wire/ProtoAdapterTest.java
+++ b/wire-tests/src/jvmJavaTest/java/com/squareup/wire/ProtoAdapterTest.java
@@ -31,7 +31,7 @@ public final class ProtoAdapterTest {
         .id(99)
         .name("Omar Little")
         .build();
-    ByteString encoded = ByteString.decodeHex("0a0b4f6d6172204c6974746c651063");
+    ByteString encoded = ByteString.decodeHex("10630a0b4f6d6172204c6974746c65");
 
     ProtoAdapter<Person> personAdapter = ProtoAdapter.get(Person.class);
     assertThat(ByteString.of(personAdapter.encode(person))).isEqualTo(encoded);

--- a/wire-tests/src/jvmJavaTest/java/com/squareup/wire/WireTest.java
+++ b/wire-tests/src/jvmJavaTest/java/com/squareup/wire/WireTest.java
@@ -392,8 +392,8 @@ public class WireTest {
     String printedPerson = person.toString();
     assertThat(printedPerson).isEqualTo(
         "Person{"
-            + "name=Such\\, I mean it\\, such \\[a\\] \\{funny\\} name., "
             + "id=1, "
+            + "name=Such\\, I mean it\\, such \\[a\\] \\{funny\\} name., "
             + "phone=[PhoneNumber{number=123\\,456\\,789}], "
             + "aliases=[B-lo\\,ved, D\\{esperado\\}]"
             + "}");

--- a/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -27,21 +27,11 @@ public final class Person extends Message<Person, Person.Builder> {
 
   private static final long serialVersionUID = 0L;
 
-  public static final String DEFAULT_NAME = "";
-
   public static final Integer DEFAULT_ID = 0;
 
-  public static final String DEFAULT_EMAIL = "";
+  public static final String DEFAULT_NAME = "";
 
-  /**
-   * The customer's full name.
-   */
-  @WireField(
-      tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
-  )
-  public final String name;
+  public static final String DEFAULT_EMAIL = "";
 
   /**
    * The customer's ID number.
@@ -52,6 +42,16 @@ public final class Person extends Message<Person, Person.Builder> {
       label = WireField.Label.REQUIRED
   )
   public final Integer id;
+
+  /**
+   * The customer's full name.
+   */
+  @WireField(
+      tag = 1,
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      label = WireField.Label.REQUIRED
+  )
+  public final String name;
 
   /**
    * Email address for the customer.
@@ -79,16 +79,16 @@ public final class Person extends Message<Person, Person.Builder> {
   )
   public final List<String> aliases;
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases) {
-    this(name, id, email, phone, aliases, ByteString.EMPTY);
+    this(id, name, email, phone, aliases, ByteString.EMPTY);
   }
 
-  public Person(String name, Integer id, String email, List<PhoneNumber> phone,
+  public Person(Integer id, String name, String email, List<PhoneNumber> phone,
       List<String> aliases, ByteString unknownFields) {
     super(ADAPTER, unknownFields);
-    this.name = name;
     this.id = id;
+    this.name = name;
     this.email = email;
     this.phone = Internal.immutableCopyOf("phone", phone);
     this.aliases = Internal.immutableCopyOf("aliases", aliases);
@@ -97,8 +97,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @Override
   public Builder newBuilder() {
     Builder builder = new Builder();
-    builder.name = name;
     builder.id = id;
+    builder.name = name;
     builder.email = email;
     builder.phone = Internal.copyOf(phone);
     builder.aliases = Internal.copyOf(aliases);
@@ -112,8 +112,8 @@ public final class Person extends Message<Person, Person.Builder> {
     if (!(other instanceof Person)) return false;
     Person o = (Person) other;
     return unknownFields().equals(o.unknownFields())
-        && name.equals(o.name)
         && id.equals(o.id)
+        && name.equals(o.name)
         && Internal.equals(email, o.email)
         && phone.equals(o.phone)
         && aliases.equals(o.aliases);
@@ -124,8 +124,8 @@ public final class Person extends Message<Person, Person.Builder> {
     int result = super.hashCode;
     if (result == 0) {
       result = unknownFields().hashCode();
-      result = result * 37 + name.hashCode();
       result = result * 37 + id.hashCode();
+      result = result * 37 + name.hashCode();
       result = result * 37 + (email != null ? email.hashCode() : 0);
       result = result * 37 + phone.hashCode();
       result = result * 37 + aliases.hashCode();
@@ -137,8 +137,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
-    builder.append(", name=").append(Internal.sanitize(name));
     builder.append(", id=").append(id);
+    builder.append(", name=").append(Internal.sanitize(name));
     if (email != null) builder.append(", email=").append(Internal.sanitize(email));
     if (!phone.isEmpty()) builder.append(", phone=").append(phone);
     if (!aliases.isEmpty()) builder.append(", aliases=").append(Internal.sanitize(aliases));
@@ -146,9 +146,9 @@ public final class Person extends Message<Person, Person.Builder> {
   }
 
   public static final class Builder extends Message.Builder<Person, Builder> {
-    public String name;
-
     public Integer id;
+
+    public String name;
 
     public String email;
 
@@ -162,18 +162,18 @@ public final class Person extends Message<Person, Person.Builder> {
     }
 
     /**
-     * The customer's full name.
-     */
-    public Builder name(String name) {
-      this.name = name;
-      return this;
-    }
-
-    /**
      * The customer's ID number.
      */
     public Builder id(Integer id) {
       this.id = id;
+      return this;
+    }
+
+    /**
+     * The customer's full name.
+     */
+    public Builder name(String name) {
+      this.name = name;
       return this;
     }
 
@@ -202,12 +202,12 @@ public final class Person extends Message<Person, Person.Builder> {
 
     @Override
     public Person build() {
-      if (name == null
-          || id == null) {
-        throw Internal.missingRequiredFields(name, "name",
-            id, "id");
+      if (id == null
+          || name == null) {
+        throw Internal.missingRequiredFields(id, "id",
+            name, "name");
       }
-      return new Person(name, id, email, phone, aliases, super.buildUnknownFields());
+      return new Person(id, name, email, phone, aliases, super.buildUnknownFields());
     }
   }
 
@@ -437,8 +437,8 @@ public final class Person extends Message<Person, Person.Builder> {
     @Override
     public int encodedSize(Person value) {
       int result = 0;
-      result += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name);
       result += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id);
+      result += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name);
       result += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email);
       result += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone);
       result += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases);
@@ -448,8 +448,8 @@ public final class Person extends Message<Person, Person.Builder> {
 
     @Override
     public void encode(ProtoWriter writer, Person value) throws IOException {
-      ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
+      ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
       ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
       PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases);
@@ -462,8 +462,8 @@ public final class Person extends Message<Person, Person.Builder> {
       ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases);
       PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone);
       ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email);
-      ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
       ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name);
+      ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id);
     }
 
     @Override

--- a/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -39,7 +39,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 0
   )
   public final Integer id;
 
@@ -49,7 +50,8 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 1
   )
   public final String name;
 
@@ -58,7 +60,8 @@ public final class Person extends Message<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 2
   )
   public final String email;
 
@@ -68,14 +71,16 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 3
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 4
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/com/squareup/wire/proto2/alltypes/AllTypes.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/com/squareup/wire/proto2/alltypes/AllTypes.java
@@ -160,563 +160,648 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   @WireField(
       tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 1
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 2
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 3
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 4
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 5
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 6
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 7
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 8
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 9
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 10
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 11
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 12
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 13
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 14
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 15
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 16
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 17
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 18
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 19
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 20
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 21
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 22
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 23
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 24
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 25
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 26
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 27
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 28
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 29
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 30
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 31
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 32
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REQUIRED
+      label = WireField.Label.REQUIRED,
+      schemaIndex = 33
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 34
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 35
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 36
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 37
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 38
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 39
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 40
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 41
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 42
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 43
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 44
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 45
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 46
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 47
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 48
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 49
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 50
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 51
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 52
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 53
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 54
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 55
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 56
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 57
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 58
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 59
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 60
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 61
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 62
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 63
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 64
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 65
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 66
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 67
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 68
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 69
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 70
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 71
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 72
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 73
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 74
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 75
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 76
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 77
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 78
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 79
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 80
   )
   public final NestedEnum default_nested_enum;
 
   @WireField(
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 81
   )
   public final Map<Integer, Integer> map_int32_int32;
 
   @WireField(
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 82
   )
   public final Map<String, String> map_string_string;
 
   @WireField(
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 83
   )
   public final Map<String, NestedMessage> map_string_message;
 
   @WireField(
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 84
   )
   public final Map<String, NestedEnum> map_string_enum;
 
@@ -725,7 +810,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1001,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32"
+      adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 85
   )
   public final Integer ext_opt_int32;
 
@@ -734,7 +820,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1002,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+      schemaIndex = 86
   )
   public final Integer ext_opt_uint32;
 
@@ -743,7 +830,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1003,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+      schemaIndex = 87
   )
   public final Integer ext_opt_sint32;
 
@@ -752,7 +840,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1004,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+      schemaIndex = 88
   )
   public final Integer ext_opt_fixed32;
 
@@ -761,7 +850,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1005,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+      schemaIndex = 89
   )
   public final Integer ext_opt_sfixed32;
 
@@ -770,7 +860,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1006,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64"
+      adapter = "com.squareup.wire.ProtoAdapter#INT64",
+      schemaIndex = 90
   )
   public final Long ext_opt_int64;
 
@@ -779,7 +870,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1007,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+      schemaIndex = 91
   )
   public final Long ext_opt_uint64;
 
@@ -788,7 +880,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1008,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+      schemaIndex = 92
   )
   public final Long ext_opt_sint64;
 
@@ -797,7 +890,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1009,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+      schemaIndex = 93
   )
   public final Long ext_opt_fixed64;
 
@@ -806,7 +900,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1010,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+      schemaIndex = 94
   )
   public final Long ext_opt_sfixed64;
 
@@ -815,7 +910,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1011,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+      schemaIndex = 95
   )
   public final Boolean ext_opt_bool;
 
@@ -824,7 +920,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1012,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+      schemaIndex = 96
   )
   public final Float ext_opt_float;
 
@@ -833,7 +930,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1013,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+      schemaIndex = 97
   )
   public final Double ext_opt_double;
 
@@ -842,7 +940,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1014,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING"
+      adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 98
   )
   public final String ext_opt_string;
 
@@ -851,7 +950,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1015,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+      schemaIndex = 99
   )
   public final ByteString ext_opt_bytes;
 
@@ -860,7 +960,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1016,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
+      schemaIndex = 100
   )
   public final NestedEnum ext_opt_nested_enum;
 
@@ -869,7 +970,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1017,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
+      schemaIndex = 101
   )
   public final NestedMessage ext_opt_nested_message;
 
@@ -879,7 +981,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 102
   )
   public final List<Integer> ext_rep_int32;
 
@@ -889,7 +992,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 103
   )
   public final List<Integer> ext_rep_uint32;
 
@@ -899,7 +1003,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 104
   )
   public final List<Integer> ext_rep_sint32;
 
@@ -909,7 +1014,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 105
   )
   public final List<Integer> ext_rep_fixed32;
 
@@ -919,7 +1025,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 106
   )
   public final List<Integer> ext_rep_sfixed32;
 
@@ -929,7 +1036,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 107
   )
   public final List<Long> ext_rep_int64;
 
@@ -939,7 +1047,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 108
   )
   public final List<Long> ext_rep_uint64;
 
@@ -949,7 +1058,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 109
   )
   public final List<Long> ext_rep_sint64;
 
@@ -959,7 +1069,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 110
   )
   public final List<Long> ext_rep_fixed64;
 
@@ -969,7 +1080,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 111
   )
   public final List<Long> ext_rep_sfixed64;
 
@@ -979,7 +1091,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 112
   )
   public final List<Boolean> ext_rep_bool;
 
@@ -989,7 +1102,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 113
   )
   public final List<Float> ext_rep_float;
 
@@ -999,7 +1113,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 114
   )
   public final List<Double> ext_rep_double;
 
@@ -1009,7 +1124,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 115
   )
   public final List<String> ext_rep_string;
 
@@ -1019,7 +1135,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 116
   )
   public final List<ByteString> ext_rep_bytes;
 
@@ -1029,7 +1146,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 117
   )
   public final List<NestedEnum> ext_rep_nested_enum;
 
@@ -1039,7 +1157,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED
+      label = WireField.Label.REPEATED,
+      schemaIndex = 118
   )
   public final List<NestedMessage> ext_rep_nested_message;
 
@@ -1049,7 +1168,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 119
   )
   public final List<Integer> ext_pack_int32;
 
@@ -1059,7 +1179,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 120
   )
   public final List<Integer> ext_pack_uint32;
 
@@ -1069,7 +1190,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 121
   )
   public final List<Integer> ext_pack_sint32;
 
@@ -1079,7 +1201,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 122
   )
   public final List<Integer> ext_pack_fixed32;
 
@@ -1089,7 +1212,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 123
   )
   public final List<Integer> ext_pack_sfixed32;
 
@@ -1099,7 +1223,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 124
   )
   public final List<Long> ext_pack_int64;
 
@@ -1109,7 +1234,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 125
   )
   public final List<Long> ext_pack_uint64;
 
@@ -1119,7 +1245,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 126
   )
   public final List<Long> ext_pack_sint64;
 
@@ -1129,7 +1256,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 127
   )
   public final List<Long> ext_pack_fixed64;
 
@@ -1139,7 +1267,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 128
   )
   public final List<Long> ext_pack_sfixed64;
 
@@ -1149,7 +1278,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 129
   )
   public final List<Boolean> ext_pack_bool;
 
@@ -1159,7 +1289,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 130
   )
   public final List<Float> ext_pack_float;
 
@@ -1169,7 +1300,8 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 131
   )
   public final List<Double> ext_pack_double;
 
@@ -1179,28 +1311,32 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED
+      label = WireField.Label.PACKED,
+      schemaIndex = 132
   )
   public final List<NestedEnum> ext_pack_nested_enum;
 
   @WireField(
       tag = 601,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 133
   )
   public final String oneof_string;
 
   @WireField(
       tag = 602,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 134
   )
   public final Integer oneof_int32;
 
   @WireField(
       tag = 603,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 135
   )
   public final NestedMessage oneof_nested_message;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All32.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All32.java
@@ -30,7 +30,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myInt32"
+      jsonName = "myInt32",
+      schemaIndex = 0
   )
   public final int my_int32;
 
@@ -38,7 +39,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myUint32"
+      jsonName = "myUint32",
+      schemaIndex = 1
   )
   public final int my_uint32;
 
@@ -46,7 +48,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySint32"
+      jsonName = "mySint32",
+      schemaIndex = 2
   )
   public final int my_sint32;
 
@@ -54,7 +57,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 4,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myFixed32"
+      jsonName = "myFixed32",
+      schemaIndex = 3
   )
   public final int my_fixed32;
 
@@ -62,7 +66,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySfixed32"
+      jsonName = "mySfixed32",
+      schemaIndex = 4
   )
   public final int my_sfixed32;
 
@@ -70,7 +75,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED,
-      jsonName = "repInt32"
+      jsonName = "repInt32",
+      schemaIndex = 5
   )
   public final List<Integer> rep_int32;
 
@@ -78,7 +84,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.REPEATED,
-      jsonName = "repUint32"
+      jsonName = "repUint32",
+      schemaIndex = 6
   )
   public final List<Integer> rep_uint32;
 
@@ -86,7 +93,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.REPEATED,
-      jsonName = "repSint32"
+      jsonName = "repSint32",
+      schemaIndex = 7
   )
   public final List<Integer> rep_sint32;
 
@@ -94,7 +102,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.REPEATED,
-      jsonName = "repFixed32"
+      jsonName = "repFixed32",
+      schemaIndex = 8
   )
   public final List<Integer> rep_fixed32;
 
@@ -102,7 +111,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.REPEATED,
-      jsonName = "repSfixed32"
+      jsonName = "repSfixed32",
+      schemaIndex = 9
   )
   public final List<Integer> rep_sfixed32;
 
@@ -110,7 +120,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.PACKED,
-      jsonName = "packInt32"
+      jsonName = "packInt32",
+      schemaIndex = 10
   )
   public final List<Integer> pack_int32;
 
@@ -118,7 +129,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.PACKED,
-      jsonName = "packUint32"
+      jsonName = "packUint32",
+      schemaIndex = 11
   )
   public final List<Integer> pack_uint32;
 
@@ -126,7 +138,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.PACKED,
-      jsonName = "packSint32"
+      jsonName = "packSint32",
+      schemaIndex = 12
   )
   public final List<Integer> pack_sint32;
 
@@ -134,7 +147,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.PACKED,
-      jsonName = "packFixed32"
+      jsonName = "packFixed32",
+      schemaIndex = 13
   )
   public final List<Integer> pack_fixed32;
 
@@ -142,7 +156,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.PACKED,
-      jsonName = "packSfixed32"
+      jsonName = "packSfixed32",
+      schemaIndex = 14
   )
   public final List<Integer> pack_sfixed32;
 
@@ -150,7 +165,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      jsonName = "mapInt32Int32"
+      jsonName = "mapInt32Int32",
+      schemaIndex = 15
   )
   public final Map<Integer, Integer> map_int32_int32;
 
@@ -158,7 +174,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      jsonName = "mapInt32Uint32"
+      jsonName = "mapInt32Uint32",
+      schemaIndex = 16
   )
   public final Map<Integer, Integer> map_int32_uint32;
 
@@ -166,7 +183,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      jsonName = "mapInt32Sint32"
+      jsonName = "mapInt32Sint32",
+      schemaIndex = 17
   )
   public final Map<Integer, Integer> map_int32_sint32;
 
@@ -174,7 +192,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      jsonName = "mapInt32Fixed32"
+      jsonName = "mapInt32Fixed32",
+      schemaIndex = 18
   )
   public final Map<Integer, Integer> map_int32_fixed32;
 
@@ -182,7 +201,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 505,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      jsonName = "mapInt32Sfixed32"
+      jsonName = "mapInt32Sfixed32",
+      schemaIndex = 19
   )
   public final Map<Integer, Integer> map_int32_sfixed32;
 
@@ -190,7 +210,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 401,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       jsonName = "oneofInt32",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 20
   )
   public final Integer oneof_int32;
 
@@ -198,7 +219,8 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 402,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       jsonName = "oneofSfixed32",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 21
   )
   public final Integer oneof_sfixed32;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All64.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All64.java
@@ -30,7 +30,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myInt64"
+      jsonName = "myInt64",
+      schemaIndex = 0
   )
   public final long my_int64;
 
@@ -38,7 +39,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myUint64"
+      jsonName = "myUint64",
+      schemaIndex = 1
   )
   public final long my_uint64;
 
@@ -46,7 +48,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySint64"
+      jsonName = "mySint64",
+      schemaIndex = 2
   )
   public final long my_sint64;
 
@@ -54,7 +57,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 4,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myFixed64"
+      jsonName = "myFixed64",
+      schemaIndex = 3
   )
   public final long my_fixed64;
 
@@ -62,7 +66,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySfixed64"
+      jsonName = "mySfixed64",
+      schemaIndex = 4
   )
   public final long my_sfixed64;
 
@@ -70,7 +75,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.REPEATED,
-      jsonName = "repInt64"
+      jsonName = "repInt64",
+      schemaIndex = 5
   )
   public final List<Long> rep_int64;
 
@@ -78,7 +84,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.REPEATED,
-      jsonName = "repUint64"
+      jsonName = "repUint64",
+      schemaIndex = 6
   )
   public final List<Long> rep_uint64;
 
@@ -86,7 +93,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.REPEATED,
-      jsonName = "repSint64"
+      jsonName = "repSint64",
+      schemaIndex = 7
   )
   public final List<Long> rep_sint64;
 
@@ -94,7 +102,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.REPEATED,
-      jsonName = "repFixed64"
+      jsonName = "repFixed64",
+      schemaIndex = 8
   )
   public final List<Long> rep_fixed64;
 
@@ -102,7 +111,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.REPEATED,
-      jsonName = "repSfixed64"
+      jsonName = "repSfixed64",
+      schemaIndex = 9
   )
   public final List<Long> rep_sfixed64;
 
@@ -110,7 +120,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.PACKED,
-      jsonName = "packInt64"
+      jsonName = "packInt64",
+      schemaIndex = 10
   )
   public final List<Long> pack_int64;
 
@@ -118,7 +129,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.PACKED,
-      jsonName = "packUint64"
+      jsonName = "packUint64",
+      schemaIndex = 11
   )
   public final List<Long> pack_uint64;
 
@@ -126,7 +138,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.PACKED,
-      jsonName = "packSint64"
+      jsonName = "packSint64",
+      schemaIndex = 12
   )
   public final List<Long> pack_sint64;
 
@@ -134,7 +147,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.PACKED,
-      jsonName = "packFixed64"
+      jsonName = "packFixed64",
+      schemaIndex = 13
   )
   public final List<Long> pack_fixed64;
 
@@ -142,7 +156,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.PACKED,
-      jsonName = "packSfixed64"
+      jsonName = "packSfixed64",
+      schemaIndex = 14
   )
   public final List<Long> pack_sfixed64;
 
@@ -150,7 +165,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      jsonName = "mapInt64Int64"
+      jsonName = "mapInt64Int64",
+      schemaIndex = 15
   )
   public final Map<Long, Long> map_int64_int64;
 
@@ -158,7 +174,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      jsonName = "mapInt64Uint64"
+      jsonName = "mapInt64Uint64",
+      schemaIndex = 16
   )
   public final Map<Long, Long> map_int64_uint64;
 
@@ -166,7 +183,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      jsonName = "mapInt64Sint64"
+      jsonName = "mapInt64Sint64",
+      schemaIndex = 17
   )
   public final Map<Long, Long> map_int64_sint64;
 
@@ -174,7 +192,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      jsonName = "mapInt64Fixed64"
+      jsonName = "mapInt64Fixed64",
+      schemaIndex = 18
   )
   public final Map<Long, Long> map_int64_fixed64;
 
@@ -182,7 +201,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 505,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      jsonName = "mapInt64Sfixed64"
+      jsonName = "mapInt64Sfixed64",
+      schemaIndex = 19
   )
   public final Map<Long, Long> map_int64_sfixed64;
 
@@ -190,7 +210,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 401,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       jsonName = "oneofInt64",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 20
   )
   public final Long oneof_int64;
 
@@ -198,7 +219,8 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 402,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       jsonName = "oneofSfixed64",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 21
   )
   public final Long oneof_sfixed64;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllStructs.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllStructs.java
@@ -24,14 +24,16 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
-      label = WireField.Label.OMIT_IDENTITY
+      label = WireField.Label.OMIT_IDENTITY,
+      schemaIndex = 0
   )
   public final Map<String, ?> struct;
 
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
-      label = WireField.Label.OMIT_IDENTITY
+      label = WireField.Label.OMIT_IDENTITY,
+      schemaIndex = 1
   )
   public final List<?> list;
 
@@ -39,7 +41,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "nullValue"
+      jsonName = "nullValue",
+      schemaIndex = 2
   )
   public final Void null_value;
 
@@ -47,7 +50,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 4,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueA"
+      jsonName = "valueA",
+      schemaIndex = 3
   )
   public final Object value_a;
 
@@ -55,7 +59,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueB"
+      jsonName = "valueB",
+      schemaIndex = 4
   )
   public final Object value_b;
 
@@ -63,7 +68,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 6,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueC"
+      jsonName = "valueC",
+      schemaIndex = 5
   )
   public final Object value_c;
 
@@ -71,7 +77,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 7,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueD"
+      jsonName = "valueD",
+      schemaIndex = 6
   )
   public final Object value_d;
 
@@ -79,7 +86,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 8,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueE"
+      jsonName = "valueE",
+      schemaIndex = 7
   )
   public final Object value_e;
 
@@ -87,7 +95,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 9,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueF"
+      jsonName = "valueF",
+      schemaIndex = 8
   )
   public final Object value_f;
 
@@ -95,7 +104,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
       label = WireField.Label.REPEATED,
-      jsonName = "repStruct"
+      jsonName = "repStruct",
+      schemaIndex = 9
   )
   public final List<Map<String, ?>> rep_struct;
 
@@ -103,7 +113,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
       label = WireField.Label.REPEATED,
-      jsonName = "repList"
+      jsonName = "repList",
+      schemaIndex = 10
   )
   public final List<List<?>> rep_list;
 
@@ -111,7 +122,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.REPEATED,
-      jsonName = "repValueA"
+      jsonName = "repValueA",
+      schemaIndex = 11
   )
   public final List<Object> rep_value_a;
 
@@ -119,7 +131,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
       label = WireField.Label.REPEATED,
-      jsonName = "repNullValue"
+      jsonName = "repNullValue",
+      schemaIndex = 12
   )
   public final List<Void> rep_null_value;
 
@@ -127,7 +140,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 301,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
-      jsonName = "mapInt32Struct"
+      jsonName = "mapInt32Struct",
+      schemaIndex = 13
   )
   public final Map<Integer, Map<String, ?>> map_int32_struct;
 
@@ -135,7 +149,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 302,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
-      jsonName = "mapInt32List"
+      jsonName = "mapInt32List",
+      schemaIndex = 14
   )
   public final Map<Integer, List<?>> map_int32_list;
 
@@ -143,7 +158,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 303,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
-      jsonName = "mapInt32ValueA"
+      jsonName = "mapInt32ValueA",
+      schemaIndex = 15
   )
   public final Map<Integer, Object> map_int32_value_a;
 
@@ -151,7 +167,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 304,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
-      jsonName = "mapInt32NullValue"
+      jsonName = "mapInt32NullValue",
+      schemaIndex = 16
   )
   public final Map<Integer, Void> map_int32_null_value;
 
@@ -159,7 +176,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
       jsonName = "oneofStruct",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 17
   )
   public final Map<String, ?> oneof_struct;
 
@@ -167,7 +185,8 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
       jsonName = "oneofList",
-      oneofName = "choice"
+      oneofName = "choice",
+      schemaIndex = 18
   )
   public final List<?> oneof_list;
 

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -39,102 +39,119 @@ public class AllTypes(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val opt_int32: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 1,
   )
   @JvmField
   public val opt_uint32: Int? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 2,
   )
   @JvmField
   public val opt_sint32: Int? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 3,
   )
   @JvmField
   public val opt_fixed32: Int? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 4,
   )
   @JvmField
   public val opt_sfixed32: Int? = null,
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 5,
   )
   @JvmField
   public val opt_int64: Long? = null,
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 6,
   )
   @JvmField
   public val opt_uint64: Long? = null,
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 7,
   )
   @JvmField
   public val opt_sint64: Long? = null,
   @field:WireField(
     tag = 9,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 8,
   )
   @JvmField
   public val opt_fixed64: Long? = null,
   @field:WireField(
     tag = 10,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 9,
   )
   @JvmField
   public val opt_sfixed64: Long? = null,
   @field:WireField(
     tag = 11,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 10,
   )
   @JvmField
   public val opt_bool: Boolean? = null,
   @field:WireField(
     tag = 12,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 11,
   )
   @JvmField
   public val opt_float: Float? = null,
   @field:WireField(
     tag = 13,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 12,
   )
   @JvmField
   public val opt_double: Double? = null,
   @field:WireField(
     tag = 14,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 13,
   )
   @JvmField
   public val opt_string: String? = null,
   @field:WireField(
     tag = 15,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 14,
   )
   @JvmField
   public val opt_bytes: ByteString? = null,
   @field:WireField(
     tag = 16,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 15,
   )
   @JvmField
   public val opt_nested_enum: NestedEnum? = null,
   @field:WireField(
     tag = 17,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 16,
   )
   @JvmField
   public val opt_nested_message: NestedMessage? = null,
@@ -142,6 +159,7 @@ public class AllTypes(
     tag = 101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 17,
   )
   @JvmField
   public val req_int32: Int,
@@ -149,6 +167,7 @@ public class AllTypes(
     tag = 102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 18,
   )
   @JvmField
   public val req_uint32: Int,
@@ -156,6 +175,7 @@ public class AllTypes(
     tag = 103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 19,
   )
   @JvmField
   public val req_sint32: Int,
@@ -163,6 +183,7 @@ public class AllTypes(
     tag = 104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 20,
   )
   @JvmField
   public val req_fixed32: Int,
@@ -170,6 +191,7 @@ public class AllTypes(
     tag = 105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 21,
   )
   @JvmField
   public val req_sfixed32: Int,
@@ -177,6 +199,7 @@ public class AllTypes(
     tag = 106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 22,
   )
   @JvmField
   public val req_int64: Long,
@@ -184,6 +207,7 @@ public class AllTypes(
     tag = 107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 23,
   )
   @JvmField
   public val req_uint64: Long,
@@ -191,6 +215,7 @@ public class AllTypes(
     tag = 108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 24,
   )
   @JvmField
   public val req_sint64: Long,
@@ -198,6 +223,7 @@ public class AllTypes(
     tag = 109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 25,
   )
   @JvmField
   public val req_fixed64: Long,
@@ -205,6 +231,7 @@ public class AllTypes(
     tag = 110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 26,
   )
   @JvmField
   public val req_sfixed64: Long,
@@ -212,6 +239,7 @@ public class AllTypes(
     tag = 111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 27,
   )
   @JvmField
   public val req_bool: Boolean,
@@ -219,6 +247,7 @@ public class AllTypes(
     tag = 112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 28,
   )
   @JvmField
   public val req_float: Float,
@@ -226,6 +255,7 @@ public class AllTypes(
     tag = 113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 29,
   )
   @JvmField
   public val req_double: Double,
@@ -233,6 +263,7 @@ public class AllTypes(
     tag = 114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 30,
   )
   @JvmField
   public val req_string: String,
@@ -240,6 +271,7 @@ public class AllTypes(
     tag = 115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 31,
   )
   @JvmField
   public val req_bytes: ByteString,
@@ -247,6 +279,7 @@ public class AllTypes(
     tag = 116,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 32,
   )
   @JvmField
   public val req_nested_enum: NestedEnum,
@@ -254,6 +287,7 @@ public class AllTypes(
     tag = 117,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 33,
   )
   @JvmField
   public val req_nested_message: NestedMessage,
@@ -291,96 +325,112 @@ public class AllTypes(
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 65,
   )
   @JvmField
   public val default_int32: Int? = null,
   @field:WireField(
     tag = 402,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 66,
   )
   @JvmField
   public val default_uint32: Int? = null,
   @field:WireField(
     tag = 403,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 67,
   )
   @JvmField
   public val default_sint32: Int? = null,
   @field:WireField(
     tag = 404,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 68,
   )
   @JvmField
   public val default_fixed32: Int? = null,
   @field:WireField(
     tag = 405,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 69,
   )
   @JvmField
   public val default_sfixed32: Int? = null,
   @field:WireField(
     tag = 406,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 70,
   )
   @JvmField
   public val default_int64: Long? = null,
   @field:WireField(
     tag = 407,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 71,
   )
   @JvmField
   public val default_uint64: Long? = null,
   @field:WireField(
     tag = 408,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 72,
   )
   @JvmField
   public val default_sint64: Long? = null,
   @field:WireField(
     tag = 409,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 73,
   )
   @JvmField
   public val default_fixed64: Long? = null,
   @field:WireField(
     tag = 410,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 74,
   )
   @JvmField
   public val default_sfixed64: Long? = null,
   @field:WireField(
     tag = 411,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 75,
   )
   @JvmField
   public val default_bool: Boolean? = null,
   @field:WireField(
     tag = 412,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 76,
   )
   @JvmField
   public val default_float: Float? = null,
   @field:WireField(
     tag = 413,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 77,
   )
   @JvmField
   public val default_double: Double? = null,
   @field:WireField(
     tag = 414,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 78,
   )
   @JvmField
   public val default_string: String? = null,
   @field:WireField(
     tag = 415,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 79,
   )
   @JvmField
   public val default_bytes: ByteString? = null,
   @field:WireField(
     tag = 416,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 80,
   )
   @JvmField
   public val default_nested_enum: NestedEnum? = null,
@@ -392,6 +442,7 @@ public class AllTypes(
     tag = 601,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     oneofName = "choice",
+    schemaIndex = 85,
   )
   @JvmField
   public val oneof_string: String? = null,
@@ -399,6 +450,7 @@ public class AllTypes(
     tag = 602,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     oneofName = "choice",
+    schemaIndex = 86,
   )
   @JvmField
   public val oneof_int32: Int? = null,
@@ -406,6 +458,7 @@ public class AllTypes(
     tag = 603,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     oneofName = "choice",
+    schemaIndex = 87,
   )
   @JvmField
   public val oneof_nested_message: NestedMessage? = null,
@@ -415,6 +468,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1001,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 88,
   )
   @JvmField
   public val ext_opt_int32: Int? = null,
@@ -424,6 +478,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1002,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 89,
   )
   @JvmField
   public val ext_opt_uint32: Int? = null,
@@ -433,6 +488,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1003,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 90,
   )
   @JvmField
   public val ext_opt_sint32: Int? = null,
@@ -442,6 +498,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1004,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 91,
   )
   @JvmField
   public val ext_opt_fixed32: Int? = null,
@@ -451,6 +508,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1005,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 92,
   )
   @JvmField
   public val ext_opt_sfixed32: Int? = null,
@@ -460,6 +518,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1006,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 93,
   )
   @JvmField
   public val ext_opt_int64: Long? = null,
@@ -469,6 +528,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1007,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 94,
   )
   @JvmField
   public val ext_opt_uint64: Long? = null,
@@ -478,6 +538,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1008,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 95,
   )
   @JvmField
   public val ext_opt_sint64: Long? = null,
@@ -487,6 +548,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1009,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 96,
   )
   @JvmField
   public val ext_opt_fixed64: Long? = null,
@@ -496,6 +558,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1010,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 97,
   )
   @JvmField
   public val ext_opt_sfixed64: Long? = null,
@@ -505,6 +568,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1011,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 98,
   )
   @JvmField
   public val ext_opt_bool: Boolean? = null,
@@ -514,6 +578,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1012,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 99,
   )
   @JvmField
   public val ext_opt_float: Float? = null,
@@ -523,6 +588,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1013,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 100,
   )
   @JvmField
   public val ext_opt_double: Double? = null,
@@ -532,6 +598,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1014,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 101,
   )
   @JvmField
   public val ext_opt_string: String? = null,
@@ -541,6 +608,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1015,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 102,
   )
   @JvmField
   public val ext_opt_bytes: ByteString? = null,
@@ -550,6 +618,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1016,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 103,
   )
   @JvmField
   public val ext_opt_nested_enum: NestedEnum? = null,
@@ -559,6 +628,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1017,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 104,
   )
   @JvmField
   public val ext_opt_nested_message: NestedMessage? = null,
@@ -599,6 +669,7 @@ public class AllTypes(
     tag = 201,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 34,
   )
   @JvmField
   public val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
@@ -607,6 +678,7 @@ public class AllTypes(
     tag = 202,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 35,
   )
   @JvmField
   public val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
@@ -615,6 +687,7 @@ public class AllTypes(
     tag = 203,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 36,
   )
   @JvmField
   public val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
@@ -623,6 +696,7 @@ public class AllTypes(
     tag = 204,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 37,
   )
   @JvmField
   public val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
@@ -631,6 +705,7 @@ public class AllTypes(
     tag = 205,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 38,
   )
   @JvmField
   public val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
@@ -639,6 +714,7 @@ public class AllTypes(
     tag = 206,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 39,
   )
   @JvmField
   public val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
@@ -647,6 +723,7 @@ public class AllTypes(
     tag = 207,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 40,
   )
   @JvmField
   public val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
@@ -655,6 +732,7 @@ public class AllTypes(
     tag = 208,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 41,
   )
   @JvmField
   public val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
@@ -663,6 +741,7 @@ public class AllTypes(
     tag = 209,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 42,
   )
   @JvmField
   public val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
@@ -671,6 +750,7 @@ public class AllTypes(
     tag = 210,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 43,
   )
   @JvmField
   public val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
@@ -679,6 +759,7 @@ public class AllTypes(
     tag = 211,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
+    schemaIndex = 44,
   )
   @JvmField
   public val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
@@ -687,6 +768,7 @@ public class AllTypes(
     tag = 212,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 45,
   )
   @JvmField
   public val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
@@ -695,6 +777,7 @@ public class AllTypes(
     tag = 213,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 46,
   )
   @JvmField
   public val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
@@ -703,6 +786,7 @@ public class AllTypes(
     tag = 214,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 47,
   )
   @JvmField
   public val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
@@ -711,6 +795,7 @@ public class AllTypes(
     tag = 215,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
+    schemaIndex = 48,
   )
   @JvmField
   public val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
@@ -719,6 +804,7 @@ public class AllTypes(
     tag = 216,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 49,
   )
   @JvmField
   public val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
@@ -727,6 +813,7 @@ public class AllTypes(
     tag = 217,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 50,
   )
   @JvmField
   public val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
@@ -736,6 +823,7 @@ public class AllTypes(
     tag = 301,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 51,
   )
   @JvmField
   public val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
@@ -744,6 +832,7 @@ public class AllTypes(
     tag = 302,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 52,
   )
   @JvmField
   public val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
@@ -752,6 +841,7 @@ public class AllTypes(
     tag = 303,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 53,
   )
   @JvmField
   public val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
@@ -760,6 +850,7 @@ public class AllTypes(
     tag = 304,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 54,
   )
   @JvmField
   public val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
@@ -768,6 +859,7 @@ public class AllTypes(
     tag = 305,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 55,
   )
   @JvmField
   public val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
@@ -776,6 +868,7 @@ public class AllTypes(
     tag = 306,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 56,
   )
   @JvmField
   public val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
@@ -784,6 +877,7 @@ public class AllTypes(
     tag = 307,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 57,
   )
   @JvmField
   public val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
@@ -792,6 +886,7 @@ public class AllTypes(
     tag = 308,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 58,
   )
   @JvmField
   public val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
@@ -800,6 +895,7 @@ public class AllTypes(
     tag = 309,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 59,
   )
   @JvmField
   public val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
@@ -808,6 +904,7 @@ public class AllTypes(
     tag = 310,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 60,
   )
   @JvmField
   public val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
@@ -816,6 +913,7 @@ public class AllTypes(
     tag = 311,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
+    schemaIndex = 61,
   )
   @JvmField
   public val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
@@ -824,6 +922,7 @@ public class AllTypes(
     tag = 312,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 62,
   )
   @JvmField
   public val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
@@ -832,6 +931,7 @@ public class AllTypes(
     tag = 313,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 63,
   )
   @JvmField
   public val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
@@ -840,6 +940,7 @@ public class AllTypes(
     tag = 316,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
+    schemaIndex = 64,
   )
   @JvmField
   public val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum",
@@ -849,6 +950,7 @@ public class AllTypes(
     tag = 501,
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 81,
   )
   @JvmField
   public val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
@@ -857,6 +959,7 @@ public class AllTypes(
     tag = 502,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 82,
   )
   @JvmField
   public val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
@@ -866,6 +969,7 @@ public class AllTypes(
     tag = 503,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 83,
   )
   @JvmField
   public val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
@@ -875,6 +979,7 @@ public class AllTypes(
     tag = 504,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 84,
   )
   @JvmField
   public val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum",
@@ -887,6 +992,7 @@ public class AllTypes(
     tag = 1101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 105,
   )
   @JvmField
   public val ext_rep_int32: List<Int> = immutableCopyOf("ext_rep_int32", ext_rep_int32)
@@ -898,6 +1004,7 @@ public class AllTypes(
     tag = 1102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 106,
   )
   @JvmField
   public val ext_rep_uint32: List<Int> = immutableCopyOf("ext_rep_uint32", ext_rep_uint32)
@@ -909,6 +1016,7 @@ public class AllTypes(
     tag = 1103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 107,
   )
   @JvmField
   public val ext_rep_sint32: List<Int> = immutableCopyOf("ext_rep_sint32", ext_rep_sint32)
@@ -920,6 +1028,7 @@ public class AllTypes(
     tag = 1104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 108,
   )
   @JvmField
   public val ext_rep_fixed32: List<Int> = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32)
@@ -931,6 +1040,7 @@ public class AllTypes(
     tag = 1105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 109,
   )
   @JvmField
   public val ext_rep_sfixed32: List<Int> = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32)
@@ -942,6 +1052,7 @@ public class AllTypes(
     tag = 1106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 110,
   )
   @JvmField
   public val ext_rep_int64: List<Long> = immutableCopyOf("ext_rep_int64", ext_rep_int64)
@@ -953,6 +1064,7 @@ public class AllTypes(
     tag = 1107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 111,
   )
   @JvmField
   public val ext_rep_uint64: List<Long> = immutableCopyOf("ext_rep_uint64", ext_rep_uint64)
@@ -964,6 +1076,7 @@ public class AllTypes(
     tag = 1108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 112,
   )
   @JvmField
   public val ext_rep_sint64: List<Long> = immutableCopyOf("ext_rep_sint64", ext_rep_sint64)
@@ -975,6 +1088,7 @@ public class AllTypes(
     tag = 1109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 113,
   )
   @JvmField
   public val ext_rep_fixed64: List<Long> = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64)
@@ -986,6 +1100,7 @@ public class AllTypes(
     tag = 1110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 114,
   )
   @JvmField
   public val ext_rep_sfixed64: List<Long> = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64)
@@ -997,6 +1112,7 @@ public class AllTypes(
     tag = 1111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
+    schemaIndex = 115,
   )
   @JvmField
   public val ext_rep_bool: List<Boolean> = immutableCopyOf("ext_rep_bool", ext_rep_bool)
@@ -1008,6 +1124,7 @@ public class AllTypes(
     tag = 1112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 116,
   )
   @JvmField
   public val ext_rep_float: List<Float> = immutableCopyOf("ext_rep_float", ext_rep_float)
@@ -1019,6 +1136,7 @@ public class AllTypes(
     tag = 1113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 117,
   )
   @JvmField
   public val ext_rep_double: List<Double> = immutableCopyOf("ext_rep_double", ext_rep_double)
@@ -1030,6 +1148,7 @@ public class AllTypes(
     tag = 1114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 118,
   )
   @JvmField
   public val ext_rep_string: List<String> = immutableCopyOf("ext_rep_string", ext_rep_string)
@@ -1041,6 +1160,7 @@ public class AllTypes(
     tag = 1115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
+    schemaIndex = 119,
   )
   @JvmField
   public val ext_rep_bytes: List<ByteString> = immutableCopyOf("ext_rep_bytes", ext_rep_bytes)
@@ -1052,6 +1172,7 @@ public class AllTypes(
     tag = 1116,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 120,
   )
   @JvmField
   public val ext_rep_nested_enum: List<NestedEnum> = immutableCopyOf("ext_rep_nested_enum",
@@ -1064,6 +1185,7 @@ public class AllTypes(
     tag = 1117,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 121,
   )
   @JvmField
   public val ext_rep_nested_message: List<NestedMessage> = immutableCopyOf("ext_rep_nested_message",
@@ -1076,6 +1198,7 @@ public class AllTypes(
     tag = 1201,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 122,
   )
   @JvmField
   public val ext_pack_int32: List<Int> = immutableCopyOf("ext_pack_int32", ext_pack_int32)
@@ -1087,6 +1210,7 @@ public class AllTypes(
     tag = 1202,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 123,
   )
   @JvmField
   public val ext_pack_uint32: List<Int> = immutableCopyOf("ext_pack_uint32", ext_pack_uint32)
@@ -1098,6 +1222,7 @@ public class AllTypes(
     tag = 1203,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 124,
   )
   @JvmField
   public val ext_pack_sint32: List<Int> = immutableCopyOf("ext_pack_sint32", ext_pack_sint32)
@@ -1109,6 +1234,7 @@ public class AllTypes(
     tag = 1204,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 125,
   )
   @JvmField
   public val ext_pack_fixed32: List<Int> = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32)
@@ -1120,6 +1246,7 @@ public class AllTypes(
     tag = 1205,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 126,
   )
   @JvmField
   public val ext_pack_sfixed32: List<Int> = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32)
@@ -1131,6 +1258,7 @@ public class AllTypes(
     tag = 1206,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 127,
   )
   @JvmField
   public val ext_pack_int64: List<Long> = immutableCopyOf("ext_pack_int64", ext_pack_int64)
@@ -1142,6 +1270,7 @@ public class AllTypes(
     tag = 1207,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 128,
   )
   @JvmField
   public val ext_pack_uint64: List<Long> = immutableCopyOf("ext_pack_uint64", ext_pack_uint64)
@@ -1153,6 +1282,7 @@ public class AllTypes(
     tag = 1208,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 129,
   )
   @JvmField
   public val ext_pack_sint64: List<Long> = immutableCopyOf("ext_pack_sint64", ext_pack_sint64)
@@ -1164,6 +1294,7 @@ public class AllTypes(
     tag = 1209,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 130,
   )
   @JvmField
   public val ext_pack_fixed64: List<Long> = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64)
@@ -1175,6 +1306,7 @@ public class AllTypes(
     tag = 1210,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 131,
   )
   @JvmField
   public val ext_pack_sfixed64: List<Long> = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64)
@@ -1186,6 +1318,7 @@ public class AllTypes(
     tag = 1211,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
+    schemaIndex = 132,
   )
   @JvmField
   public val ext_pack_bool: List<Boolean> = immutableCopyOf("ext_pack_bool", ext_pack_bool)
@@ -1197,6 +1330,7 @@ public class AllTypes(
     tag = 1212,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 133,
   )
   @JvmField
   public val ext_pack_float: List<Float> = immutableCopyOf("ext_pack_float", ext_pack_float)
@@ -1208,6 +1342,7 @@ public class AllTypes(
     tag = 1213,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 134,
   )
   @JvmField
   public val ext_pack_double: List<Double> = immutableCopyOf("ext_pack_double", ext_pack_double)
@@ -1219,6 +1354,7 @@ public class AllTypes(
     tag = 1216,
     adapter = "com.squareup.wire.proto2.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
+    schemaIndex = 135,
   )
   @JvmField
   public val ext_pack_nested_enum: List<NestedEnum> = immutableCopyOf("ext_pack_nested_enum",

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
@@ -34,6 +34,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myInt32",
+    schemaIndex = 0,
   )
   @JvmField
   public val my_int32: Int = 0,
@@ -42,6 +43,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myUint32",
+    schemaIndex = 1,
   )
   @JvmField
   public val my_uint32: Int = 0,
@@ -50,6 +52,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySint32",
+    schemaIndex = 2,
   )
   @JvmField
   public val my_sint32: Int = 0,
@@ -58,6 +61,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myFixed32",
+    schemaIndex = 3,
   )
   @JvmField
   public val my_fixed32: Int = 0,
@@ -66,6 +70,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySfixed32",
+    schemaIndex = 4,
   )
   @JvmField
   public val my_sfixed32: Int = 0,
@@ -84,6 +89,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "oneofInt32",
     oneofName = "choice",
+    schemaIndex = 15,
   )
   @JvmField
   public val oneof_int32: Int? = null,
@@ -92,6 +98,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     jsonName = "oneofSfixed32",
     oneofName = "choice",
+    schemaIndex = 16,
   )
   @JvmField
   public val oneof_sfixed32: Int? = null,
@@ -107,6 +114,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
     jsonName = "repInt32",
+    schemaIndex = 5,
   )
   @JvmField
   public val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
@@ -116,6 +124,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
     jsonName = "repUint32",
+    schemaIndex = 6,
   )
   @JvmField
   public val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
@@ -125,6 +134,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
     jsonName = "repSint32",
+    schemaIndex = 7,
   )
   @JvmField
   public val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
@@ -134,6 +144,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
     jsonName = "repFixed32",
+    schemaIndex = 8,
   )
   @JvmField
   public val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
@@ -143,6 +154,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
     jsonName = "repSfixed32",
+    schemaIndex = 9,
   )
   @JvmField
   public val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
@@ -152,6 +164,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
     jsonName = "packInt32",
+    schemaIndex = 10,
   )
   @JvmField
   public val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
@@ -161,6 +174,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
     jsonName = "packUint32",
+    schemaIndex = 11,
   )
   @JvmField
   public val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
@@ -170,6 +184,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
     jsonName = "packSint32",
+    schemaIndex = 12,
   )
   @JvmField
   public val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
@@ -179,6 +194,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
     jsonName = "packFixed32",
+    schemaIndex = 13,
   )
   @JvmField
   public val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
@@ -188,6 +204,7 @@ public class All32(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
     jsonName = "packSfixed32",
+    schemaIndex = 14,
   )
   @JvmField
   public val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
@@ -197,6 +214,7 @@ public class All32(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "mapInt32Int32",
+    schemaIndex = 17,
   )
   @JvmField
   public val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
@@ -206,6 +224,7 @@ public class All32(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     jsonName = "mapInt32Uint32",
+    schemaIndex = 18,
   )
   @JvmField
   public val map_int32_uint32: Map<Int, Int> = immutableCopyOf("map_int32_uint32", map_int32_uint32)
@@ -215,6 +234,7 @@ public class All32(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     jsonName = "mapInt32Sint32",
+    schemaIndex = 19,
   )
   @JvmField
   public val map_int32_sint32: Map<Int, Int> = immutableCopyOf("map_int32_sint32", map_int32_sint32)
@@ -224,6 +244,7 @@ public class All32(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     jsonName = "mapInt32Fixed32",
+    schemaIndex = 20,
   )
   @JvmField
   public val map_int32_fixed32: Map<Int, Int> = immutableCopyOf("map_int32_fixed32",
@@ -234,6 +255,7 @@ public class All32(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     jsonName = "mapInt32Sfixed32",
+    schemaIndex = 21,
   )
   @JvmField
   public val map_int32_sfixed32: Map<Int, Int> = immutableCopyOf("map_int32_sfixed32",

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
@@ -34,6 +34,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myInt64",
+    schemaIndex = 0,
   )
   @JvmField
   public val my_int64: Long = 0L,
@@ -42,6 +43,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myUint64",
+    schemaIndex = 1,
   )
   @JvmField
   public val my_uint64: Long = 0L,
@@ -50,6 +52,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySint64",
+    schemaIndex = 2,
   )
   @JvmField
   public val my_sint64: Long = 0L,
@@ -58,6 +61,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myFixed64",
+    schemaIndex = 3,
   )
   @JvmField
   public val my_fixed64: Long = 0L,
@@ -66,6 +70,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySfixed64",
+    schemaIndex = 4,
   )
   @JvmField
   public val my_sfixed64: Long = 0L,
@@ -84,6 +89,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     jsonName = "oneofInt64",
     oneofName = "choice",
+    schemaIndex = 15,
   )
   @JvmField
   public val oneof_int64: Long? = null,
@@ -92,6 +98,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     jsonName = "oneofSfixed64",
     oneofName = "choice",
+    schemaIndex = 16,
   )
   @JvmField
   public val oneof_sfixed64: Long? = null,
@@ -107,6 +114,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
     jsonName = "repInt64",
+    schemaIndex = 5,
   )
   @JvmField
   public val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
@@ -116,6 +124,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
     jsonName = "repUint64",
+    schemaIndex = 6,
   )
   @JvmField
   public val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
@@ -125,6 +134,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
     jsonName = "repSint64",
+    schemaIndex = 7,
   )
   @JvmField
   public val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
@@ -134,6 +144,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
     jsonName = "repFixed64",
+    schemaIndex = 8,
   )
   @JvmField
   public val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
@@ -143,6 +154,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
     jsonName = "repSfixed64",
+    schemaIndex = 9,
   )
   @JvmField
   public val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
@@ -152,6 +164,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
     jsonName = "packInt64",
+    schemaIndex = 10,
   )
   @JvmField
   public val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
@@ -161,6 +174,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
     jsonName = "packUint64",
+    schemaIndex = 11,
   )
   @JvmField
   public val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
@@ -170,6 +184,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
     jsonName = "packSint64",
+    schemaIndex = 12,
   )
   @JvmField
   public val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
@@ -179,6 +194,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
     jsonName = "packFixed64",
+    schemaIndex = 13,
   )
   @JvmField
   public val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
@@ -188,6 +204,7 @@ public class All64(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
     jsonName = "packSfixed64",
+    schemaIndex = 14,
   )
   @JvmField
   public val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
@@ -197,6 +214,7 @@ public class All64(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     jsonName = "mapInt64Int64",
+    schemaIndex = 17,
   )
   @JvmField
   public val map_int64_int64: Map<Long, Long> = immutableCopyOf("map_int64_int64", map_int64_int64)
@@ -206,6 +224,7 @@ public class All64(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     jsonName = "mapInt64Uint64",
+    schemaIndex = 18,
   )
   @JvmField
   public val map_int64_uint64: Map<Long, Long> = immutableCopyOf("map_int64_uint64",
@@ -216,6 +235,7 @@ public class All64(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     jsonName = "mapInt64Sint64",
+    schemaIndex = 19,
   )
   @JvmField
   public val map_int64_sint64: Map<Long, Long> = immutableCopyOf("map_int64_sint64",
@@ -226,6 +246,7 @@ public class All64(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     jsonName = "mapInt64Fixed64",
+    schemaIndex = 20,
   )
   @JvmField
   public val map_int64_fixed64: Map<Long, Long> = immutableCopyOf("map_int64_fixed64",
@@ -236,6 +257,7 @@ public class All64(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     jsonName = "mapInt64Sfixed64",
+    schemaIndex = 21,
   )
   @JvmField
   public val map_int64_sfixed64: Map<Long, Long> = immutableCopyOf("map_int64_sfixed64",

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
@@ -54,6 +54,7 @@ public class AllStructs(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   @JvmField
   public val struct: Map<String, *>? = immutableCopyOfStruct("struct", struct)
@@ -62,6 +63,7 @@ public class AllStructs(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 1,
   )
   @JvmField
   public val list: List<*>? = immutableCopyOfStruct("list", list)
@@ -71,6 +73,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "nullValue",
+    schemaIndex = 2,
   )
   @JvmField
   public val null_value: Nothing? = immutableCopyOfStruct("null_value", null_value)
@@ -80,6 +83,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "valueA",
+    schemaIndex = 3,
   )
   @JvmField
   public val value_a: Any? = immutableCopyOfStruct("value_a", value_a)
@@ -89,6 +93,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "valueB",
+    schemaIndex = 4,
   )
   @JvmField
   public val value_b: Any? = immutableCopyOfStruct("value_b", value_b)
@@ -98,6 +103,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "valueC",
+    schemaIndex = 5,
   )
   @JvmField
   public val value_c: Any? = immutableCopyOfStruct("value_c", value_c)
@@ -107,6 +113,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "valueD",
+    schemaIndex = 6,
   )
   @JvmField
   public val value_d: Any? = immutableCopyOfStruct("value_d", value_d)
@@ -116,6 +123,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "valueE",
+    schemaIndex = 7,
   )
   @JvmField
   public val value_e: Any? = immutableCopyOfStruct("value_e", value_e)
@@ -125,6 +133,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "valueF",
+    schemaIndex = 8,
   )
   @JvmField
   public val value_f: Any? = immutableCopyOfStruct("value_f", value_f)
@@ -134,6 +143,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.REPEATED,
     jsonName = "repStruct",
+    schemaIndex = 9,
   )
   @JvmField
   public val rep_struct: List<Map<String, *>?> = immutableCopyOfStruct("rep_struct", rep_struct)
@@ -143,6 +153,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     label = WireField.Label.REPEATED,
     jsonName = "repList",
+    schemaIndex = 10,
   )
   @JvmField
   public val rep_list: List<List<*>?> = immutableCopyOfStruct("rep_list", rep_list)
@@ -152,6 +163,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repValueA",
+    schemaIndex = 11,
   )
   @JvmField
   public val rep_value_a: List<Any?> = immutableCopyOfStruct("rep_value_a", rep_value_a)
@@ -161,6 +173,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     label = WireField.Label.REPEATED,
     jsonName = "repNullValue",
+    schemaIndex = 12,
   )
   @JvmField
   public val rep_null_value: List<Nothing?> = immutableCopyOfStruct("rep_null_value",
@@ -171,6 +184,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     jsonName = "oneofStruct",
     oneofName = "choice",
+    schemaIndex = 13,
   )
   @JvmField
   public val oneof_struct: Map<String, *>? = immutableCopyOfStruct("oneof_struct", oneof_struct)
@@ -180,6 +194,7 @@ public class AllStructs(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     jsonName = "oneofList",
     oneofName = "choice",
+    schemaIndex = 14,
   )
   @JvmField
   public val oneof_list: List<*>? = immutableCopyOfStruct("oneof_list", oneof_list)
@@ -189,6 +204,7 @@ public class AllStructs(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     jsonName = "mapInt32Struct",
+    schemaIndex = 15,
   )
   @JvmField
   public val map_int32_struct: Map<Int, Map<String, *>?> =
@@ -199,6 +215,7 @@ public class AllStructs(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     jsonName = "mapInt32List",
+    schemaIndex = 16,
   )
   @JvmField
   public val map_int32_list: Map<Int, List<*>?> =
@@ -209,6 +226,7 @@ public class AllStructs(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     jsonName = "mapInt32ValueA",
+    schemaIndex = 17,
   )
   @JvmField
   public val map_int32_value_a: Map<Int, Any?> =
@@ -219,6 +237,7 @@ public class AllStructs(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     jsonName = "mapInt32NullValue",
+    schemaIndex = 18,
   )
   @JvmField
   public val map_int32_null_value: Map<Int, Nothing?> =

--- a/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -38,29 +38,32 @@ import okio.ByteString
  */
 public class Person(
   /**
-   * The customer's full name.
-   */
-  @field:WireField(
-    tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REQUIRED,
-  )
-  public val name: String,
-  /**
    * The customer's ID number.
    */
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 0,
   )
   public val id: Int,
+  /**
+   * The customer's full name.
+   */
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REQUIRED,
+    schemaIndex = 1,
+  )
+  public val name: String,
   /**
    * Email address for the customer.
    */
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   public val email: String? = null,
   phone: List<PhoneNumber> = emptyList(),
@@ -74,6 +77,7 @@ public class Person(
     tag = 4,
     adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 3,
   )
   public val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
 
@@ -81,6 +85,7 @@ public class Person(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   public val aliases: List<String> = immutableCopyOf("aliases", aliases)
 
@@ -95,8 +100,8 @@ public class Person(
     if (other === this) return true
     if (other !is Person) return false
     if (unknownFields != other.unknownFields) return false
-    if (name != other.name) return false
     if (id != other.id) return false
+    if (name != other.name) return false
     if (email != other.email) return false
     if (phone != other.phone) return false
     if (aliases != other.aliases) return false
@@ -107,8 +112,8 @@ public class Person(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
+      result = result * 37 + name.hashCode()
       result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       result = result * 37 + aliases.hashCode()
@@ -119,8 +124,8 @@ public class Person(
 
   public override fun toString(): String {
     val result = mutableListOf<String>()
-    result += """name=${sanitize(name)}"""
     result += """id=$id"""
+    result += """name=${sanitize(name)}"""
     if (email != null) result += """email=${sanitize(email)}"""
     if (phone.isNotEmpty()) result += """phone=$phone"""
     if (aliases.isNotEmpty()) result += """aliases=${sanitize(aliases)}"""
@@ -128,13 +133,13 @@ public class Person(
   }
 
   public fun copy(
-    name: String = this.name,
     id: Int = this.id,
+    name: String = this.name,
     email: String? = this.email,
     phone: List<PhoneNumber> = this.phone,
     aliases: List<String> = this.aliases,
     unknownFields: ByteString = this.unknownFields,
-  ): Person = Person(name, id, email, phone, aliases, unknownFields)
+  ): Person = Person(id, name, email, phone, aliases, unknownFields)
 
   public companion object {
     @JvmField
@@ -148,8 +153,8 @@ public class Person(
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
-        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
         size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
@@ -157,8 +162,8 @@ public class Person(
       }
 
       public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
-        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
@@ -170,20 +175,20 @@ public class Person(
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
-        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
       }
 
       public override fun decode(reader: ProtoReader): Person {
-        var name: String? = null
         var id: Int? = null
+        var name: String? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
         val aliases = mutableListOf<String>()
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
-            1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
+            1 -> name = ProtoAdapter.STRING.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
             5 -> aliases.add(ProtoAdapter.STRING.decode(reader))
@@ -191,8 +196,8 @@ public class Person(
           }
         }
         return Person(
-          name = name ?: throw missingRequiredFields(name, "name"),
           id = id ?: throw missingRequiredFields(id, "id"),
+          name = name ?: throw missingRequiredFields(name, "name"),
           email = email,
           phone = phone,
           aliases = aliases,

--- a/wire-tests/src/jvmKotlinInteropTest/kotlin/com/squareup/wire/ProtoAdapterTest.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/kotlin/com/squareup/wire/ProtoAdapterTest.kt
@@ -27,7 +27,7 @@ class ProtoAdapterTest {
       .id(99)
       .name("Omar Little")
       .build()
-    val encoded = "0a0b4f6d6172204c6974746c651063".decodeHex()
+    val encoded = "10630a0b4f6d6172204c6974746c65".decodeHex()
     val personAdapter = ProtoAdapter.get(Person::class.java)
     assertThat(personAdapter.encode(person).toByteString()).isEqualTo(encoded)
     assertThat(personAdapter.decode(encoded)).isEqualTo(person)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -34,31 +34,34 @@ import okio.ByteString
  */
 public class Person(
   /**
-   * The customer's full name.
-   */
-  @field:WireField(
-    tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#STRING",
-    label = WireField.Label.REQUIRED,
-  )
-  @JvmField
-  public val name: String,
-  /**
    * The customer's ID number.
    */
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 0,
   )
   @JvmField
   public val id: Int,
+  /**
+   * The customer's full name.
+   */
+  @field:WireField(
+    tag = 1,
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    label = WireField.Label.REQUIRED,
+    schemaIndex = 1,
+  )
+  @JvmField
+  public val name: String,
   /**
    * Email address for the customer.
    */
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   @JvmField
   public val email: String? = null,
@@ -73,6 +76,7 @@ public class Person(
     tag = 4,
     adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 3,
   )
   @JvmField
   public val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
@@ -81,14 +85,15 @@ public class Person(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   @JvmField
   public val aliases: List<String> = immutableCopyOf("aliases", aliases)
 
   public override fun newBuilder(): Builder {
     val builder = Builder()
-    builder.name = name
     builder.id = id
+    builder.name = name
     builder.email = email
     builder.phone = phone
     builder.aliases = aliases
@@ -100,8 +105,8 @@ public class Person(
     if (other === this) return true
     if (other !is Person) return false
     if (unknownFields != other.unknownFields) return false
-    if (name != other.name) return false
     if (id != other.id) return false
+    if (name != other.name) return false
     if (email != other.email) return false
     if (phone != other.phone) return false
     if (aliases != other.aliases) return false
@@ -112,8 +117,8 @@ public class Person(
     var result = super.hashCode
     if (result == 0) {
       result = unknownFields.hashCode()
-      result = result * 37 + name.hashCode()
       result = result * 37 + id.hashCode()
+      result = result * 37 + name.hashCode()
       result = result * 37 + (email?.hashCode() ?: 0)
       result = result * 37 + phone.hashCode()
       result = result * 37 + aliases.hashCode()
@@ -124,8 +129,8 @@ public class Person(
 
   public override fun toString(): String {
     val result = mutableListOf<String>()
-    result += """name=${sanitize(name)}"""
     result += """id=$id"""
+    result += """name=${sanitize(name)}"""
     if (email != null) result += """email=${sanitize(email)}"""
     if (phone.isNotEmpty()) result += """phone=$phone"""
     if (aliases.isNotEmpty()) result += """aliases=${sanitize(aliases)}"""
@@ -133,20 +138,20 @@ public class Person(
   }
 
   public fun copy(
-    name: String = this.name,
     id: Int = this.id,
+    name: String = this.name,
     email: String? = this.email,
     phone: List<PhoneNumber> = this.phone,
     aliases: List<String> = this.aliases,
     unknownFields: ByteString = this.unknownFields,
-  ): Person = Person(name, id, email, phone, aliases, unknownFields)
+  ): Person = Person(id, name, email, phone, aliases, unknownFields)
 
   public class Builder : Message.Builder<Person, Builder>() {
     @JvmField
-    public var name: String? = null
+    public var id: Int? = null
 
     @JvmField
-    public var id: Int? = null
+    public var name: String? = null
 
     @JvmField
     public var email: String? = null
@@ -158,18 +163,18 @@ public class Person(
     public var aliases: List<String> = emptyList()
 
     /**
-     * The customer's full name.
-     */
-    public fun name(name: String): Builder {
-      this.name = name
-      return this
-    }
-
-    /**
      * The customer's ID number.
      */
     public fun id(id: Int): Builder {
       this.id = id
+      return this
+    }
+
+    /**
+     * The customer's full name.
+     */
+    public fun name(name: String): Builder {
+      this.name = name
       return this
     }
 
@@ -197,8 +202,8 @@ public class Person(
     }
 
     public override fun build(): Person = Person(
-      name = name ?: throw missingRequiredFields(name, "name"),
       id = id ?: throw missingRequiredFields(id, "id"),
+      name = name ?: throw missingRequiredFields(name, "name"),
       email = email,
       phone = phone,
       aliases = aliases,
@@ -218,8 +223,8 @@ public class Person(
     ) {
       public override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
-        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
         size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
         size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phone)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
@@ -227,8 +232,8 @@ public class Person(
       }
 
       public override fun encode(writer: ProtoWriter, `value`: Person): Unit {
-        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
@@ -240,20 +245,20 @@ public class Person(
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phone)
         ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
-        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
         ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
       }
 
       public override fun decode(reader: ProtoReader): Person {
-        var name: String? = null
         var id: Int? = null
+        var name: String? = null
         var email: String? = null
         val phone = mutableListOf<PhoneNumber>()
         val aliases = mutableListOf<String>()
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
-            1 -> name = ProtoAdapter.STRING.decode(reader)
             2 -> id = ProtoAdapter.INT32.decode(reader)
+            1 -> name = ProtoAdapter.STRING.decode(reader)
             3 -> email = ProtoAdapter.STRING.decode(reader)
             4 -> phone.add(PhoneNumber.ADAPTER.decode(reader))
             5 -> aliases.add(ProtoAdapter.STRING.decode(reader))
@@ -261,8 +266,8 @@ public class Person(
           }
         }
         return Person(
-          name = name ?: throw missingRequiredFields(name, "name"),
           id = id ?: throw missingRequiredFields(id, "id"),
+          name = name ?: throw missingRequiredFields(name, "name"),
           email = email,
           phone = phone,
           aliases = aliases,


### PR DESCRIPTION
First commit generates everything so check the second commit please!

Wire was relying on `Class.getDeclaredFields()` to guarantee the fields order which it does NOT. The PR adds a new value to `WireField` which lets one sort the declared fields in the order they were set in the constructor.

Fixes #2432