### PR TITLE
SwiftPoet 1.5

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,7 @@ protobuf-gradlePlugin = { module = "com.google.protobuf:protobuf-gradle-plugin",
 protobuf-java = { module = "com.google.protobuf:protobuf-java", version.ref = "protobuf" }
 protobuf-javaUtil = { module = "com.google.protobuf:protobuf-java-util", version.ref = "protobuf" }
 protobuf-protoc = { module = "com.google.protobuf:protoc", version.ref = "protobuf" }
-swiftpoet = { module = "io.outfoxx:swiftpoet", version = "1.3.1" }
+swiftpoet = { module = "io.outfoxx:swiftpoet", version = "1.5.0" }
 truth = { module = "com.google.truth:truth", version = "1.1.3" }
 vanniktechPublishPlugin = { module = "com.vanniktech:gradle-maven-publish-plugin", version = "0.20.0" }
 

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
@@ -85,21 +85,24 @@ extension Duration : Sendable {
 #endif
 
 extension Duration : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/google.protobuf.Duration"
     }
+
 }
 
 extension Duration : Proto3Codable {
-    public init(from reader: ProtoReader) throws {
-        var seconds: Int64 = 0
-        var nanos: Int32 = 0
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var seconds: Swift.Int64 = 0
+        var nanos: Swift.Int32 = 0
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: seconds = try reader.decode(Int64.self)
-            case 2: nanos = try reader.decode(Int32.self)
+            case 1: seconds = try reader.decode(Swift.Int64.self)
+            case 2: nanos = try reader.decode(Swift.Int32.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -109,9 +112,10 @@ extension Duration : Proto3Codable {
         self.nanos = nanos
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.seconds)
         try writer.encode(tag: 2, value: self.nanos)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -27,13 +27,16 @@ extension OneofOptions : Sendable {
 #endif
 
 extension OneofOptions : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/google.protobuf.OneofOptions"
     }
+
 }
 
 extension OneofOptions : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -44,14 +47,17 @@ extension OneofOptions : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension OneofOptions : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
@@ -97,21 +97,24 @@ extension Timestamp : Sendable {
 #endif
 
 extension Timestamp : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/google.protobuf.Timestamp"
     }
+
 }
 
 extension Timestamp : Proto3Codable {
-    public init(from reader: ProtoReader) throws {
-        var seconds: Int64 = 0
-        var nanos: Int32 = 0
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var seconds: Swift.Int64 = 0
+        var nanos: Swift.Int32 = 0
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: seconds = try reader.decode(Int64.self)
-            case 2: nanos = try reader.decode(Int32.self)
+            case 1: seconds = try reader.decode(Swift.Int64.self)
+            case 2: nanos = try reader.decode(Swift.Int32.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -121,9 +124,10 @@ extension Timestamp : Proto3Codable {
         self.nanos = nanos
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.seconds)
         try writer.encode(tag: 2, value: self.nanos)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }

--- a/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
+++ b/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
@@ -50,26 +50,29 @@ extension Dinosaur : Sendable {
 #endif
 
 extension Dinosaur : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.dinosaurs.Dinosaur"
     }
+
 }
 
 extension Dinosaur : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var name: String? = nil
-        var picture_urls: [String] = []
-        var length_meters: Double? = nil
-        var mass_kilograms: Double? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var name: Swift.String? = nil
+        var picture_urls: [Swift.String] = []
+        var length_meters: Swift.Double? = nil
+        var mass_kilograms: Swift.Double? = nil
         var period: Period? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: name = try reader.decode(String.self)
+            case 1: name = try reader.decode(Swift.String.self)
             case 2: try reader.decode(into: &picture_urls)
-            case 3: length_meters = try reader.decode(Double.self)
-            case 4: mass_kilograms = try reader.decode(Double.self)
+            case 3: length_meters = try reader.decode(Swift.Double.self)
+            case 4: mass_kilograms = try reader.decode(Swift.Double.self)
             case 5: period = try reader.decode(Period.self)
             default: try reader.readUnknownField(tag: tag)
             }
@@ -83,7 +86,7 @@ extension Dinosaur : Proto2Codable {
         self.period = period
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.name)
         try writer.encode(tag: 2, value: self.picture_urls)
         try writer.encode(tag: 3, value: self.length_meters)
@@ -91,21 +94,23 @@ extension Dinosaur : Proto2Codable {
         try writer.encode(tag: 5, value: self.period)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Dinosaur : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(String.self, forKey: "name")
-        self.picture_urls = try container.decodeProtoArray(String.self, firstOfKeys: "pictureUrls", "picture_urls")
-        self.length_meters = try container.decodeIfPresent(Double.self, firstOfKeys: "lengthMeters", "length_meters")
-        self.mass_kilograms = try container.decodeIfPresent(Double.self, firstOfKeys: "massKilograms", "mass_kilograms")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self.picture_urls = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "pictureUrls", "picture_urls")
+        self.length_meters = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "lengthMeters", "length_meters")
+        self.mass_kilograms = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "massKilograms", "mass_kilograms")
         self.period = try container.decodeIfPresent(Period.self, forKey: "period")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
@@ -117,5 +122,6 @@ extension Dinosaur : Codable {
         try container.encodeIfPresent(self.mass_kilograms, forKey: preferCamelCase ? "massKilograms" : "mass_kilograms")
         try container.encodeIfPresent(self.period, forKey: "period")
     }
+
 }
 #endif

--- a/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
@@ -30,13 +30,16 @@ extension ContainsDuration : Sendable {
 #endif
 
 extension ContainsDuration : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos3.kotlin.contains_duration.ContainsDuration"
     }
+
 }
 
 extension ContainsDuration : Proto3Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         var duration: Duration? = nil
 
         let token = try reader.beginMessage()
@@ -51,23 +54,26 @@ extension ContainsDuration : Proto3Codable {
         self.duration = duration
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.duration)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension ContainsDuration : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.duration = try container.decodeIfPresent(Duration.self, forKey: "duration")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.duration, forKey: "duration")
     }
+
 }
 #endif

--- a/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
@@ -30,13 +30,16 @@ extension ContainsTimestamp : Sendable {
 #endif
 
 extension ContainsTimestamp : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos3.kotlin.contains_timestamp.ContainsTimestamp"
     }
+
 }
 
 extension ContainsTimestamp : Proto3Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         var timestamp: Timestamp? = nil
 
         let token = try reader.beginMessage()
@@ -51,23 +54,26 @@ extension ContainsTimestamp : Proto3Codable {
         self.timestamp = timestamp
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.timestamp)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension ContainsTimestamp : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.timestamp = try container.decodeIfPresent(Timestamp.self, forKey: "timestamp")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.timestamp, forKey: "timestamp")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -142,7 +142,7 @@ public struct AllTypes {
             storage.opt_bytes = newValue
         }
     }
