### PR TITLE
If a valid grpc-status header is present, raise a GrpcException rathe…

### DIFF
--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
@@ -1110,11 +1110,9 @@ class GrpcClientTest {
     try {
       grpcCall.executeBlocking(Point(latitude = 5, longitude = 6))
       fail()
-    } catch (expected: IOException) {
-      assertThat(expected).hasMessage(
-        "gRPC transport failure (HTTP status=200, grpc-status=2, grpc-message=null)"
-      )
-      assertThat(expected.cause).hasMessage("expected 1 message but got none")
+    } catch (expected: GrpcException) {
+      assertThat(expected.grpcStatus).isEqualTo(GrpcStatus.UNKNOWN)
+      assertThat(expected.grpcMessage).isNull()
     }
   }
 
@@ -1130,11 +1128,9 @@ class GrpcClientTest {
     try {
       grpcCall.executeBlocking(Point(latitude = 5, longitude = 6))
       fail()
-    } catch (expected: IOException) {
-      assertThat(expected).hasMessage(
-        "gRPC transport failure (HTTP status=200, grpc-status=13, grpc-message=boom)"
-      )
-      assertThat(expected.cause).hasMessage("expected 1 message but got none")
+    } catch (expected: GrpcException) {
+      assertThat(expected.grpcStatus).isEqualTo(GrpcStatus.INTERNAL)
+      assertThat(expected.grpcMessage).isEqualTo("boom")
     }
   }
 


### PR DESCRIPTION
…r than an IOException, even when we see a transport error

Right now, when Wire encounters a response with an empty message, but with a valid, non-0 `grpc-status` header, it raises an `IOException`. This doesn't seem right to me: I'd like my Wire client to let me know that the server reported an error even if it didn't include a message in the response.

This change makes it so that in `grpcResponseToException` we check for a valid, non-0 `grpc-status` header, and raise a `GrpcException` in response to it, before checking for a `transportException`.