### PR TITLE
Guard better for unavailable or corrupt JAR inside WireCompiler.podspec

### DIFF
--- a/WireCompiler.podspec
+++ b/WireCompiler.podspec
@@ -16,6 +16,10 @@ Pod::Spec.new do |s|
 
   s.prepare_command = <<-CMD
     curl https://repo.maven.apache.org/maven2/com/squareup/wire/wire-compiler/#{version}/wire-compiler-#{version}-jar-with-dependencies.jar --output compiler.jar
+    if ! jar tf compiler.jar >/dev/null 2>&1; then
+      echo "[WireCompiler] The compiler.jar file is invalid or corrupted."
+      exit 1
+    fi
   CMD
 
   s.preserve_paths = 'compiler.jar'


### PR DESCRIPTION
If a new version of the WireCompiler.podspec is published but the corresponding JAR did not, or is corrupt, CocoaPods will still successfully "install" WireCompiler pod, since I believe the `curl` command returns a JAR that is just a placeholder or invalid.

The consequence of this is that because CocoaPods thinks everything installed fine, it will "poison" its local cache. Uploading the JAR _afterwards_ and running `pod install` will not re-run the `prepare_command` because CocoaPods will pull it from its local cache instead.

This ensures that the JAR we download is actually published and valid, otherwise it fails `pod install`.