-    public var opt_nested_enum: NestedEnum? {
+    public var opt_nested_enum: AllTypes.NestedEnum? {
         get {
             storage.opt_nested_enum
         }
@@ -151,7 +151,7 @@ public struct AllTypes {
             storage.opt_nested_enum = newValue
         }
     }
-    public var opt_nested_message: NestedMessage? {
+    public var opt_nested_message: AllTypes.NestedMessage? {
         get {
             storage.opt_nested_message
         }
@@ -295,7 +295,7 @@ public struct AllTypes {
             storage.req_bytes = newValue
         }
     }
-    public var req_nested_enum: NestedEnum {
+    public var req_nested_enum: AllTypes.NestedEnum {
         get {
             storage.req_nested_enum
         }
@@ -304,7 +304,7 @@ public struct AllTypes {
             storage.req_nested_enum = newValue
         }
     }
-    public var req_nested_message: NestedMessage {
+    public var req_nested_message: AllTypes.NestedMessage {
         get {
             storage.req_nested_message
         }
@@ -448,7 +448,7 @@ public struct AllTypes {
             storage.rep_bytes = newValue
         }
     }
-    public var rep_nested_enum: [NestedEnum] {
+    public var rep_nested_enum: [AllTypes.NestedEnum] {
         get {
             storage.rep_nested_enum
         }
@@ -457,7 +457,7 @@ public struct AllTypes {
             storage.rep_nested_enum = newValue
         }
     }
-    public var rep_nested_message: [NestedMessage] {
+    public var rep_nested_message: [AllTypes.NestedMessage] {
         get {
             storage.rep_nested_message
         }
@@ -583,7 +583,7 @@ public struct AllTypes {
             storage.pack_double = newValue
         }
     }
-    public var pack_nested_enum: [NestedEnum] {
+    public var pack_nested_enum: [AllTypes.NestedEnum] {
         get {
             storage.pack_nested_enum
         }
@@ -727,7 +727,7 @@ public struct AllTypes {
             storage.default_bytes = newValue
         }
     }
-    public var default_nested_enum: NestedEnum? {
+    public var default_nested_enum: AllTypes.NestedEnum? {
         get {
             storage.default_nested_enum
         }
@@ -754,7 +754,7 @@ public struct AllTypes {
             storage.map_string_string = newValue
         }
     }
-    public var map_string_message: [String : NestedMessage] {
+    public var map_string_message: [String : AllTypes.NestedMessage] {
         get {
             storage.map_string_message
         }
@@ -763,7 +763,7 @@ public struct AllTypes {
             storage.map_string_message = newValue
         }
     }
-    public var map_string_enum: [String : NestedEnum] {
+    public var map_string_enum: [String : AllTypes.NestedEnum] {
         get {
             storage.map_string_enum
         }
@@ -1015,7 +1015,7 @@ public struct AllTypes {
             storage.ext_opt_bytes = newValue
         }
     }
-    public var ext_opt_nested_enum: NestedEnum? {
+    public var ext_opt_nested_enum: AllTypes.NestedEnum? {
         get {
             storage.ext_opt_nested_enum
         }
@@ -1024,7 +1024,7 @@ public struct AllTypes {
             storage.ext_opt_nested_enum = newValue
         }
     }
-    public var ext_opt_nested_message: NestedMessage? {
+    public var ext_opt_nested_message: AllTypes.NestedMessage? {
         get {
             storage.ext_opt_nested_message
         }
@@ -1168,7 +1168,7 @@ public struct AllTypes {
             storage.ext_rep_bytes = newValue
         }
     }
-    public var ext_rep_nested_enum: [NestedEnum] {
+    public var ext_rep_nested_enum: [AllTypes.NestedEnum] {
         get {
             storage.ext_rep_nested_enum
         }
@@ -1177,7 +1177,7 @@ public struct AllTypes {
             storage.ext_rep_nested_enum = newValue
         }
     }
-    public var ext_rep_nested_message: [NestedMessage] {
+    public var ext_rep_nested_message: [AllTypes.NestedMessage] {
         get {
             storage.ext_rep_nested_message
         }
@@ -1303,7 +1303,7 @@ public struct AllTypes {
             storage.ext_pack_double = newValue
         }
     }
-    public var ext_pack_nested_enum: [NestedEnum] {
+    public var ext_pack_nested_enum: [AllTypes.NestedEnum] {
         get {
             storage.ext_pack_nested_enum
         }
@@ -1338,8 +1338,8 @@ public struct AllTypes {
         opt_double: Double? = nil,
         opt_string: String? = nil,
         opt_bytes: Data? = nil,
-        opt_nested_enum: NestedEnum? = nil,
-        opt_nested_message: NestedMessage? = nil,
+        opt_nested_enum: AllTypes.NestedEnum? = nil,
+        opt_nested_message: AllTypes.NestedMessage? = nil,
         req_int32: Int32,
         req_uint32: UInt32,
         req_sint32: Int32,
@@ -1355,8 +1355,8 @@ public struct AllTypes {
         req_double: Double,
         req_string: String,
         req_bytes: Data,
-        req_nested_enum: NestedEnum,
-        req_nested_message: NestedMessage,
+        req_nested_enum: AllTypes.NestedEnum,
+        req_nested_message: AllTypes.NestedMessage,
         rep_int32: [Int32] = [],
         rep_uint32: [UInt32] = [],
         rep_sint32: [Int32] = [],
@@ -1372,8 +1372,8 @@ public struct AllTypes {
         rep_double: [Double] = [],
         rep_string: [String] = [],
         rep_bytes: [Data] = [],
-        rep_nested_enum: [NestedEnum] = [],
-        rep_nested_message: [NestedMessage] = [],
+        rep_nested_enum: [AllTypes.NestedEnum] = [],
+        rep_nested_message: [AllTypes.NestedMessage] = [],
         pack_int32: [Int32] = [],
         pack_uint32: [UInt32] = [],
         pack_sint32: [Int32] = [],
@@ -1387,7 +1387,7 @@ public struct AllTypes {
         pack_bool: [Bool] = [],
         pack_float: [Float] = [],
         pack_double: [Double] = [],
-        pack_nested_enum: [NestedEnum] = [],
+        pack_nested_enum: [AllTypes.NestedEnum] = [],
         default_int32: Int32? = nil,
         default_uint32: UInt32? = nil,
         default_sint32: Int32? = nil,
@@ -1403,11 +1403,11 @@ public struct AllTypes {
         default_double: Double? = nil,
         default_string: String? = nil,
         default_bytes: Data? = nil,
-        default_nested_enum: NestedEnum? = nil,
+        default_nested_enum: AllTypes.NestedEnum? = nil,
         map_int32_int32: [Int32 : Int32] = [:],
         map_string_string: [String : String] = [:],
-        map_string_message: [String : NestedMessage] = [:],
-        map_string_enum: [String : NestedEnum] = [:],
+        map_string_message: [String : AllTypes.NestedMessage] = [:],
+        map_string_enum: [String : AllTypes.NestedEnum] = [:],
         array_int32: [Int32] = [],
         array_uint32: [UInt32] = [],
         array_sint32: [Int32] = [],
@@ -1435,8 +1435,8 @@ public struct AllTypes {
         ext_opt_double: Double? = nil,
         ext_opt_string: String? = nil,
         ext_opt_bytes: Data? = nil,
-        ext_opt_nested_enum: NestedEnum? = nil,
-        ext_opt_nested_message: NestedMessage? = nil,
+        ext_opt_nested_enum: AllTypes.NestedEnum? = nil,
+        ext_opt_nested_message: AllTypes.NestedMessage? = nil,
         ext_rep_int32: [Int32] = [],
         ext_rep_uint32: [UInt32] = [],
         ext_rep_sint32: [Int32] = [],
@@ -1452,8 +1452,8 @@ public struct AllTypes {
         ext_rep_double: [Double] = [],
         ext_rep_string: [String] = [],
         ext_rep_bytes: [Data] = [],
-        ext_rep_nested_enum: [NestedEnum] = [],
-        ext_rep_nested_message: [NestedMessage] = [],
+        ext_rep_nested_enum: [AllTypes.NestedEnum] = [],
+        ext_rep_nested_message: [AllTypes.NestedMessage] = [],
         ext_pack_int32: [Int32] = [],
         ext_pack_uint32: [UInt32] = [],
         ext_pack_sint32: [Int32] = [],
@@ -1467,7 +1467,7 @@ public struct AllTypes {
         ext_pack_bool: [Bool] = [],
         ext_pack_float: [Float] = [],
         ext_pack_double: [Double] = [],
-        ext_pack_nested_enum: [NestedEnum] = []
+        ext_pack_nested_enum: [AllTypes.NestedEnum] = []
     ) {
         self.storage = _AllTypes(opt_int32: opt_int32, opt_uint32: opt_uint32,
                 opt_sint32: opt_sint32, opt_fixed32: opt_fixed32, opt_sfixed32: opt_sfixed32,
@@ -2034,19 +2034,22 @@ extension AllTypes.NestedMessage : Sendable {
 #endif
 
 extension AllTypes.NestedMessage : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes.NestedMessage"
     }
+
 }
 
 extension AllTypes.NestedMessage : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var a: Int32? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var a: Swift.Int32? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: a = try reader.decode(Int32.self)
+            case 1: a = try reader.decode(Swift.Int32.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -2055,24 +2058,27 @@ extension AllTypes.NestedMessage : Proto2Codable {
         self.a = a
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.a)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension AllTypes.NestedMessage : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.a = try container.decodeIfPresent(Int32.self, forKey: "a")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.a = try container.decodeIfPresent(Swift.Int32.self, forKey: "a")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.a, forKey: "a")
     }
+
 }
 #endif
 
@@ -2092,204 +2098,209 @@ extension AllTypes : @unchecked Sendable {
 #endif
 
 extension AllTypes : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         self.storage = try _AllTypes(from: reader)
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try storage.encode(to: writer)
     }
+
 }
 
 extension _AllTypes : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.alltypes.AllTypes"
     }
+
 }
 
 extension _AllTypes : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var opt_int32: Int32? = nil
-        var opt_uint32: UInt32? = nil
-        var opt_sint32: Int32? = nil
-        var opt_fixed32: UInt32? = nil
-        var opt_sfixed32: Int32? = nil
-        var opt_int64: Int64? = nil
-        var opt_uint64: UInt64? = nil
-        var opt_sint64: Int64? = nil
-        var opt_fixed64: UInt64? = nil
-        var opt_sfixed64: Int64? = nil
-        var opt_bool: Bool? = nil
-        var opt_float: Float? = nil
-        var opt_double: Double? = nil
-        var opt_string: String? = nil
-        var opt_bytes: Data? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var opt_int32: Swift.Int32? = nil
+        var opt_uint32: Swift.UInt32? = nil
+        var opt_sint32: Swift.Int32? = nil
+        var opt_fixed32: Swift.UInt32? = nil
+        var opt_sfixed32: Swift.Int32? = nil
+        var opt_int64: Swift.Int64? = nil
+        var opt_uint64: Swift.UInt64? = nil
+        var opt_sint64: Swift.Int64? = nil
+        var opt_fixed64: Swift.UInt64? = nil
+        var opt_sfixed64: Swift.Int64? = nil
+        var opt_bool: Swift.Bool? = nil
+        var opt_float: Swift.Float? = nil
+        var opt_double: Swift.Double? = nil
+        var opt_string: Swift.String? = nil
+        var opt_bytes: Foundation.Data? = nil
         var opt_nested_enum: AllTypes.NestedEnum? = nil
         var opt_nested_message: AllTypes.NestedMessage? = nil
-        var req_int32: Int32? = nil
-        var req_uint32: UInt32? = nil
-        var req_sint32: Int32? = nil
-        var req_fixed32: UInt32? = nil
-        var req_sfixed32: Int32? = nil
-        var req_int64: Int64? = nil
-        var req_uint64: UInt64? = nil
-        var req_sint64: Int64? = nil
-        var req_fixed64: UInt64? = nil
-        var req_sfixed64: Int64? = nil
-        var req_bool: Bool? = nil
-        var req_float: Float? = nil
-        var req_double: Double? = nil
-        var req_string: String? = nil
-        var req_bytes: Data? = nil
+        var req_int32: Swift.Int32? = nil
+        var req_uint32: Swift.UInt32? = nil
+        var req_sint32: Swift.Int32? = nil
+        var req_fixed32: Swift.UInt32? = nil
+        var req_sfixed32: Swift.Int32? = nil
+        var req_int64: Swift.Int64? = nil
+        var req_uint64: Swift.UInt64? = nil
+        var req_sint64: Swift.Int64? = nil
+        var req_fixed64: Swift.UInt64? = nil
+        var req_sfixed64: Swift.Int64? = nil
+        var req_bool: Swift.Bool? = nil
+        var req_float: Swift.Float? = nil
+        var req_double: Swift.Double? = nil
+        var req_string: Swift.String? = nil
+        var req_bytes: Foundation.Data? = nil
         var req_nested_enum: AllTypes.NestedEnum? = nil
         var req_nested_message: AllTypes.NestedMessage? = nil
-        var rep_int32: [Int32] = []
-        var rep_uint32: [UInt32] = []
-        var rep_sint32: [Int32] = []
-        var rep_fixed32: [UInt32] = []
-        var rep_sfixed32: [Int32] = []
-        var rep_int64: [Int64] = []
-        var rep_uint64: [UInt64] = []
-        var rep_sint64: [Int64] = []
-        var rep_fixed64: [UInt64] = []
-        var rep_sfixed64: [Int64] = []
-        var rep_bool: [Bool] = []
-        var rep_float: [Float] = []
-        var rep_double: [Double] = []
-        var rep_string: [String] = []
-        var rep_bytes: [Data] = []
+        var rep_int32: [Swift.Int32] = []
+        var rep_uint32: [Swift.UInt32] = []
+        var rep_sint32: [Swift.Int32] = []
+        var rep_fixed32: [Swift.UInt32] = []
+        var rep_sfixed32: [Swift.Int32] = []
+        var rep_int64: [Swift.Int64] = []
+        var rep_uint64: [Swift.UInt64] = []
+        var rep_sint64: [Swift.Int64] = []
+        var rep_fixed64: [Swift.UInt64] = []
+        var rep_sfixed64: [Swift.Int64] = []
+        var rep_bool: [Swift.Bool] = []
+        var rep_float: [Swift.Float] = []
+        var rep_double: [Swift.Double] = []
+        var rep_string: [Swift.String] = []
+        var rep_bytes: [Foundation.Data] = []
         var rep_nested_enum: [AllTypes.NestedEnum] = []
         var rep_nested_message: [AllTypes.NestedMessage] = []
-        var pack_int32: [Int32] = []
-        var pack_uint32: [UInt32] = []
-        var pack_sint32: [Int32] = []
-        var pack_fixed32: [UInt32] = []
-        var pack_sfixed32: [Int32] = []
-        var pack_int64: [Int64] = []
-        var pack_uint64: [UInt64] = []
-        var pack_sint64: [Int64] = []
-        var pack_fixed64: [UInt64] = []
-        var pack_sfixed64: [Int64] = []
-        var pack_bool: [Bool] = []
-        var pack_float: [Float] = []
-        var pack_double: [Double] = []
+        var pack_int32: [Swift.Int32] = []
+        var pack_uint32: [Swift.UInt32] = []
+        var pack_sint32: [Swift.Int32] = []
+        var pack_fixed32: [Swift.UInt32] = []
+        var pack_sfixed32: [Swift.Int32] = []
+        var pack_int64: [Swift.Int64] = []
+        var pack_uint64: [Swift.UInt64] = []
+        var pack_sint64: [Swift.Int64] = []
+        var pack_fixed64: [Swift.UInt64] = []
+        var pack_sfixed64: [Swift.Int64] = []
+        var pack_bool: [Swift.Bool] = []
+        var pack_float: [Swift.Float] = []
+        var pack_double: [Swift.Double] = []
         var pack_nested_enum: [AllTypes.NestedEnum] = []
-        var default_int32: Int32? = nil
-        var default_uint32: UInt32? = nil
-        var default_sint32: Int32? = nil
-        var default_fixed32: UInt32? = nil
-        var default_sfixed32: Int32? = nil
-        var default_int64: Int64? = nil
-        var default_uint64: UInt64? = nil
-        var default_sint64: Int64? = nil
-        var default_fixed64: UInt64? = nil
-        var default_sfixed64: Int64? = nil
-        var default_bool: Bool? = nil
-        var default_float: Float? = nil
-        var default_double: Double? = nil
-        var default_string: String? = nil
-        var default_bytes: Data? = nil
+        var default_int32: Swift.Int32? = nil
+        var default_uint32: Swift.UInt32? = nil
+        var default_sint32: Swift.Int32? = nil
+        var default_fixed32: Swift.UInt32? = nil
+        var default_sfixed32: Swift.Int32? = nil
+        var default_int64: Swift.Int64? = nil
+        var default_uint64: Swift.UInt64? = nil
+        var default_sint64: Swift.Int64? = nil
+        var default_fixed64: Swift.UInt64? = nil
+        var default_sfixed64: Swift.Int64? = nil
+        var default_bool: Swift.Bool? = nil
+        var default_float: Swift.Float? = nil
+        var default_double: Swift.Double? = nil
+        var default_string: Swift.String? = nil
+        var default_bytes: Foundation.Data? = nil
         var default_nested_enum: AllTypes.NestedEnum? = nil
-        var map_int32_int32: [Int32 : Int32] = [:]
-        var map_string_string: [String : String] = [:]
-        var map_string_message: [String : AllTypes.NestedMessage] = [:]
-        var map_string_enum: [String : AllTypes.NestedEnum] = [:]
-        var array_int32: [Int32] = []
-        var array_uint32: [UInt32] = []
-        var array_sint32: [Int32] = []
-        var array_fixed32: [UInt32] = []
-        var array_sfixed32: [Int32] = []
-        var array_int64: [Int64] = []
-        var array_uint64: [UInt64] = []
-        var array_sint64: [Int64] = []
-        var array_fixed64: [UInt64] = []
-        var array_sfixed64: [Int64] = []
-        var array_float: [Float] = []
-        var array_double: [Double] = []
-        var ext_opt_int32: Int32? = nil
-        var ext_opt_uint32: UInt32? = nil
-        var ext_opt_sint32: Int32? = nil
-        var ext_opt_fixed32: UInt32? = nil
-        var ext_opt_sfixed32: Int32? = nil
-        var ext_opt_int64: Int64? = nil
-        var ext_opt_uint64: UInt64? = nil
-        var ext_opt_sint64: Int64? = nil
-        var ext_opt_fixed64: UInt64? = nil
-        var ext_opt_sfixed64: Int64? = nil
-        var ext_opt_bool: Bool? = nil
-        var ext_opt_float: Float? = nil
-        var ext_opt_double: Double? = nil
-        var ext_opt_string: String? = nil
-        var ext_opt_bytes: Data? = nil
+        var map_int32_int32: [Swift.Int32 : Swift.Int32] = [:]
+        var map_string_string: [Swift.String : Swift.String] = [:]
+        var map_string_message: [Swift.String : AllTypes.NestedMessage] = [:]
+        var map_string_enum: [Swift.String : AllTypes.NestedEnum] = [:]
+        var array_int32: [Swift.Int32] = []
+        var array_uint32: [Swift.UInt32] = []
+        var array_sint32: [Swift.Int32] = []
+        var array_fixed32: [Swift.UInt32] = []
+        var array_sfixed32: [Swift.Int32] = []
+        var array_int64: [Swift.Int64] = []
+        var array_uint64: [Swift.UInt64] = []
+        var array_sint64: [Swift.Int64] = []
+        var array_fixed64: [Swift.UInt64] = []
+        var array_sfixed64: [Swift.Int64] = []
+        var array_float: [Swift.Float] = []
+        var array_double: [Swift.Double] = []
+        var ext_opt_int32: Swift.Int32? = nil
+        var ext_opt_uint32: Swift.UInt32? = nil
+        var ext_opt_sint32: Swift.Int32? = nil
+        var ext_opt_fixed32: Swift.UInt32? = nil
+        var ext_opt_sfixed32: Swift.Int32? = nil
+        var ext_opt_int64: Swift.Int64? = nil
+        var ext_opt_uint64: Swift.UInt64? = nil
+        var ext_opt_sint64: Swift.Int64? = nil
+        var ext_opt_fixed64: Swift.UInt64? = nil
+        var ext_opt_sfixed64: Swift.Int64? = nil
+        var ext_opt_bool: Swift.Bool? = nil
+        var ext_opt_float: Swift.Float? = nil
+        var ext_opt_double: Swift.Double? = nil
+        var ext_opt_string: Swift.String? = nil
+        var ext_opt_bytes: Foundation.Data? = nil
         var ext_opt_nested_enum: AllTypes.NestedEnum? = nil
         var ext_opt_nested_message: AllTypes.NestedMessage? = nil
-        var ext_rep_int32: [Int32] = []
-        var ext_rep_uint32: [UInt32] = []
-        var ext_rep_sint32: [Int32] = []
-        var ext_rep_fixed32: [UInt32] = []
-        var ext_rep_sfixed32: [Int32] = []
-        var ext_rep_int64: [Int64] = []
-        var ext_rep_uint64: [UInt64] = []
-        var ext_rep_sint64: [Int64] = []
-        var ext_rep_fixed64: [UInt64] = []
-        var ext_rep_sfixed64: [Int64] = []
-        var ext_rep_bool: [Bool] = []
-        var ext_rep_float: [Float] = []
-        var ext_rep_double: [Double] = []
-        var ext_rep_string: [String] = []
-        var ext_rep_bytes: [Data] = []
+        var ext_rep_int32: [Swift.Int32] = []
+        var ext_rep_uint32: [Swift.UInt32] = []
+        var ext_rep_sint32: [Swift.Int32] = []
+        var ext_rep_fixed32: [Swift.UInt32] = []
+        var ext_rep_sfixed32: [Swift.Int32] = []
+        var ext_rep_int64: [Swift.Int64] = []
+        var ext_rep_uint64: [Swift.UInt64] = []
+        var ext_rep_sint64: [Swift.Int64] = []
+        var ext_rep_fixed64: [Swift.UInt64] = []
+        var ext_rep_sfixed64: [Swift.Int64] = []
+        var ext_rep_bool: [Swift.Bool] = []
+        var ext_rep_float: [Swift.Float] = []
+        var ext_rep_double: [Swift.Double] = []
+        var ext_rep_string: [Swift.String] = []
+        var ext_rep_bytes: [Foundation.Data] = []
         var ext_rep_nested_enum: [AllTypes.NestedEnum] = []
         var ext_rep_nested_message: [AllTypes.NestedMessage] = []
-        var ext_pack_int32: [Int32] = []
-        var ext_pack_uint32: [UInt32] = []
-        var ext_pack_sint32: [Int32] = []
-        var ext_pack_fixed32: [UInt32] = []
-        var ext_pack_sfixed32: [Int32] = []
-        var ext_pack_int64: [Int64] = []
-        var ext_pack_uint64: [UInt64] = []
-        var ext_pack_sint64: [Int64] = []
-        var ext_pack_fixed64: [UInt64] = []
-        var ext_pack_sfixed64: [Int64] = []
-        var ext_pack_bool: [Bool] = []
-        var ext_pack_float: [Float] = []
-        var ext_pack_double: [Double] = []
+        var ext_pack_int32: [Swift.Int32] = []
+        var ext_pack_uint32: [Swift.UInt32] = []
+        var ext_pack_sint32: [Swift.Int32] = []
+        var ext_pack_fixed32: [Swift.UInt32] = []
+        var ext_pack_sfixed32: [Swift.Int32] = []
+        var ext_pack_int64: [Swift.Int64] = []
+        var ext_pack_uint64: [Swift.UInt64] = []
+        var ext_pack_sint64: [Swift.Int64] = []
+        var ext_pack_fixed64: [Swift.UInt64] = []
+        var ext_pack_sfixed64: [Swift.Int64] = []
+        var ext_pack_bool: [Swift.Bool] = []
+        var ext_pack_float: [Swift.Float] = []
+        var ext_pack_double: [Swift.Double] = []
         var ext_pack_nested_enum: [AllTypes.NestedEnum] = []
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: opt_int32 = try reader.decode(Int32.self)
-            case 2: opt_uint32 = try reader.decode(UInt32.self)
-            case 3: opt_sint32 = try reader.decode(Int32.self, encoding: .signed)
-            case 4: opt_fixed32 = try reader.decode(UInt32.self, encoding: .fixed)
-            case 5: opt_sfixed32 = try reader.decode(Int32.self)
-            case 6: opt_int64 = try reader.decode(Int64.self)
-            case 7: opt_uint64 = try reader.decode(UInt64.self)
-            case 8: opt_sint64 = try reader.decode(Int64.self, encoding: .signed)
-            case 9: opt_fixed64 = try reader.decode(UInt64.self, encoding: .fixed)
-            case 10: opt_sfixed64 = try reader.decode(Int64.self)
-            case 11: opt_bool = try reader.decode(Bool.self)
-            case 12: opt_float = try reader.decode(Float.self)
-            case 13: opt_double = try reader.decode(Double.self)
-            case 14: opt_string = try reader.decode(String.self)
-            case 15: opt_bytes = try reader.decode(Data.self)
+            case 1: opt_int32 = try reader.decode(Swift.Int32.self)
+            case 2: opt_uint32 = try reader.decode(Swift.UInt32.self)
+            case 3: opt_sint32 = try reader.decode(Swift.Int32.self, encoding: .signed)
+            case 4: opt_fixed32 = try reader.decode(Swift.UInt32.self, encoding: .fixed)
+            case 5: opt_sfixed32 = try reader.decode(Swift.Int32.self)
+            case 6: opt_int64 = try reader.decode(Swift.Int64.self)
+            case 7: opt_uint64 = try reader.decode(Swift.UInt64.self)
+            case 8: opt_sint64 = try reader.decode(Swift.Int64.self, encoding: .signed)
+            case 9: opt_fixed64 = try reader.decode(Swift.UInt64.self, encoding: .fixed)
+            case 10: opt_sfixed64 = try reader.decode(Swift.Int64.self)
+            case 11: opt_bool = try reader.decode(Swift.Bool.self)
+            case 12: opt_float = try reader.decode(Swift.Float.self)
+            case 13: opt_double = try reader.decode(Swift.Double.self)
+            case 14: opt_string = try reader.decode(Swift.String.self)
+            case 15: opt_bytes = try reader.decode(Foundation.Data.self)
             case 16: opt_nested_enum = try reader.decode(AllTypes.NestedEnum.self)
             case 17: opt_nested_message = try reader.decode(AllTypes.NestedMessage.self)
-            case 101: req_int32 = try reader.decode(Int32.self)
-            case 102: req_uint32 = try reader.decode(UInt32.self)
-            case 103: req_sint32 = try reader.decode(Int32.self, encoding: .signed)
-            case 104: req_fixed32 = try reader.decode(UInt32.self, encoding: .fixed)
-            case 105: req_sfixed32 = try reader.decode(Int32.self)
-            case 106: req_int64 = try reader.decode(Int64.self)
-            case 107: req_uint64 = try reader.decode(UInt64.self)
-            case 108: req_sint64 = try reader.decode(Int64.self, encoding: .signed)
-            case 109: req_fixed64 = try reader.decode(UInt64.self, encoding: .fixed)
-            case 110: req_sfixed64 = try reader.decode(Int64.self)
-            case 111: req_bool = try reader.decode(Bool.self)
-            case 112: req_float = try reader.decode(Float.self)
-            case 113: req_double = try reader.decode(Double.self)
-            case 114: req_string = try reader.decode(String.self)
-            case 115: req_bytes = try reader.decode(Data.self)
+            case 101: req_int32 = try reader.decode(Swift.Int32.self)
+            case 102: req_uint32 = try reader.decode(Swift.UInt32.self)
+            case 103: req_sint32 = try reader.decode(Swift.Int32.self, encoding: .signed)
+            case 104: req_fixed32 = try reader.decode(Swift.UInt32.self, encoding: .fixed)
+            case 105: req_sfixed32 = try reader.decode(Swift.Int32.self)
+            case 106: req_int64 = try reader.decode(Swift.Int64.self)
+            case 107: req_uint64 = try reader.decode(Swift.UInt64.self)
+            case 108: req_sint64 = try reader.decode(Swift.Int64.self, encoding: .signed)
+            case 109: req_fixed64 = try reader.decode(Swift.UInt64.self, encoding: .fixed)
+            case 110: req_sfixed64 = try reader.decode(Swift.Int64.self)
+            case 111: req_bool = try reader.decode(Swift.Bool.self)
+            case 112: req_float = try reader.decode(Swift.Float.self)
+            case 113: req_double = try reader.decode(Swift.Double.self)
+            case 114: req_string = try reader.decode(Swift.String.self)
+            case 115: req_bytes = try reader.decode(Foundation.Data.self)
             case 116: req_nested_enum = try reader.decode(AllTypes.NestedEnum.self)
             case 117: req_nested_message = try reader.decode(AllTypes.NestedMessage.self)
             case 201: try reader.decode(into: &rep_int32)
@@ -2323,21 +2334,21 @@ extension _AllTypes : Proto2Codable {
             case 312: try reader.decode(into: &pack_float)
             case 313: try reader.decode(into: &pack_double)
             case 316: try reader.decode(into: &pack_nested_enum)
-            case 401: default_int32 = try reader.decode(Int32.self)
-            case 402: default_uint32 = try reader.decode(UInt32.self)
-            case 403: default_sint32 = try reader.decode(Int32.self, encoding: .signed)
-            case 404: default_fixed32 = try reader.decode(UInt32.self, encoding: .fixed)
-            case 405: default_sfixed32 = try reader.decode(Int32.self)
-            case 406: default_int64 = try reader.decode(Int64.self)
-            case 407: default_uint64 = try reader.decode(UInt64.self)
-            case 408: default_sint64 = try reader.decode(Int64.self, encoding: .signed)
-            case 409: default_fixed64 = try reader.decode(UInt64.self, encoding: .fixed)
-            case 410: default_sfixed64 = try reader.decode(Int64.self)
-            case 411: default_bool = try reader.decode(Bool.self)
-            case 412: default_float = try reader.decode(Float.self)
-            case 413: default_double = try reader.decode(Double.self)
-            case 414: default_string = try reader.decode(String.self)
-            case 415: default_bytes = try reader.decode(Data.self)
+            case 401: default_int32 = try reader.decode(Swift.Int32.self)
+            case 402: default_uint32 = try reader.decode(Swift.UInt32.self)
+            case 403: default_sint32 = try reader.decode(Swift.Int32.self, encoding: .signed)
+            case 404: default_fixed32 = try reader.decode(Swift.UInt32.self, encoding: .fixed)
+            case 405: default_sfixed32 = try reader.decode(Swift.Int32.self)
+            case 406: default_int64 = try reader.decode(Swift.Int64.self)
+            case 407: default_uint64 = try reader.decode(Swift.UInt64.self)
+            case 408: default_sint64 = try reader.decode(Swift.Int64.self, encoding: .signed)
+            case 409: default_fixed64 = try reader.decode(Swift.UInt64.self, encoding: .fixed)
+            case 410: default_sfixed64 = try reader.decode(Swift.Int64.self)
+            case 411: default_bool = try reader.decode(Swift.Bool.self)
+            case 412: default_float = try reader.decode(Swift.Float.self)
+            case 413: default_double = try reader.decode(Swift.Double.self)
+            case 414: default_string = try reader.decode(Swift.String.self)
+            case 415: default_bytes = try reader.decode(Foundation.Data.self)
             case 416: default_nested_enum = try reader.decode(AllTypes.NestedEnum.self)
             case 501: try reader.decode(into: &map_int32_int32)
             case 502: try reader.decode(into: &map_string_string)
@@ -2355,21 +2366,21 @@ extension _AllTypes : Proto2Codable {
             case 610: try reader.decode(into: &array_sfixed64)
             case 611: try reader.decode(into: &array_float)
             case 612: try reader.decode(into: &array_double)
-            case 1001: ext_opt_int32 = try reader.decode(Int32.self)
-            case 1002: ext_opt_uint32 = try reader.decode(UInt32.self)
-            case 1003: ext_opt_sint32 = try reader.decode(Int32.self, encoding: .signed)
-            case 1004: ext_opt_fixed32 = try reader.decode(UInt32.self, encoding: .fixed)
-            case 1005: ext_opt_sfixed32 = try reader.decode(Int32.self)
-            case 1006: ext_opt_int64 = try reader.decode(Int64.self)
-            case 1007: ext_opt_uint64 = try reader.decode(UInt64.self)
-            case 1008: ext_opt_sint64 = try reader.decode(Int64.self, encoding: .signed)
-            case 1009: ext_opt_fixed64 = try reader.decode(UInt64.self, encoding: .fixed)
-            case 1010: ext_opt_sfixed64 = try reader.decode(Int64.self)
-            case 1011: ext_opt_bool = try reader.decode(Bool.self)
-            case 1012: ext_opt_float = try reader.decode(Float.self)
-            case 1013: ext_opt_double = try reader.decode(Double.self)
-            case 1014: ext_opt_string = try reader.decode(String.self)
-            case 1015: ext_opt_bytes = try reader.decode(Data.self)
+            case 1001: ext_opt_int32 = try reader.decode(Swift.Int32.self)
+            case 1002: ext_opt_uint32 = try reader.decode(Swift.UInt32.self)
+            case 1003: ext_opt_sint32 = try reader.decode(Swift.Int32.self, encoding: .signed)
+            case 1004: ext_opt_fixed32 = try reader.decode(Swift.UInt32.self, encoding: .fixed)
+            case 1005: ext_opt_sfixed32 = try reader.decode(Swift.Int32.self)
+            case 1006: ext_opt_int64 = try reader.decode(Swift.Int64.self)
+            case 1007: ext_opt_uint64 = try reader.decode(Swift.UInt64.self)
+            case 1008: ext_opt_sint64 = try reader.decode(Swift.Int64.self, encoding: .signed)
+            case 1009: ext_opt_fixed64 = try reader.decode(Swift.UInt64.self, encoding: .fixed)
+            case 1010: ext_opt_sfixed64 = try reader.decode(Swift.Int64.self)
+            case 1011: ext_opt_bool = try reader.decode(Swift.Bool.self)
+            case 1012: ext_opt_float = try reader.decode(Swift.Float.self)
+            case 1013: ext_opt_double = try reader.decode(Swift.Double.self)
+            case 1014: ext_opt_string = try reader.decode(Swift.String.self)
+            case 1015: ext_opt_bytes = try reader.decode(Foundation.Data.self)
             case 1016: ext_opt_nested_enum = try reader.decode(AllTypes.NestedEnum.self)
             case 1017: ext_opt_nested_message = try reader.decode(AllTypes.NestedMessage.self)
             case 1101: try reader.decode(into: &ext_rep_int32)
@@ -2555,7 +2566,7 @@ extension _AllTypes : Proto2Codable {
         self.ext_pack_nested_enum = ext_pack_nested_enum
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.opt_int32)
         try writer.encode(tag: 2, value: self.opt_uint32)
         try writer.encode(tag: 3, value: self.opt_sint32, encoding: .signed)
@@ -2703,175 +2714,179 @@ extension _AllTypes : Proto2Codable {
         try writer.encode(tag: 1216, value: self.ext_pack_nested_enum, packed: true)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension AllTypes : Codable {
-    public init(from decoder: Decoder) throws {
+
+    public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.singleValueContainer()
         self.storage = try container.decode(_AllTypes.self)
     }
 
-    public func encode(to encoder: Encoder) throws {
+    public func encode(to encoder: Swift.Encoder) throws {
         var container = encoder.singleValueContainer()
         try container.encode(storage)
     }
+
 }
 #endif
 
 #if !WIRE_REMOVE_CODABLE
 extension _AllTypes : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.opt_int32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "optInt32", "opt_int32")
-        self.opt_uint32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "optUint32", "opt_uint32")
-        self.opt_sint32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "optSint32", "opt_sint32")
-        self.opt_fixed32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "optFixed32", "opt_fixed32")
-        self.opt_sfixed32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "optSfixed32", "opt_sfixed32")
-        self.opt_int64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "optInt64", "opt_int64")
-        self.opt_uint64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "optUint64", "opt_uint64")
-        self.opt_sint64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "optSint64", "opt_sint64")
-        self.opt_fixed64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "optFixed64", "opt_fixed64")
-        self.opt_sfixed64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "optSfixed64", "opt_sfixed64")
-        self.opt_bool = try container.decodeIfPresent(Bool.self, firstOfKeys: "optBool", "opt_bool")
-        self.opt_float = try container.decodeIfPresent(Float.self, firstOfKeys: "optFloat", "opt_float")
-        self.opt_double = try container.decodeIfPresent(Double.self, firstOfKeys: "optDouble", "opt_double")
-        self.opt_string = try container.decodeIfPresent(String.self, firstOfKeys: "optString", "opt_string")
-        self.opt_bytes = try container.decodeIfPresent(stringEncoded: Data.self, firstOfKeys: "optBytes", "opt_bytes")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.opt_int32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optInt32", "opt_int32")
+        self.opt_uint32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "optUint32", "opt_uint32")
+        self.opt_sint32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optSint32", "opt_sint32")
+        self.opt_fixed32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "optFixed32", "opt_fixed32")
+        self.opt_sfixed32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optSfixed32", "opt_sfixed32")
+        self.opt_int64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optInt64", "opt_int64")
+        self.opt_uint64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "optUint64", "opt_uint64")
+        self.opt_sint64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optSint64", "opt_sint64")
+        self.opt_fixed64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "optFixed64", "opt_fixed64")
+        self.opt_sfixed64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optSfixed64", "opt_sfixed64")
+        self.opt_bool = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "optBool", "opt_bool")
+        self.opt_float = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "optFloat", "opt_float")
+        self.opt_double = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "optDouble", "opt_double")
+        self.opt_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "optString", "opt_string")
+        self.opt_bytes = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "optBytes", "opt_bytes")
         self.opt_nested_enum = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "optNestedEnum", "opt_nested_enum")
         self.opt_nested_message = try container.decodeIfPresent(AllTypes.NestedMessage.self, firstOfKeys: "optNestedMessage", "opt_nested_message")
-        self.req_int32 = try container.decode(Int32.self, firstOfKeys: "reqInt32", "req_int32")
-        self.req_uint32 = try container.decode(UInt32.self, firstOfKeys: "reqUint32", "req_uint32")
-        self.req_sint32 = try container.decode(Int32.self, firstOfKeys: "reqSint32", "req_sint32")
-        self.req_fixed32 = try container.decode(UInt32.self, firstOfKeys: "reqFixed32", "req_fixed32")
-        self.req_sfixed32 = try container.decode(Int32.self, firstOfKeys: "reqSfixed32", "req_sfixed32")
-        self.req_int64 = try container.decode(stringEncoded: Int64.self, firstOfKeys: "reqInt64", "req_int64")
-        self.req_uint64 = try container.decode(stringEncoded: UInt64.self, firstOfKeys: "reqUint64", "req_uint64")
-        self.req_sint64 = try container.decode(stringEncoded: Int64.self, firstOfKeys: "reqSint64", "req_sint64")
-        self.req_fixed64 = try container.decode(stringEncoded: UInt64.self, firstOfKeys: "reqFixed64", "req_fixed64")
-        self.req_sfixed64 = try container.decode(stringEncoded: Int64.self, firstOfKeys: "reqSfixed64", "req_sfixed64")
-        self.req_bool = try container.decode(Bool.self, firstOfKeys: "reqBool", "req_bool")
-        self.req_float = try container.decode(Float.self, firstOfKeys: "reqFloat", "req_float")
-        self.req_double = try container.decode(Double.self, firstOfKeys: "reqDouble", "req_double")
-        self.req_string = try container.decode(String.self, firstOfKeys: "reqString", "req_string")
-        self.req_bytes = try container.decode(stringEncoded: Data.self, firstOfKeys: "reqBytes", "req_bytes")
+        self.req_int32 = try container.decode(Swift.Int32.self, firstOfKeys: "reqInt32", "req_int32")
+        self.req_uint32 = try container.decode(Swift.UInt32.self, firstOfKeys: "reqUint32", "req_uint32")
+        self.req_sint32 = try container.decode(Swift.Int32.self, firstOfKeys: "reqSint32", "req_sint32")
+        self.req_fixed32 = try container.decode(Swift.UInt32.self, firstOfKeys: "reqFixed32", "req_fixed32")
+        self.req_sfixed32 = try container.decode(Swift.Int32.self, firstOfKeys: "reqSfixed32", "req_sfixed32")
+        self.req_int64 = try container.decode(stringEncoded: Swift.Int64.self, firstOfKeys: "reqInt64", "req_int64")
+        self.req_uint64 = try container.decode(stringEncoded: Swift.UInt64.self, firstOfKeys: "reqUint64", "req_uint64")
+        self.req_sint64 = try container.decode(stringEncoded: Swift.Int64.self, firstOfKeys: "reqSint64", "req_sint64")
+        self.req_fixed64 = try container.decode(stringEncoded: Swift.UInt64.self, firstOfKeys: "reqFixed64", "req_fixed64")
+        self.req_sfixed64 = try container.decode(stringEncoded: Swift.Int64.self, firstOfKeys: "reqSfixed64", "req_sfixed64")
+        self.req_bool = try container.decode(Swift.Bool.self, firstOfKeys: "reqBool", "req_bool")
+        self.req_float = try container.decode(Swift.Float.self, firstOfKeys: "reqFloat", "req_float")
+        self.req_double = try container.decode(Swift.Double.self, firstOfKeys: "reqDouble", "req_double")
+        self.req_string = try container.decode(Swift.String.self, firstOfKeys: "reqString", "req_string")
+        self.req_bytes = try container.decode(stringEncoded: Foundation.Data.self, firstOfKeys: "reqBytes", "req_bytes")
         self.req_nested_enum = try container.decode(AllTypes.NestedEnum.self, firstOfKeys: "reqNestedEnum", "req_nested_enum")
         self.req_nested_message = try container.decode(AllTypes.NestedMessage.self, firstOfKeys: "reqNestedMessage", "req_nested_message")
-        self.rep_int32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "repInt32", "rep_int32")
-        self.rep_uint32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "repUint32", "rep_uint32")
-        self.rep_sint32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "repSint32", "rep_sint32")
-        self.rep_fixed32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "repFixed32", "rep_fixed32")
-        self.rep_sfixed32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "repSfixed32", "rep_sfixed32")
-        self.rep_int64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "repInt64", "rep_int64")
-        self.rep_uint64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "repUint64", "rep_uint64")
-        self.rep_sint64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "repSint64", "rep_sint64")
-        self.rep_fixed64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "repFixed64", "rep_fixed64")
-        self.rep_sfixed64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "repSfixed64", "rep_sfixed64")
-        self.rep_bool = try container.decodeProtoArray(Bool.self, firstOfKeys: "repBool", "rep_bool")
-        self.rep_float = try container.decodeProtoArray(Float.self, firstOfKeys: "repFloat", "rep_float")
-        self.rep_double = try container.decodeProtoArray(Double.self, firstOfKeys: "repDouble", "rep_double")
-        self.rep_string = try container.decodeProtoArray(String.self, firstOfKeys: "repString", "rep_string")
-        self.rep_bytes = try container.decodeProtoArray(Data.self, firstOfKeys: "repBytes", "rep_bytes")
+        self.rep_int32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "repInt32", "rep_int32")
+        self.rep_uint32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "repUint32", "rep_uint32")
+        self.rep_sint32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "repSint32", "rep_sint32")
+        self.rep_fixed32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "repFixed32", "rep_fixed32")
+        self.rep_sfixed32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "repSfixed32", "rep_sfixed32")
+        self.rep_int64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "repInt64", "rep_int64")
+        self.rep_uint64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "repUint64", "rep_uint64")
+        self.rep_sint64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "repSint64", "rep_sint64")
+        self.rep_fixed64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "repFixed64", "rep_fixed64")
+        self.rep_sfixed64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "repSfixed64", "rep_sfixed64")
+        self.rep_bool = try container.decodeProtoArray(Swift.Bool.self, firstOfKeys: "repBool", "rep_bool")
+        self.rep_float = try container.decodeProtoArray(Swift.Float.self, firstOfKeys: "repFloat", "rep_float")
+        self.rep_double = try container.decodeProtoArray(Swift.Double.self, firstOfKeys: "repDouble", "rep_double")
+        self.rep_string = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "repString", "rep_string")
+        self.rep_bytes = try container.decodeProtoArray(Foundation.Data.self, firstOfKeys: "repBytes", "rep_bytes")
         self.rep_nested_enum = try container.decodeProtoArray(AllTypes.NestedEnum.self, firstOfKeys: "repNestedEnum", "rep_nested_enum")
         self.rep_nested_message = try container.decodeProtoArray(AllTypes.NestedMessage.self, firstOfKeys: "repNestedMessage", "rep_nested_message")
