### PR TITLE
iOS: Resolve Redactable regression

### DIFF
--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -451,6 +451,7 @@ class SwiftGenerator private constructor(
           .addSuperType(redactable)
           .addType(
             TypeAliasSpec.builder("RedactedKeys", structType.nestedType("RedactedKeys"))
+              .addModifiers(PUBLIC)
               .build()
           )
           .build()


### PR DESCRIPTION
```
#if !WIRE_REMOVE_REDACTABLE
extension TeamMember.Storage : Redactable {

    typealias RedactedKeys = TeamMember.RedactedKeys

}
#endif
```

> Type alias ‘RedactedKeys’ must be declared public because it matches a requirement in public protocol ‘Redactable’