### PR TITLE
Pass target payload to custom schemahandler

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -372,7 +372,12 @@ data class CustomTarget(
   }
 
   override fun newHandler(): SchemaHandler {
-    return schemaHandlerFactory.create()
+    return schemaHandlerFactory.create(
+      includes = includes,
+      excludes = excludes,
+      exclusive = exclusive,
+      outDirectory = outDirectory,
+    )
   }
 }
 

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -970,7 +970,7 @@ class WirePluginTest {
 
     val result = gradleRunner.runFixture(fixtureRoot) { buildAndFail() }
     assertThat(result.output)
-      .contains("custom handler is running!!")
+      .contains("custom handler is running!! *, , true")
   }
 
   @Test

--- a/wire-gradle-plugin/src/test/projects/custom-output/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/custom-output/build.gradle
@@ -1,4 +1,5 @@
 import com.squareup.wire.schema.SchemaHandler
+import org.jetbrains.annotations.NotNull
 
 plugins {
   id 'application'
@@ -7,7 +8,14 @@ plugins {
 
 class MyCustomHandlerFactory implements SchemaHandler.Factory {
   @Override public SchemaHandler create() {
-    throw new RuntimeException("custom handler is running!!");
+    throw new RuntimeException("boom");
+  }
+
+  @Override
+  SchemaHandler create(@NotNull List<String> list, @NotNull List<String> list1, boolean b,
+      @NotNull String s) {
+    throw new RuntimeException("custom handler is running!! " +
+        list.join(", ") + ", " + list1.join(", ") + ", " + b);
   }
 }
 

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -815,6 +815,11 @@ public final class com/squareup/wire/schema/SchemaHandler$Context {
 
 public abstract interface class com/squareup/wire/schema/SchemaHandler$Factory : java/io/Serializable {
 	public abstract fun create ()Lcom/squareup/wire/schema/SchemaHandler;
+	public abstract fun create (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;)Lcom/squareup/wire/schema/SchemaHandler;
+}
+
+public final class com/squareup/wire/schema/SchemaHandler$Factory$DefaultImpls {
+	public static fun create (Lcom/squareup/wire/schema/SchemaHandler$Factory;Ljava/util/List;Ljava/util/List;ZLjava/lang/String;)Lcom/squareup/wire/schema/SchemaHandler;
 }
 
 public final class com/squareup/wire/schema/SchemaHandler$Module {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
@@ -190,6 +190,16 @@ abstract class SchemaHandler {
 
   /** Implementations of this interface must have a no-arguments public constructor. */
   interface Factory : Serializable {
+    @Deprecated("Wire does not call this method anymore. Implement the other 'create' method to receive the payload associated with the schema handler.")
     fun create(): SchemaHandler
+
+    fun create(
+      includes: List<String>,
+      excludes: List<String>,
+      exclusive: Boolean,
+      outDirectory: String,
+    ): SchemaHandler {
+      return create()
+    }
   }
 }


### PR DESCRIPTION
I'm not sure why I didn't do it from the get-go.... This would break Java implementers (we have one in `squareup`) but I think we have to do it.
Right now something like
```
custom {
  includes = xxxx
  exclusive = xxx
}
```
would all be lost.

I wonder if I could make a `Any` like argument (maybe a String) for the schema handler to parse it as they wish and be able to set payloads. Our java/kotlin targets needed some so we can assume new targets will want something. => https://github.com/square/wire/pull/2497