-        self.pack_int32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "packInt32", "pack_int32")
-        self.pack_uint32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "packUint32", "pack_uint32")
-        self.pack_sint32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "packSint32", "pack_sint32")
-        self.pack_fixed32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "packFixed32", "pack_fixed32")
-        self.pack_sfixed32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "packSfixed32", "pack_sfixed32")
-        self.pack_int64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "packInt64", "pack_int64")
-        self.pack_uint64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "packUint64", "pack_uint64")
-        self.pack_sint64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "packSint64", "pack_sint64")
-        self.pack_fixed64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "packFixed64", "pack_fixed64")
-        self.pack_sfixed64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "packSfixed64", "pack_sfixed64")
-        self.pack_bool = try container.decodeProtoArray(Bool.self, firstOfKeys: "packBool", "pack_bool")
-        self.pack_float = try container.decodeProtoArray(Float.self, firstOfKeys: "packFloat", "pack_float")
-        self.pack_double = try container.decodeProtoArray(Double.self, firstOfKeys: "packDouble", "pack_double")
+        self.pack_int32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "packInt32", "pack_int32")
+        self.pack_uint32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "packUint32", "pack_uint32")
+        self.pack_sint32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "packSint32", "pack_sint32")
+        self.pack_fixed32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "packFixed32", "pack_fixed32")
+        self.pack_sfixed32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "packSfixed32", "pack_sfixed32")
+        self.pack_int64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "packInt64", "pack_int64")
+        self.pack_uint64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "packUint64", "pack_uint64")
+        self.pack_sint64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "packSint64", "pack_sint64")
+        self.pack_fixed64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "packFixed64", "pack_fixed64")
+        self.pack_sfixed64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "packSfixed64", "pack_sfixed64")
+        self.pack_bool = try container.decodeProtoArray(Swift.Bool.self, firstOfKeys: "packBool", "pack_bool")
+        self.pack_float = try container.decodeProtoArray(Swift.Float.self, firstOfKeys: "packFloat", "pack_float")
+        self.pack_double = try container.decodeProtoArray(Swift.Double.self, firstOfKeys: "packDouble", "pack_double")
         self.pack_nested_enum = try container.decodeProtoArray(AllTypes.NestedEnum.self, firstOfKeys: "packNestedEnum", "pack_nested_enum")
