### PR TITLE
[swift] Create `UnknownFields` typealias.

### DIFF
--- a/wire-runtime-swift/src/main/swift/UnknownFields.swift
+++ b/wire-runtime-swift/src/main/swift/UnknownFields.swift
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2023 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Foundation
+
+/// Used to disambiguate between Foundation.Data and potential messages named Data.
+public typealias UnknownFields = Data

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/Duration.swift
@@ -60,7 +60,7 @@ public struct Duration {
      * to +999,999,999 inclusive.
      */
     public var nanos: Int32
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(seconds: Int64, nanos: Int32) {
         self.seconds = seconds

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -4,7 +4,7 @@ import Foundation
 
 public struct OneofOptions {
 
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init() {
     }

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/Timestamp.swift
@@ -72,7 +72,7 @@ public struct Timestamp {
      * inclusive.
      */
     public var nanos: Int32
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(seconds: Int64, nanos: Int32) {
         self.seconds = seconds

--- a/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
+++ b/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
@@ -16,7 +16,7 @@ public struct Dinosaur {
     public var length_meters: Double?
     public var mass_kilograms: Double?
     public var period: Period?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         name: String? = nil,

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -82,6 +82,8 @@ class SwiftGenerator private constructor(
   private val encoder = DeclaredTypeName.typeName("Swift.Encoder")
   private val writableKeyPath = DeclaredTypeName.typeName("Swift.WritableKeyPath")
 
+  private val unknownFields = DeclaredTypeName.typeName("Wire.UnknownFields", true)
+
   private val deprecated = AttributeSpec.builder("available").addArguments("*", "deprecated").build()
 
   private val ProtoType.typeName
@@ -1007,7 +1009,7 @@ class SwiftGenerator private constructor(
     }
 
     addProperty(
-      PropertySpec.varBuilder("unknownFields", DATA, PUBLIC)
+      PropertySpec.varBuilder("unknownFields", unknownFields, PUBLIC)
         .initializer(".init()")
         .build()
     )

--- a/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
@@ -6,7 +6,7 @@ import Wire
 public struct ContainsDuration {
 
     public var duration: Duration?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(duration: Duration? = nil) {
         self.duration = duration

--- a/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
@@ -6,7 +6,7 @@ import Wire
 public struct ContainsTimestamp {
 
     public var timestamp: Timestamp?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(timestamp: Timestamp? = nil) {
         self.timestamp = timestamp

--- a/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -254,7 +254,7 @@ public struct AllTypes {
     public struct NestedMessage {
 
         public var a: Int32?
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init(a: Int32? = nil) {
             self.a = a
@@ -497,7 +497,7 @@ extension AllTypes {
         public var ext_pack_float: [Swift.Float]
         public var ext_pack_double: [Swift.Double]
         public var ext_pack_nested_enum: [AllTypes.NestedEnum]
-        public var unknownFields: Foundation.Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init(
             opt_int32: Swift.Int32?,

--- a/wire-tests-swift/src/main/swift/DeprecatedProto.swift
+++ b/wire-tests-swift/src/main/swift/DeprecatedProto.swift
@@ -7,7 +7,7 @@ public struct DeprecatedProto {
 
     @available(*, deprecated)
     public var foo: String?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(foo: String? = nil) {
         self.foo = foo

--- a/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -7,7 +7,7 @@ public struct EmbeddedMessage {
 
     public var inner_repeated_number: [Int32]
     public var inner_number_after: Int32?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(inner_repeated_number: [Int32] = [], inner_number_after: Int32? = nil) {
         self.inner_repeated_number = inner_repeated_number

--- a/wire-tests-swift/src/main/swift/ExternalMessage.swift
+++ b/wire-tests-swift/src/main/swift/ExternalMessage.swift
@@ -6,7 +6,7 @@ import Wire
 public struct ExternalMessage {
 
     public var f: Float?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(f: Float? = nil) {
         self.f = f

--- a/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/src/main/swift/FooBar.swift
@@ -15,7 +15,7 @@ public struct FooBar {
     public var ext: FooBar.FooBarBazEnum?
     public var rep: [FooBar.FooBarBazEnum]
     public var more_string: String?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         foo: Int32? = nil,
@@ -44,7 +44,7 @@ public struct FooBar {
     public struct Nested {
 
         public var value: FooBar.FooBarBazEnum?
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init(value: FooBar.FooBarBazEnum? = nil) {
             self.value = value
@@ -55,7 +55,7 @@ public struct FooBar {
     public struct More {
 
         public var serial: [Int32]
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init(serial: [Int32] = []) {
             self.serial = serial

--- a/wire-tests-swift/src/main/swift/ForeignMessage.swift
+++ b/wire-tests-swift/src/main/swift/ForeignMessage.swift
@@ -6,7 +6,7 @@ import Wire
 public struct ForeignMessage {
 
     public var i: Int32?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(i: Int32? = nil) {
         self.i = i

--- a/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-tests-swift/src/main/swift/Form.swift
@@ -7,7 +7,7 @@ public struct Form {
 
     public var choice: Choice?
     public var decision: Decision?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(choice: Choice? = nil, decision: Decision? = nil) {
         self.choice = choice
@@ -77,7 +77,7 @@ public struct Form {
 
     public struct ButtonElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -86,7 +86,7 @@ public struct Form {
 
     public struct LocalImageElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -95,7 +95,7 @@ public struct Form {
 
     public struct RemoteImageElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -104,7 +104,7 @@ public struct Form {
 
     public struct MoneyElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -113,7 +113,7 @@ public struct Form {
 
     public struct SpacerElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -123,7 +123,7 @@ public struct Form {
     public struct TextElement {
 
         public var text: String?
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init(text: String? = nil) {
             self.text = text
@@ -133,7 +133,7 @@ public struct Form {
 
     public struct CustomizedCardElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -142,7 +142,7 @@ public struct Form {
 
     public struct AddressElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -151,7 +151,7 @@ public struct Form {
 
     public struct TextInputElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -160,7 +160,7 @@ public struct Form {
 
     public struct OptionPickerElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -169,7 +169,7 @@ public struct Form {
 
     public struct DetailRowElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }
@@ -178,7 +178,7 @@ public struct Form {
 
     public struct CurrencyConversionFlagsElement {
 
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init() {
         }

--- a/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-tests-swift/src/main/swift/Mappy.swift
@@ -6,7 +6,7 @@ import Wire
 public struct Mappy {
 
     public var things: [String : Thing]
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(things: [String : Thing] = [:]) {
         self.things = things

--- a/wire-tests-swift/src/main/swift/MappyTwo.swift
+++ b/wire-tests-swift/src/main/swift/MappyTwo.swift
@@ -9,7 +9,7 @@ public struct MappyTwo {
     public var int_things: [Int64 : Thing]
     public var string_ints: [String : Int64]
     public var int_things_two: [Int32 : Thing]
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         string_enums: [String : MappyTwo.ValueEnum] = [:],

--- a/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
@@ -10,7 +10,7 @@ public struct MessageUsingMultipleEnums {
 
     public var a: MessageWithStatus.Status?
     public var b: OtherMessageWithStatus.Status?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(a: MessageWithStatus.Status? = nil, b: OtherMessageWithStatus.Status? = nil) {
         self.a = a

--- a/wire-tests-swift/src/main/swift/MessageWithOptions.swift
+++ b/wire-tests-swift/src/main/swift/MessageWithOptions.swift
@@ -5,7 +5,7 @@ import Wire
 
 public struct MessageWithOptions {
 
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init() {
     }

--- a/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -5,7 +5,7 @@ import Wire
 
 public struct MessageWithStatus {
 
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init() {
     }

--- a/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -23,7 +23,7 @@ public struct ModelEvaluation {
     public var name: String?
     public var score: Double?
     public var models: [String : ModelEvaluation]
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         name: String? = nil,

--- a/wire-tests-swift/src/main/swift/NestedVersionOne.swift
+++ b/wire-tests-swift/src/main/swift/NestedVersionOne.swift
@@ -6,7 +6,7 @@ import Wire
 public struct NestedVersionOne {
 
     public var i: Int32?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(i: Int32? = nil) {
         self.i = i

--- a/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -11,7 +11,7 @@ public struct NestedVersionTwo {
     public var v2_f32: UInt32?
     public var v2_f64: UInt64?
     public var v2_rs: [String]
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         i: Int32? = nil,

--- a/wire-tests-swift/src/main/swift/NoFields.swift
+++ b/wire-tests-swift/src/main/swift/NoFields.swift
@@ -5,7 +5,7 @@ import Wire
 
 public struct NoFields {
 
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init() {
     }

--- a/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -12,7 +12,7 @@ public struct OneOfMessage {
      * Must have a foo or a bar or a baz.
      */
     public var choice: Choice?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(choice: Choice? = nil) {
         self.choice = choice

--- a/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -6,7 +6,7 @@ import Wire
 public struct OptionalEnumUser {
 
     public var optional_enum: OptionalEnumUser.OptionalEnum?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(optional_enum: OptionalEnumUser.OptionalEnum? = nil) {
         self.optional_enum = optional_enum

--- a/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -5,7 +5,7 @@ import Wire
 
 public struct OtherMessageWithStatus {
 
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init() {
     }

--- a/wire-tests-swift/src/main/swift/OuterMessage.swift
+++ b/wire-tests-swift/src/main/swift/OuterMessage.swift
@@ -7,7 +7,7 @@ public struct OuterMessage {
 
     public var outer_number_before: Int32?
     public var embedded_message: EmbeddedMessage?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(outer_number_before: Int32? = nil, embedded_message: EmbeddedMessage? = nil) {
         self.outer_number_before = outer_number_before

--- a/wire-tests-swift/src/main/swift/Percents.swift
+++ b/wire-tests-swift/src/main/swift/Percents.swift
@@ -9,7 +9,7 @@ public struct Percents {
      * e.g. "No limits, free to send and just 2.75% to receive".
      */
     public var text: String?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(text: String? = nil) {
         self.text = text

--- a/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-tests-swift/src/main/swift/Person.swift
@@ -25,7 +25,7 @@ public struct Person {
      */
     public var phone: [Person.PhoneNumber]
     public var aliases: [String]
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         id: Int32,
@@ -73,7 +73,7 @@ public struct Person {
          * The type of phone stored here.
          */
         public var type: Person.PhoneType?
-        public var unknownFields: Data = .init()
+        public var unknownFields: Wire.UnknownFields = .init()
 
         public init(number: String, type: Person.PhoneType? = nil) {
             self.number = number

--- a/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -6,7 +6,7 @@ import Wire
 public struct RedactedOneOf {
 
     public var a: A?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(a: A? = nil) {
         self.a = a

--- a/wire-tests-swift/src/main/swift/Thing.swift
+++ b/wire-tests-swift/src/main/swift/Thing.swift
@@ -6,7 +6,7 @@ import Wire
 public struct Thing {
 
     public var name: String?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(name: String? = nil) {
         self.name = name

--- a/wire-tests-swift/src/main/swift/VersionOne.swift
+++ b/wire-tests-swift/src/main/swift/VersionOne.swift
@@ -8,7 +8,7 @@ public struct VersionOne {
     public var i: Int32?
     public var obj: NestedVersionOne?
     public var en: EnumVersionOne?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         i: Int32? = nil,

--- a/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -13,7 +13,7 @@ public struct VersionTwo {
     public var v2_rs: [String]
     public var obj: NestedVersionTwo?
     public var en: EnumVersionTwo?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(
         i: Int32? = nil,

--- a/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -9,7 +9,7 @@ import Wire
 public struct VeryLongProtoNameCausingBrokenLineBreaks {
 
     public var foo: String?
-    public var unknownFields: Data = .init()
+    public var unknownFields: Wire.UnknownFields = .init()
 
     public init(foo: String? = nil) {
         self.foo = foo


### PR DESCRIPTION
This is the initial fix that @amorde had done here https://github.com/square/wire/pull/2491.

If we add `message Data` in our `.proto` file it exposes a second issue where a proto defines a message `Data` and a field of type `bytes` exists within the same module.

For now this is an incremental fix that we can take and then proceed further with landing https://github.com/square/wire/pull/2491