### PR TITLE
Introduce Wire's Visitor

### DIFF
--- a/wire-compiler/api/wire-compiler.api
+++ b/wire-compiler/api/wire-compiler.api
@@ -194,11 +194,12 @@ public final class com/squareup/wire/schema/TargetKt {
 }
 
 public final class com/squareup/wire/schema/WireRun {
-	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Z)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component10 ()Ljava/util/Map;
 	public final fun component11 ()Z
+	public final fun component12 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/List;
@@ -207,8 +208,8 @@ public final class com/squareup/wire/schema/WireRun {
 	public final fun component7 ()Ljava/lang/String;
 	public final fun component8 ()Ljava/lang/String;
 	public final fun component9 ()Ljava/util/List;
-	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;Z)Lcom/squareup/wire/schema/WireRun;
-	public static synthetic fun copy$default (Lcom/squareup/wire/schema/WireRun;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZILjava/lang/Object;)Lcom/squareup/wire/schema/WireRun;
+	public final fun copy (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;)Lcom/squareup/wire/schema/WireRun;
+	public static synthetic fun copy$default (Lcom/squareup/wire/schema/WireRun;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;ILjava/lang/Object;)Lcom/squareup/wire/schema/WireRun;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun execute (Lokio/FileSystem;Lcom/squareup/wire/WireLogger;)V
 	public static synthetic fun execute$default (Lcom/squareup/wire/schema/WireRun;Lokio/FileSystem;Lcom/squareup/wire/WireLogger;ILjava/lang/Object;)V
@@ -223,6 +224,7 @@ public final class com/squareup/wire/schema/WireRun {
 	public final fun getTreeShakingRoots ()Ljava/util/List;
 	public final fun getTreeShakingRubbish ()Ljava/util/List;
 	public final fun getUntilVersion ()Ljava/lang/String;
+	public final fun getVisitors ()Ljava/util/List;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -923,6 +923,27 @@ public final class com/squareup/wire/schema/Type$Companion {
 	public final fun toElements (Ljava/util/List;)Ljava/util/List;
 }
 
+public abstract class com/squareup/wire/schema/Visitor {
+	public fun <init> ()V
+	public fun end ()V
+	public fun loadSchemaEnd (Lcom/squareup/wire/schema/Schema;)V
+	public fun loadSchemaStart ()V
+	public fun moveTypesEnd (Lcom/squareup/wire/schema/Schema;Ljava/util/List;)V
+	public fun moveTypesStart (Lcom/squareup/wire/schema/Schema;Ljava/util/List;)V
+	public fun schemaHandlerEnd (Ljava/lang/String;Lcom/squareup/wire/schema/EmittingRules;)V
+	public fun schemaHandlerStart (Ljava/lang/String;Lcom/squareup/wire/schema/EmittingRules;)V
+	public fun schemaHandlersEnd ()V
+	public fun schemaHandlersStart ()V
+	public fun start ()V
+	public fun treeShakeEnd (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/PruningRules;)V
+	public fun treeShakeStart (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/PruningRules;)V
+	public fun validate ()V
+}
+
+public abstract interface class com/squareup/wire/schema/Visitor$Factory {
+	public abstract fun create ()Lcom/squareup/wire/schema/Visitor;
+}
+
 public final class com/squareup/wire/schema/internal/DagChecker {
 	public fun <init> (Ljava/lang/Iterable;Lkotlin/jvm/functions/Function1;)V
 	public final fun check ()Ljava/util/Set;

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Visitor.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Visitor.kt
@@ -1,0 +1,100 @@
+package com.squareup.wire.schema
+
+import com.squareup.wire.schema.internal.TypeMover
+
+/**
+ * Extend this class to audit Wire, receive metrics, and validate them, including all [schema handlers][SchemaHandler]
+ * involved in the Protobuf schema manipulation.
+ *
+ * The events' order is as follows:
+ *  - start
+ *  - loadSchemaStart
+ *  - loadSchemaEnd
+ *  - treeShakeStart
+ *  - treeShakeEnd
+ *  - moveTypesStart
+ *  - moveTypesEnd
+ *  - schemaHandlersStart // Looping over all handlers.
+ *    - schemaHandlerStart
+ *    - schemaHandlerEnd
+ *  - schemaHandlersEnd
+ *  - validate
+ *  - end
+ */
+abstract class Visitor {
+  /**
+   * Invoked prior to [end]. Use this method if you want to wait for the completion of all Wire's operations before
+   * executing some work.
+   */
+  open fun validate() {}
+
+  /** Invoked prior to Wire starting. */
+  open fun start() {}
+
+  /** Invoked after Wire has executed all operations. This is the last visitor's method called. */
+  open fun end() {}
+
+  /**
+   * Invoked prior to loading the Protobuf schema. this includes parsing `.proto` files, and resolving all referenced
+   * types.
+   */
+  open fun loadSchemaStart() {}
+
+  /**
+   * Invoked after having loaded the Protobuf [schema]. this includes parsing `.proto` files, and resolving all
+   * referenced types.
+   */
+  open fun loadSchemaEnd(
+    schema: Schema,
+  ) {}
+
+  /** Invoked prior to refactoring the Protobuf [schema] by tree-shaking it using the [pruning rules][PruningRules]. */
+  open fun treeShakeStart(
+    schema: Schema,
+    pruningRules: PruningRules,
+  ) {}
+
+  /** Invoked after having refactored the Protobuf schema by tree-shaking it using the [pruning rules][PruningRules]. */
+  open fun treeShakeEnd(
+    refactoredSchema: Schema,
+    pruningRules: PruningRules,
+  ) {}
+
+  /** Invoked prior to refactoring the Protobuf [schema] by applying the [moves]. */
+  open fun moveTypesStart(
+    schema: Schema,
+    moves: List<TypeMover.Move>,
+  ) {}
+
+  /** Invoked after having refactored the Protobuf schema by applying the [moves]. */
+  open fun moveTypesEnd(
+    refactoredSchema: Schema,
+    moves: List<TypeMover.Move>,
+  ) {}
+
+  /** Invoked prior to executing all [schema handler][SchemaHandler]. */
+  open fun schemaHandlersStart() {}
+
+  /** Invoked after having executed all [schema handler][SchemaHandler]. */
+  open fun schemaHandlersEnd() {}
+
+  /** Invoked prior a [schema handler][SchemaHandler] starting. */
+  open fun schemaHandlerStart(
+    targetName: String,
+    emittingRules: EmittingRules,
+  ) {}
+
+  /** Invoked after a [schema handler][SchemaHandler] has finished. */
+  open fun schemaHandlerEnd(
+    targetName: String,
+    emittingRules: EmittingRules,
+  ) {}
+
+  fun interface Factory {
+    /**
+     * Creates an instance of the [Visitor] for one Wire execution. The returned [Visitor] instance will be used during
+     * the lifecycle of the Wire's task.
+     */
+    fun create(): Visitor
+  }
+}


### PR DESCRIPTION
There was discussions around getting WireLogger to become somewhat a listener but it's an interface which would break the world every time we'd wanna make a change, and we can only set one.

I would like something like an EventListener but which would also be able to log, do whatever it wants, even throwing if something doesn't please it. One use case we have would be to force pruning rules exhaustion and throw if there are unused roots for instance.

I'm open to suggestions if something seems off on the software design level.