-        self.default_int32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "defaultInt32", "default_int32")
-        self.default_uint32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "defaultUint32", "default_uint32")
-        self.default_sint32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "defaultSint32", "default_sint32")
-        self.default_fixed32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "defaultFixed32", "default_fixed32")
-        self.default_sfixed32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "defaultSfixed32", "default_sfixed32")
-        self.default_int64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "defaultInt64", "default_int64")
-        self.default_uint64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "defaultUint64", "default_uint64")
-        self.default_sint64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "defaultSint64", "default_sint64")
-        self.default_fixed64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "defaultFixed64", "default_fixed64")
-        self.default_sfixed64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "defaultSfixed64", "default_sfixed64")
-        self.default_bool = try container.decodeIfPresent(Bool.self, firstOfKeys: "defaultBool", "default_bool")
-        self.default_float = try container.decodeIfPresent(Float.self, firstOfKeys: "defaultFloat", "default_float")
-        self.default_double = try container.decodeIfPresent(Double.self, firstOfKeys: "defaultDouble", "default_double")
-        self.default_string = try container.decodeIfPresent(String.self, firstOfKeys: "defaultString", "default_string")
-        self.default_bytes = try container.decodeIfPresent(stringEncoded: Data.self, firstOfKeys: "defaultBytes", "default_bytes")
+        self.default_int32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultInt32", "default_int32")
+        self.default_uint32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "defaultUint32", "default_uint32")
+        self.default_sint32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultSint32", "default_sint32")
+        self.default_fixed32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "defaultFixed32", "default_fixed32")
+        self.default_sfixed32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultSfixed32", "default_sfixed32")
+        self.default_int64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultInt64", "default_int64")
+        self.default_uint64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "defaultUint64", "default_uint64")
+        self.default_sint64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultSint64", "default_sint64")
+        self.default_fixed64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "defaultFixed64", "default_fixed64")
+        self.default_sfixed64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultSfixed64", "default_sfixed64")
+        self.default_bool = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "defaultBool", "default_bool")
+        self.default_float = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "defaultFloat", "default_float")
+        self.default_double = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "defaultDouble", "default_double")
+        self.default_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "defaultString", "default_string")
+        self.default_bytes = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "defaultBytes", "default_bytes")
         self.default_nested_enum = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "defaultNestedEnum", "default_nested_enum")
-        self.map_int32_int32 = try container.decodeProtoMap([Int32 : Int32].self, firstOfKeys: "mapInt32Int32", "map_int32_int32")
-        self.map_string_string = try container.decodeProtoMap([String : String].self, firstOfKeys: "mapStringString", "map_string_string")
-        self.map_string_message = try container.decodeProtoMap([String : AllTypes.NestedMessage].self, firstOfKeys: "mapStringMessage", "map_string_message")
-        self.map_string_enum = try container.decodeProtoMap([String : AllTypes.NestedEnum].self, firstOfKeys: "mapStringEnum", "map_string_enum")
-        self.array_int32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "arrayInt32", "array_int32")
-        self.array_uint32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "arrayUint32", "array_uint32")
-        self.array_sint32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "arraySint32", "array_sint32")
-        self.array_fixed32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "arrayFixed32", "array_fixed32")
-        self.array_sfixed32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "arraySfixed32", "array_sfixed32")
-        self.array_int64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "arrayInt64", "array_int64")
-        self.array_uint64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "arrayUint64", "array_uint64")
-        self.array_sint64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "arraySint64", "array_sint64")
-        self.array_fixed64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "arrayFixed64", "array_fixed64")
-        self.array_sfixed64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "arraySfixed64", "array_sfixed64")
-        self.array_float = try container.decodeProtoArray(Float.self, firstOfKeys: "arrayFloat", "array_float")
-        self.array_double = try container.decodeProtoArray(Double.self, firstOfKeys: "arrayDouble", "array_double")
-        self.ext_opt_int32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "extOptInt32", "ext_opt_int32")
-        self.ext_opt_uint32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "extOptUint32", "ext_opt_uint32")
-        self.ext_opt_sint32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "extOptSint32", "ext_opt_sint32")
-        self.ext_opt_fixed32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "extOptFixed32", "ext_opt_fixed32")
-        self.ext_opt_sfixed32 = try container.decodeIfPresent(Int32.self, firstOfKeys: "extOptSfixed32", "ext_opt_sfixed32")
-        self.ext_opt_int64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "extOptInt64", "ext_opt_int64")
-        self.ext_opt_uint64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "extOptUint64", "ext_opt_uint64")
-        self.ext_opt_sint64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "extOptSint64", "ext_opt_sint64")
-        self.ext_opt_fixed64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "extOptFixed64", "ext_opt_fixed64")
-        self.ext_opt_sfixed64 = try container.decodeIfPresent(stringEncoded: Int64.self, firstOfKeys: "extOptSfixed64", "ext_opt_sfixed64")
-        self.ext_opt_bool = try container.decodeIfPresent(Bool.self, firstOfKeys: "extOptBool", "ext_opt_bool")
-        self.ext_opt_float = try container.decodeIfPresent(Float.self, firstOfKeys: "extOptFloat", "ext_opt_float")
-        self.ext_opt_double = try container.decodeIfPresent(Double.self, firstOfKeys: "extOptDouble", "ext_opt_double")
-        self.ext_opt_string = try container.decodeIfPresent(String.self, firstOfKeys: "extOptString", "ext_opt_string")
-        self.ext_opt_bytes = try container.decodeIfPresent(stringEncoded: Data.self, firstOfKeys: "extOptBytes", "ext_opt_bytes")
+        self.map_int32_int32 = try container.decodeProtoMap([Swift.Int32 : Swift.Int32].self, firstOfKeys: "mapInt32Int32", "map_int32_int32")
+        self.map_string_string = try container.decodeProtoMap([Swift.String : Swift.String].self, firstOfKeys: "mapStringString", "map_string_string")
+        self.map_string_message = try container.decodeProtoMap([Swift.String : AllTypes.NestedMessage].self, firstOfKeys: "mapStringMessage", "map_string_message")
+        self.map_string_enum = try container.decodeProtoMap([Swift.String : AllTypes.NestedEnum].self, firstOfKeys: "mapStringEnum", "map_string_enum")
+        self.array_int32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "arrayInt32", "array_int32")
+        self.array_uint32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "arrayUint32", "array_uint32")
+        self.array_sint32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "arraySint32", "array_sint32")
+        self.array_fixed32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "arrayFixed32", "array_fixed32")
+        self.array_sfixed32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "arraySfixed32", "array_sfixed32")
+        self.array_int64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "arrayInt64", "array_int64")
+        self.array_uint64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "arrayUint64", "array_uint64")
+        self.array_sint64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "arraySint64", "array_sint64")
+        self.array_fixed64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "arrayFixed64", "array_fixed64")
+        self.array_sfixed64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "arraySfixed64", "array_sfixed64")
+        self.array_float = try container.decodeProtoArray(Swift.Float.self, firstOfKeys: "arrayFloat", "array_float")
+        self.array_double = try container.decodeProtoArray(Swift.Double.self, firstOfKeys: "arrayDouble", "array_double")
+        self.ext_opt_int32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptInt32", "ext_opt_int32")
+        self.ext_opt_uint32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "extOptUint32", "ext_opt_uint32")
+        self.ext_opt_sint32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptSint32", "ext_opt_sint32")
+        self.ext_opt_fixed32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "extOptFixed32", "ext_opt_fixed32")
+        self.ext_opt_sfixed32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptSfixed32", "ext_opt_sfixed32")
+        self.ext_opt_int64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptInt64", "ext_opt_int64")
+        self.ext_opt_uint64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "extOptUint64", "ext_opt_uint64")
+        self.ext_opt_sint64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptSint64", "ext_opt_sint64")
+        self.ext_opt_fixed64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "extOptFixed64", "ext_opt_fixed64")
+        self.ext_opt_sfixed64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptSfixed64", "ext_opt_sfixed64")
+        self.ext_opt_bool = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "extOptBool", "ext_opt_bool")
+        self.ext_opt_float = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "extOptFloat", "ext_opt_float")
+        self.ext_opt_double = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "extOptDouble", "ext_opt_double")
+        self.ext_opt_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "extOptString", "ext_opt_string")
+        self.ext_opt_bytes = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "extOptBytes", "ext_opt_bytes")
         self.ext_opt_nested_enum = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "extOptNestedEnum", "ext_opt_nested_enum")
         self.ext_opt_nested_message = try container.decodeIfPresent(AllTypes.NestedMessage.self, firstOfKeys: "extOptNestedMessage", "ext_opt_nested_message")
-        self.ext_rep_int32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "extRepInt32", "ext_rep_int32")
-        self.ext_rep_uint32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "extRepUint32", "ext_rep_uint32")
-        self.ext_rep_sint32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "extRepSint32", "ext_rep_sint32")
-        self.ext_rep_fixed32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "extRepFixed32", "ext_rep_fixed32")
-        self.ext_rep_sfixed32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "extRepSfixed32", "ext_rep_sfixed32")
-        self.ext_rep_int64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "extRepInt64", "ext_rep_int64")
-        self.ext_rep_uint64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "extRepUint64", "ext_rep_uint64")
-        self.ext_rep_sint64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "extRepSint64", "ext_rep_sint64")
-        self.ext_rep_fixed64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "extRepFixed64", "ext_rep_fixed64")
-        self.ext_rep_sfixed64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "extRepSfixed64", "ext_rep_sfixed64")
-        self.ext_rep_bool = try container.decodeProtoArray(Bool.self, firstOfKeys: "extRepBool", "ext_rep_bool")
-        self.ext_rep_float = try container.decodeProtoArray(Float.self, firstOfKeys: "extRepFloat", "ext_rep_float")
-        self.ext_rep_double = try container.decodeProtoArray(Double.self, firstOfKeys: "extRepDouble", "ext_rep_double")
-        self.ext_rep_string = try container.decodeProtoArray(String.self, firstOfKeys: "extRepString", "ext_rep_string")
-        self.ext_rep_bytes = try container.decodeProtoArray(Data.self, firstOfKeys: "extRepBytes", "ext_rep_bytes")
+        self.ext_rep_int32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extRepInt32", "ext_rep_int32")
+        self.ext_rep_uint32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "extRepUint32", "ext_rep_uint32")
+        self.ext_rep_sint32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extRepSint32", "ext_rep_sint32")
+        self.ext_rep_fixed32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "extRepFixed32", "ext_rep_fixed32")
+        self.ext_rep_sfixed32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extRepSfixed32", "ext_rep_sfixed32")
+        self.ext_rep_int64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "extRepInt64", "ext_rep_int64")
+        self.ext_rep_uint64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "extRepUint64", "ext_rep_uint64")
+        self.ext_rep_sint64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "extRepSint64", "ext_rep_sint64")
+        self.ext_rep_fixed64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "extRepFixed64", "ext_rep_fixed64")
+        self.ext_rep_sfixed64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "extRepSfixed64", "ext_rep_sfixed64")
+        self.ext_rep_bool = try container.decodeProtoArray(Swift.Bool.self, firstOfKeys: "extRepBool", "ext_rep_bool")
+        self.ext_rep_float = try container.decodeProtoArray(Swift.Float.self, firstOfKeys: "extRepFloat", "ext_rep_float")
+        self.ext_rep_double = try container.decodeProtoArray(Swift.Double.self, firstOfKeys: "extRepDouble", "ext_rep_double")
+        self.ext_rep_string = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "extRepString", "ext_rep_string")
+        self.ext_rep_bytes = try container.decodeProtoArray(Foundation.Data.self, firstOfKeys: "extRepBytes", "ext_rep_bytes")
         self.ext_rep_nested_enum = try container.decodeProtoArray(AllTypes.NestedEnum.self, firstOfKeys: "extRepNestedEnum", "ext_rep_nested_enum")
         self.ext_rep_nested_message = try container.decodeProtoArray(AllTypes.NestedMessage.self, firstOfKeys: "extRepNestedMessage", "ext_rep_nested_message")
-        self.ext_pack_int32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "extPackInt32", "ext_pack_int32")
-        self.ext_pack_uint32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "extPackUint32", "ext_pack_uint32")
-        self.ext_pack_sint32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "extPackSint32", "ext_pack_sint32")
-        self.ext_pack_fixed32 = try container.decodeProtoArray(UInt32.self, firstOfKeys: "extPackFixed32", "ext_pack_fixed32")
-        self.ext_pack_sfixed32 = try container.decodeProtoArray(Int32.self, firstOfKeys: "extPackSfixed32", "ext_pack_sfixed32")
-        self.ext_pack_int64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "extPackInt64", "ext_pack_int64")
-        self.ext_pack_uint64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "extPackUint64", "ext_pack_uint64")
-        self.ext_pack_sint64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "extPackSint64", "ext_pack_sint64")
-        self.ext_pack_fixed64 = try container.decodeProtoArray(UInt64.self, firstOfKeys: "extPackFixed64", "ext_pack_fixed64")
-        self.ext_pack_sfixed64 = try container.decodeProtoArray(Int64.self, firstOfKeys: "extPackSfixed64", "ext_pack_sfixed64")
-        self.ext_pack_bool = try container.decodeProtoArray(Bool.self, firstOfKeys: "extPackBool", "ext_pack_bool")
-        self.ext_pack_float = try container.decodeProtoArray(Float.self, firstOfKeys: "extPackFloat", "ext_pack_float")
-        self.ext_pack_double = try container.decodeProtoArray(Double.self, firstOfKeys: "extPackDouble", "ext_pack_double")
+        self.ext_pack_int32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extPackInt32", "ext_pack_int32")
+        self.ext_pack_uint32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "extPackUint32", "ext_pack_uint32")
+        self.ext_pack_sint32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extPackSint32", "ext_pack_sint32")
+        self.ext_pack_fixed32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "extPackFixed32", "ext_pack_fixed32")
+        self.ext_pack_sfixed32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extPackSfixed32", "ext_pack_sfixed32")
+        self.ext_pack_int64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "extPackInt64", "ext_pack_int64")
+        self.ext_pack_uint64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "extPackUint64", "ext_pack_uint64")
+        self.ext_pack_sint64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "extPackSint64", "ext_pack_sint64")
+        self.ext_pack_fixed64 = try container.decodeProtoArray(Swift.UInt64.self, firstOfKeys: "extPackFixed64", "ext_pack_fixed64")
+        self.ext_pack_sfixed64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "extPackSfixed64", "ext_pack_sfixed64")
+        self.ext_pack_bool = try container.decodeProtoArray(Swift.Bool.self, firstOfKeys: "extPackBool", "ext_pack_bool")
+        self.ext_pack_float = try container.decodeProtoArray(Swift.Float.self, firstOfKeys: "extPackFloat", "ext_pack_float")
+        self.ext_pack_double = try container.decodeProtoArray(Swift.Double.self, firstOfKeys: "extPackDouble", "ext_pack_double")
         self.ext_pack_nested_enum = try container.decodeProtoArray(AllTypes.NestedEnum.self, firstOfKeys: "extPackNestedEnum", "ext_pack_nested_enum")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
@@ -3209,6 +3224,7 @@ extension _AllTypes : Codable {
             try container.encodeProtoArray(self.ext_pack_nested_enum, forKey: preferCamelCase ? "extPackNestedEnum" : "ext_pack_nested_enum")
         }
     }
+
 }
 #endif
 

--- a/wire-tests-swift/src/main/swift/DeprecatedProto.swift
+++ b/wire-tests-swift/src/main/swift/DeprecatedProto.swift
@@ -31,19 +31,22 @@ extension DeprecatedProto : Sendable {
 #endif
 
 extension DeprecatedProto : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.DeprecatedProto"
     }
+
 }
 
 extension DeprecatedProto : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var foo: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var foo: Swift.String? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: foo = try reader.decode(String.self)
+            case 1: foo = try reader.decode(Swift.String.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -52,23 +55,26 @@ extension DeprecatedProto : Proto2Codable {
         self.foo = foo
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.foo)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension DeprecatedProto : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.foo = try container.decodeIfPresent(String.self, forKey: "foo")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.foo = try container.decodeIfPresent(Swift.String.self, forKey: "foo")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.foo, forKey: "foo")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -32,21 +32,24 @@ extension EmbeddedMessage : Sendable {
 #endif
 
 extension EmbeddedMessage : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.packed_encoding.EmbeddedMessage"
     }
+
 }
 
 extension EmbeddedMessage : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var inner_repeated_number: [Int32] = []
-        var inner_number_after: Int32? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var inner_repeated_number: [Swift.Int32] = []
+        var inner_number_after: Swift.Int32? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
             case 1: try reader.decode(into: &inner_repeated_number)
-            case 2: inner_number_after = try reader.decode(Int32.self)
+            case 2: inner_number_after = try reader.decode(Swift.Int32.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -56,23 +59,25 @@ extension EmbeddedMessage : Proto2Codable {
         self.inner_number_after = inner_number_after
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.inner_repeated_number, packed: true)
         try writer.encode(tag: 2, value: self.inner_number_after)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension EmbeddedMessage : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.inner_repeated_number = try container.decodeProtoArray(Int32.self, firstOfKeys: "innerRepeatedNumber", "inner_repeated_number")
-        self.inner_number_after = try container.decodeIfPresent(Int32.self, firstOfKeys: "innerNumberAfter", "inner_number_after")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.inner_repeated_number = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "innerRepeatedNumber", "inner_repeated_number")
+        self.inner_number_after = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "innerNumberAfter", "inner_number_after")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
@@ -81,5 +86,6 @@ extension EmbeddedMessage : Codable {
         }
         try container.encodeIfPresent(self.inner_number_after, forKey: preferCamelCase ? "innerNumberAfter" : "inner_number_after")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/ExternalMessage.swift
+++ b/wire-tests-swift/src/main/swift/ExternalMessage.swift
@@ -30,19 +30,22 @@ extension ExternalMessage : Sendable {
 #endif
 
 extension ExternalMessage : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.simple.ExternalMessage"
     }
+
 }
 
 extension ExternalMessage : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var f: Float? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var f: Swift.Float? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: f = try reader.decode(Float.self)
+            case 1: f = try reader.decode(Swift.Float.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -51,23 +54,26 @@ extension ExternalMessage : Proto2Codable {
         self.f = f
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.f)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension ExternalMessage : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.f = try container.decodeIfPresent(Float.self, forKey: "f")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.f = try container.decodeIfPresent(Swift.Float.self, forKey: "f")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.f, forKey: "f")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/src/main/swift/FooBar.swift
@@ -7,26 +7,26 @@ public struct FooBar {
 
     public var foo: Int32?
     public var bar: String?
-    public var baz: Nested?
+    public var baz: FooBar.Nested?
     public var qux: UInt64?
     public var fred: [Float]
     public var daisy: Double?
     public var nested: [FooBar]
-    public var ext: FooBarBazEnum?
-    public var rep: [FooBarBazEnum]
+    public var ext: FooBar.FooBarBazEnum?
+    public var rep: [FooBar.FooBarBazEnum]
     public var more_string: String?
     public var unknownFields: Data = .init()
 
     public init(
         foo: Int32? = nil,
         bar: String? = nil,
-        baz: Nested? = nil,
+        baz: FooBar.Nested? = nil,
         qux: UInt64? = nil,
         fred: [Float] = [],
         daisy: Double? = nil,
         nested: [FooBar] = [],
-        ext: FooBarBazEnum? = nil,
-        rep: [FooBarBazEnum] = [],
+        ext: FooBar.FooBarBazEnum? = nil,
+        rep: [FooBar.FooBarBazEnum] = [],
         more_string: String? = nil
     ) {
         self.foo = foo
@@ -43,10 +43,10 @@ public struct FooBar {
 
     public struct Nested {
 
-        public var value: FooBarBazEnum?
+        public var value: FooBar.FooBarBazEnum?
         public var unknownFields: Data = .init()
 
-        public init(value: FooBarBazEnum? = nil) {
+        public init(value: FooBar.FooBarBazEnum? = nil) {
             self.value = value
         }
 
@@ -97,13 +97,16 @@ extension FooBar.Nested : Sendable {
 #endif
 
 extension FooBar.Nested : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.custom_options.FooBar.Nested"
     }
+
 }
 
 extension FooBar.Nested : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         var value: FooBar.FooBarBazEnum? = nil
 
         let token = try reader.beginMessage()
@@ -118,24 +121,27 @@ extension FooBar.Nested : Proto2Codable {
         self.value = value
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.value)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension FooBar.Nested : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.value = try container.decodeIfPresent(FooBar.FooBarBazEnum.self, forKey: "value")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.value, forKey: "value")
     }
+
 }
 #endif
 
@@ -155,14 +161,17 @@ extension FooBar.More : Sendable {
 #endif
 
 extension FooBar.More : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.custom_options.FooBar.More"
     }
+
 }
 
 extension FooBar.More : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var serial: [Int32] = []
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var serial: [Swift.Int32] = []
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
@@ -176,27 +185,30 @@ extension FooBar.More : Proto2Codable {
         self.serial = serial
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.serial)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension FooBar.More : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.serial = try container.decodeProtoArray(Int32.self, forKey: "serial")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.serial = try container.decodeProtoArray(Swift.Int32.self, forKey: "serial")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
         if includeDefaults || !self.serial.isEmpty {
             try container.encodeProtoArray(self.serial, forKey: "serial")
         }
     }
+
 }
 #endif
 
@@ -221,37 +233,40 @@ extension FooBar : Sendable {
 #endif
 
 extension FooBar : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.custom_options.FooBar"
     }
+
 }
 
 extension FooBar : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var foo: Int32? = nil
-        var bar: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var foo: Swift.Int32? = nil
+        var bar: Swift.String? = nil
         var baz: FooBar.Nested? = nil
-        var qux: UInt64? = nil
-        var fred: [Float] = []
-        var daisy: Double? = nil
+        var qux: Swift.UInt64? = nil
+        var fred: [Swift.Float] = []
+        var daisy: Swift.Double? = nil
         var nested: [FooBar] = []
         var ext: FooBar.FooBarBazEnum? = nil
         var rep: [FooBar.FooBarBazEnum] = []
-        var more_string: String? = nil
+        var more_string: Swift.String? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: foo = try reader.decode(Int32.self)
-            case 2: bar = try reader.decode(String.self)
+            case 1: foo = try reader.decode(Swift.Int32.self)
+            case 2: bar = try reader.decode(Swift.String.self)
             case 3: baz = try reader.decode(FooBar.Nested.self)
-            case 4: qux = try reader.decode(UInt64.self)
+            case 4: qux = try reader.decode(Swift.UInt64.self)
             case 5: try reader.decode(into: &fred)
-            case 6: daisy = try reader.decode(Double.self)
+            case 6: daisy = try reader.decode(Swift.Double.self)
             case 7: try reader.decode(into: &nested)
             case 101: ext = try reader.decode(FooBar.FooBarBazEnum.self)
             case 102: try reader.decode(into: &rep)
-            case 150: more_string = try reader.decode(String.self)
+            case 150: more_string = try reader.decode(Swift.String.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -269,7 +284,7 @@ extension FooBar : Proto2Codable {
         self.more_string = more_string
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.foo)
         try writer.encode(tag: 2, value: self.bar)
         try writer.encode(tag: 3, value: self.baz)
@@ -282,26 +297,28 @@ extension FooBar : Proto2Codable {
         try writer.encode(tag: 150, value: self.more_string)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension FooBar : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.foo = try container.decodeIfPresent(Int32.self, forKey: "foo")
-        self.bar = try container.decodeIfPresent(String.self, forKey: "bar")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.foo = try container.decodeIfPresent(Swift.Int32.self, forKey: "foo")
+        self.bar = try container.decodeIfPresent(Swift.String.self, forKey: "bar")
         self.baz = try container.decodeIfPresent(FooBar.Nested.self, forKey: "baz")
-        self.qux = try container.decodeIfPresent(stringEncoded: UInt64.self, forKey: "qux")
-        self.fred = try container.decodeProtoArray(Float.self, forKey: "fred")
-        self.daisy = try container.decodeIfPresent(Double.self, forKey: "daisy")
+        self.qux = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, forKey: "qux")
+        self.fred = try container.decodeProtoArray(Swift.Float.self, forKey: "fred")
+        self.daisy = try container.decodeIfPresent(Swift.Double.self, forKey: "daisy")
         self.nested = try container.decodeProtoArray(FooBar.self, forKey: "nested")
         self.ext = try container.decodeIfPresent(FooBar.FooBarBazEnum.self, forKey: "ext")
         self.rep = try container.decodeProtoArray(FooBar.FooBarBazEnum.self, forKey: "rep")
-        self.more_string = try container.decodeIfPresent(String.self, firstOfKeys: "moreString", "more_string")
+        self.more_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "moreString", "more_string")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
@@ -322,15 +339,18 @@ extension FooBar : Codable {
         }
         try container.encodeIfPresent(self.more_string, forKey: preferCamelCase ? "moreString" : "more_string")
     }
+
 }
 #endif
 
 #if !WIRE_REMOVE_REDACTABLE
 extension FooBar : Redactable {
-    public enum RedactedKeys : String, RedactedKey {
+
+    public enum RedactedKeys : Swift.String, Wire.RedactedKey {
 
         case nested
 
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/ForeignMessage.swift
+++ b/wire-tests-swift/src/main/swift/ForeignMessage.swift
@@ -30,19 +30,22 @@ extension ForeignMessage : Sendable {
 #endif
 
 extension ForeignMessage : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.foreign.ForeignMessage"
     }
+
 }
 
 extension ForeignMessage : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var i: Int32? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var i: Swift.Int32? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: i = try reader.decode(Int32.self)
+            case 1: i = try reader.decode(Swift.Int32.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -51,23 +54,26 @@ extension ForeignMessage : Proto2Codable {
         self.i = i
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.i)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension ForeignMessage : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Int32.self, forKey: "i")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.i, forKey: "i")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-tests-swift/src/main/swift/Form.swift
@@ -16,19 +16,19 @@ public struct Form {
 
     public enum Choice {
 
-        case button_element(ButtonElement)
-        case local_image_element(LocalImageElement)
-        case remote_image_element(RemoteImageElement)
-        case money_element(MoneyElement)
-        case spacer_element(SpacerElement)
-        case text_element(TextElement)
-        case customized_card_element(CustomizedCardElement)
-        case address_element(AddressElement)
-        case text_input_element(TextInputElement)
+        case button_element(Form.ButtonElement)
+        case local_image_element(Form.LocalImageElement)
+        case remote_image_element(Form.RemoteImageElement)
+        case money_element(Form.MoneyElement)
+        case spacer_element(Form.SpacerElement)
+        case text_element(Form.TextElement)
+        case customized_card_element(Form.CustomizedCardElement)
+        case address_element(Form.AddressElement)
+        case text_input_element(Form.TextInputElement)
         @available(*, deprecated)
-        case option_picker_element(OptionPickerElement)
-        case detail_row_element(DetailRowElement)
-        case currency_conversion_flags_element(CurrencyConversionFlagsElement)
+        case option_picker_element(Form.OptionPickerElement)
+        case detail_row_element(Form.DetailRowElement)
+        case currency_conversion_flags_element(Form.CurrencyConversionFlagsElement)
 
         fileprivate func encode(to writer: ProtoWriter) throws {
             switch self {
@@ -219,11 +219,13 @@ extension Form.Decision : Sendable {
 
 #if !WIRE_REMOVE_REDACTABLE
 extension Form.Decision : Redactable {
-    public enum RedactedKeys : String, RedactedKey {
+
+    public enum RedactedKeys : Swift.String, Wire.RedactedKey {
 
         case e
 
     }
+
 }
 #endif
 
@@ -243,13 +245,16 @@ extension Form.ButtonElement : Sendable {
 #endif
 
 extension Form.ButtonElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.ButtonElement"
     }
+
 }
 
 extension Form.ButtonElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -260,15 +265,18 @@ extension Form.ButtonElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.ButtonElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -288,13 +296,16 @@ extension Form.LocalImageElement : Sendable {
 #endif
 
 extension Form.LocalImageElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.LocalImageElement"
     }
+
 }
 
 extension Form.LocalImageElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -305,15 +316,18 @@ extension Form.LocalImageElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.LocalImageElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -333,13 +347,16 @@ extension Form.RemoteImageElement : Sendable {
 #endif
 
 extension Form.RemoteImageElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.RemoteImageElement"
     }
+
 }
 
 extension Form.RemoteImageElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -350,15 +367,18 @@ extension Form.RemoteImageElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.RemoteImageElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -378,13 +398,16 @@ extension Form.MoneyElement : Sendable {
 #endif
 
 extension Form.MoneyElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.MoneyElement"
     }
+
 }
 
 extension Form.MoneyElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -395,15 +418,18 @@ extension Form.MoneyElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.MoneyElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -423,13 +449,16 @@ extension Form.SpacerElement : Sendable {
 #endif
 
 extension Form.SpacerElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.SpacerElement"
     }
+
 }
 
 extension Form.SpacerElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -440,15 +469,18 @@ extension Form.SpacerElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.SpacerElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -468,19 +500,22 @@ extension Form.TextElement : Sendable {
 #endif
 
 extension Form.TextElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextElement"
     }
+
 }
 
 extension Form.TextElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var text: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var text: Swift.String? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: text = try reader.decode(String.self)
+            case 1: text = try reader.decode(Swift.String.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -489,24 +524,27 @@ extension Form.TextElement : Proto2Codable {
         self.text = text
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.text)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.TextElement : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.text = try container.decodeIfPresent(String.self, forKey: "text")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.text = try container.decodeIfPresent(Swift.String.self, forKey: "text")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.text, forKey: "text")
     }
+
 }
 #endif
 
@@ -526,13 +564,16 @@ extension Form.CustomizedCardElement : Sendable {
 #endif
 
 extension Form.CustomizedCardElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CustomizedCardElement"
     }
+
 }
 
 extension Form.CustomizedCardElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -543,15 +584,18 @@ extension Form.CustomizedCardElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.CustomizedCardElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -571,13 +615,16 @@ extension Form.AddressElement : Sendable {
 #endif
 
 extension Form.AddressElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.AddressElement"
     }
+
 }
 
 extension Form.AddressElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -588,15 +635,18 @@ extension Form.AddressElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.AddressElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -616,13 +666,16 @@ extension Form.TextInputElement : Sendable {
 #endif
 
 extension Form.TextInputElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.TextInputElement"
     }
+
 }
 
 extension Form.TextInputElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -633,15 +686,18 @@ extension Form.TextInputElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.TextInputElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -661,13 +717,16 @@ extension Form.OptionPickerElement : Sendable {
 #endif
 
 extension Form.OptionPickerElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.OptionPickerElement"
     }
+
 }
 
 extension Form.OptionPickerElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -678,15 +737,18 @@ extension Form.OptionPickerElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.OptionPickerElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -706,13 +768,16 @@ extension Form.DetailRowElement : Sendable {
 #endif
 
 extension Form.DetailRowElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.DetailRowElement"
     }
+
 }
 
 extension Form.DetailRowElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -723,15 +788,18 @@ extension Form.DetailRowElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.DetailRowElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -751,13 +819,16 @@ extension Form.CurrencyConversionFlagsElement : Sendable {
 #endif
 
 extension Form.CurrencyConversionFlagsElement : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form.CurrencyConversionFlagsElement"
     }
+
 }
 
 extension Form.CurrencyConversionFlagsElement : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -768,15 +839,18 @@ extension Form.CurrencyConversionFlagsElement : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form.CurrencyConversionFlagsElement : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif
 
@@ -796,15 +870,18 @@ extension Form : Sendable {
 #endif
 
 extension Form : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.Form"
     }
+
 }
 
 extension Form : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var choice: Form.Choice? = nil
-        var decision: Form.Decision? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var choice: Choice? = nil
+        var decision: Decision? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
@@ -821,14 +898,14 @@ extension Form : Proto2Codable {
             case 10: choice = .option_picker_element(try reader.decode(Form.OptionPickerElement.self))
             case 11: choice = .detail_row_element(try reader.decode(Form.DetailRowElement.self))
             case 12: choice = .currency_conversion_flags_element(try reader.decode(Form.CurrencyConversionFlagsElement.self))
-            case 101: decision = .a(try reader.decode(String.self))
-            case 102: decision = .b(try reader.decode(String.self))
-            case 103: decision = .c(try reader.decode(String.self))
-            case 104: decision = .d(try reader.decode(String.self))
-            case 105: decision = .e(try reader.decode(String.self))
-            case 106: decision = .f(try reader.decode(String.self))
-            case 107: decision = .g(try reader.decode(String.self))
-            case 108: decision = .h(try reader.decode(String.self))
+            case 101: decision = .a(try reader.decode(Swift.String.self))
+            case 102: decision = .b(try reader.decode(Swift.String.self))
+            case 103: decision = .c(try reader.decode(Swift.String.self))
+            case 104: decision = .d(try reader.decode(Swift.String.self))
+            case 105: decision = .e(try reader.decode(Swift.String.self))
+            case 106: decision = .f(try reader.decode(Swift.String.self))
+            case 107: decision = .g(try reader.decode(Swift.String.self))
+            case 108: decision = .h(try reader.decode(Swift.String.self))
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -838,7 +915,7 @@ extension Form : Proto2Codable {
         self.decision = decision
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         if let choice = self.choice {
             try choice.encode(to: writer)
         }
@@ -847,12 +924,14 @@ extension Form : Proto2Codable {
         }
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Form : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         if let button_element = try container.decodeIfPresent(Form.ButtonElement.self, forKey: "buttonElement") {
             self.choice = .button_element(button_element)
         } else if let button_element = try container.decodeIfPresent(Form.ButtonElement.self, forKey: "button_element") {
@@ -904,29 +983,29 @@ extension Form : Codable {
         } else {
             self.choice = nil
         }
-        if let a = try container.decodeIfPresent(String.self, forKey: "a") {
+        if let a = try container.decodeIfPresent(Swift.String.self, forKey: "a") {
             self.decision = .a(a)
-        } else if let b = try container.decodeIfPresent(String.self, forKey: "b") {
+        } else if let b = try container.decodeIfPresent(Swift.String.self, forKey: "b") {
             self.decision = .b(b)
-        } else if let c = try container.decodeIfPresent(String.self, forKey: "c") {
+        } else if let c = try container.decodeIfPresent(Swift.String.self, forKey: "c") {
             self.decision = .c(c)
-        } else if let d = try container.decodeIfPresent(String.self, forKey: "d") {
+        } else if let d = try container.decodeIfPresent(Swift.String.self, forKey: "d") {
             self.decision = .d(d)
-        } else if let e = try container.decodeIfPresent(String.self, forKey: "e") {
+        } else if let e = try container.decodeIfPresent(Swift.String.self, forKey: "e") {
             self.decision = .e(e)
-        } else if let f = try container.decodeIfPresent(String.self, forKey: "f") {
+        } else if let f = try container.decodeIfPresent(Swift.String.self, forKey: "f") {
             self.decision = .f(f)
-        } else if let g = try container.decodeIfPresent(String.self, forKey: "g") {
+        } else if let g = try container.decodeIfPresent(Swift.String.self, forKey: "g") {
             self.decision = .g(g)
-        } else if let h = try container.decodeIfPresent(String.self, forKey: "h") {
+        } else if let h = try container.decodeIfPresent(Swift.String.self, forKey: "h") {
             self.decision = .h(h)
         } else {
             self.decision = nil
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
 
         switch self.choice {
@@ -942,7 +1021,7 @@ extension Form : Codable {
         case .option_picker_element(let option_picker_element): try container.encode(option_picker_element, forKey: preferCamelCase ? "optionPickerElement" : "option_picker_element")
         case .detail_row_element(let detail_row_element): try container.encode(detail_row_element, forKey: preferCamelCase ? "detailRowElement" : "detail_row_element")
         case .currency_conversion_flags_element(let currency_conversion_flags_element): try container.encode(currency_conversion_flags_element, forKey: preferCamelCase ? "currencyConversionFlagsElement" : "currency_conversion_flags_element")
-        case Optional.none: break
+        case Swift.Optional.none: break
         }
         switch self.decision {
         case .a(let a): try container.encode(a, forKey: "a")
@@ -953,8 +1032,9 @@ extension Form : Codable {
         case .f(let f): try container.encode(f, forKey: "f")
         case .g(let g): try container.encode(g, forKey: "g")
         case .h(let h): try container.encode(h, forKey: "h")
-        case Optional.none: break
+        case Swift.Optional.none: break
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-tests-swift/src/main/swift/Mappy.swift
@@ -30,14 +30,17 @@ extension Mappy : Sendable {
 #endif
 
 extension Mappy : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Mappy"
     }
+
 }
 
 extension Mappy : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var things: [String : Thing] = [:]
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var things: [Swift.String : Thing] = [:]
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
@@ -51,26 +54,29 @@ extension Mappy : Proto2Codable {
         self.things = things
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.things)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Mappy : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.things = try container.decodeProtoMap([String : Thing].self, forKey: "things")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.things = try container.decodeProtoMap([Swift.String : Thing].self, forKey: "things")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
         if includeDefaults || !self.things.isEmpty {
             try container.encodeProtoMap(self.things, forKey: "things")
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/MappyTwo.swift
+++ b/wire-tests-swift/src/main/swift/MappyTwo.swift
@@ -5,14 +5,14 @@ import Wire
 
 public struct MappyTwo {
 
-    public var string_enums: [String : ValueEnum]
+    public var string_enums: [String : MappyTwo.ValueEnum]
     public var int_things: [Int64 : Thing]
     public var string_ints: [String : Int64]
     public var int_things_two: [Int32 : Thing]
     public var unknownFields: Data = .init()
 
     public init(
-        string_enums: [String : ValueEnum] = [:],
+        string_enums: [String : MappyTwo.ValueEnum] = [:],
         int_things: [Int64 : Thing] = [:],
         string_ints: [String : Int64] = [:],
         int_things_two: [Int32 : Thing] = [:]
@@ -62,17 +62,20 @@ extension MappyTwo : Sendable {
 #endif
 
 extension MappyTwo : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/com.squareup.wire.protos.kotlin.map.MappyTwo"
     }
+
 }
 
 extension MappyTwo : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var string_enums: [String : MappyTwo.ValueEnum] = [:]
-        var int_things: [Int64 : Thing] = [:]
-        var string_ints: [String : Int64] = [:]
-        var int_things_two: [Int32 : Thing] = [:]
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var string_enums: [Swift.String : MappyTwo.ValueEnum] = [:]
+        var int_things: [Swift.Int64 : Thing] = [:]
+        var string_ints: [Swift.String : Swift.Int64] = [:]
+        var int_things_two: [Swift.Int32 : Thing] = [:]
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
@@ -92,27 +95,29 @@ extension MappyTwo : Proto2Codable {
         self.int_things_two = int_things_two
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.string_enums)
         try writer.encode(tag: 2, value: self.int_things, keyEncoding: .signed)
         try writer.encode(tag: 3, value: self.string_ints, valueEncoding: .signed)
         try writer.encode(tag: 4, value: self.int_things_two, keyEncoding: .signed)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension MappyTwo : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.string_enums = try container.decodeProtoMap([String : MappyTwo.ValueEnum].self, firstOfKeys: "stringEnums", "string_enums")
-        self.int_things = try container.decodeProtoMap([Int64 : Thing].self, firstOfKeys: "intThings", "int_things")
-        self.string_ints = try container.decodeProtoMap([String : Int64].self, firstOfKeys: "stringInts", "string_ints")
-        self.int_things_two = try container.decodeProtoMap([Int32 : Thing].self, firstOfKeys: "intThingsTwo", "int_things_two")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.string_enums = try container.decodeProtoMap([Swift.String : MappyTwo.ValueEnum].self, firstOfKeys: "stringEnums", "string_enums")
+        self.int_things = try container.decodeProtoMap([Swift.Int64 : Thing].self, firstOfKeys: "intThings", "int_things")
+        self.string_ints = try container.decodeProtoMap([Swift.String : Swift.Int64].self, firstOfKeys: "stringInts", "string_ints")
+        self.int_things_two = try container.decodeProtoMap([Swift.Int32 : Thing].self, firstOfKeys: "intThingsTwo", "int_things_two")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
@@ -129,5 +134,6 @@ extension MappyTwo : Codable {
             try container.encodeProtoMap(self.int_things_two, forKey: preferCamelCase ? "intThingsTwo" : "int_things_two")
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
@@ -35,13 +35,16 @@ extension MessageUsingMultipleEnums : Sendable {
 #endif
 
 extension MessageUsingMultipleEnums : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.MessageUsingMultipleEnums"
     }
+
 }
 
 extension MessageUsingMultipleEnums : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         var a: MessageWithStatus.Status? = nil
         var b: OtherMessageWithStatus.Status? = nil
 
@@ -59,26 +62,29 @@ extension MessageUsingMultipleEnums : Proto2Codable {
         self.b = b
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.a)
         try writer.encode(tag: 2, value: self.b)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension MessageUsingMultipleEnums : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.a = try container.decodeIfPresent(MessageWithStatus.Status.self, forKey: "a")
         self.b = try container.decodeIfPresent(OtherMessageWithStatus.Status.self, forKey: "b")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.a, forKey: "a")
         try container.encodeIfPresent(self.b, forKey: "b")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/MessageWithOptions.swift
+++ b/wire-tests-swift/src/main/swift/MessageWithOptions.swift
@@ -28,13 +28,16 @@ extension MessageWithOptions : Sendable {
 #endif
 
 extension MessageWithOptions : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.custom_options.MessageWithOptions"
     }
+
 }
 
 extension MessageWithOptions : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -45,14 +48,17 @@ extension MessageWithOptions : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension MessageWithOptions : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -45,13 +45,16 @@ extension MessageWithStatus : Sendable {
 #endif
 
 extension MessageWithStatus : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.MessageWithStatus"
     }
+
 }
 
 extension MessageWithStatus : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -62,14 +65,17 @@ extension MessageWithStatus : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension MessageWithStatus : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -53,22 +53,25 @@ extension ModelEvaluation : Sendable {
 #endif
 
 extension ModelEvaluation : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/ModelEvaluation"
     }
+
 }
 
 extension ModelEvaluation : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var name: String? = nil
-        var score: Double? = nil
-        var models: [String : ModelEvaluation] = [:]
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var name: Swift.String? = nil
+        var score: Swift.Double? = nil
+        var models: [Swift.String : ModelEvaluation] = [:]
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: name = try reader.decode(String.self)
-            case 2: score = try reader.decode(Double.self)
+            case 1: name = try reader.decode(Swift.String.self)
+            case 2: score = try reader.decode(Swift.Double.self)
             case 3: try reader.decode(into: &models)
             default: try reader.readUnknownField(tag: tag)
             }
@@ -80,25 +83,27 @@ extension ModelEvaluation : Proto2Codable {
         self.models = models
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.name)
         try writer.encode(tag: 2, value: self.score)
         try writer.encode(tag: 3, value: self.models)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension ModelEvaluation : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(String.self, forKey: "name")
-        self.score = try container.decodeIfPresent(Double.self, forKey: "score")
-        self.models = try container.decodeProtoMap([String : ModelEvaluation].self, forKey: "models")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self.score = try container.decodeIfPresent(Swift.Double.self, forKey: "score")
+        self.models = try container.decodeProtoMap([Swift.String : ModelEvaluation].self, forKey: "models")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
         try container.encodeIfPresent(self.name, forKey: "name")
@@ -107,5 +112,6 @@ extension ModelEvaluation : Codable {
             try container.encodeProtoMap(self.models, forKey: "models")
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/NestedVersionOne.swift
+++ b/wire-tests-swift/src/main/swift/NestedVersionOne.swift
@@ -30,19 +30,22 @@ extension NestedVersionOne : Sendable {
 #endif
 
 extension NestedVersionOne : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionOne"
     }
+
 }
 
 extension NestedVersionOne : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var i: Int32? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var i: Swift.Int32? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: i = try reader.decode(Int32.self)
+            case 1: i = try reader.decode(Swift.Int32.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -51,23 +54,26 @@ extension NestedVersionOne : Proto2Codable {
         self.i = i
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.i)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension NestedVersionOne : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Int32.self, forKey: "i")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.i, forKey: "i")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -47,28 +47,31 @@ extension NestedVersionTwo : Sendable {
 #endif
 
 extension NestedVersionTwo : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.NestedVersionTwo"
     }
+
 }
 
 extension NestedVersionTwo : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var i: Int32? = nil
-        var v2_i: Int32? = nil
-        var v2_s: String? = nil
-        var v2_f32: UInt32? = nil
-        var v2_f64: UInt64? = nil
-        var v2_rs: [String] = []
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var i: Swift.Int32? = nil
+        var v2_i: Swift.Int32? = nil
+        var v2_s: Swift.String? = nil
+        var v2_f32: Swift.UInt32? = nil
+        var v2_f64: Swift.UInt64? = nil
+        var v2_rs: [Swift.String] = []
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: i = try reader.decode(Int32.self)
-            case 2: v2_i = try reader.decode(Int32.self)
-            case 3: v2_s = try reader.decode(String.self)
-            case 4: v2_f32 = try reader.decode(UInt32.self, encoding: .fixed)
-            case 5: v2_f64 = try reader.decode(UInt64.self, encoding: .fixed)
+            case 1: i = try reader.decode(Swift.Int32.self)
+            case 2: v2_i = try reader.decode(Swift.Int32.self)
+            case 3: v2_s = try reader.decode(Swift.String.self)
+            case 4: v2_f32 = try reader.decode(Swift.UInt32.self, encoding: .fixed)
+            case 5: v2_f64 = try reader.decode(Swift.UInt64.self, encoding: .fixed)
             case 6: try reader.decode(into: &v2_rs)
             default: try reader.readUnknownField(tag: tag)
             }
@@ -83,7 +86,7 @@ extension NestedVersionTwo : Proto2Codable {
         self.v2_rs = v2_rs
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.i)
         try writer.encode(tag: 2, value: self.v2_i)
         try writer.encode(tag: 3, value: self.v2_s)
@@ -92,22 +95,24 @@ extension NestedVersionTwo : Proto2Codable {
         try writer.encode(tag: 6, value: self.v2_rs)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension NestedVersionTwo : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Int32.self, forKey: "i")
-        self.v2_i = try container.decodeIfPresent(Int32.self, firstOfKeys: "v2I", "v2_i")
-        self.v2_s = try container.decodeIfPresent(String.self, firstOfKeys: "v2S", "v2_s")
-        self.v2_f32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "v2F32", "v2_f32")
-        self.v2_f64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "v2F64", "v2_f64")
-        self.v2_rs = try container.decodeProtoArray(String.self, firstOfKeys: "v2Rs", "v2_rs")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
+        self.v2_i = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "v2I", "v2_i")
+        self.v2_s = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "v2S", "v2_s")
+        self.v2_f32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "v2F32", "v2_f32")
+        self.v2_f64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "v2F64", "v2_f64")
+        self.v2_rs = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "v2Rs", "v2_rs")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
@@ -120,5 +125,6 @@ extension NestedVersionTwo : Codable {
             try container.encodeProtoArray(self.v2_rs, forKey: preferCamelCase ? "v2Rs" : "v2_rs")
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/NoFields.swift
+++ b/wire-tests-swift/src/main/swift/NoFields.swift
@@ -28,13 +28,16 @@ extension NoFields : Sendable {
 #endif
 
 extension NoFields : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.NoFields"
     }
+
 }
 
 extension NoFields : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -45,14 +48,17 @@ extension NoFields : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension NoFields : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -76,21 +76,24 @@ extension OneOfMessage : Sendable {
 #endif
 
 extension OneOfMessage : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.oneof.OneOfMessage"
     }
+
 }
 
 extension OneOfMessage : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var choice: OneOfMessage.Choice? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var choice: Choice? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: choice = .foo(try reader.decode(Int32.self))
-            case 3: choice = .bar(try reader.decode(String.self))
-            case 4: choice = .baz(try reader.decode(String.self))
+            case 1: choice = .foo(try reader.decode(Swift.Int32.self))
+            case 3: choice = .bar(try reader.decode(Swift.String.self))
+            case 4: choice = .baz(try reader.decode(Swift.String.self))
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -99,38 +102,41 @@ extension OneOfMessage : Proto2Codable {
         self.choice = choice
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         if let choice = self.choice {
             try choice.encode(to: writer)
         }
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension OneOfMessage : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        if let foo = try container.decodeIfPresent(Int32.self, forKey: "foo") {
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        if let foo = try container.decodeIfPresent(Swift.Int32.self, forKey: "foo") {
             self.choice = .foo(foo)
-        } else if let bar = try container.decodeIfPresent(String.self, forKey: "bar") {
+        } else if let bar = try container.decodeIfPresent(Swift.String.self, forKey: "bar") {
             self.choice = .bar(bar)
-        } else if let baz = try container.decodeIfPresent(String.self, forKey: "baz") {
+        } else if let baz = try container.decodeIfPresent(Swift.String.self, forKey: "baz") {
             self.choice = .baz(baz)
         } else {
             self.choice = nil
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         switch self.choice {
         case .foo(let foo): try container.encode(foo, forKey: "foo")
         case .bar(let bar): try container.encode(bar, forKey: "bar")
         case .baz(let baz): try container.encode(baz, forKey: "baz")
-        case Optional.none: break
+        case Swift.Optional.none: break
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -5,10 +5,10 @@ import Wire
 
 public struct OptionalEnumUser {
 
-    public var optional_enum: OptionalEnum?
+    public var optional_enum: OptionalEnumUser.OptionalEnum?
     public var unknownFields: Data = .init()
 
-    public init(optional_enum: OptionalEnum? = nil) {
+    public init(optional_enum: OptionalEnumUser.OptionalEnum? = nil) {
         self.optional_enum = optional_enum
     }
 
@@ -49,13 +49,16 @@ extension OptionalEnumUser : Sendable {
 #endif
 
 extension OptionalEnumUser : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.OptionalEnumUser"
     }
+
 }
 
 extension OptionalEnumUser : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         var optional_enum: OptionalEnumUser.OptionalEnum? = nil
 
         let token = try reader.beginMessage()
@@ -70,24 +73,27 @@ extension OptionalEnumUser : Proto2Codable {
         self.optional_enum = optional_enum
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.optional_enum)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension OptionalEnumUser : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.optional_enum = try container.decodeIfPresent(OptionalEnumUser.OptionalEnum.self, firstOfKeys: "optionalEnum", "optional_enum")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
 
         try container.encodeIfPresent(self.optional_enum, forKey: preferCamelCase ? "optionalEnum" : "optional_enum")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -45,13 +45,16 @@ extension OtherMessageWithStatus : Sendable {
 #endif
 
 extension OtherMessageWithStatus : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.OtherMessageWithStatus"
     }
+
 }
 
 extension OtherMessageWithStatus : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
+
+    public init(from reader: Wire.ProtoReader) throws {
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
@@ -62,14 +65,17 @@ extension OtherMessageWithStatus : Proto2Codable {
 
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension OtherMessageWithStatus : Codable {
-    public enum CodingKeys : CodingKey {
+
+    public enum CodingKeys : Swift.CodingKey {
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/OuterMessage.swift
+++ b/wire-tests-swift/src/main/swift/OuterMessage.swift
@@ -32,20 +32,23 @@ extension OuterMessage : Sendable {
 #endif
 
 extension OuterMessage : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.packed_encoding.OuterMessage"
     }
+
 }
 
 extension OuterMessage : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var outer_number_before: Int32? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var outer_number_before: Swift.Int32? = nil
         var embedded_message: EmbeddedMessage? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: outer_number_before = try reader.decode(Int32.self)
+            case 1: outer_number_before = try reader.decode(Swift.Int32.self)
             case 2: embedded_message = try reader.decode(EmbeddedMessage.self)
             default: try reader.readUnknownField(tag: tag)
             }
@@ -56,27 +59,30 @@ extension OuterMessage : Proto2Codable {
         self.embedded_message = embedded_message
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.outer_number_before)
         try writer.encode(tag: 2, value: self.embedded_message)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension OuterMessage : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.outer_number_before = try container.decodeIfPresent(Int32.self, firstOfKeys: "outerNumberBefore", "outer_number_before")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.outer_number_before = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "outerNumberBefore", "outer_number_before")
         self.embedded_message = try container.decodeIfPresent(EmbeddedMessage.self, firstOfKeys: "embeddedMessage", "embedded_message")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
 
         try container.encodeIfPresent(self.outer_number_before, forKey: preferCamelCase ? "outerNumberBefore" : "outer_number_before")
         try container.encodeIfPresent(self.embedded_message, forKey: preferCamelCase ? "embeddedMessage" : "embedded_message")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/Percents.swift
+++ b/wire-tests-swift/src/main/swift/Percents.swift
@@ -33,19 +33,22 @@ extension Percents : Sendable {
 #endif
 
 extension Percents : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.Percents"
     }
+
 }
 
 extension Percents : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var text: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var text: Swift.String? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: text = try reader.decode(String.self)
+            case 1: text = try reader.decode(Swift.String.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -54,23 +57,26 @@ extension Percents : Proto2Codable {
         self.text = text
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.text)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Percents : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.text = try container.decodeIfPresent(String.self, forKey: "text")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.text = try container.decodeIfPresent(Swift.String.self, forKey: "text")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.text, forKey: "text")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-tests-swift/src/main/swift/Person.swift
@@ -23,7 +23,7 @@ public struct Person {
     /**
      * A list of the customer's phone numbers.
      */
-    public var phone: [PhoneNumber]
+    public var phone: [Person.PhoneNumber]
     public var aliases: [String]
     public var unknownFields: Data = .init()
 
@@ -31,7 +31,7 @@ public struct Person {
         id: Int32,
         name: String,
         email: String? = nil,
-        phone: [PhoneNumber] = [],
+        phone: [Person.PhoneNumber] = [],
         aliases: [String] = []
     ) {
         self.id = id
@@ -72,10 +72,10 @@ public struct Person {
         /**
          * The type of phone stored here.
          */
-        public var type: PhoneType?
+        public var type: Person.PhoneType?
         public var unknownFields: Data = .init()
 
-        public init(number: String, type: PhoneType? = nil) {
+        public init(number: String, type: Person.PhoneType? = nil) {
             self.number = number
             self.type = type
         }
@@ -105,20 +105,23 @@ extension Person.PhoneNumber : Sendable {
 #endif
 
 extension Person.PhoneNumber : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
     }
+
 }
 
 extension Person.PhoneNumber : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var number: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var number: Swift.String? = nil
         var type: Person.PhoneType? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: number = try reader.decode(String.self)
+            case 1: number = try reader.decode(Swift.String.self)
             case 2: type = try reader.decode(Person.PhoneType.self)
             default: try reader.readUnknownField(tag: tag)
             }
@@ -129,23 +132,25 @@ extension Person.PhoneNumber : Proto2Codable {
         self.type = type
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.number)
         try writer.encode(tag: 2, value: self.type)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Person.PhoneNumber : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.number = try container.decode(String.self, forKey: "number")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.number = try container.decode(Swift.String.self, forKey: "number")
         self.type = try container.decodeIfPresent(Person.PhoneType.self, forKey: "type")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
         if includeDefaults || !self.number.isEmpty {
@@ -153,6 +158,7 @@ extension Person.PhoneNumber : Codable {
         }
         try container.encodeIfPresent(self.type, forKey: "type")
     }
+
 }
 #endif
 
@@ -172,25 +178,28 @@ extension Person : Sendable {
 #endif
 
 extension Person : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.person.Person"
     }
+
 }
 
 extension Person : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var id: Int32? = nil
-        var name: String? = nil
-        var email: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var id: Swift.Int32? = nil
+        var name: Swift.String? = nil
+        var email: Swift.String? = nil
         var phone: [Person.PhoneNumber] = []
-        var aliases: [String] = []
+        var aliases: [Swift.String] = []
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 2: id = try reader.decode(Int32.self)
-            case 1: name = try reader.decode(String.self)
-            case 3: email = try reader.decode(String.self)
+            case 2: id = try reader.decode(Swift.Int32.self)
+            case 1: name = try reader.decode(Swift.String.self)
+            case 3: email = try reader.decode(Swift.String.self)
             case 4: try reader.decode(into: &phone)
             case 5: try reader.decode(into: &aliases)
             default: try reader.readUnknownField(tag: tag)
@@ -205,7 +214,7 @@ extension Person : Proto2Codable {
         self.aliases = aliases
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 2, value: self.id)
         try writer.encode(tag: 1, value: self.name)
         try writer.encode(tag: 3, value: self.email)
@@ -213,21 +222,23 @@ extension Person : Proto2Codable {
         try writer.encode(tag: 5, value: self.aliases)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Person : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.id = try container.decode(Int32.self, forKey: "id")
-        self.name = try container.decode(String.self, forKey: "name")
-        self.email = try container.decodeIfPresent(String.self, forKey: "email")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.id = try container.decode(Swift.Int32.self, forKey: "id")
+        self.name = try container.decode(Swift.String.self, forKey: "name")
+        self.email = try container.decodeIfPresent(Swift.String.self, forKey: "email")
         self.phone = try container.decodeProtoArray(Person.PhoneNumber.self, forKey: "phone")
-        self.aliases = try container.decodeProtoArray(String.self, forKey: "aliases")
+        self.aliases = try container.decodeProtoArray(Swift.String.self, forKey: "aliases")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
         if includeDefaults || self.id != 0 {
@@ -244,5 +255,6 @@ extension Person : Codable {
             try container.encodeProtoArray(self.aliases, forKey: "aliases")
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -45,11 +45,13 @@ extension RedactedOneOf.A : Sendable {
 
 #if !WIRE_REMOVE_REDACTABLE
 extension RedactedOneOf.A : Redactable {
-    public enum RedactedKeys : String, RedactedKey {
+
+    public enum RedactedKeys : Swift.String, Wire.RedactedKey {
 
         case c
 
     }
+
 }
 #endif
 
@@ -69,20 +71,23 @@ extension RedactedOneOf : Sendable {
 #endif
 
 extension RedactedOneOf : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.redacted_test.RedactedOneOf"
     }
+
 }
 
 extension RedactedOneOf : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var a: RedactedOneOf.A? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var a: A? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: a = .b(try reader.decode(Int32.self))
-            case 2: a = .c(try reader.decode(String.self))
+            case 1: a = .b(try reader.decode(Swift.Int32.self))
+            case 2: a = .c(try reader.decode(Swift.String.self))
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -91,35 +96,38 @@ extension RedactedOneOf : Proto2Codable {
         self.a = a
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         if let a = self.a {
             try a.encode(to: writer)
         }
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension RedactedOneOf : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        if let b = try container.decodeIfPresent(Int32.self, forKey: "b") {
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        if let b = try container.decodeIfPresent(Swift.Int32.self, forKey: "b") {
             self.a = .b(b)
-        } else if let c = try container.decodeIfPresent(String.self, forKey: "c") {
+        } else if let c = try container.decodeIfPresent(Swift.String.self, forKey: "c") {
             self.a = .c(c)
         } else {
             self.a = nil
         }
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         switch self.a {
         case .b(let b): try container.encode(b, forKey: "b")
         case .c(let c): try container.encode(c, forKey: "c")
-        case Optional.none: break
+        case Swift.Optional.none: break
         }
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/Thing.swift
+++ b/wire-tests-swift/src/main/swift/Thing.swift
@@ -30,19 +30,22 @@ extension Thing : Sendable {
 #endif
 
 extension Thing : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/com.squareup.wire.protos.kotlin.map.Thing"
     }
+
 }
 
 extension Thing : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var name: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var name: Swift.String? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: name = try reader.decode(String.self)
+            case 1: name = try reader.decode(Swift.String.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -51,23 +54,26 @@ extension Thing : Proto2Codable {
         self.name = name
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.name)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension Thing : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(String.self, forKey: "name")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.name, forKey: "name")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/VersionOne.swift
+++ b/wire-tests-swift/src/main/swift/VersionOne.swift
@@ -38,21 +38,24 @@ extension VersionOne : Sendable {
 #endif
 
 extension VersionOne : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionOne"
     }
+
 }
 
 extension VersionOne : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var i: Int32? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var i: Swift.Int32? = nil
         var obj: NestedVersionOne? = nil
         var en: EnumVersionOne? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: i = try reader.decode(Int32.self)
+            case 1: i = try reader.decode(Swift.Int32.self)
             case 7: obj = try reader.decode(NestedVersionOne.self)
             case 8: en = try reader.decode(EnumVersionOne.self)
             default: try reader.readUnknownField(tag: tag)
@@ -65,29 +68,32 @@ extension VersionOne : Proto2Codable {
         self.en = en
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.i)
         try writer.encode(tag: 7, value: self.obj)
         try writer.encode(tag: 8, value: self.en)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension VersionOne : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Int32.self, forKey: "i")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
         self.obj = try container.decodeIfPresent(NestedVersionOne.self, forKey: "obj")
         self.en = try container.decodeIfPresent(EnumVersionOne.self, forKey: "en")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.i, forKey: "i")
         try container.encodeIfPresent(self.obj, forKey: "obj")
         try container.encodeIfPresent(self.en, forKey: "en")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -53,30 +53,33 @@ extension VersionTwo : Sendable {
 #endif
 
 extension VersionTwo : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.kotlin.unknownfields.VersionTwo"
     }
+
 }
 
 extension VersionTwo : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var i: Int32? = nil
-        var v2_i: Int32? = nil
-        var v2_s: String? = nil
-        var v2_f32: UInt32? = nil
-        var v2_f64: UInt64? = nil
-        var v2_rs: [String] = []
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var i: Swift.Int32? = nil
+        var v2_i: Swift.Int32? = nil
+        var v2_s: Swift.String? = nil
+        var v2_f32: Swift.UInt32? = nil
+        var v2_f64: Swift.UInt64? = nil
+        var v2_rs: [Swift.String] = []
         var obj: NestedVersionTwo? = nil
         var en: EnumVersionTwo? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: i = try reader.decode(Int32.self)
-            case 2: v2_i = try reader.decode(Int32.self)
-            case 3: v2_s = try reader.decode(String.self)
-            case 4: v2_f32 = try reader.decode(UInt32.self, encoding: .fixed)
-            case 5: v2_f64 = try reader.decode(UInt64.self, encoding: .fixed)
+            case 1: i = try reader.decode(Swift.Int32.self)
+            case 2: v2_i = try reader.decode(Swift.Int32.self)
+            case 3: v2_s = try reader.decode(Swift.String.self)
+            case 4: v2_f32 = try reader.decode(Swift.UInt32.self, encoding: .fixed)
+            case 5: v2_f64 = try reader.decode(Swift.UInt64.self, encoding: .fixed)
             case 6: try reader.decode(into: &v2_rs)
             case 7: obj = try reader.decode(NestedVersionTwo.self)
             case 8: en = try reader.decode(EnumVersionTwo.self)
@@ -95,7 +98,7 @@ extension VersionTwo : Proto2Codable {
         self.en = en
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.i)
         try writer.encode(tag: 2, value: self.v2_i)
         try writer.encode(tag: 3, value: self.v2_s)
@@ -106,24 +109,26 @@ extension VersionTwo : Proto2Codable {
         try writer.encode(tag: 8, value: self.en)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension VersionTwo : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Int32.self, forKey: "i")
-        self.v2_i = try container.decodeIfPresent(Int32.self, firstOfKeys: "v2I", "v2_i")
-        self.v2_s = try container.decodeIfPresent(String.self, firstOfKeys: "v2S", "v2_s")
-        self.v2_f32 = try container.decodeIfPresent(UInt32.self, firstOfKeys: "v2F32", "v2_f32")
-        self.v2_f64 = try container.decodeIfPresent(stringEncoded: UInt64.self, firstOfKeys: "v2F64", "v2_f64")
-        self.v2_rs = try container.decodeProtoArray(String.self, firstOfKeys: "v2Rs", "v2_rs")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
+        self.v2_i = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "v2I", "v2_i")
+        self.v2_s = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "v2S", "v2_s")
+        self.v2_f32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "v2F32", "v2_f32")
+        self.v2_f64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "v2F64", "v2_f64")
+        self.v2_rs = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "v2Rs", "v2_rs")
         self.obj = try container.decodeIfPresent(NestedVersionTwo.self, forKey: "obj")
         self.en = try container.decodeIfPresent(EnumVersionTwo.self, forKey: "en")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 
@@ -138,5 +143,6 @@ extension VersionTwo : Codable {
         try container.encodeIfPresent(self.obj, forKey: "obj")
         try container.encodeIfPresent(self.en, forKey: "en")
     }
+
 }
 #endif

--- a/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -33,19 +33,22 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Sendable {
 #endif
 
 extension VeryLongProtoNameCausingBrokenLineBreaks : ProtoMessage {
-    public static func protoMessageTypeURL() -> String {
+
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.protos.tostring.VeryLongProtoNameCausingBrokenLineBreaks"
     }
+
 }
 
 extension VeryLongProtoNameCausingBrokenLineBreaks : Proto2Codable {
-    public init(from reader: ProtoReader) throws {
-        var foo: String? = nil
+
+    public init(from reader: Wire.ProtoReader) throws {
+        var foo: Swift.String? = nil
 
         let token = try reader.beginMessage()
         while let tag = try reader.nextTag(token: token) {
             switch tag {
-            case 1: foo = try reader.decode(String.self)
+            case 1: foo = try reader.decode(Swift.String.self)
             default: try reader.readUnknownField(tag: tag)
             }
         }
@@ -54,23 +57,26 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Proto2Codable {
         self.foo = foo
     }
 
-    public func encode(to writer: ProtoWriter) throws {
+    public func encode(to writer: Wire.ProtoWriter) throws {
         try writer.encode(tag: 1, value: self.foo)
         try writer.writeUnknownFields(unknownFields)
     }
+
 }
 
 #if !WIRE_REMOVE_CODABLE
 extension VeryLongProtoNameCausingBrokenLineBreaks : Codable {
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.foo = try container.decodeIfPresent(String.self, forKey: "foo")
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.foo = try container.decodeIfPresent(Swift.String.self, forKey: "foo")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
 
         try container.encodeIfPresent(self.foo, forKey: "foo")
     }
+
 }
 #endif


### PR DESCRIPTION
Update SwiftPoet to v1.5 in preparation for supporting [subscripts](https://github.com/outfoxx/swiftpoet/pull/76)

What's strange is for some reason the generator is fully qualifying `Swift.Foo` and `Wire.Foo` even tho we're importing Wire and Swift is _implicitly_ imported.

[Ticket filed](https://github.com/outfoxx/swiftpoet/issues/81) for this regression.