### PR TITLE
Generate schemaIndex every time

### DIFF
--- a/wire-golden-files/src/main/kotlin/squareup/wire/buildersonly/SomeMessage.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/buildersonly/SomeMessage.kt
@@ -22,6 +22,7 @@ public class SomeMessage internal constructor(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val opt_int32: Int? = null,
@@ -128,6 +129,7 @@ public class SomeMessage internal constructor(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0,
     )
     @JvmField
     public val a: Int? = null,

--- a/wire-golden-files/src/main/kotlin/squareup/wire/repeateddata/ParameterValue.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/repeateddata/ParameterValue.kt
@@ -34,6 +34,7 @@ public class ParameterValue(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
     declaredName = "data",
+    schemaIndex = 0,
   )
   public val data_: List<Float> = immutableCopyOf("data_", data_)
 

--- a/wire-golden-files/src/main/kotlin/squareup/wire/repeateddata/ParameterValueWithArray.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/repeateddata/ParameterValueWithArray.kt
@@ -34,6 +34,7 @@ public class ParameterValueWithArray(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
     declaredName = "data",
+    schemaIndex = 0,
   )
   public val data_: List<Float> = immutableCopyOf("data_", data_)
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Feature.kt
@@ -35,6 +35,7 @@ public class Feature(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val name: String? = null,
   /**
@@ -43,6 +44,7 @@ public class Feature(
   @field:WireField(
     tag = 2,
     adapter = "routeguide.Point#ADAPTER",
+    schemaIndex = 1,
   )
   public val location: Point? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/FeatureDatabase.kt
@@ -36,6 +36,7 @@ public class FeatureDatabase(
     tag = 1,
     adapter = "routeguide.Feature#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 0,
   )
   public val feature: List<Feature> = immutableCopyOf("feature", feature)
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Point.kt
@@ -32,11 +32,13 @@ public class Point(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val latitude: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val longitude: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/Rectangle.kt
@@ -33,6 +33,7 @@ public class Rectangle(
   @field:WireField(
     tag = 1,
     adapter = "routeguide.Point#ADAPTER",
+    schemaIndex = 0,
   )
   public val lo: Point? = null,
   /**
@@ -41,6 +42,7 @@ public class Rectangle(
   @field:WireField(
     tag = 2,
     adapter = "routeguide.Point#ADAPTER",
+    schemaIndex = 1,
   )
   public val hi: Point? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteNote.kt
@@ -33,6 +33,7 @@ public class RouteNote(
   @field:WireField(
     tag = 1,
     adapter = "routeguide.Point#ADAPTER",
+    schemaIndex = 0,
   )
   public val location: Point? = null,
   /**
@@ -41,6 +42,7 @@ public class RouteNote(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 1,
   )
   public val message: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteSummary.kt
@@ -36,6 +36,7 @@ public class RouteSummary(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val point_count: Int? = null,
   /**
@@ -44,6 +45,7 @@ public class RouteSummary(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val feature_count: Int? = null,
   /**
@@ -52,6 +54,7 @@ public class RouteSummary(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 2,
   )
   public val distance: Int? = null,
   /**
@@ -60,6 +63,7 @@ public class RouteSummary(
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 3,
   )
   public val elapsed_time: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-gson-support/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
+++ b/wire-gson-support/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
@@ -160,648 +160,563 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   @WireField(
       tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 0
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 1
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 2
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 3
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 4
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 5
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 6
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 7
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 8
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 9
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 10
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 11
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 12
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 13
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 14
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 15
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 16
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 17
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 18
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 19
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 20
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 21
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 22
+      label = WireField.Label.REQUIRED
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 23
+      label = WireField.Label.REQUIRED
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 24
+      label = WireField.Label.REQUIRED
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 25
+      label = WireField.Label.REQUIRED
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 26
+      label = WireField.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 27
+      label = WireField.Label.REQUIRED
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 28
+      label = WireField.Label.REQUIRED
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 29
+      label = WireField.Label.REQUIRED
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 30
+      label = WireField.Label.REQUIRED
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 31
+      label = WireField.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 32
+      label = WireField.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 33
+      label = WireField.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 34
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 35
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 36
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 37
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 38
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 39
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 40
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 41
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 42
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 43
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 44
+      label = WireField.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 45
+      label = WireField.Label.REPEATED
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 46
+      label = WireField.Label.REPEATED
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 47
+      label = WireField.Label.REPEATED
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 48
+      label = WireField.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 49
+      label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 50
+      label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 51
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 52
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 53
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 54
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 55
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 56
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 57
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 58
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 59
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 60
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED,
-      schemaIndex = 61
+      label = WireField.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED,
-      schemaIndex = 62
+      label = WireField.Label.PACKED
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED,
-      schemaIndex = 63
+      label = WireField.Label.PACKED
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED,
-      schemaIndex = 64
+      label = WireField.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 65
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 66
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 67
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 68
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 69
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 70
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 71
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 72
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 73
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 74
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 75
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 76
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 77
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 78
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 79
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 80
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum default_nested_enum;
 
   @WireField(
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 81
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Map<Integer, Integer> map_int32_int32;
 
   @WireField(
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 82
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final Map<String, String> map_string_string;
 
   @WireField(
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 83
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final Map<String, NestedMessage> map_string_message;
 
   @WireField(
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 84
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final Map<String, NestedEnum> map_string_enum;
 
@@ -810,8 +725,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1001,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 85
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer ext_opt_int32;
 
@@ -820,8 +734,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1002,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 86
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer ext_opt_uint32;
 
@@ -830,8 +743,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1003,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 87
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer ext_opt_sint32;
 
@@ -840,8 +752,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1004,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 88
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer ext_opt_fixed32;
 
@@ -850,8 +761,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1005,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 89
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer ext_opt_sfixed32;
 
@@ -860,8 +770,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1006,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 90
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long ext_opt_int64;
 
@@ -870,8 +779,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1007,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 91
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long ext_opt_uint64;
 
@@ -880,8 +788,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1008,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 92
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long ext_opt_sint64;
 
@@ -890,8 +797,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1009,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 93
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long ext_opt_fixed64;
 
@@ -900,8 +806,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1010,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 94
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long ext_opt_sfixed64;
 
@@ -910,8 +815,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1011,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 95
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean ext_opt_bool;
 
@@ -920,8 +824,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1012,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 96
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float ext_opt_float;
 
@@ -930,8 +833,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1013,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 97
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double ext_opt_double;
 
@@ -940,8 +842,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1014,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 98
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String ext_opt_string;
 
@@ -950,8 +851,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1015,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 99
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString ext_opt_bytes;
 
@@ -960,8 +860,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1016,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 100
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum ext_opt_nested_enum;
 
@@ -970,8 +869,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1017,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 101
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage ext_opt_nested_message;
 
@@ -981,8 +879,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 102
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_int32;
 
@@ -992,8 +889,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 103
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_uint32;
 
@@ -1003,8 +899,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 104
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_sint32;
 
@@ -1014,8 +909,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 105
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_fixed32;
 
@@ -1025,8 +919,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 106
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_sfixed32;
 
@@ -1036,8 +929,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 107
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_int64;
 
@@ -1047,8 +939,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 108
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_uint64;
 
@@ -1058,8 +949,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 109
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_sint64;
 
@@ -1069,8 +959,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 110
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_fixed64;
 
@@ -1080,8 +969,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 111
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_sfixed64;
 
@@ -1091,8 +979,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 112
+      label = WireField.Label.REPEATED
   )
   public final List<Boolean> ext_rep_bool;
 
@@ -1102,8 +989,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 113
+      label = WireField.Label.REPEATED
   )
   public final List<Float> ext_rep_float;
 
@@ -1113,8 +999,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 114
+      label = WireField.Label.REPEATED
   )
   public final List<Double> ext_rep_double;
 
@@ -1124,8 +1009,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 115
+      label = WireField.Label.REPEATED
   )
   public final List<String> ext_rep_string;
 
@@ -1135,8 +1019,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 116
+      label = WireField.Label.REPEATED
   )
   public final List<ByteString> ext_rep_bytes;
 
@@ -1146,8 +1029,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 117
+      label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> ext_rep_nested_enum;
 
@@ -1157,8 +1039,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 118
+      label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> ext_rep_nested_message;
 
@@ -1168,8 +1049,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 119
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_int32;
 
@@ -1179,8 +1059,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 120
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_uint32;
 
@@ -1190,8 +1069,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 121
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_sint32;
 
@@ -1201,8 +1079,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 122
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_fixed32;
 
@@ -1212,8 +1089,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 123
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_sfixed32;
 
@@ -1223,8 +1099,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 124
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_int64;
 
@@ -1234,8 +1109,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 125
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_uint64;
 
@@ -1245,8 +1119,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 126
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_sint64;
 
@@ -1256,8 +1129,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 127
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_fixed64;
 
@@ -1267,8 +1139,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 128
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_sfixed64;
 
@@ -1278,8 +1149,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED,
-      schemaIndex = 129
+      label = WireField.Label.PACKED
   )
   public final List<Boolean> ext_pack_bool;
 
@@ -1289,8 +1159,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED,
-      schemaIndex = 130
+      label = WireField.Label.PACKED
   )
   public final List<Float> ext_pack_float;
 
@@ -1300,8 +1169,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED,
-      schemaIndex = 131
+      label = WireField.Label.PACKED
   )
   public final List<Double> ext_pack_double;
 
@@ -1311,32 +1179,28 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED,
-      schemaIndex = 132
+      label = WireField.Label.PACKED
   )
   public final List<NestedEnum> ext_pack_nested_enum;
 
   @WireField(
       tag = 601,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      oneofName = "choice",
-      schemaIndex = 133
+      oneofName = "choice"
   )
   public final String oneof_string;
 
   @WireField(
       tag = 602,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      oneofName = "choice",
-      schemaIndex = 134
+      oneofName = "choice"
   )
   public final Integer oneof_int32;
 
   @WireField(
       tag = 603,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      oneofName = "choice",
-      schemaIndex = 135
+      oneofName = "choice"
   )
   public final NestedMessage oneof_nested_message;
 

--- a/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -31,6 +31,7 @@ public class Dinosaur(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   @JvmField
   public val name: String? = null,
@@ -38,18 +39,21 @@ public class Dinosaur(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 2,
   )
   @JvmField
   public val length_meters: Double? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 3,
   )
   @JvmField
   public val mass_kilograms: Double? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.proto2.geology.javainteropkotlin.Period#ADAPTER",
+    schemaIndex = 4,
   )
   @JvmField
   public val period: Period? = null,
@@ -62,6 +66,7 @@ public class Dinosaur(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   @JvmField
   public val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)

--- a/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-gson-support/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -34,22 +34,26 @@ public class Dinosaur(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val name: String? = null,
   picture_urls: List<String> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 2,
   )
   public val length_meters: Double? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 3,
   )
   public val mass_kilograms: Double? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.proto2.geology.kotlin.Period#ADAPTER",
+    schemaIndex = 4,
   )
   public val period: Period? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -61,6 +65,7 @@ public class Dinosaur(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   public val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)
 

--- a/wire-gson-support/src/test/java/com/squareup/wire/proto2/kotlin/Getters.kt
+++ b/wire-gson-support/src/test/java/com/squareup/wire/proto2/kotlin/Getters.kt
@@ -32,6 +32,7 @@ public class Getters(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val isa: Int? = null,
   /**
@@ -40,6 +41,7 @@ public class Getters(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val isA: Int? = null,
   /**
@@ -48,6 +50,7 @@ public class Getters(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 2,
   )
   public val is_a: Int? = null,
   /**
@@ -56,6 +59,7 @@ public class Getters(
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 3,
   )
   public val is32: Int? = null,
   /**
@@ -64,6 +68,7 @@ public class Getters(
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 4,
   )
   public val isb: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-gson-support/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
+++ b/wire-gson-support/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
@@ -43,6 +43,7 @@ public class Person(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 0,
   )
   public val name: String,
   /**
@@ -52,6 +53,7 @@ public class Person(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 1,
   )
   public val id: Int,
   /**
@@ -60,6 +62,7 @@ public class Person(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   public val email: String? = null,
   phone: List<PhoneNumber> = emptyList(),
@@ -72,6 +75,7 @@ public class Person(
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 6,
   )
   public val is_canadian: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -83,6 +87,7 @@ public class Person(
     tag = 4,
     adapter = "com.squareup.wire.proto2.person.kotlin.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 3,
   )
   public val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
 
@@ -90,6 +95,7 @@ public class Person(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 4,
   )
   public val favorite_numbers: List<Int> = immutableCopyOf("favorite_numbers", favorite_numbers)
 
@@ -97,6 +103,7 @@ public class Person(
     tag = 6,
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 5,
   )
   public val area_numbers: Map<Int, String> = immutableCopyOf("area_numbers", area_numbers)
 
@@ -300,6 +307,7 @@ public class Person(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED,
+      schemaIndex = 0,
     )
     public val number: String,
     /**
@@ -308,6 +316,7 @@ public class Person(
     @field:WireField(
       tag = 2,
       adapter = "com.squareup.wire.proto2.person.kotlin.Person${'$'}PhoneType#ADAPTER",
+      schemaIndex = 1,
     )
     public val type: PhoneType? = null,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-gson-support/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -34,6 +34,7 @@ public class KeywordKotlin(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     declaredName = "object",
+    schemaIndex = 0,
   )
   @JvmField
   public val object_: String? = null,
@@ -42,6 +43,7 @@ public class KeywordKotlin(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
     declaredName = "when",
+    schemaIndex = 1,
   )
   @JvmField
   public val when_: Int,
@@ -55,6 +57,7 @@ public class KeywordKotlin(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     declaredName = "fun",
+    schemaIndex = 2,
   )
   @JvmField
   public val fun_: Map<String, String> = immutableCopyOf("fun_", fun_)
@@ -64,6 +67,7 @@ public class KeywordKotlin(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
     declaredName = "return",
+    schemaIndex = 3,
   )
   @JvmField
   public val return_: List<Boolean> = immutableCopyOf("return_", return_)
@@ -72,6 +76,7 @@ public class KeywordKotlin(
     tag = 5,
     adapter = "squareup.proto2.keywords.KeywordKotlin${'$'}KeywordKotlinEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   @JvmField
   public val enums: List<KeywordKotlinEnum> = immutableCopyOf("enums", enums)

--- a/wire-gson-support/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -28,6 +28,7 @@ public class BuyOneGetOnePromotion(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   public val coupon: String = "",
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-gson-support/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
@@ -30,6 +30,7 @@ public class FreeDrinkPromotion(
     tag = 1,
     adapter = "squareup.proto3.FreeDrinkPromotion${'$'}Drink#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   public val drink: Drink = Drink.UNKNOWN,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-gson-support/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -28,6 +28,7 @@ public class FreeGarlicBreadPromotion(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "isExtraCheesey",
+    schemaIndex = 0,
   )
   public val is_extra_cheesey: Boolean = false,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-gson-support/src/test/java/squareup/proto3/Pizza.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/Pizza.kt
@@ -33,6 +33,7 @@ public class Pizza(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 0,
   )
   public val toppings: List<String> = immutableCopyOf("toppings", toppings)
 

--- a/wire-gson-support/src/test/java/squareup/proto3/PizzaDelivery.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/PizzaDelivery.kt
@@ -37,12 +37,14 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "phoneNumber",
+    schemaIndex = 0,
   )
   public val phone_number: String = "",
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 1,
   )
   public val address: String = "",
   pizzas: List<Pizza> = emptyList(),
@@ -50,6 +52,7 @@ public class PizzaDelivery(
     tag = 4,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 3,
   )
   public val promotion: AnyMessage? = null,
   @field:WireField(
@@ -57,6 +60,7 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#DURATION",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "deliveredWithinOrFree",
+    schemaIndex = 4,
   )
   public val delivered_within_or_free: Duration? = null,
   loyalty: Map<String, *>? = null,
@@ -65,6 +69,7 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "orderedAt",
+    schemaIndex = 6,
   )
   public val ordered_at: Instant? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -73,6 +78,7 @@ public class PizzaDelivery(
     tag = 3,
     adapter = "squareup.proto3.Pizza#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 2,
   )
   public val pizzas: List<Pizza> = immutableCopyOf("pizzas", pizzas)
 
@@ -80,6 +86,7 @@ public class PizzaDelivery(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 5,
   )
   public val loyalty: Map<String, *>? = immutableCopyOfStruct("loyalty", loyalty)
 

--- a/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
+++ b/wire-java-generator/src/test/java/com/squareup/wire/java/JavaGeneratorTest.java
@@ -465,16 +465,14 @@ public final class JavaGeneratorTest {
     assertThat(javaOutput).contains(""
       + "  @WireField(\n"
       + "      tag = 2,\n"
-      + "      adapter = \"com.squareup.wire.ProtoAdapter#STRING\",\n"
-      + "      schemaIndex = 0\n"
+      + "      adapter = \"com.squareup.wire.ProtoAdapter#STRING\"\n"
       + "  )\n"
       + "  @Nullable\n"
       + "  public final String two;");
     assertThat(javaOutput).contains(""
       + "  @WireField(\n"
       + "      tag = 1,\n"
-      + "      adapter = \"com.squareup.wire.ProtoAdapter#STRING\",\n"
-      + "      schemaIndex = 1\n"
+      + "      adapter = \"com.squareup.wire.ProtoAdapter#STRING\"\n"
       + "  )\n"
       + "  @Nullable\n"
       + "  public final String one;");

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1073,10 +1073,7 @@ class KotlinGenerator private constructor(
   ): List<Pair<ParameterSpec, PropertySpec>> {
     val result = mutableListOf<Pair<ParameterSpec, PropertySpec>>()
 
-    var index = 0
-    val fieldsAndOneOfFieldTags = message.fieldsAndOneOfFields.map { it.tag }
-    val printSchemaIndex = fieldsAndOneOfFieldTags != fieldsAndOneOfFieldTags.sorted()
-
+    var schemaIndex = 0
     for (fieldOrOneOf in message.fieldsAndFlatOneOfFieldsAndBoxedOneOfs()) {
       when (fieldOrOneOf) {
         is Field -> result.add(
@@ -1084,7 +1081,7 @@ class KotlinGenerator private constructor(
             message = message,
             field = fieldOrOneOf,
             nameAllocator = nameAllocator,
-            schemaIndex = if (printSchemaIndex) index++ else null,
+            schemaIndex = schemaIndex++,
           )
         )
         is OneOf -> result.add(

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -1676,6 +1676,7 @@ class KotlinGeneratorTest {
         |  @field:WireField(
         |    tag = 2,
         |    adapter = "com.example.StringPointAdapter#INSTANCE",
+        |    schemaIndex = 1,
         |  )
         |  public val location: String? = null,
         """.trimMargin()
@@ -1790,6 +1791,7 @@ class KotlinGeneratorTest {
          |  @field:WireField(
          |    tag = 1,
          |    adapter = "com.squareup.wire.ProtoAdapter#STRING",
+         |    schemaIndex = 0,
          |  )
          |  public val name: String? = null,
          """.trimMargin()

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/alltypes/AllTypes.java
@@ -160,648 +160,563 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   @WireField(
       tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 0
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 1
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 2
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 3
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 4
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 5
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 6
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 7
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 8
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 9
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 10
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 11
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 12
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 13
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 14
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 15
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 16
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 17
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 18
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 19
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 20
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 21
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 22
+      label = WireField.Label.REQUIRED
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 23
+      label = WireField.Label.REQUIRED
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 24
+      label = WireField.Label.REQUIRED
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 25
+      label = WireField.Label.REQUIRED
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 26
+      label = WireField.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 27
+      label = WireField.Label.REQUIRED
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 28
+      label = WireField.Label.REQUIRED
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 29
+      label = WireField.Label.REQUIRED
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 30
+      label = WireField.Label.REQUIRED
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 31
+      label = WireField.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 32
+      label = WireField.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 33
+      label = WireField.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 34
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 35
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 36
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 37
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 38
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 39
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 40
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 41
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 42
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 43
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 44
+      label = WireField.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 45
+      label = WireField.Label.REPEATED
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 46
+      label = WireField.Label.REPEATED
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 47
+      label = WireField.Label.REPEATED
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 48
+      label = WireField.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 49
+      label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 50
+      label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 51
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 52
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 53
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 54
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 55
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 56
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 57
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 58
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 59
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 60
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED,
-      schemaIndex = 61
+      label = WireField.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED,
-      schemaIndex = 62
+      label = WireField.Label.PACKED
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED,
-      schemaIndex = 63
+      label = WireField.Label.PACKED
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED,
-      schemaIndex = 64
+      label = WireField.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 65
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 66
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 67
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 68
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 69
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 70
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 71
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 72
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 73
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 74
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 75
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 76
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 77
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 78
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 79
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 80
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum default_nested_enum;
 
   @WireField(
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 81
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Map<Integer, Integer> map_int32_int32;
 
   @WireField(
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 82
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final Map<String, String> map_string_string;
 
   @WireField(
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 83
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final Map<String, NestedMessage> map_string_message;
 
   @WireField(
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 84
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final Map<String, NestedEnum> map_string_enum;
 
@@ -810,8 +725,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1001,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 85
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer ext_opt_int32;
 
@@ -820,8 +734,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1002,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 86
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer ext_opt_uint32;
 
@@ -830,8 +743,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1003,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 87
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer ext_opt_sint32;
 
@@ -840,8 +752,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1004,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 88
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer ext_opt_fixed32;
 
@@ -850,8 +761,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1005,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 89
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer ext_opt_sfixed32;
 
@@ -860,8 +770,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1006,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 90
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long ext_opt_int64;
 
@@ -870,8 +779,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1007,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 91
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long ext_opt_uint64;
 
@@ -880,8 +788,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1008,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 92
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long ext_opt_sint64;
 
@@ -890,8 +797,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1009,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 93
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long ext_opt_fixed64;
 
@@ -900,8 +806,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1010,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 94
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long ext_opt_sfixed64;
 
@@ -910,8 +815,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1011,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 95
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean ext_opt_bool;
 
@@ -920,8 +824,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1012,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 96
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float ext_opt_float;
 
@@ -930,8 +833,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1013,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 97
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double ext_opt_double;
 
@@ -940,8 +842,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1014,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 98
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String ext_opt_string;
 
@@ -950,8 +851,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1015,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 99
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString ext_opt_bytes;
 
@@ -960,8 +860,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1016,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 100
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum ext_opt_nested_enum;
 
@@ -970,8 +869,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1017,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 101
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage ext_opt_nested_message;
 
@@ -981,8 +879,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 102
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_int32;
 
@@ -992,8 +889,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 103
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_uint32;
 
@@ -1003,8 +899,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 104
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_sint32;
 
@@ -1014,8 +909,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 105
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_fixed32;
 
@@ -1025,8 +919,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 106
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_sfixed32;
 
@@ -1036,8 +929,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 107
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_int64;
 
@@ -1047,8 +939,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 108
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_uint64;
 
@@ -1058,8 +949,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 109
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_sint64;
 
@@ -1069,8 +959,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 110
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_fixed64;
 
@@ -1080,8 +969,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 111
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_sfixed64;
 
@@ -1091,8 +979,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 112
+      label = WireField.Label.REPEATED
   )
   public final List<Boolean> ext_rep_bool;
 
@@ -1102,8 +989,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 113
+      label = WireField.Label.REPEATED
   )
   public final List<Float> ext_rep_float;
 
@@ -1113,8 +999,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 114
+      label = WireField.Label.REPEATED
   )
   public final List<Double> ext_rep_double;
 
@@ -1124,8 +1009,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 115
+      label = WireField.Label.REPEATED
   )
   public final List<String> ext_rep_string;
 
@@ -1135,8 +1019,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 116
+      label = WireField.Label.REPEATED
   )
   public final List<ByteString> ext_rep_bytes;
 
@@ -1146,8 +1029,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 117
+      label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> ext_rep_nested_enum;
 
@@ -1157,8 +1039,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 118
+      label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> ext_rep_nested_message;
 
@@ -1168,8 +1049,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 119
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_int32;
 
@@ -1179,8 +1059,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 120
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_uint32;
 
@@ -1190,8 +1069,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 121
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_sint32;
 
@@ -1201,8 +1079,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 122
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_fixed32;
 
@@ -1212,8 +1089,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 123
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_sfixed32;
 
@@ -1223,8 +1099,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 124
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_int64;
 
@@ -1234,8 +1109,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 125
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_uint64;
 
@@ -1245,8 +1119,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 126
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_sint64;
 
@@ -1256,8 +1129,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 127
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_fixed64;
 
@@ -1267,8 +1139,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 128
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_sfixed64;
 
@@ -1278,8 +1149,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED,
-      schemaIndex = 129
+      label = WireField.Label.PACKED
   )
   public final List<Boolean> ext_pack_bool;
 
@@ -1289,8 +1159,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED,
-      schemaIndex = 130
+      label = WireField.Label.PACKED
   )
   public final List<Float> ext_pack_float;
 
@@ -1300,8 +1169,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED,
-      schemaIndex = 131
+      label = WireField.Label.PACKED
   )
   public final List<Double> ext_pack_double;
 
@@ -1311,32 +1179,28 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED,
-      schemaIndex = 132
+      label = WireField.Label.PACKED
   )
   public final List<NestedEnum> ext_pack_nested_enum;
 
   @WireField(
       tag = 601,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      oneofName = "choice",
-      schemaIndex = 133
+      oneofName = "choice"
   )
   public final String oneof_string;
 
   @WireField(
       tag = 602,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      oneofName = "choice",
-      schemaIndex = 134
+      oneofName = "choice"
   )
   public final Integer oneof_int32;
 
   @WireField(
       tag = 603,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      oneofName = "choice",
-      schemaIndex = 135
+      oneofName = "choice"
   )
   public final NestedMessage oneof_nested_message;
 

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/javainteropkotlin/Dinosaur.kt
@@ -31,6 +31,7 @@ public class Dinosaur(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   @JvmField
   public val name: String? = null,
@@ -38,18 +39,21 @@ public class Dinosaur(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 2,
   )
   @JvmField
   public val length_meters: Double? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 3,
   )
   @JvmField
   public val mass_kilograms: Double? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.proto2.geology.javainteropkotlin.Period#ADAPTER",
+    schemaIndex = 4,
   )
   @JvmField
   public val period: Period? = null,
@@ -62,6 +66,7 @@ public class Dinosaur(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   @JvmField
   public val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/dinosaurs/kotlin/Dinosaur.kt
@@ -34,22 +34,26 @@ public class Dinosaur(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val name: String? = null,
   picture_urls: List<String> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 2,
   )
   public val length_meters: Double? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 3,
   )
   public val mass_kilograms: Double? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.proto2.geology.kotlin.Period#ADAPTER",
+    schemaIndex = 4,
   )
   public val period: Period? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -61,6 +65,7 @@ public class Dinosaur(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   public val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)
 

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/kotlin/Getters.kt
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/kotlin/Getters.kt
@@ -32,6 +32,7 @@ public class Getters(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val isa: Int? = null,
   /**
@@ -40,6 +41,7 @@ public class Getters(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val isA: Int? = null,
   /**
@@ -48,6 +50,7 @@ public class Getters(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 2,
   )
   public val is_a: Int? = null,
   /**
@@ -56,6 +59,7 @@ public class Getters(
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 3,
   )
   public val is32: Int? = null,
   /**
@@ -64,6 +68,7 @@ public class Getters(
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 4,
   )
   public val isb: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/javainteropkotlin/Person.kt
@@ -38,6 +38,7 @@ public class Person(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 0,
   )
   @JvmField
   public val name: String,
@@ -48,6 +49,7 @@ public class Person(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 1,
   )
   @JvmField
   public val id: Int,
@@ -57,6 +59,7 @@ public class Person(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   @JvmField
   public val email: String? = null,
@@ -70,6 +73,7 @@ public class Person(
     tag = 4,
     adapter = "com.squareup.wire.proto2.person.javainteropkotlin.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 3,
   )
   @JvmField
   public val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
@@ -289,6 +293,7 @@ public class Person(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED,
+      schemaIndex = 0,
     )
     @JvmField
     public val number: String,
@@ -298,6 +303,7 @@ public class Person(
     @field:WireField(
       tag = 2,
       adapter = "com.squareup.wire.proto2.person.javainteropkotlin.Person${'$'}PhoneType#ADAPTER",
+      schemaIndex = 1,
     )
     @JvmField
     public val type: PhoneType? = null,

--- a/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
+++ b/wire-moshi-adapter/src/test/java/com/squareup/wire/proto2/person/kotlin/Person.kt
@@ -43,6 +43,7 @@ public class Person(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 0,
   )
   public val name: String,
   /**
@@ -52,6 +53,7 @@ public class Person(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 1,
   )
   public val id: Int,
   /**
@@ -60,6 +62,7 @@ public class Person(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   public val email: String? = null,
   phone: List<PhoneNumber> = emptyList(),
@@ -72,6 +75,7 @@ public class Person(
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 6,
   )
   public val is_canadian: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -83,6 +87,7 @@ public class Person(
     tag = 4,
     adapter = "com.squareup.wire.proto2.person.kotlin.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 3,
   )
   public val phone: List<PhoneNumber> = immutableCopyOf("phone", phone)
 
@@ -90,6 +95,7 @@ public class Person(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 4,
   )
   public val favorite_numbers: List<Int> = immutableCopyOf("favorite_numbers", favorite_numbers)
 
@@ -97,6 +103,7 @@ public class Person(
     tag = 6,
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 5,
   )
   public val area_numbers: Map<Int, String> = immutableCopyOf("area_numbers", area_numbers)
 
@@ -300,6 +307,7 @@ public class Person(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED,
+      schemaIndex = 0,
     )
     public val number: String,
     /**
@@ -308,6 +316,7 @@ public class Person(
     @field:WireField(
       tag = 2,
       adapter = "com.squareup.wire.proto2.person.kotlin.Person${'$'}PhoneType#ADAPTER",
+      schemaIndex = 1,
     )
     public val type: PhoneType? = null,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto2/keywords/KeywordKotlin.kt
@@ -34,6 +34,7 @@ public class KeywordKotlin(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     declaredName = "object",
+    schemaIndex = 0,
   )
   @JvmField
   public val object_: String? = null,
@@ -42,6 +43,7 @@ public class KeywordKotlin(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
     declaredName = "when",
+    schemaIndex = 1,
   )
   @JvmField
   public val when_: Int,
@@ -55,6 +57,7 @@ public class KeywordKotlin(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     declaredName = "fun",
+    schemaIndex = 2,
   )
   @JvmField
   public val fun_: Map<String, String> = immutableCopyOf("fun_", fun_)
@@ -64,6 +67,7 @@ public class KeywordKotlin(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
     declaredName = "return",
+    schemaIndex = 3,
   )
   @JvmField
   public val return_: List<Boolean> = immutableCopyOf("return_", return_)
@@ -72,6 +76,7 @@ public class KeywordKotlin(
     tag = 5,
     adapter = "squareup.proto2.keywords.KeywordKotlin${'$'}KeywordKotlinEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   @JvmField
   public val enums: List<KeywordKotlinEnum> = immutableCopyOf("enums", enums)

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -28,6 +28,7 @@ public class BuyOneGetOnePromotion(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   public val coupon: String = "",
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
@@ -30,6 +30,7 @@ public class FreeDrinkPromotion(
     tag = 1,
     adapter = "squareup.proto3.FreeDrinkPromotion${'$'}Drink#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   public val drink: Drink = Drink.UNKNOWN,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -28,6 +28,7 @@ public class FreeGarlicBreadPromotion(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "isExtraCheesey",
+    schemaIndex = 0,
   )
   public val is_extra_cheesey: Boolean = false,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/Pizza.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/Pizza.kt
@@ -33,6 +33,7 @@ public class Pizza(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 0,
   )
   public val toppings: List<String> = immutableCopyOf("toppings", toppings)
 

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/PizzaDelivery.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/PizzaDelivery.kt
@@ -37,12 +37,14 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "phoneNumber",
+    schemaIndex = 0,
   )
   public val phone_number: String = "",
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 1,
   )
   public val address: String = "",
   pizzas: List<Pizza> = emptyList(),
@@ -50,6 +52,7 @@ public class PizzaDelivery(
     tag = 4,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 3,
   )
   public val promotion: AnyMessage? = null,
   @field:WireField(
@@ -57,6 +60,7 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#DURATION",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "deliveredWithinOrFree",
+    schemaIndex = 4,
   )
   public val delivered_within_or_free: Duration? = null,
   loyalty: Map<String, *>? = null,
@@ -65,6 +69,7 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "orderedAt",
+    schemaIndex = 6,
   )
   public val ordered_at: Instant? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -73,6 +78,7 @@ public class PizzaDelivery(
     tag = 3,
     adapter = "squareup.proto3.Pizza#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 2,
   )
   public val pizzas: List<Pizza> = immutableCopyOf("pizzas", pizzas)
 
@@ -80,6 +86,7 @@ public class PizzaDelivery(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 5,
   )
   public val loyalty: Map<String, *>? = immutableCopyOfStruct("loyalty", loyalty)
 

--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/WireField.kt
@@ -65,7 +65,7 @@ annotation class WireField(
   /**
    * This is the order that this field was declared in the `.proto` schema.
    *
-   * It is -1 if their tags are declared in ascending order.
+   * It is -1 if the order does not matter for JSON serialization.
    */
   val schemaIndex: Int = -1,
 ) {

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/dinosaurs/Dinosaur.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/dinosaurs/Dinosaur.kt
@@ -34,22 +34,26 @@ public class Dinosaur(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val name: String? = null,
   picture_urls: List<String> = emptyList(),
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 2,
   )
   public val length_meters: Double? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 3,
   )
   public val mass_kilograms: Double? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.geology.Period#ADAPTER",
+    schemaIndex = 4,
   )
   public val period: Period? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -61,6 +65,7 @@ public class Dinosaur(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   public val picture_urls: List<String> = immutableCopyOf("picture_urls", picture_urls)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
@@ -46,6 +46,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "int32",
+    schemaIndex = 0,
   )
   public val proto3_kotlin_int32: Int = 0,
   @field:WireField(
@@ -53,6 +54,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "uint32",
+    schemaIndex = 1,
   )
   public val proto3_kotlin_uint32: Int = 0,
   @field:WireField(
@@ -60,6 +62,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "sint32",
+    schemaIndex = 2,
   )
   public val proto3_kotlin_sint32: Int = 0,
   @field:WireField(
@@ -67,6 +70,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "fixed32",
+    schemaIndex = 3,
   )
   public val proto3_kotlin_fixed32: Int = 0,
   @field:WireField(
@@ -74,6 +78,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "sfixed32",
+    schemaIndex = 4,
   )
   public val proto3_kotlin_sfixed32: Int = 0,
   @field:WireField(
@@ -81,6 +86,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "int64",
+    schemaIndex = 5,
   )
   public val proto3_kotlin_int64: Long = 0L,
   @field:WireField(
@@ -88,6 +94,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "uint64",
+    schemaIndex = 6,
   )
   public val proto3_kotlin_uint64: Long = 0L,
   @field:WireField(
@@ -95,6 +102,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "sint64",
+    schemaIndex = 7,
   )
   public val proto3_kotlin_sint64: Long = 0L,
   @field:WireField(
@@ -102,6 +110,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "fixed64",
+    schemaIndex = 8,
   )
   public val proto3_kotlin_fixed64: Long = 0L,
   @field:WireField(
@@ -109,6 +118,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "sfixed64",
+    schemaIndex = 9,
   )
   public val proto3_kotlin_sfixed64: Long = 0L,
   @field:WireField(
@@ -116,6 +126,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "bool",
+    schemaIndex = 10,
   )
   public val proto3_kotlin_bool: Boolean = false,
   @field:WireField(
@@ -123,6 +134,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "float",
+    schemaIndex = 11,
   )
   public val proto3_kotlin_float: Float = 0f,
   @field:WireField(
@@ -130,6 +142,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "double",
+    schemaIndex = 12,
   )
   public val proto3_kotlin_double: Double = 0.0,
   @field:WireField(
@@ -137,6 +150,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "string",
+    schemaIndex = 13,
   )
   public val proto3_kotlin_string: String = "",
   @field:WireField(
@@ -144,6 +158,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "bytes",
+    schemaIndex = 14,
   )
   public val proto3_kotlin_bytes: ByteString = ByteString.EMPTY,
   @field:WireField(
@@ -151,6 +166,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "nestedEnum",
+    schemaIndex = 15,
   )
   public val nested_enum: NestedEnum = NestedEnum.UNKNOWN,
   @field:WireField(
@@ -158,18 +174,21 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "nestedMessage",
+    schemaIndex = 16,
   )
   public val nested_message: NestedMessage? = null,
   @field:WireField(
     tag = 18,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 17,
   )
   public val any: AnyMessage? = null,
   @field:WireField(
     tag = 19,
     adapter = "com.squareup.wire.ProtoAdapter#DURATION",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 18,
   )
   public val duration: Duration? = null,
   struct: Map<String, *>? = null,
@@ -180,102 +199,119 @@ public class AllTypes(
     tag = 24,
     adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 23,
   )
   public val empty: Unit? = null,
   @field:WireField(
     tag = 25,
     adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 24,
   )
   public val timestamp: Instant? = null,
   @field:WireField(
     tag = 101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "optInt32",
+    schemaIndex = 25,
   )
   public val opt_int32: Int? = null,
   @field:WireField(
     tag = 102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     jsonName = "optUint32",
+    schemaIndex = 26,
   )
   public val opt_uint32: Int? = null,
   @field:WireField(
     tag = 103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     jsonName = "optSint32",
+    schemaIndex = 27,
   )
   public val opt_sint32: Int? = null,
   @field:WireField(
     tag = 104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     jsonName = "optFixed32",
+    schemaIndex = 28,
   )
   public val opt_fixed32: Int? = null,
   @field:WireField(
     tag = 105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     jsonName = "optSfixed32",
+    schemaIndex = 29,
   )
   public val opt_sfixed32: Int? = null,
   @field:WireField(
     tag = 106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     jsonName = "optInt64",
+    schemaIndex = 30,
   )
   public val opt_int64: Long? = null,
   @field:WireField(
     tag = 107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     jsonName = "optUint64",
+    schemaIndex = 31,
   )
   public val opt_uint64: Long? = null,
   @field:WireField(
     tag = 108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     jsonName = "optSint64",
+    schemaIndex = 32,
   )
   public val opt_sint64: Long? = null,
   @field:WireField(
     tag = 109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     jsonName = "optFixed64",
+    schemaIndex = 33,
   )
   public val opt_fixed64: Long? = null,
   @field:WireField(
     tag = 110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     jsonName = "optSfixed64",
+    schemaIndex = 34,
   )
   public val opt_sfixed64: Long? = null,
   @field:WireField(
     tag = 111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     jsonName = "optBool",
+    schemaIndex = 35,
   )
   public val opt_bool: Boolean? = null,
   @field:WireField(
     tag = 112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     jsonName = "optFloat",
+    schemaIndex = 36,
   )
   public val opt_float: Float? = null,
   @field:WireField(
     tag = 113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     jsonName = "optDouble",
+    schemaIndex = 37,
   )
   public val opt_double: Double? = null,
   @field:WireField(
     tag = 114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "optString",
+    schemaIndex = 38,
   )
   public val opt_string: String? = null,
   @field:WireField(
     tag = 115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     jsonName = "optBytes",
+    schemaIndex = 39,
   )
   public val opt_bytes: ByteString? = null,
   rep_int32: List<Int> = emptyList(),
@@ -335,6 +371,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "oneofString",
     oneofName = "choice",
+    schemaIndex = 92,
   )
   public val oneof_string: String? = null,
   @field:WireField(
@@ -342,6 +379,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "oneofInt32",
     oneofName = "choice",
+    schemaIndex = 93,
   )
   public val oneof_int32: Int? = null,
   @field:WireField(
@@ -349,6 +387,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
     jsonName = "oneofNestedMessage",
     oneofName = "choice",
+    schemaIndex = 94,
   )
   public val oneof_nested_message: NestedMessage? = null,
   @field:WireField(
@@ -356,6 +395,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     jsonName = "oneofAny",
     oneofName = "choice",
+    schemaIndex = 95,
   )
   public val oneof_any: AnyMessage? = null,
   @field:WireField(
@@ -363,6 +403,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DURATION",
     jsonName = "oneofDuration",
     oneofName = "choice",
+    schemaIndex = 96,
   )
   public val oneof_duration: Duration? = null,
   oneof_struct: Map<String, *>? = null,
@@ -376,6 +417,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
     jsonName = "oneofEmpty",
     oneofName = "choice",
+    schemaIndex = 99,
   )
   public val oneof_empty: Unit? = null,
   @field:WireField(
@@ -383,6 +425,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
     jsonName = "oneofTimestamp",
     oneofName = "choice",
+    schemaIndex = 100,
   )
   public val oneof_timestamp: Instant? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -391,6 +434,7 @@ public class AllTypes(
     tag = 20,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 19,
   )
   public val struct: Map<String, *>? = immutableCopyOfStruct("struct", struct)
 
@@ -399,6 +443,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "listValue",
+    schemaIndex = 20,
   )
   public val list_value: List<*>? = immutableCopyOfStruct("list_value", list_value)
 
@@ -407,6 +452,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.OMIT_IDENTITY,
     declaredName = "value",
+    schemaIndex = 21,
   )
   public val value_: Any? = immutableCopyOfStruct("value_", value_)
 
@@ -415,6 +461,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "nullValue",
+    schemaIndex = 22,
   )
   public val null_value: Nothing? = immutableCopyOfStruct("null_value", null_value)
 
@@ -423,6 +470,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
     jsonName = "repInt32",
+    schemaIndex = 40,
   )
   public val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
 
@@ -431,6 +479,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
     jsonName = "repUint32",
+    schemaIndex = 41,
   )
   public val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
 
@@ -439,6 +488,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
     jsonName = "repSint32",
+    schemaIndex = 42,
   )
   public val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
 
@@ -447,6 +497,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
     jsonName = "repFixed32",
+    schemaIndex = 43,
   )
   public val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
 
@@ -455,6 +506,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
     jsonName = "repSfixed32",
+    schemaIndex = 44,
   )
   public val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
 
@@ -463,6 +515,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
     jsonName = "repInt64",
+    schemaIndex = 45,
   )
   public val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
 
@@ -471,6 +524,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
     jsonName = "repUint64",
+    schemaIndex = 46,
   )
   public val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
 
@@ -479,6 +533,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
     jsonName = "repSint64",
+    schemaIndex = 47,
   )
   public val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
 
@@ -487,6 +542,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
     jsonName = "repFixed64",
+    schemaIndex = 48,
   )
   public val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
 
@@ -495,6 +551,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
     jsonName = "repSfixed64",
+    schemaIndex = 49,
   )
   public val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
 
@@ -503,6 +560,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
     jsonName = "repBool",
+    schemaIndex = 50,
   )
   public val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
 
@@ -511,6 +569,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
     jsonName = "repFloat",
+    schemaIndex = 51,
   )
   public val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
 
@@ -519,6 +578,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
     jsonName = "repDouble",
+    schemaIndex = 52,
   )
   public val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
 
@@ -527,6 +587,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
     jsonName = "repString",
+    schemaIndex = 53,
   )
   public val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
 
@@ -535,6 +596,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
     jsonName = "repBytes",
+    schemaIndex = 54,
   )
   public val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
 
@@ -543,6 +605,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
     jsonName = "repNestedEnum",
+    schemaIndex = 55,
   )
   public val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
 
@@ -551,6 +614,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
     jsonName = "repNestedMessage",
+    schemaIndex = 56,
   )
   public val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
       rep_nested_message)
@@ -560,6 +624,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.REPEATED,
     jsonName = "repAny",
+    schemaIndex = 57,
   )
   public val rep_any: List<AnyMessage> = immutableCopyOf("rep_any", rep_any)
 
@@ -568,6 +633,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DURATION",
     label = WireField.Label.REPEATED,
     jsonName = "repDuration",
+    schemaIndex = 58,
   )
   public val rep_duration: List<Duration> = immutableCopyOf("rep_duration", rep_duration)
 
@@ -576,6 +642,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.REPEATED,
     jsonName = "repStruct",
+    schemaIndex = 59,
   )
   public val rep_struct: List<Map<String, *>?> = immutableCopyOfStruct("rep_struct", rep_struct)
 
@@ -584,6 +651,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     label = WireField.Label.REPEATED,
     jsonName = "repListValue",
+    schemaIndex = 60,
   )
   public val rep_list_value: List<List<*>?> = immutableCopyOfStruct("rep_list_value",
       rep_list_value)
@@ -593,6 +661,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repValue",
+    schemaIndex = 61,
   )
   public val rep_value: List<Any?> = immutableCopyOfStruct("rep_value", rep_value)
 
@@ -601,6 +670,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     label = WireField.Label.REPEATED,
     jsonName = "repNullValue",
+    schemaIndex = 62,
   )
   public val rep_null_value: List<Nothing?> = immutableCopyOfStruct("rep_null_value",
       rep_null_value)
@@ -610,6 +680,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
     label = WireField.Label.REPEATED,
     jsonName = "repEmpty",
+    schemaIndex = 63,
   )
   public val rep_empty: List<Unit> = immutableCopyOf("rep_empty", rep_empty)
 
@@ -618,6 +689,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
     label = WireField.Label.REPEATED,
     jsonName = "repTimestamp",
+    schemaIndex = 64,
   )
   public val rep_timestamp: List<Instant> = immutableCopyOf("rep_timestamp", rep_timestamp)
 
@@ -626,6 +698,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
     jsonName = "packInt32",
+    schemaIndex = 65,
   )
   public val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
 
@@ -634,6 +707,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
     jsonName = "packUint32",
+    schemaIndex = 66,
   )
   public val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
 
@@ -642,6 +716,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
     jsonName = "packSint32",
+    schemaIndex = 67,
   )
   public val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
 
@@ -650,6 +725,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
     jsonName = "packFixed32",
+    schemaIndex = 68,
   )
   public val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
 
@@ -658,6 +734,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
     jsonName = "packSfixed32",
+    schemaIndex = 69,
   )
   public val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
 
@@ -666,6 +743,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
     jsonName = "packInt64",
+    schemaIndex = 70,
   )
   public val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
 
@@ -674,6 +752,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
     jsonName = "packUint64",
+    schemaIndex = 71,
   )
   public val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
 
@@ -682,6 +761,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
     jsonName = "packSint64",
+    schemaIndex = 72,
   )
   public val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
 
@@ -690,6 +770,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
     jsonName = "packFixed64",
+    schemaIndex = 73,
   )
   public val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
 
@@ -698,6 +779,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
     jsonName = "packSfixed64",
+    schemaIndex = 74,
   )
   public val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
 
@@ -706,6 +788,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
     jsonName = "packBool",
+    schemaIndex = 75,
   )
   public val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
 
@@ -714,6 +797,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
     jsonName = "packFloat",
+    schemaIndex = 76,
   )
   public val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
 
@@ -722,6 +806,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
     jsonName = "packDouble",
+    schemaIndex = 77,
   )
   public val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
 
@@ -730,6 +815,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
     jsonName = "packNestedEnum",
+    schemaIndex = 78,
   )
   public val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum",
       pack_nested_enum)
@@ -739,6 +825,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     label = WireField.Label.PACKED,
     jsonName = "packNullValue",
+    schemaIndex = 79,
   )
   public val pack_null_value: List<Nothing?> = immutableCopyOfStruct("pack_null_value",
       pack_null_value)
@@ -748,6 +835,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "mapInt32Int32",
+    schemaIndex = 80,
   )
   public val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
 
@@ -756,6 +844,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "mapStringString",
+    schemaIndex = 81,
   )
   public val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
       map_string_string)
@@ -765,6 +854,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedMessage#ADAPTER",
     jsonName = "mapStringMessage",
+    schemaIndex = 82,
   )
   public val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
       map_string_message)
@@ -774,6 +864,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.proto3.kotlin.all_types.AllTypes${'$'}NestedEnum#ADAPTER",
     jsonName = "mapStringEnum",
+    schemaIndex = 83,
   )
   public val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum",
       map_string_enum)
@@ -783,6 +874,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     jsonName = "mapInt32Any",
+    schemaIndex = 84,
   )
   public val map_int32_any: Map<Int, AnyMessage> = immutableCopyOf("map_int32_any", map_int32_any)
 
@@ -791,6 +883,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#DURATION",
     jsonName = "mapInt32Duration",
+    schemaIndex = 85,
   )
   public val map_int32_duration: Map<Int, Duration> = immutableCopyOf("map_int32_duration",
       map_int32_duration)
@@ -800,6 +893,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     jsonName = "mapInt32Struct",
+    schemaIndex = 86,
   )
   public val map_int32_struct: Map<Int, Map<String, *>?> =
       immutableCopyOfMapWithStructValues("map_int32_struct", map_int32_struct)
@@ -809,6 +903,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     jsonName = "mapInt32ListValue",
+    schemaIndex = 87,
   )
   public val map_int32_list_value: Map<Int, List<*>?> =
       immutableCopyOfMapWithStructValues("map_int32_list_value", map_int32_list_value)
@@ -818,6 +913,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
     jsonName = "mapInt32Value",
+    schemaIndex = 88,
   )
   public val map_int32_value: Map<Int, Any?> = immutableCopyOfMapWithStructValues("map_int32_value",
       map_int32_value)
@@ -827,6 +923,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
     jsonName = "mapInt32NullValue",
+    schemaIndex = 89,
   )
   public val map_int32_null_value: Map<Int, Nothing?> =
       immutableCopyOfMapWithStructValues("map_int32_null_value", map_int32_null_value)
@@ -836,6 +933,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#EMPTY",
     jsonName = "mapInt32Empty",
+    schemaIndex = 90,
   )
   public val map_int32_empty: Map<Int, Unit> = immutableCopyOf("map_int32_empty", map_int32_empty)
 
@@ -844,6 +942,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
     jsonName = "mapInt32Timestamp",
+    schemaIndex = 91,
   )
   public val map_int32_timestamp: Map<Int, Instant> = immutableCopyOf("map_int32_timestamp",
       map_int32_timestamp)
@@ -853,6 +952,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     jsonName = "oneofStruct",
     oneofName = "choice",
+    schemaIndex = 97,
   )
   public val oneof_struct: Map<String, *>? = immutableCopyOfStruct("oneof_struct", oneof_struct)
 
@@ -861,6 +961,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
     jsonName = "oneofListValue",
     oneofName = "choice",
+    schemaIndex = 98,
   )
   public val oneof_list_value: List<*>? = immutableCopyOfStruct("oneof_list_value",
       oneof_list_value)
@@ -2275,6 +2376,7 @@ public class AllTypes(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.OMIT_IDENTITY,
+      schemaIndex = 0,
     )
     public val a: Int = 0,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
@@ -41,6 +41,7 @@ public class Person(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   public val name: String = "",
   /**
@@ -50,6 +51,7 @@ public class Person(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 1,
   )
   public val id: Int = 0,
   /**
@@ -59,6 +61,7 @@ public class Person(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 2,
   )
   public val email: String = "",
   phones: List<PhoneNumber> = emptyList(),
@@ -67,12 +70,14 @@ public class Person(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     oneofName = "choice",
+    schemaIndex = 5,
   )
   public val foo: Int? = null,
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     oneofName = "choice",
+    schemaIndex = 6,
   )
   public val bar: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -84,6 +89,7 @@ public class Person(
     tag = 4,
     adapter = "com.squareup.wire.proto3.kotlin.person.Person${'$'}PhoneNumber#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 3,
   )
   public val phones: List<PhoneNumber> = immutableCopyOf("phones", phones)
 
@@ -91,6 +97,7 @@ public class Person(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   public val aliases: List<String> = immutableCopyOf("aliases", aliases)
 
@@ -287,6 +294,7 @@ public class Person(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.OMIT_IDENTITY,
+      schemaIndex = 0,
     )
     public val number: String = "",
     /**
@@ -296,6 +304,7 @@ public class Person(
       tag = 2,
       adapter = "com.squareup.wire.proto3.kotlin.person.Person${'$'}PhoneType#ADAPTER",
       label = WireField.Label.OMIT_IDENTITY,
+      schemaIndex = 1,
     )
     public val type: PhoneType = PhoneType.MOBILE,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -41,18 +41,21 @@ public class FooBar(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val foo: Int? = null,
   @MyFieldOptionTwoOption(33.5f)
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 1,
   )
   public val bar: String? = null,
   @MyFieldOptionThreeOption(FooBarBazEnum.BAR)
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}Nested#ADAPTER",
+    schemaIndex = 2,
   )
   public val baz: Nested? = null,
   @MyFieldOptionOneOption(18)
@@ -71,12 +74,14 @@ public class FooBar(
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 3,
   )
   public val qux: Long? = null,
   fred: List<Float> = emptyList(),
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 5,
   )
   public val daisy: Double? = null,
   nested: List<FooBar> = emptyList(),
@@ -86,6 +91,7 @@ public class FooBar(
   @field:WireField(
     tag = 150,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 7,
   )
   public val more_string: String? = null,
   /**
@@ -94,6 +100,7 @@ public class FooBar(
   @field:WireField(
     tag = 101,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
+    schemaIndex = 8,
   )
   public val ext: FooBarBazEnum? = null,
   rep: List<FooBarBazEnum> = emptyList(),
@@ -104,6 +111,7 @@ public class FooBar(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   public val fred: List<Float> = immutableCopyOf("fred", fred)
 
@@ -112,6 +120,7 @@ public class FooBar(
     adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
     label = WireField.Label.REPEATED,
     redacted = true,
+    schemaIndex = 6,
   )
   public val nested: List<FooBar> = immutableCopyOf("nested", nested)
 
@@ -122,6 +131,7 @@ public class FooBar(
     tag = 102,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 9,
   )
   public val rep: List<FooBarBazEnum> = immutableCopyOf("rep", rep)
 
@@ -314,6 +324,7 @@ public class FooBar(
       tag = 1,
       adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
       declaredName = "value",
+      schemaIndex = 0,
     )
     public val value_: FooBarBazEnum? = null,
     unknownFields: ByteString = ByteString.EMPTY,
@@ -413,6 +424,7 @@ public class FooBar(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED,
+      schemaIndex = 0,
     )
     public val serial: List<Int> = immutableCopyOf("serial", serial)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -28,6 +28,7 @@ public class DeprecatedProto(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val foo: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -556,6 +556,7 @@ public class Form(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 0,
     )
     public val text: String? = null,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -29,11 +29,13 @@ public class MessageUsingMultipleEnums(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.protos.kotlin.MessageWithStatus${'$'}Status#ADAPTER",
+    schemaIndex = 0,
   )
   public val a: MessageWithStatus.Status? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.OtherMessageWithStatus${'$'}Status#ADAPTER",
+    schemaIndex = 1,
   )
   public val b: OtherMessageWithStatus.Status? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -35,6 +35,7 @@ public class OneOfMessage(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     oneofName = "choice",
+    schemaIndex = 0,
   )
   public val foo: Int? = null,
   /**
@@ -44,6 +45,7 @@ public class OneOfMessage(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     oneofName = "choice",
+    schemaIndex = 1,
   )
   public val bar: String? = null,
   /**
@@ -53,6 +55,7 @@ public class OneOfMessage(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     oneofName = "choice",
+    schemaIndex = 2,
   )
   public val baz: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/OptionalEnumUser.kt
@@ -29,6 +29,7 @@ public class OptionalEnumUser(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.protos.kotlin.OptionalEnumUser${'$'}OptionalEnum#ADAPTER",
+    schemaIndex = 0,
   )
   public val optional_enum: OptionalEnum? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/VeryLongProtoNameCausingBrokenLineBreaks.kt
@@ -30,6 +30,7 @@ public class VeryLongProtoNameCausingBrokenLineBreaks(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val foo: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -71,188 +71,222 @@ public class AllTypes(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val opt_int32: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 1,
   )
   public val opt_uint32: Int? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 2,
   )
   public val opt_sint32: Int? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 3,
   )
   public val opt_fixed32: Int? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 4,
   )
   public val opt_sfixed32: Int? = null,
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 5,
   )
   public val opt_int64: Long? = null,
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 6,
   )
   public val opt_uint64: Long? = null,
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 7,
   )
   public val opt_sint64: Long? = null,
   @field:WireField(
     tag = 9,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 8,
   )
   public val opt_fixed64: Long? = null,
   @field:WireField(
     tag = 10,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 9,
   )
   public val opt_sfixed64: Long? = null,
   @field:WireField(
     tag = 11,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 10,
   )
   public val opt_bool: Boolean? = null,
   @field:WireField(
     tag = 12,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 11,
   )
   public val opt_float: Float? = null,
   @field:WireField(
     tag = 13,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 12,
   )
   public val opt_double: Double? = null,
   @field:WireField(
     tag = 14,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 13,
   )
   public val opt_string: String? = null,
   @field:WireField(
     tag = 15,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 14,
   )
   public val opt_bytes: ByteString? = null,
   @field:WireField(
     tag = 16,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 15,
   )
   public val opt_nested_enum: NestedEnum? = null,
   @field:WireField(
     tag = 17,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 16,
   )
   public val opt_nested_message: NestedMessage? = null,
   @field:WireField(
     tag = 101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 17,
   )
   public val req_int32: Int,
   @field:WireField(
     tag = 102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 18,
   )
   public val req_uint32: Int,
   @field:WireField(
     tag = 103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 19,
   )
   public val req_sint32: Int,
   @field:WireField(
     tag = 104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 20,
   )
   public val req_fixed32: Int,
   @field:WireField(
     tag = 105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 21,
   )
   public val req_sfixed32: Int,
   @field:WireField(
     tag = 106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 22,
   )
   public val req_int64: Long,
   @field:WireField(
     tag = 107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 23,
   )
   public val req_uint64: Long,
   @field:WireField(
     tag = 108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 24,
   )
   public val req_sint64: Long,
   @field:WireField(
     tag = 109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 25,
   )
   public val req_fixed64: Long,
   @field:WireField(
     tag = 110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 26,
   )
   public val req_sfixed64: Long,
   @field:WireField(
     tag = 111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 27,
   )
   public val req_bool: Boolean,
   @field:WireField(
     tag = 112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 28,
   )
   public val req_float: Float,
   @field:WireField(
     tag = 113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 29,
   )
   public val req_double: Double,
   @field:WireField(
     tag = 114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 30,
   )
   public val req_string: String,
   @field:WireField(
     tag = 115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 31,
   )
   public val req_bytes: ByteString,
   @field:WireField(
     tag = 116,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 32,
   )
   public val req_nested_enum: NestedEnum,
   @field:WireField(
     tag = 117,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 33,
   )
   public val req_nested_message: NestedMessage,
   rep_int32: List<Int> = emptyList(),
@@ -289,81 +323,97 @@ public class AllTypes(
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 65,
   )
   public val default_int32: Int? = null,
   @field:WireField(
     tag = 402,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 66,
   )
   public val default_uint32: Int? = null,
   @field:WireField(
     tag = 403,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 67,
   )
   public val default_sint32: Int? = null,
   @field:WireField(
     tag = 404,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 68,
   )
   public val default_fixed32: Int? = null,
   @field:WireField(
     tag = 405,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 69,
   )
   public val default_sfixed32: Int? = null,
   @field:WireField(
     tag = 406,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 70,
   )
   public val default_int64: Long? = null,
   @field:WireField(
     tag = 407,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 71,
   )
   public val default_uint64: Long? = null,
   @field:WireField(
     tag = 408,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 72,
   )
   public val default_sint64: Long? = null,
   @field:WireField(
     tag = 409,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 73,
   )
   public val default_fixed64: Long? = null,
   @field:WireField(
     tag = 410,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 74,
   )
   public val default_sfixed64: Long? = null,
   @field:WireField(
     tag = 411,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 75,
   )
   public val default_bool: Boolean? = null,
   @field:WireField(
     tag = 412,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 76,
   )
   public val default_float: Float? = null,
   @field:WireField(
     tag = 413,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 77,
   )
   public val default_double: Double? = null,
   @field:WireField(
     tag = 414,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 78,
   )
   public val default_string: String? = null,
   @field:WireField(
     tag = 415,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 79,
   )
   public val default_bytes: ByteString? = null,
   @field:WireField(
     tag = 416,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 80,
   )
   public val default_nested_enum: NestedEnum? = null,
   map_int32_int32: Map<Int, Int> = emptyMap(),
@@ -374,72 +424,84 @@ public class AllTypes(
     tag = 601,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 85,
   )
   public val array_int32: IntArray = intArrayOf(),
   @field:WireField(
     tag = 602,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 86,
   )
   public val array_uint32: IntArray = intArrayOf(),
   @field:WireField(
     tag = 603,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 87,
   )
   public val array_sint32: IntArray = intArrayOf(),
   @field:WireField(
     tag = 604,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 88,
   )
   public val array_fixed32: IntArray = intArrayOf(),
   @field:WireField(
     tag = 605,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 89,
   )
   public val array_sfixed32: IntArray = intArrayOf(),
   @field:WireField(
     tag = 606,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 90,
   )
   public val array_int64: LongArray = longArrayOf(),
   @field:WireField(
     tag = 607,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 91,
   )
   public val array_uint64: LongArray = longArrayOf(),
   @field:WireField(
     tag = 608,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 92,
   )
   public val array_sint64: LongArray = longArrayOf(),
   @field:WireField(
     tag = 609,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 93,
   )
   public val array_fixed64: LongArray = longArrayOf(),
   @field:WireField(
     tag = 610,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 94,
   )
   public val array_sfixed64: LongArray = longArrayOf(),
   @field:WireField(
     tag = 611,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 95,
   )
   public val array_float: FloatArray = floatArrayOf(),
   @field:WireField(
     tag = 612,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 96,
   )
   public val array_double: DoubleArray = doubleArrayOf(),
   /**
@@ -448,6 +510,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_001,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 97,
   )
   public val ext_opt_int32: Int? = null,
   /**
@@ -456,6 +519,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_002,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 98,
   )
   public val ext_opt_uint32: Int? = null,
   /**
@@ -464,6 +528,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_003,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 99,
   )
   public val ext_opt_sint32: Int? = null,
   /**
@@ -472,6 +537,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_004,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 100,
   )
   public val ext_opt_fixed32: Int? = null,
   /**
@@ -480,6 +546,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_005,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 101,
   )
   public val ext_opt_sfixed32: Int? = null,
   /**
@@ -488,6 +555,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_006,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 102,
   )
   public val ext_opt_int64: Long? = null,
   /**
@@ -496,6 +564,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_007,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 103,
   )
   public val ext_opt_uint64: Long? = null,
   /**
@@ -504,6 +573,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_008,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 104,
   )
   public val ext_opt_sint64: Long? = null,
   /**
@@ -512,6 +582,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_009,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 105,
   )
   public val ext_opt_fixed64: Long? = null,
   /**
@@ -520,6 +591,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_010,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 106,
   )
   public val ext_opt_sfixed64: Long? = null,
   /**
@@ -528,6 +600,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_011,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 107,
   )
   public val ext_opt_bool: Boolean? = null,
   /**
@@ -536,6 +609,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_012,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 108,
   )
   public val ext_opt_float: Float? = null,
   /**
@@ -544,6 +618,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_013,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 109,
   )
   public val ext_opt_double: Double? = null,
   /**
@@ -552,6 +627,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_014,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 110,
   )
   public val ext_opt_string: String? = null,
   /**
@@ -560,6 +636,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_015,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 111,
   )
   public val ext_opt_bytes: ByteString? = null,
   /**
@@ -568,6 +645,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_016,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 112,
   )
   public val ext_opt_nested_enum: NestedEnum? = null,
   /**
@@ -576,6 +654,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_017,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 113,
   )
   public val ext_opt_nested_message: NestedMessage? = null,
   ext_rep_int32: List<Int> = emptyList(),
@@ -615,6 +694,7 @@ public class AllTypes(
     tag = 201,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 34,
   )
   public val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
 
@@ -622,6 +702,7 @@ public class AllTypes(
     tag = 202,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 35,
   )
   public val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
 
@@ -629,6 +710,7 @@ public class AllTypes(
     tag = 203,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 36,
   )
   public val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
 
@@ -636,6 +718,7 @@ public class AllTypes(
     tag = 204,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 37,
   )
   public val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
 
@@ -643,6 +726,7 @@ public class AllTypes(
     tag = 205,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 38,
   )
   public val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
 
@@ -650,6 +734,7 @@ public class AllTypes(
     tag = 206,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 39,
   )
   public val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
 
@@ -657,6 +742,7 @@ public class AllTypes(
     tag = 207,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 40,
   )
   public val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
 
@@ -664,6 +750,7 @@ public class AllTypes(
     tag = 208,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 41,
   )
   public val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
 
@@ -671,6 +758,7 @@ public class AllTypes(
     tag = 209,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 42,
   )
   public val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
 
@@ -678,6 +766,7 @@ public class AllTypes(
     tag = 210,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 43,
   )
   public val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
 
@@ -685,6 +774,7 @@ public class AllTypes(
     tag = 211,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
+    schemaIndex = 44,
   )
   public val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
 
@@ -692,6 +782,7 @@ public class AllTypes(
     tag = 212,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 45,
   )
   public val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
 
@@ -699,6 +790,7 @@ public class AllTypes(
     tag = 213,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 46,
   )
   public val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
 
@@ -706,6 +798,7 @@ public class AllTypes(
     tag = 214,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 47,
   )
   public val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
 
@@ -713,6 +806,7 @@ public class AllTypes(
     tag = 215,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
+    schemaIndex = 48,
   )
   public val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
 
@@ -720,6 +814,7 @@ public class AllTypes(
     tag = 216,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 49,
   )
   public val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
 
@@ -727,6 +822,7 @@ public class AllTypes(
     tag = 217,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 50,
   )
   public val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
       rep_nested_message)
@@ -735,6 +831,7 @@ public class AllTypes(
     tag = 301,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 51,
   )
   public val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
 
@@ -742,6 +839,7 @@ public class AllTypes(
     tag = 302,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 52,
   )
   public val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
 
@@ -749,6 +847,7 @@ public class AllTypes(
     tag = 303,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 53,
   )
   public val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
 
@@ -756,6 +855,7 @@ public class AllTypes(
     tag = 304,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 54,
   )
   public val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
 
@@ -763,6 +863,7 @@ public class AllTypes(
     tag = 305,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 55,
   )
   public val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
 
@@ -770,6 +871,7 @@ public class AllTypes(
     tag = 306,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 56,
   )
   public val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
 
@@ -777,6 +879,7 @@ public class AllTypes(
     tag = 307,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 57,
   )
   public val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
 
@@ -784,6 +887,7 @@ public class AllTypes(
     tag = 308,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 58,
   )
   public val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
 
@@ -791,6 +895,7 @@ public class AllTypes(
     tag = 309,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 59,
   )
   public val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
 
@@ -798,6 +903,7 @@ public class AllTypes(
     tag = 310,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 60,
   )
   public val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
 
@@ -805,6 +911,7 @@ public class AllTypes(
     tag = 311,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
+    schemaIndex = 61,
   )
   public val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
 
@@ -812,6 +919,7 @@ public class AllTypes(
     tag = 312,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 62,
   )
   public val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
 
@@ -819,6 +927,7 @@ public class AllTypes(
     tag = 313,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 63,
   )
   public val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
 
@@ -826,6 +935,7 @@ public class AllTypes(
     tag = 316,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
+    schemaIndex = 64,
   )
   public val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum",
       pack_nested_enum)
@@ -834,6 +944,7 @@ public class AllTypes(
     tag = 501,
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 81,
   )
   public val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
 
@@ -841,6 +952,7 @@ public class AllTypes(
     tag = 502,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 82,
   )
   public val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
       map_string_string)
@@ -849,6 +961,7 @@ public class AllTypes(
     tag = 503,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 83,
   )
   public val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
       map_string_message)
@@ -857,6 +970,7 @@ public class AllTypes(
     tag = 504,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 84,
   )
   public val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum",
       map_string_enum)
@@ -868,6 +982,7 @@ public class AllTypes(
     tag = 1_101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 114,
   )
   public val ext_rep_int32: List<Int> = immutableCopyOf("ext_rep_int32", ext_rep_int32)
 
@@ -878,6 +993,7 @@ public class AllTypes(
     tag = 1_102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 115,
   )
   public val ext_rep_uint32: List<Int> = immutableCopyOf("ext_rep_uint32", ext_rep_uint32)
 
@@ -888,6 +1004,7 @@ public class AllTypes(
     tag = 1_103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 116,
   )
   public val ext_rep_sint32: List<Int> = immutableCopyOf("ext_rep_sint32", ext_rep_sint32)
 
@@ -898,6 +1015,7 @@ public class AllTypes(
     tag = 1_104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 117,
   )
   public val ext_rep_fixed32: List<Int> = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32)
 
@@ -908,6 +1026,7 @@ public class AllTypes(
     tag = 1_105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 118,
   )
   public val ext_rep_sfixed32: List<Int> = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32)
 
@@ -918,6 +1037,7 @@ public class AllTypes(
     tag = 1_106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 119,
   )
   public val ext_rep_int64: List<Long> = immutableCopyOf("ext_rep_int64", ext_rep_int64)
 
@@ -928,6 +1048,7 @@ public class AllTypes(
     tag = 1_107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 120,
   )
   public val ext_rep_uint64: List<Long> = immutableCopyOf("ext_rep_uint64", ext_rep_uint64)
 
@@ -938,6 +1059,7 @@ public class AllTypes(
     tag = 1_108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 121,
   )
   public val ext_rep_sint64: List<Long> = immutableCopyOf("ext_rep_sint64", ext_rep_sint64)
 
@@ -948,6 +1070,7 @@ public class AllTypes(
     tag = 1_109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 122,
   )
   public val ext_rep_fixed64: List<Long> = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64)
 
@@ -958,6 +1081,7 @@ public class AllTypes(
     tag = 1_110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 123,
   )
   public val ext_rep_sfixed64: List<Long> = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64)
 
@@ -968,6 +1092,7 @@ public class AllTypes(
     tag = 1_111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
+    schemaIndex = 124,
   )
   public val ext_rep_bool: List<Boolean> = immutableCopyOf("ext_rep_bool", ext_rep_bool)
 
@@ -978,6 +1103,7 @@ public class AllTypes(
     tag = 1_112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 125,
   )
   public val ext_rep_float: List<Float> = immutableCopyOf("ext_rep_float", ext_rep_float)
 
@@ -988,6 +1114,7 @@ public class AllTypes(
     tag = 1_113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 126,
   )
   public val ext_rep_double: List<Double> = immutableCopyOf("ext_rep_double", ext_rep_double)
 
@@ -998,6 +1125,7 @@ public class AllTypes(
     tag = 1_114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 127,
   )
   public val ext_rep_string: List<String> = immutableCopyOf("ext_rep_string", ext_rep_string)
 
@@ -1008,6 +1136,7 @@ public class AllTypes(
     tag = 1_115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
+    schemaIndex = 128,
   )
   public val ext_rep_bytes: List<ByteString> = immutableCopyOf("ext_rep_bytes", ext_rep_bytes)
 
@@ -1018,6 +1147,7 @@ public class AllTypes(
     tag = 1_116,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 129,
   )
   public val ext_rep_nested_enum: List<NestedEnum> = immutableCopyOf("ext_rep_nested_enum",
       ext_rep_nested_enum)
@@ -1029,6 +1159,7 @@ public class AllTypes(
     tag = 1_117,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 130,
   )
   public val ext_rep_nested_message: List<NestedMessage> = immutableCopyOf("ext_rep_nested_message",
       ext_rep_nested_message)
@@ -1040,6 +1171,7 @@ public class AllTypes(
     tag = 1_201,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 131,
   )
   public val ext_pack_int32: List<Int> = immutableCopyOf("ext_pack_int32", ext_pack_int32)
 
@@ -1050,6 +1182,7 @@ public class AllTypes(
     tag = 1_202,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 132,
   )
   public val ext_pack_uint32: List<Int> = immutableCopyOf("ext_pack_uint32", ext_pack_uint32)
 
@@ -1060,6 +1193,7 @@ public class AllTypes(
     tag = 1_203,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 133,
   )
   public val ext_pack_sint32: List<Int> = immutableCopyOf("ext_pack_sint32", ext_pack_sint32)
 
@@ -1070,6 +1204,7 @@ public class AllTypes(
     tag = 1_204,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 134,
   )
   public val ext_pack_fixed32: List<Int> = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32)
 
@@ -1080,6 +1215,7 @@ public class AllTypes(
     tag = 1_205,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 135,
   )
   public val ext_pack_sfixed32: List<Int> = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32)
 
@@ -1090,6 +1226,7 @@ public class AllTypes(
     tag = 1_206,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 136,
   )
   public val ext_pack_int64: List<Long> = immutableCopyOf("ext_pack_int64", ext_pack_int64)
 
@@ -1100,6 +1237,7 @@ public class AllTypes(
     tag = 1_207,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 137,
   )
   public val ext_pack_uint64: List<Long> = immutableCopyOf("ext_pack_uint64", ext_pack_uint64)
 
@@ -1110,6 +1248,7 @@ public class AllTypes(
     tag = 1_208,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 138,
   )
   public val ext_pack_sint64: List<Long> = immutableCopyOf("ext_pack_sint64", ext_pack_sint64)
 
@@ -1120,6 +1259,7 @@ public class AllTypes(
     tag = 1_209,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 139,
   )
   public val ext_pack_fixed64: List<Long> = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64)
 
@@ -1130,6 +1270,7 @@ public class AllTypes(
     tag = 1_210,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 140,
   )
   public val ext_pack_sfixed64: List<Long> = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64)
 
@@ -1140,6 +1281,7 @@ public class AllTypes(
     tag = 1_211,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
+    schemaIndex = 141,
   )
   public val ext_pack_bool: List<Boolean> = immutableCopyOf("ext_pack_bool", ext_pack_bool)
 
@@ -1150,6 +1292,7 @@ public class AllTypes(
     tag = 1_212,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 142,
   )
   public val ext_pack_float: List<Float> = immutableCopyOf("ext_pack_float", ext_pack_float)
 
@@ -1160,6 +1303,7 @@ public class AllTypes(
     tag = 1_213,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 143,
   )
   public val ext_pack_double: List<Double> = immutableCopyOf("ext_pack_double", ext_pack_double)
 
@@ -1170,6 +1314,7 @@ public class AllTypes(
     tag = 1_216,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
+    schemaIndex = 144,
   )
   public val ext_pack_nested_enum: List<NestedEnum> = immutableCopyOf("ext_pack_nested_enum",
       ext_pack_nested_enum)
@@ -3143,6 +3288,7 @@ public class AllTypes(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0,
     )
     public val a: Int? = null,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/bool/TrueBoolean.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/bool/TrueBoolean.kt
@@ -26,6 +26,7 @@ public class TrueBoolean(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 0,
   )
   public val isTrue: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneBytesField.kt
@@ -26,6 +26,7 @@ public class OneBytesField(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 0,
   )
   public val opt_bytes: ByteString? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/OneField.kt
@@ -26,6 +26,7 @@ public class OneField(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val opt_int32: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/edgecases/Recursive.kt
@@ -27,11 +27,13 @@ public class Recursive(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     declaredName = "value",
+    schemaIndex = 0,
   )
   public val value_: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.edgecases.Recursive#ADAPTER",
+    schemaIndex = 1,
   )
   public val recursive: Recursive? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -26,6 +26,7 @@ public class ForeignMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val i: Int? = null,
   /**
@@ -34,6 +35,7 @@ public class ForeignMessage(
   @field:WireField(
     tag = 100,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val j: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -34,6 +34,7 @@ public class Mappy(
     tag = 1,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER",
+    schemaIndex = 0,
   )
   public val things: Map<String, Thing> = immutableCopyOf("things", things)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/MappyTwo.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/MappyTwo.kt
@@ -40,6 +40,7 @@ public class MappyTwo(
     tag = 1,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.map.MappyTwo${'$'}ValueEnum#ADAPTER",
+    schemaIndex = 0,
   )
   public val string_enums: Map<String, ValueEnum> = immutableCopyOf("string_enums", string_enums)
 
@@ -47,6 +48,7 @@ public class MappyTwo(
     tag = 2,
     keyAdapter = "com.squareup.wire.ProtoAdapter#SINT64",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER",
+    schemaIndex = 1,
   )
   public val int_things: Map<Long, Thing> = immutableCopyOf("int_things", int_things)
 
@@ -54,6 +56,7 @@ public class MappyTwo(
     tag = 3,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 2,
   )
   public val string_ints: Map<String, Long> = immutableCopyOf("string_ints", string_ints)
 
@@ -61,6 +64,7 @@ public class MappyTwo(
     tag = 4,
     keyAdapter = "com.squareup.wire.ProtoAdapter#SINT32",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER",
+    schemaIndex = 3,
   )
   public val int_things_two: Map<Int, Thing> = immutableCopyOf("int_things_two", int_things_two)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -27,6 +27,7 @@ public class Thing(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val name: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -253,6 +253,7 @@ public class Person(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED,
+      schemaIndex = 0,
     )
     public val number: String,
     /**
@@ -261,6 +262,7 @@ public class Person(
     @field:WireField(
       tag = 2,
       adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneType#ADAPTER",
+      schemaIndex = 1,
     )
     public val type: PhoneType? = null,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/NotRedacted.kt
@@ -27,11 +27,13 @@ public class NotRedacted(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val a: String? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 1,
   )
   public val b: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedChild.kt
@@ -27,16 +27,19 @@ public class RedactedChild(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   public val a: String? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedFields#ADAPTER",
+    schemaIndex = 1,
   )
   public val b: RedactedFields? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.protos.kotlin.redacted.NotRedacted#ADAPTER",
+    schemaIndex = 2,
   )
   public val c: NotRedacted? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleA.kt
@@ -26,6 +26,7 @@ public class RedactedCycleA(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedCycleB#ADAPTER",
+    schemaIndex = 0,
   )
   public val b: RedactedCycleB? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedCycleB.kt
@@ -26,6 +26,7 @@ public class RedactedCycleB(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedCycleA#ADAPTER",
+    schemaIndex = 0,
   )
   public val a: RedactedCycleA? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedExtension.kt
@@ -28,11 +28,13 @@ public class RedactedExtension(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     redacted = true,
+    schemaIndex = 0,
   )
   public val d: String? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 1,
   )
   public val e: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedFields.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedFields.kt
@@ -28,16 +28,19 @@ public class RedactedFields(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     redacted = true,
+    schemaIndex = 0,
   )
   public val a: String? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 1,
   )
   public val b: String? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   public val c: String? = null,
   /**
@@ -46,6 +49,7 @@ public class RedactedFields(
   @field:WireField(
     tag = 10,
     adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedExtension#ADAPTER",
+    schemaIndex = 3,
   )
   public val extension: RedactedExtension? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -28,6 +28,7 @@ public class RedactedOneOf(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     oneofName = "a",
+    schemaIndex = 0,
   )
   public val b: Int? = null,
   @field:WireField(
@@ -35,6 +36,7 @@ public class RedactedOneOf(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     redacted = true,
     oneofName = "a",
+    schemaIndex = 1,
   )
   public val c: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRepeated.kt
@@ -35,6 +35,7 @@ public class RedactedRepeated(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
     redacted = true,
+    schemaIndex = 0,
   )
   public val a: List<String> = immutableCopyOf("a", a)
 
@@ -45,6 +46,7 @@ public class RedactedRepeated(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.redacted.RedactedFields#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   public val b: List<RedactedFields> = immutableCopyOf("b", b)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedRequired.kt
@@ -30,6 +30,7 @@ public class RedactedRequired(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REQUIRED,
     redacted = true,
+    schemaIndex = 0,
   )
   public val a: String,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -29,6 +29,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 0,
   )
   public val f: Float? = null,
   fooext: List<Int> = emptyList(),
@@ -38,6 +39,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 126,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 2,
   )
   public val barext: Int? = null,
   /**
@@ -46,6 +48,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 127,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 3,
   )
   public val bazext: Int? = null,
   /**
@@ -54,6 +57,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 128,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 4,
   )
   public val nested_message_ext: SimpleMessage.NestedMessage? = null,
   /**
@@ -62,6 +66,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 129,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 5,
   )
   public val nested_enum_ext: SimpleMessage.NestedEnum? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -73,6 +78,7 @@ public class ExternalMessage(
     tag = 125,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   public val fooext: List<Int> = immutableCopyOf("fooext", fooext)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -41,6 +41,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val optional_int32: Int? = null,
   /**
@@ -50,6 +51,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 1,
   )
   public val optional_nested_msg: NestedMessage? = null,
   /**
@@ -58,11 +60,13 @@ public class SimpleMessage(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.protos.kotlin.simple.ExternalMessage#ADAPTER",
+    schemaIndex = 2,
   )
   public val optional_external_msg: ExternalMessage? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 3,
   )
   public val default_nested_enum: NestedEnum? = null,
   /**
@@ -72,6 +76,7 @@ public class SimpleMessage(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 4,
   )
   public val required_int32: Int,
   repeated_double: List<Double> = emptyList(),
@@ -81,6 +86,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.foreign.ForeignEnum#ADAPTER",
+    schemaIndex = 6,
   )
   public val default_foreign_enum: ForeignEnum? = null,
   /**
@@ -89,6 +95,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.protos.kotlin.foreign.ForeignEnum#ADAPTER",
+    schemaIndex = 7,
   )
   public val no_default_foreign_enum: ForeignEnum? = null,
   /**
@@ -98,6 +105,7 @@ public class SimpleMessage(
     tag = 9,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     declaredName = "package",
+    schemaIndex = 8,
   )
   public val package_: String? = null,
   /**
@@ -106,6 +114,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 10,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 9,
   )
   public val result: String? = null,
   /**
@@ -114,6 +123,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 11,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 10,
   )
   public val other: String? = null,
   /**
@@ -122,6 +132,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 12,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 11,
   )
   public val o: String? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -134,6 +145,7 @@ public class SimpleMessage(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 5,
   )
   public val repeated_double: List<Double> = immutableCopyOf("repeated_double", repeated_double)
 
@@ -366,6 +378,7 @@ public class SimpleMessage(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0,
     )
     public val bb: Int? = null,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -26,6 +26,7 @@ public class NestedVersionOne(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val i: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -29,26 +29,31 @@ public class NestedVersionTwo(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val i: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val v2_i: Int? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   public val v2_s: String? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 3,
   )
   public val v2_f32: Int? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 4,
   )
   public val v2_f64: Long? = null,
   v2_rs: List<String> = emptyList(),
@@ -58,6 +63,7 @@ public class NestedVersionTwo(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 5,
   )
   public val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -26,16 +26,19 @@ public class VersionOne(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val i: Int? = null,
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.NestedVersionOne#ADAPTER",
+    schemaIndex = 1,
   )
   public val obj: NestedVersionOne? = null,
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.EnumVersionOne#ADAPTER",
+    schemaIndex = 2,
   )
   public val en: EnumVersionOne? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -29,37 +29,44 @@ public class VersionTwo(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val i: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val v2_i: Int? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   public val v2_s: String? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 3,
   )
   public val v2_f32: Int? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 4,
   )
   public val v2_f64: Long? = null,
   v2_rs: List<String> = emptyList(),
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.NestedVersionTwo#ADAPTER",
+    schemaIndex = 6,
   )
   public val obj: NestedVersionTwo? = null,
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.EnumVersionTwo#ADAPTER",
+    schemaIndex = 7,
   )
   public val en: EnumVersionTwo? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -68,6 +75,7 @@ public class VersionTwo(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 5,
   )
   public val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)
 

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -30,6 +30,7 @@ public class UsesAny(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
+    schemaIndex = 0,
   )
   public val just_one: AnyMessage? = null,
   many_anys: List<AnyMessage> = emptyList(),
@@ -39,6 +40,7 @@ public class UsesAny(
     tag = 2,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   public val many_anys: List<AnyMessage> = immutableCopyOf("many_anys", many_anys)
 

--- a/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -29,6 +29,7 @@ public class EmbeddedMessage(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   public val inner_number_after: Int? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -37,6 +38,7 @@ public class EmbeddedMessage(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 0,
   )
   public val inner_repeated_number: List<Int> = immutableCopyOf("inner_repeated_number",
       inner_repeated_number)

--- a/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -26,11 +26,13 @@ public class OuterMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   public val outer_number_before: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "squareup.protos.packed_encoding.EmbeddedMessage#ADAPTER",
+    schemaIndex = 1,
   )
   public val embedded_message: EmbeddedMessage? = null,
   unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaAndroidCompactTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -36,8 +36,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 0
+      label = WireField.Label.REQUIRED
   )
   public final Integer id;
 
@@ -47,8 +46,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 1
+      label = WireField.Label.REQUIRED
   )
   public final String name;
 
@@ -57,8 +55,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 2
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String email;
 
@@ -68,16 +65,14 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 3
+      label = WireField.Label.REPEATED
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 4
+      label = WireField.Label.REPEATED
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaAndroidTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -43,8 +43,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 0
+      label = WireField.Label.REQUIRED
   )
   public final Integer id;
 
@@ -54,8 +53,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 1
+      label = WireField.Label.REQUIRED
   )
   public final String name;
 
@@ -64,8 +62,7 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 2
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String email;
 
@@ -75,16 +72,14 @@ public final class Person extends AndroidMessage<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 3
+      label = WireField.Label.REPEATED
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 4
+      label = WireField.Label.REPEATED
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaNoOptionsTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -39,8 +39,7 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 0
+      label = WireField.Label.REQUIRED
   )
   public final Integer id;
 
@@ -50,8 +49,7 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 1
+      label = WireField.Label.REQUIRED
   )
   public final String name;
 
@@ -60,8 +58,7 @@ public final class Person extends Message<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 2
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String email;
 
@@ -71,16 +68,14 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 3
+      label = WireField.Label.REPEATED
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 4
+      label = WireField.Label.REPEATED
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
+++ b/wire-tests/src/jvmJavaTest/proto-java/com/squareup/wire/protos/person/Person.java
@@ -39,8 +39,7 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 0
+      label = WireField.Label.REQUIRED
   )
   public final Integer id;
 
@@ -50,8 +49,7 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 1
+      label = WireField.Label.REQUIRED
   )
   public final String name;
 
@@ -60,8 +58,7 @@ public final class Person extends Message<Person, Person.Builder> {
    */
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 2
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String email;
 
@@ -71,16 +68,14 @@ public final class Person extends Message<Person, Person.Builder> {
   @WireField(
       tag = 4,
       adapter = "com.squareup.wire.protos.person.Person$PhoneNumber#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 3
+      label = WireField.Label.REPEATED
   )
   public final List<PhoneNumber> phone;
 
   @WireField(
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 4
+      label = WireField.Label.REPEATED
   )
   public final List<String> aliases;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/com/squareup/wire/proto2/alltypes/AllTypes.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/com/squareup/wire/proto2/alltypes/AllTypes.java
@@ -160,648 +160,563 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
 
   @WireField(
       tag = 1,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 0
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer opt_int32;
 
   @WireField(
       tag = 2,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 1
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer opt_uint32;
 
   @WireField(
       tag = 3,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 2
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer opt_sint32;
 
   @WireField(
       tag = 4,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 3
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer opt_fixed32;
 
   @WireField(
       tag = 5,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 4
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer opt_sfixed32;
 
   @WireField(
       tag = 6,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 5
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long opt_int64;
 
   @WireField(
       tag = 7,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 6
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long opt_uint64;
 
   @WireField(
       tag = 8,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 7
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long opt_sint64;
 
   @WireField(
       tag = 9,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 8
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long opt_fixed64;
 
   @WireField(
       tag = 10,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 9
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long opt_sfixed64;
 
   @WireField(
       tag = 11,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 10
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean opt_bool;
 
   @WireField(
       tag = 12,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 11
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float opt_float;
 
   @WireField(
       tag = 13,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 12
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double opt_double;
 
   @WireField(
       tag = 14,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 13
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String opt_string;
 
   @WireField(
       tag = 15,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 14
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString opt_bytes;
 
   @WireField(
       tag = 16,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 15
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum opt_nested_enum;
 
   @WireField(
       tag = 17,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 16
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage opt_nested_message;
 
   @WireField(
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 17
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_int32;
 
   @WireField(
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 18
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_uint32;
 
   @WireField(
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 19
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_sint32;
 
   @WireField(
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 20
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_fixed32;
 
   @WireField(
       tag = 105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 21
+      label = WireField.Label.REQUIRED
   )
   public final Integer req_sfixed32;
 
   @WireField(
       tag = 106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 22
+      label = WireField.Label.REQUIRED
   )
   public final Long req_int64;
 
   @WireField(
       tag = 107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 23
+      label = WireField.Label.REQUIRED
   )
   public final Long req_uint64;
 
   @WireField(
       tag = 108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 24
+      label = WireField.Label.REQUIRED
   )
   public final Long req_sint64;
 
   @WireField(
       tag = 109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 25
+      label = WireField.Label.REQUIRED
   )
   public final Long req_fixed64;
 
   @WireField(
       tag = 110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 26
+      label = WireField.Label.REQUIRED
   )
   public final Long req_sfixed64;
 
   @WireField(
       tag = 111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 27
+      label = WireField.Label.REQUIRED
   )
   public final Boolean req_bool;
 
   @WireField(
       tag = 112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 28
+      label = WireField.Label.REQUIRED
   )
   public final Float req_float;
 
   @WireField(
       tag = 113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 29
+      label = WireField.Label.REQUIRED
   )
   public final Double req_double;
 
   @WireField(
       tag = 114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 30
+      label = WireField.Label.REQUIRED
   )
   public final String req_string;
 
   @WireField(
       tag = 115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 31
+      label = WireField.Label.REQUIRED
   )
   public final ByteString req_bytes;
 
   @WireField(
       tag = 116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 32
+      label = WireField.Label.REQUIRED
   )
   public final NestedEnum req_nested_enum;
 
   @WireField(
       tag = 117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REQUIRED,
-      schemaIndex = 33
+      label = WireField.Label.REQUIRED
   )
   public final NestedMessage req_nested_message;
 
   @WireField(
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 34
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_int32;
 
   @WireField(
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 35
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_uint32;
 
   @WireField(
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 36
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sint32;
 
   @WireField(
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 37
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_fixed32;
 
   @WireField(
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 38
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> rep_sfixed32;
 
   @WireField(
       tag = 206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 39
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_int64;
 
   @WireField(
       tag = 207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 40
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_uint64;
 
   @WireField(
       tag = 208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 41
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sint64;
 
   @WireField(
       tag = 209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 42
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_fixed64;
 
   @WireField(
       tag = 210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 43
+      label = WireField.Label.REPEATED
   )
   public final List<Long> rep_sfixed64;
 
   @WireField(
       tag = 211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 44
+      label = WireField.Label.REPEATED
   )
   public final List<Boolean> rep_bool;
 
   @WireField(
       tag = 212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 45
+      label = WireField.Label.REPEATED
   )
   public final List<Float> rep_float;
 
   @WireField(
       tag = 213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 46
+      label = WireField.Label.REPEATED
   )
   public final List<Double> rep_double;
 
   @WireField(
       tag = 214,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 47
+      label = WireField.Label.REPEATED
   )
   public final List<String> rep_string;
 
   @WireField(
       tag = 215,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 48
+      label = WireField.Label.REPEATED
   )
   public final List<ByteString> rep_bytes;
 
   @WireField(
       tag = 216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 49
+      label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> rep_nested_enum;
 
   @WireField(
       tag = 217,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 50
+      label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> rep_nested_message;
 
   @WireField(
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 51
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_int32;
 
   @WireField(
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 52
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_uint32;
 
   @WireField(
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 53
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sint32;
 
   @WireField(
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 54
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_fixed32;
 
   @WireField(
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 55
+      label = WireField.Label.PACKED
   )
   public final List<Integer> pack_sfixed32;
 
   @WireField(
       tag = 306,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 56
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_int64;
 
   @WireField(
       tag = 307,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 57
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_uint64;
 
   @WireField(
       tag = 308,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 58
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_sint64;
 
   @WireField(
       tag = 309,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 59
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_fixed64;
 
   @WireField(
       tag = 310,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 60
+      label = WireField.Label.PACKED
   )
   public final List<Long> pack_sfixed64;
 
   @WireField(
       tag = 311,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED,
-      schemaIndex = 61
+      label = WireField.Label.PACKED
   )
   public final List<Boolean> pack_bool;
 
   @WireField(
       tag = 312,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED,
-      schemaIndex = 62
+      label = WireField.Label.PACKED
   )
   public final List<Float> pack_float;
 
   @WireField(
       tag = 313,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED,
-      schemaIndex = 63
+      label = WireField.Label.PACKED
   )
   public final List<Double> pack_double;
 
   @WireField(
       tag = 316,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED,
-      schemaIndex = 64
+      label = WireField.Label.PACKED
   )
   public final List<NestedEnum> pack_nested_enum;
 
   @WireField(
       tag = 401,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 65
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer default_int32;
 
   @WireField(
       tag = 402,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 66
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer default_uint32;
 
   @WireField(
       tag = 403,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 67
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer default_sint32;
 
   @WireField(
       tag = 404,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 68
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer default_fixed32;
 
   @WireField(
       tag = 405,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 69
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer default_sfixed32;
 
   @WireField(
       tag = 406,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 70
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long default_int64;
 
   @WireField(
       tag = 407,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 71
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long default_uint64;
 
   @WireField(
       tag = 408,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 72
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long default_sint64;
 
   @WireField(
       tag = 409,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 73
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long default_fixed64;
 
   @WireField(
       tag = 410,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 74
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long default_sfixed64;
 
   @WireField(
       tag = 411,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 75
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean default_bool;
 
   @WireField(
       tag = 412,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 76
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float default_float;
 
   @WireField(
       tag = 413,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 77
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double default_double;
 
   @WireField(
       tag = 414,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 78
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String default_string;
 
   @WireField(
       tag = 415,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 79
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString default_bytes;
 
   @WireField(
       tag = 416,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 80
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum default_nested_enum;
 
   @WireField(
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 81
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Map<Integer, Integer> map_int32_int32;
 
   @WireField(
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 82
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final Map<String, String> map_string_string;
 
   @WireField(
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 83
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final Map<String, NestedMessage> map_string_message;
 
   @WireField(
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 84
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final Map<String, NestedEnum> map_string_enum;
 
@@ -810,8 +725,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1001,
-      adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      schemaIndex = 85
+      adapter = "com.squareup.wire.ProtoAdapter#INT32"
   )
   public final Integer ext_opt_int32;
 
@@ -820,8 +734,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1002,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      schemaIndex = 86
+      adapter = "com.squareup.wire.ProtoAdapter#UINT32"
   )
   public final Integer ext_opt_uint32;
 
@@ -830,8 +743,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1003,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      schemaIndex = 87
+      adapter = "com.squareup.wire.ProtoAdapter#SINT32"
   )
   public final Integer ext_opt_sint32;
 
@@ -840,8 +752,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1004,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      schemaIndex = 88
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED32"
   )
   public final Integer ext_opt_fixed32;
 
@@ -850,8 +761,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1005,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      schemaIndex = 89
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED32"
   )
   public final Integer ext_opt_sfixed32;
 
@@ -860,8 +770,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1006,
-      adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      schemaIndex = 90
+      adapter = "com.squareup.wire.ProtoAdapter#INT64"
   )
   public final Long ext_opt_int64;
 
@@ -870,8 +779,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1007,
-      adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      schemaIndex = 91
+      adapter = "com.squareup.wire.ProtoAdapter#UINT64"
   )
   public final Long ext_opt_uint64;
 
@@ -880,8 +788,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1008,
-      adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      schemaIndex = 92
+      adapter = "com.squareup.wire.ProtoAdapter#SINT64"
   )
   public final Long ext_opt_sint64;
 
@@ -890,8 +797,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1009,
-      adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      schemaIndex = 93
+      adapter = "com.squareup.wire.ProtoAdapter#FIXED64"
   )
   public final Long ext_opt_fixed64;
 
@@ -900,8 +806,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1010,
-      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      schemaIndex = 94
+      adapter = "com.squareup.wire.ProtoAdapter#SFIXED64"
   )
   public final Long ext_opt_sfixed64;
 
@@ -910,8 +815,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1011,
-      adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      schemaIndex = 95
+      adapter = "com.squareup.wire.ProtoAdapter#BOOL"
   )
   public final Boolean ext_opt_bool;
 
@@ -920,8 +824,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1012,
-      adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      schemaIndex = 96
+      adapter = "com.squareup.wire.ProtoAdapter#FLOAT"
   )
   public final Float ext_opt_float;
 
@@ -930,8 +833,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1013,
-      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      schemaIndex = 97
+      adapter = "com.squareup.wire.ProtoAdapter#DOUBLE"
   )
   public final Double ext_opt_double;
 
@@ -940,8 +842,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1014,
-      adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      schemaIndex = 98
+      adapter = "com.squareup.wire.ProtoAdapter#STRING"
   )
   public final String ext_opt_string;
 
@@ -950,8 +851,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1015,
-      adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      schemaIndex = 99
+      adapter = "com.squareup.wire.ProtoAdapter#BYTES"
   )
   public final ByteString ext_opt_bytes;
 
@@ -960,8 +860,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1016,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      schemaIndex = 100
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER"
   )
   public final NestedEnum ext_opt_nested_enum;
 
@@ -970,8 +869,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
    */
   @WireField(
       tag = 1017,
-      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      schemaIndex = 101
+      adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER"
   )
   public final NestedMessage ext_opt_nested_message;
 
@@ -981,8 +879,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1101,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 102
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_int32;
 
@@ -992,8 +889,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1102,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 103
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_uint32;
 
@@ -1003,8 +899,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1103,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 104
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_sint32;
 
@@ -1014,8 +909,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1104,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 105
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_fixed32;
 
@@ -1025,8 +919,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1105,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 106
+      label = WireField.Label.REPEATED
   )
   public final List<Integer> ext_rep_sfixed32;
 
@@ -1036,8 +929,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1106,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 107
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_int64;
 
@@ -1047,8 +939,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1107,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 108
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_uint64;
 
@@ -1058,8 +949,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1108,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 109
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_sint64;
 
@@ -1069,8 +959,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1109,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 110
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_fixed64;
 
@@ -1080,8 +969,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1110,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 111
+      label = WireField.Label.REPEATED
   )
   public final List<Long> ext_rep_sfixed64;
 
@@ -1091,8 +979,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1111,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 112
+      label = WireField.Label.REPEATED
   )
   public final List<Boolean> ext_rep_bool;
 
@@ -1102,8 +989,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1112,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 113
+      label = WireField.Label.REPEATED
   )
   public final List<Float> ext_rep_float;
 
@@ -1113,8 +999,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1113,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 114
+      label = WireField.Label.REPEATED
   )
   public final List<Double> ext_rep_double;
 
@@ -1124,8 +1009,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1114,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 115
+      label = WireField.Label.REPEATED
   )
   public final List<String> ext_rep_string;
 
@@ -1135,8 +1019,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1115,
       adapter = "com.squareup.wire.ProtoAdapter#BYTES",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 116
+      label = WireField.Label.REPEATED
   )
   public final List<ByteString> ext_rep_bytes;
 
@@ -1146,8 +1029,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1116,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 117
+      label = WireField.Label.REPEATED
   )
   public final List<NestedEnum> ext_rep_nested_enum;
 
@@ -1157,8 +1039,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1117,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      label = WireField.Label.REPEATED,
-      schemaIndex = 118
+      label = WireField.Label.REPEATED
   )
   public final List<NestedMessage> ext_rep_nested_message;
 
@@ -1168,8 +1049,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 119
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_int32;
 
@@ -1179,8 +1059,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 120
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_uint32;
 
@@ -1190,8 +1069,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 121
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_sint32;
 
@@ -1201,8 +1079,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 122
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_fixed32;
 
@@ -1212,8 +1089,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      label = WireField.Label.PACKED,
-      schemaIndex = 123
+      label = WireField.Label.PACKED
   )
   public final List<Integer> ext_pack_sfixed32;
 
@@ -1223,8 +1099,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1206,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 124
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_int64;
 
@@ -1234,8 +1109,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1207,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 125
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_uint64;
 
@@ -1245,8 +1119,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1208,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 126
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_sint64;
 
@@ -1256,8 +1129,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1209,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 127
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_fixed64;
 
@@ -1267,8 +1139,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1210,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      label = WireField.Label.PACKED,
-      schemaIndex = 128
+      label = WireField.Label.PACKED
   )
   public final List<Long> ext_pack_sfixed64;
 
@@ -1278,8 +1149,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1211,
       adapter = "com.squareup.wire.ProtoAdapter#BOOL",
-      label = WireField.Label.PACKED,
-      schemaIndex = 129
+      label = WireField.Label.PACKED
   )
   public final List<Boolean> ext_pack_bool;
 
@@ -1289,8 +1159,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1212,
       adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
-      label = WireField.Label.PACKED,
-      schemaIndex = 130
+      label = WireField.Label.PACKED
   )
   public final List<Float> ext_pack_float;
 
@@ -1300,8 +1169,7 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1213,
       adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
-      label = WireField.Label.PACKED,
-      schemaIndex = 131
+      label = WireField.Label.PACKED
   )
   public final List<Double> ext_pack_double;
 
@@ -1311,32 +1179,28 @@ public final class AllTypes extends Message<AllTypes, AllTypes.Builder> {
   @WireField(
       tag = 1216,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedEnum#ADAPTER",
-      label = WireField.Label.PACKED,
-      schemaIndex = 132
+      label = WireField.Label.PACKED
   )
   public final List<NestedEnum> ext_pack_nested_enum;
 
   @WireField(
       tag = 601,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
-      oneofName = "choice",
-      schemaIndex = 133
+      oneofName = "choice"
   )
   public final String oneof_string;
 
   @WireField(
       tag = 602,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      oneofName = "choice",
-      schemaIndex = 134
+      oneofName = "choice"
   )
   public final Integer oneof_int32;
 
   @WireField(
       tag = 603,
       adapter = "com.squareup.wire.proto2.alltypes.AllTypes$NestedMessage#ADAPTER",
-      oneofName = "choice",
-      schemaIndex = 135
+      oneofName = "choice"
   )
   public final NestedMessage oneof_nested_message;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All32.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All32.java
@@ -30,8 +30,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myInt32",
-      schemaIndex = 0
+      jsonName = "myInt32"
   )
   public final int my_int32;
 
@@ -39,8 +38,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myUint32",
-      schemaIndex = 1
+      jsonName = "myUint32"
   )
   public final int my_uint32;
 
@@ -48,8 +46,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySint32",
-      schemaIndex = 2
+      jsonName = "mySint32"
   )
   public final int my_sint32;
 
@@ -57,8 +54,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 4,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myFixed32",
-      schemaIndex = 3
+      jsonName = "myFixed32"
   )
   public final int my_fixed32;
 
@@ -66,8 +62,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySfixed32",
-      schemaIndex = 4
+      jsonName = "mySfixed32"
   )
   public final int my_sfixed32;
 
@@ -75,8 +70,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED,
-      jsonName = "repInt32",
-      schemaIndex = 5
+      jsonName = "repInt32"
   )
   public final List<Integer> rep_int32;
 
@@ -84,8 +78,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.REPEATED,
-      jsonName = "repUint32",
-      schemaIndex = 6
+      jsonName = "repUint32"
   )
   public final List<Integer> rep_uint32;
 
@@ -93,8 +86,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.REPEATED,
-      jsonName = "repSint32",
-      schemaIndex = 7
+      jsonName = "repSint32"
   )
   public final List<Integer> rep_sint32;
 
@@ -102,8 +94,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.REPEATED,
-      jsonName = "repFixed32",
-      schemaIndex = 8
+      jsonName = "repFixed32"
   )
   public final List<Integer> rep_fixed32;
 
@@ -111,8 +102,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.REPEATED,
-      jsonName = "repSfixed32",
-      schemaIndex = 9
+      jsonName = "repSfixed32"
   )
   public final List<Integer> rep_sfixed32;
 
@@ -120,8 +110,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.PACKED,
-      jsonName = "packInt32",
-      schemaIndex = 10
+      jsonName = "packInt32"
   )
   public final List<Integer> pack_int32;
 
@@ -129,8 +118,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
       label = WireField.Label.PACKED,
-      jsonName = "packUint32",
-      schemaIndex = 11
+      jsonName = "packUint32"
   )
   public final List<Integer> pack_uint32;
 
@@ -138,8 +126,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
       label = WireField.Label.PACKED,
-      jsonName = "packSint32",
-      schemaIndex = 12
+      jsonName = "packSint32"
   )
   public final List<Integer> pack_sint32;
 
@@ -147,8 +134,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
       label = WireField.Label.PACKED,
-      jsonName = "packFixed32",
-      schemaIndex = 13
+      jsonName = "packFixed32"
   )
   public final List<Integer> pack_fixed32;
 
@@ -156,8 +142,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       label = WireField.Label.PACKED,
-      jsonName = "packSfixed32",
-      schemaIndex = 14
+      jsonName = "packSfixed32"
   )
   public final List<Integer> pack_sfixed32;
 
@@ -165,8 +150,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
-      jsonName = "mapInt32Int32",
-      schemaIndex = 15
+      jsonName = "mapInt32Int32"
   )
   public final Map<Integer, Integer> map_int32_int32;
 
@@ -174,8 +158,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#UINT32",
-      jsonName = "mapInt32Uint32",
-      schemaIndex = 16
+      jsonName = "mapInt32Uint32"
   )
   public final Map<Integer, Integer> map_int32_uint32;
 
@@ -183,8 +166,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#SINT32",
-      jsonName = "mapInt32Sint32",
-      schemaIndex = 17
+      jsonName = "mapInt32Sint32"
   )
   public final Map<Integer, Integer> map_int32_sint32;
 
@@ -192,8 +174,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
-      jsonName = "mapInt32Fixed32",
-      schemaIndex = 18
+      jsonName = "mapInt32Fixed32"
   )
   public final Map<Integer, Integer> map_int32_fixed32;
 
@@ -201,8 +182,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 505,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
-      jsonName = "mapInt32Sfixed32",
-      schemaIndex = 19
+      jsonName = "mapInt32Sfixed32"
   )
   public final Map<Integer, Integer> map_int32_sfixed32;
 
@@ -210,8 +190,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 401,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       jsonName = "oneofInt32",
-      oneofName = "choice",
-      schemaIndex = 20
+      oneofName = "choice"
   )
   public final Integer oneof_int32;
 
@@ -219,8 +198,7 @@ public final class All32 extends Message<All32, All32.Builder> {
       tag = 402,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
       jsonName = "oneofSfixed32",
-      oneofName = "choice",
-      schemaIndex = 21
+      oneofName = "choice"
   )
   public final Integer oneof_sfixed32;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All64.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/All64.java
@@ -30,8 +30,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myInt64",
-      schemaIndex = 0
+      jsonName = "myInt64"
   )
   public final long my_int64;
 
@@ -39,8 +38,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myUint64",
-      schemaIndex = 1
+      jsonName = "myUint64"
   )
   public final long my_uint64;
 
@@ -48,8 +46,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySint64",
-      schemaIndex = 2
+      jsonName = "mySint64"
   )
   public final long my_sint64;
 
@@ -57,8 +54,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 4,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "myFixed64",
-      schemaIndex = 3
+      jsonName = "myFixed64"
   )
   public final long my_fixed64;
 
@@ -66,8 +62,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "mySfixed64",
-      schemaIndex = 4
+      jsonName = "mySfixed64"
   )
   public final long my_sfixed64;
 
@@ -75,8 +70,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.REPEATED,
-      jsonName = "repInt64",
-      schemaIndex = 5
+      jsonName = "repInt64"
   )
   public final List<Long> rep_int64;
 
@@ -84,8 +78,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.REPEATED,
-      jsonName = "repUint64",
-      schemaIndex = 6
+      jsonName = "repUint64"
   )
   public final List<Long> rep_uint64;
 
@@ -93,8 +86,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 203,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.REPEATED,
-      jsonName = "repSint64",
-      schemaIndex = 7
+      jsonName = "repSint64"
   )
   public final List<Long> rep_sint64;
 
@@ -102,8 +94,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 204,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.REPEATED,
-      jsonName = "repFixed64",
-      schemaIndex = 8
+      jsonName = "repFixed64"
   )
   public final List<Long> rep_fixed64;
 
@@ -111,8 +102,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 205,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.REPEATED,
-      jsonName = "repSfixed64",
-      schemaIndex = 9
+      jsonName = "repSfixed64"
   )
   public final List<Long> rep_sfixed64;
 
@@ -120,8 +110,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 301,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       label = WireField.Label.PACKED,
-      jsonName = "packInt64",
-      schemaIndex = 10
+      jsonName = "packInt64"
   )
   public final List<Long> pack_int64;
 
@@ -129,8 +118,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 302,
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
       label = WireField.Label.PACKED,
-      jsonName = "packUint64",
-      schemaIndex = 11
+      jsonName = "packUint64"
   )
   public final List<Long> pack_uint64;
 
@@ -138,8 +126,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 303,
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
       label = WireField.Label.PACKED,
-      jsonName = "packSint64",
-      schemaIndex = 12
+      jsonName = "packSint64"
   )
   public final List<Long> pack_sint64;
 
@@ -147,8 +134,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 304,
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
       label = WireField.Label.PACKED,
-      jsonName = "packFixed64",
-      schemaIndex = 13
+      jsonName = "packFixed64"
   )
   public final List<Long> pack_fixed64;
 
@@ -156,8 +142,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 305,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       label = WireField.Label.PACKED,
-      jsonName = "packSfixed64",
-      schemaIndex = 14
+      jsonName = "packSfixed64"
   )
   public final List<Long> pack_sfixed64;
 
@@ -165,8 +150,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 501,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
-      jsonName = "mapInt64Int64",
-      schemaIndex = 15
+      jsonName = "mapInt64Int64"
   )
   public final Map<Long, Long> map_int64_int64;
 
@@ -174,8 +158,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 502,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#UINT64",
-      jsonName = "mapInt64Uint64",
-      schemaIndex = 16
+      jsonName = "mapInt64Uint64"
   )
   public final Map<Long, Long> map_int64_uint64;
 
@@ -183,8 +166,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 503,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#SINT64",
-      jsonName = "mapInt64Sint64",
-      schemaIndex = 17
+      jsonName = "mapInt64Sint64"
   )
   public final Map<Long, Long> map_int64_sint64;
 
@@ -192,8 +174,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 504,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
-      jsonName = "mapInt64Fixed64",
-      schemaIndex = 18
+      jsonName = "mapInt64Fixed64"
   )
   public final Map<Long, Long> map_int64_fixed64;
 
@@ -201,8 +182,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 505,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
-      jsonName = "mapInt64Sfixed64",
-      schemaIndex = 19
+      jsonName = "mapInt64Sfixed64"
   )
   public final Map<Long, Long> map_int64_sfixed64;
 
@@ -210,8 +190,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 401,
       adapter = "com.squareup.wire.ProtoAdapter#INT64",
       jsonName = "oneofInt64",
-      oneofName = "choice",
-      schemaIndex = 20
+      oneofName = "choice"
   )
   public final Long oneof_int64;
 
@@ -219,8 +198,7 @@ public final class All64 extends Message<All64, All64.Builder> {
       tag = 402,
       adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
       jsonName = "oneofSfixed64",
-      oneofName = "choice",
-      schemaIndex = 21
+      oneofName = "choice"
   )
   public final Long oneof_sfixed64;
 

--- a/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllStructs.java
+++ b/wire-tests/src/jvmJsonJavaTest/proto-java/squareup/proto3/AllStructs.java
@@ -24,16 +24,14 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
   @WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
-      label = WireField.Label.OMIT_IDENTITY,
-      schemaIndex = 0
+      label = WireField.Label.OMIT_IDENTITY
   )
   public final Map<String, ?> struct;
 
   @WireField(
       tag = 2,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
-      label = WireField.Label.OMIT_IDENTITY,
-      schemaIndex = 1
+      label = WireField.Label.OMIT_IDENTITY
   )
   public final List<?> list;
 
@@ -41,8 +39,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 3,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "nullValue",
-      schemaIndex = 2
+      jsonName = "nullValue"
   )
   public final Void null_value;
 
@@ -50,8 +47,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 4,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueA",
-      schemaIndex = 3
+      jsonName = "valueA"
   )
   public final Object value_a;
 
@@ -59,8 +55,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 5,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueB",
-      schemaIndex = 4
+      jsonName = "valueB"
   )
   public final Object value_b;
 
@@ -68,8 +63,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 6,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueC",
-      schemaIndex = 5
+      jsonName = "valueC"
   )
   public final Object value_c;
 
@@ -77,8 +71,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 7,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueD",
-      schemaIndex = 6
+      jsonName = "valueD"
   )
   public final Object value_d;
 
@@ -86,8 +79,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 8,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueE",
-      schemaIndex = 7
+      jsonName = "valueE"
   )
   public final Object value_e;
 
@@ -95,8 +87,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 9,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.OMIT_IDENTITY,
-      jsonName = "valueF",
-      schemaIndex = 8
+      jsonName = "valueF"
   )
   public final Object value_f;
 
@@ -104,8 +95,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 101,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
       label = WireField.Label.REPEATED,
-      jsonName = "repStruct",
-      schemaIndex = 9
+      jsonName = "repStruct"
   )
   public final List<Map<String, ?>> rep_struct;
 
@@ -113,8 +103,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 102,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
       label = WireField.Label.REPEATED,
-      jsonName = "repList",
-      schemaIndex = 10
+      jsonName = "repList"
   )
   public final List<List<?>> rep_list;
 
@@ -122,8 +111,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 103,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
       label = WireField.Label.REPEATED,
-      jsonName = "repValueA",
-      schemaIndex = 11
+      jsonName = "repValueA"
   )
   public final List<Object> rep_value_a;
 
@@ -131,8 +119,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 104,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
       label = WireField.Label.REPEATED,
-      jsonName = "repNullValue",
-      schemaIndex = 12
+      jsonName = "repNullValue"
   )
   public final List<Void> rep_null_value;
 
@@ -140,8 +127,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 301,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
-      jsonName = "mapInt32Struct",
-      schemaIndex = 13
+      jsonName = "mapInt32Struct"
   )
   public final Map<Integer, Map<String, ?>> map_int32_struct;
 
@@ -149,8 +135,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 302,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
-      jsonName = "mapInt32List",
-      schemaIndex = 14
+      jsonName = "mapInt32List"
   )
   public final Map<Integer, List<?>> map_int32_list;
 
@@ -158,8 +143,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 303,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_VALUE",
-      jsonName = "mapInt32ValueA",
-      schemaIndex = 15
+      jsonName = "mapInt32ValueA"
   )
   public final Map<Integer, Object> map_int32_value_a;
 
@@ -167,8 +151,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 304,
       keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_NULL",
-      jsonName = "mapInt32NullValue",
-      schemaIndex = 16
+      jsonName = "mapInt32NullValue"
   )
   public final Map<Integer, Void> map_int32_null_value;
 
@@ -176,8 +159,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 201,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
       jsonName = "oneofStruct",
-      oneofName = "choice",
-      schemaIndex = 17
+      oneofName = "choice"
   )
   public final Map<String, ?> oneof_struct;
 
@@ -185,8 +167,7 @@ public final class AllStructs extends Message<AllStructs, AllStructs.Builder> {
       tag = 202,
       adapter = "com.squareup.wire.ProtoAdapter#STRUCT_LIST",
       jsonName = "oneofList",
-      oneofName = "choice",
-      schemaIndex = 18
+      oneofName = "choice"
   )
   public final List<?> oneof_list;
 

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto2/alltypes/AllTypes.kt
@@ -4616,6 +4616,7 @@ public class AllTypes(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0,
     )
     @JvmField
     public val a: Int? = null,

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
@@ -37,6 +37,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myInt32",
+    schemaIndex = 0,
   )
   @JvmField
   public val my_int32: Int = 0,
@@ -45,6 +46,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myUint32",
+    schemaIndex = 1,
   )
   @JvmField
   public val my_uint32: Int = 0,
@@ -53,6 +55,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySint32",
+    schemaIndex = 2,
   )
   @JvmField
   public val my_sint32: Int = 0,
@@ -61,6 +64,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myFixed32",
+    schemaIndex = 3,
   )
   @JvmField
   public val my_fixed32: Int = 0,
@@ -69,6 +73,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySfixed32",
+    schemaIndex = 4,
   )
   @JvmField
   public val my_sfixed32: Int = 0,
@@ -77,6 +82,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myInt64",
+    schemaIndex = 5,
   )
   @JvmField
   public val my_int64: Long = 0L,
@@ -85,6 +91,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myUint64",
+    schemaIndex = 6,
   )
   @JvmField
   public val my_uint64: Long = 0L,
@@ -93,6 +100,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySint64",
+    schemaIndex = 7,
   )
   @JvmField
   public val my_sint64: Long = 0L,
@@ -101,6 +109,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myFixed64",
+    schemaIndex = 8,
   )
   @JvmField
   public val my_fixed64: Long = 0L,
@@ -109,6 +118,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "mySfixed64",
+    schemaIndex = 9,
   )
   @JvmField
   public val my_sfixed64: Long = 0L,
@@ -117,6 +127,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myBool",
+    schemaIndex = 10,
   )
   @JvmField
   public val my_bool: Boolean = false,
@@ -125,6 +136,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myFloat",
+    schemaIndex = 11,
   )
   @JvmField
   public val my_float: Float = 0f,
@@ -133,6 +145,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myDouble",
+    schemaIndex = 12,
   )
   @JvmField
   public val my_double: Double = 0.0,
@@ -141,6 +154,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myString",
+    schemaIndex = 13,
   )
   @JvmField
   public val my_string: String = "",
@@ -149,6 +163,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "myBytes",
+    schemaIndex = 14,
   )
   @JvmField
   public val my_bytes: ByteString = ByteString.EMPTY,
@@ -157,6 +172,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "nestedEnum",
+    schemaIndex = 15,
   )
   @JvmField
   public val nested_enum: NestedEnum = NestedEnum.UNKNOWN,
@@ -165,6 +181,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "nestedMessage",
+    schemaIndex = 16,
   )
   @JvmField
   public val nested_message: NestedMessage? = null,
@@ -172,6 +189,7 @@ public class AllTypes(
     tag = 101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "optInt32",
+    schemaIndex = 17,
   )
   @JvmField
   public val opt_int32: Int? = null,
@@ -179,6 +197,7 @@ public class AllTypes(
     tag = 102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     jsonName = "optUint32",
+    schemaIndex = 18,
   )
   @JvmField
   public val opt_uint32: Int? = null,
@@ -186,6 +205,7 @@ public class AllTypes(
     tag = 103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     jsonName = "optSint32",
+    schemaIndex = 19,
   )
   @JvmField
   public val opt_sint32: Int? = null,
@@ -193,6 +213,7 @@ public class AllTypes(
     tag = 104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     jsonName = "optFixed32",
+    schemaIndex = 20,
   )
   @JvmField
   public val opt_fixed32: Int? = null,
@@ -200,6 +221,7 @@ public class AllTypes(
     tag = 105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     jsonName = "optSfixed32",
+    schemaIndex = 21,
   )
   @JvmField
   public val opt_sfixed32: Int? = null,
@@ -207,6 +229,7 @@ public class AllTypes(
     tag = 106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     jsonName = "optInt64",
+    schemaIndex = 22,
   )
   @JvmField
   public val opt_int64: Long? = null,
@@ -214,6 +237,7 @@ public class AllTypes(
     tag = 107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     jsonName = "optUint64",
+    schemaIndex = 23,
   )
   @JvmField
   public val opt_uint64: Long? = null,
@@ -221,6 +245,7 @@ public class AllTypes(
     tag = 108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     jsonName = "optSint64",
+    schemaIndex = 24,
   )
   @JvmField
   public val opt_sint64: Long? = null,
@@ -228,6 +253,7 @@ public class AllTypes(
     tag = 109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     jsonName = "optFixed64",
+    schemaIndex = 25,
   )
   @JvmField
   public val opt_fixed64: Long? = null,
@@ -235,6 +261,7 @@ public class AllTypes(
     tag = 110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     jsonName = "optSfixed64",
+    schemaIndex = 26,
   )
   @JvmField
   public val opt_sfixed64: Long? = null,
@@ -242,6 +269,7 @@ public class AllTypes(
     tag = 111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     jsonName = "optBool",
+    schemaIndex = 27,
   )
   @JvmField
   public val opt_bool: Boolean? = null,
@@ -249,6 +277,7 @@ public class AllTypes(
     tag = 112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     jsonName = "optFloat",
+    schemaIndex = 28,
   )
   @JvmField
   public val opt_float: Float? = null,
@@ -256,6 +285,7 @@ public class AllTypes(
     tag = 113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     jsonName = "optDouble",
+    schemaIndex = 29,
   )
   @JvmField
   public val opt_double: Double? = null,
@@ -263,6 +293,7 @@ public class AllTypes(
     tag = 114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "optString",
+    schemaIndex = 30,
   )
   @JvmField
   public val opt_string: String? = null,
@@ -270,6 +301,7 @@ public class AllTypes(
     tag = 115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     jsonName = "optBytes",
+    schemaIndex = 31,
   )
   @JvmField
   public val opt_bytes: ByteString? = null,
@@ -313,6 +345,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "oneofString",
     oneofName = "choice",
+    schemaIndex = 67,
   )
   @JvmField
   public val oneof_string: String? = null,
@@ -321,6 +354,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "oneofInt32",
     oneofName = "choice",
+    schemaIndex = 68,
   )
   @JvmField
   public val oneof_int32: Int? = null,
@@ -329,6 +363,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     jsonName = "oneofNestedMessage",
     oneofName = "choice",
+    schemaIndex = 69,
   )
   @JvmField
   public val oneof_nested_message: NestedMessage? = null,
@@ -339,6 +374,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
     jsonName = "repInt32",
+    schemaIndex = 32,
   )
   @JvmField
   public val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
@@ -348,6 +384,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
     jsonName = "repUint32",
+    schemaIndex = 33,
   )
   @JvmField
   public val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
@@ -357,6 +394,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
     jsonName = "repSint32",
+    schemaIndex = 34,
   )
   @JvmField
   public val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
@@ -366,6 +404,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
     jsonName = "repFixed32",
+    schemaIndex = 35,
   )
   @JvmField
   public val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
@@ -375,6 +414,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
     jsonName = "repSfixed32",
+    schemaIndex = 36,
   )
   @JvmField
   public val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
@@ -384,6 +424,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
     jsonName = "repInt64",
+    schemaIndex = 37,
   )
   @JvmField
   public val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
@@ -393,6 +434,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
     jsonName = "repUint64",
+    schemaIndex = 38,
   )
   @JvmField
   public val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
@@ -402,6 +444,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
     jsonName = "repSint64",
+    schemaIndex = 39,
   )
   @JvmField
   public val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
@@ -411,6 +454,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
     jsonName = "repFixed64",
+    schemaIndex = 40,
   )
   @JvmField
   public val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
@@ -420,6 +464,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
     jsonName = "repSfixed64",
+    schemaIndex = 41,
   )
   @JvmField
   public val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
@@ -429,6 +474,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
     jsonName = "repBool",
+    schemaIndex = 42,
   )
   @JvmField
   public val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
@@ -438,6 +484,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
     jsonName = "repFloat",
+    schemaIndex = 43,
   )
   @JvmField
   public val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
@@ -447,6 +494,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
     jsonName = "repDouble",
+    schemaIndex = 44,
   )
   @JvmField
   public val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
@@ -456,6 +504,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
     jsonName = "repString",
+    schemaIndex = 45,
   )
   @JvmField
   public val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
@@ -465,6 +514,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
     jsonName = "repBytes",
+    schemaIndex = 46,
   )
   @JvmField
   public val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
@@ -474,6 +524,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
     jsonName = "repNestedEnum",
+    schemaIndex = 47,
   )
   @JvmField
   public val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
@@ -483,6 +534,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
     jsonName = "repNestedMessage",
+    schemaIndex = 48,
   )
   @JvmField
   public val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
@@ -493,6 +545,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
     jsonName = "packInt32",
+    schemaIndex = 49,
   )
   @JvmField
   public val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
@@ -502,6 +555,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
     jsonName = "packUint32",
+    schemaIndex = 50,
   )
   @JvmField
   public val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
@@ -511,6 +565,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
     jsonName = "packSint32",
+    schemaIndex = 51,
   )
   @JvmField
   public val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
@@ -520,6 +575,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
     jsonName = "packFixed32",
+    schemaIndex = 52,
   )
   @JvmField
   public val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
@@ -529,6 +585,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
     jsonName = "packSfixed32",
+    schemaIndex = 53,
   )
   @JvmField
   public val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
@@ -538,6 +595,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
     jsonName = "packInt64",
+    schemaIndex = 54,
   )
   @JvmField
   public val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
@@ -547,6 +605,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
     jsonName = "packUint64",
+    schemaIndex = 55,
   )
   @JvmField
   public val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
@@ -556,6 +615,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
     jsonName = "packSint64",
+    schemaIndex = 56,
   )
   @JvmField
   public val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
@@ -565,6 +625,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
     jsonName = "packFixed64",
+    schemaIndex = 57,
   )
   @JvmField
   public val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
@@ -574,6 +635,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
     jsonName = "packSfixed64",
+    schemaIndex = 58,
   )
   @JvmField
   public val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
@@ -583,6 +645,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
     jsonName = "packBool",
+    schemaIndex = 59,
   )
   @JvmField
   public val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
@@ -592,6 +655,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
     jsonName = "packFloat",
+    schemaIndex = 60,
   )
   @JvmField
   public val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
@@ -601,6 +665,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
     jsonName = "packDouble",
+    schemaIndex = 61,
   )
   @JvmField
   public val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
@@ -610,6 +675,7 @@ public class AllTypes(
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
     jsonName = "packNestedEnum",
+    schemaIndex = 62,
   )
   @JvmField
   public val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum",
@@ -620,6 +686,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "mapInt32Int32",
+    schemaIndex = 63,
   )
   @JvmField
   public val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
@@ -629,6 +696,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "mapStringString",
+    schemaIndex = 64,
   )
   @JvmField
   public val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
@@ -639,6 +707,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     jsonName = "mapStringMessage",
+    schemaIndex = 65,
   )
   @JvmField
   public val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
@@ -649,6 +718,7 @@ public class AllTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.proto3.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     jsonName = "mapStringEnum",
+    schemaIndex = 66,
   )
   @JvmField
   public val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum",
@@ -2386,6 +2456,7 @@ public class AllTypes(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.OMIT_IDENTITY,
+      schemaIndex = 0,
     )
     @JvmField
     public val a: Int = 0,

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
@@ -31,6 +31,7 @@ public class AllWrappers(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE_VALUE",
     jsonName = "doubleValue",
+    schemaIndex = 0,
   )
   @JvmField
   public val double_value: Double? = null,
@@ -38,6 +39,7 @@ public class AllWrappers(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT_VALUE",
     jsonName = "floatValue",
+    schemaIndex = 1,
   )
   @JvmField
   public val float_value: Float? = null,
@@ -45,6 +47,7 @@ public class AllWrappers(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#INT64_VALUE",
     jsonName = "int64Value",
+    schemaIndex = 2,
   )
   @JvmField
   public val int64_value: Long? = null,
@@ -52,6 +55,7 @@ public class AllWrappers(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64_VALUE",
     jsonName = "uint64Value",
+    schemaIndex = 3,
   )
   @JvmField
   public val uint64_value: Long? = null,
@@ -59,6 +63,7 @@ public class AllWrappers(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#INT32_VALUE",
     jsonName = "int32Value",
+    schemaIndex = 4,
   )
   @JvmField
   public val int32_value: Int? = null,
@@ -66,6 +71,7 @@ public class AllWrappers(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32_VALUE",
     jsonName = "uint32Value",
+    schemaIndex = 5,
   )
   @JvmField
   public val uint32_value: Int? = null,
@@ -73,6 +79,7 @@ public class AllWrappers(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL_VALUE",
     jsonName = "boolValue",
+    schemaIndex = 6,
   )
   @JvmField
   public val bool_value: Boolean? = null,
@@ -80,6 +87,7 @@ public class AllWrappers(
     tag = 8,
     adapter = "com.squareup.wire.ProtoAdapter#STRING_VALUE",
     jsonName = "stringValue",
+    schemaIndex = 7,
   )
   @JvmField
   public val string_value: String? = null,
@@ -87,6 +95,7 @@ public class AllWrappers(
     tag = 9,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES_VALUE",
     jsonName = "bytesValue",
+    schemaIndex = 8,
   )
   @JvmField
   public val bytes_value: ByteString? = null,
@@ -115,6 +124,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repDoubleValue",
+    schemaIndex = 9,
   )
   @JvmField
   public val rep_double_value: List<Double?> = immutableCopyOf("rep_double_value", rep_double_value)
@@ -124,6 +134,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repFloatValue",
+    schemaIndex = 10,
   )
   @JvmField
   public val rep_float_value: List<Float?> = immutableCopyOf("rep_float_value", rep_float_value)
@@ -133,6 +144,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#INT64_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repInt64Value",
+    schemaIndex = 11,
   )
   @JvmField
   public val rep_int64_value: List<Long?> = immutableCopyOf("rep_int64_value", rep_int64_value)
@@ -142,6 +154,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#UINT64_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repUint64Value",
+    schemaIndex = 12,
   )
   @JvmField
   public val rep_uint64_value: List<Long?> = immutableCopyOf("rep_uint64_value", rep_uint64_value)
@@ -151,6 +164,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#INT32_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repInt32Value",
+    schemaIndex = 13,
   )
   @JvmField
   public val rep_int32_value: List<Int?> = immutableCopyOf("rep_int32_value", rep_int32_value)
@@ -160,6 +174,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#UINT32_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repUint32Value",
+    schemaIndex = 14,
   )
   @JvmField
   public val rep_uint32_value: List<Int?> = immutableCopyOf("rep_uint32_value", rep_uint32_value)
@@ -169,6 +184,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repBoolValue",
+    schemaIndex = 15,
   )
   @JvmField
   public val rep_bool_value: List<Boolean?> = immutableCopyOf("rep_bool_value", rep_bool_value)
@@ -178,6 +194,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#STRING_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repStringValue",
+    schemaIndex = 16,
   )
   @JvmField
   public val rep_string_value: List<String?> = immutableCopyOf("rep_string_value", rep_string_value)
@@ -187,6 +204,7 @@ public class AllWrappers(
     adapter = "com.squareup.wire.ProtoAdapter#BYTES_VALUE",
     label = WireField.Label.REPEATED,
     jsonName = "repBytesValue",
+    schemaIndex = 17,
   )
   @JvmField
   public val rep_bytes_value: List<ByteString?> = immutableCopyOf("rep_bytes_value",
@@ -197,6 +215,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE_VALUE",
     jsonName = "mapInt32DoubleValue",
+    schemaIndex = 18,
   )
   @JvmField
   public val map_int32_double_value: Map<Int, Double?> = immutableCopyOf("map_int32_double_value",
@@ -207,6 +226,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT_VALUE",
     jsonName = "mapInt32FloatValue",
+    schemaIndex = 19,
   )
   @JvmField
   public val map_int32_float_value: Map<Int, Float?> = immutableCopyOf("map_int32_float_value",
@@ -217,6 +237,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT64_VALUE",
     jsonName = "mapInt32Int64Value",
+    schemaIndex = 20,
   )
   @JvmField
   public val map_int32_int64_value: Map<Int, Long?> = immutableCopyOf("map_int32_int64_value",
@@ -227,6 +248,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#UINT64_VALUE",
     jsonName = "mapInt32Uint64Value",
+    schemaIndex = 21,
   )
   @JvmField
   public val map_int32_uint64_value: Map<Int, Long?> = immutableCopyOf("map_int32_uint64_value",
@@ -237,6 +259,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32_VALUE",
     jsonName = "mapInt32Int32Value",
+    schemaIndex = 22,
   )
   @JvmField
   public val map_int32_int32_value: Map<Int, Int?> = immutableCopyOf("map_int32_int32_value",
@@ -247,6 +270,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#UINT32_VALUE",
     jsonName = "mapInt32Uint32Value",
+    schemaIndex = 23,
   )
   @JvmField
   public val map_int32_uint32_value: Map<Int, Int?> = immutableCopyOf("map_int32_uint32_value",
@@ -257,6 +281,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#BOOL_VALUE",
     jsonName = "mapInt32BoolValue",
+    schemaIndex = 24,
   )
   @JvmField
   public val map_int32_bool_value: Map<Int, Boolean?> = immutableCopyOf("map_int32_bool_value",
@@ -267,6 +292,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#STRING_VALUE",
     jsonName = "mapInt32StringValue",
+    schemaIndex = 25,
   )
   @JvmField
   public val map_int32_string_value: Map<Int, String?> = immutableCopyOf("map_int32_string_value",
@@ -277,6 +303,7 @@ public class AllWrappers(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#BYTES_VALUE",
     jsonName = "mapInt32BytesValue",
+    schemaIndex = 26,
   )
   @JvmField
   public val map_int32_bytes_value: Map<Int, ByteString?> = immutableCopyOf("map_int32_bytes_value",

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -24,6 +24,7 @@ public class BuyOneGetOnePromotion(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   @JvmField
   public val coupon: String = "",

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
@@ -30,6 +30,7 @@ public class CamelCase(
     adapter = "squareup.proto3.CamelCase${'$'}NestedCamelCase#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "nestedMessage",
+    schemaIndex = 0,
   )
   @JvmField
   public val nested__message: NestedCamelCase? = null,
@@ -39,6 +40,7 @@ public class CamelCase(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "IDitItMyWAy",
+    schemaIndex = 2,
   )
   @JvmField
   public val IDitIt_my_wAy: String = "",
@@ -50,6 +52,7 @@ public class CamelCase(
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
     jsonName = "RepInt32",
+    schemaIndex = 1,
   )
   @JvmField
   public val _Rep_int32: List<Int> = immutableCopyOf("_Rep_int32", _Rep_int32)
@@ -59,6 +62,7 @@ public class CamelCase(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "mapInt32Int32",
+    schemaIndex = 3,
   )
   @JvmField
   public val map_int32_Int32: Map<Int, Int> = immutableCopyOf("map_int32_Int32", map_int32_Int32)
@@ -249,6 +253,7 @@ public class CamelCase(
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.OMIT_IDENTITY,
       jsonName = "oneInt32",
+      schemaIndex = 0,
     )
     @JvmField
     public val one_int32: Int = 0,

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
@@ -26,6 +26,7 @@ public class FreeDrinkPromotion(
     tag = 1,
     adapter = "squareup.proto3.FreeDrinkPromotion${'$'}Drink#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 0,
   )
   @JvmField
   public val drink: Drink = Drink.UNKNOWN,

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -24,6 +24,7 @@ public class FreeGarlicBreadPromotion(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "isExtraCheesey",
+    schemaIndex = 0,
   )
   @JvmField
   public val is_extra_cheesey: Boolean = false,

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/MapTypes.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/MapTypes.kt
@@ -40,6 +40,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "mapStringString",
+    schemaIndex = 0,
   )
   @JvmField
   public val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
@@ -50,6 +51,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "mapInt32Int32",
+    schemaIndex = 1,
   )
   @JvmField
   public val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
@@ -59,6 +61,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#SINT32",
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     jsonName = "mapSint32Sint32",
+    schemaIndex = 2,
   )
   @JvmField
   public val map_sint32_sint32: Map<Int, Int> = immutableCopyOf("map_sint32_sint32",
@@ -69,6 +72,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     jsonName = "mapSfixed32Sfixed32",
+    schemaIndex = 3,
   )
   @JvmField
   public val map_sfixed32_sfixed32: Map<Int, Int> = immutableCopyOf("map_sfixed32_sfixed32",
@@ -79,6 +83,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     jsonName = "mapFixed32Fixed32",
+    schemaIndex = 4,
   )
   @JvmField
   public val map_fixed32_fixed32: Map<Int, Int> = immutableCopyOf("map_fixed32_fixed32",
@@ -89,6 +94,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#UINT32",
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     jsonName = "mapUint32Uint32",
+    schemaIndex = 5,
   )
   @JvmField
   public val map_uint32_uint32: Map<Int, Int> = immutableCopyOf("map_uint32_uint32",
@@ -99,6 +105,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT64",
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     jsonName = "mapInt64Int64",
+    schemaIndex = 6,
   )
   @JvmField
   public val map_int64_int64: Map<Long, Long> = immutableCopyOf("map_int64_int64", map_int64_int64)
@@ -108,6 +115,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     jsonName = "mapSfixed64Sfixed64",
+    schemaIndex = 7,
   )
   @JvmField
   public val map_sfixed64_sfixed64: Map<Long, Long> = immutableCopyOf("map_sfixed64_sfixed64",
@@ -118,6 +126,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#SINT64",
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     jsonName = "mapSint64Sint64",
+    schemaIndex = 8,
   )
   @JvmField
   public val map_sint64_sint64: Map<Long, Long> = immutableCopyOf("map_sint64_sint64",
@@ -128,6 +137,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     jsonName = "mapFixed64Fixed64",
+    schemaIndex = 9,
   )
   @JvmField
   public val map_fixed64_fixed64: Map<Long, Long> = immutableCopyOf("map_fixed64_fixed64",
@@ -138,6 +148,7 @@ public class MapTypes(
     keyAdapter = "com.squareup.wire.ProtoAdapter#UINT64",
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     jsonName = "mapUint64Uint64",
+    schemaIndex = 10,
   )
   @JvmField
   public val map_uint64_uint64: Map<Long, Long> = immutableCopyOf("map_uint64_uint64",

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/Pizza.kt
@@ -30,6 +30,7 @@ public class Pizza(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 0,
   )
   @JvmField
   public val toppings: List<String> = immutableCopyOf("toppings", toppings)

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
@@ -34,6 +34,7 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "phoneNumber",
+    schemaIndex = 0,
   )
   @JvmField
   public val phone_number: String = "",
@@ -41,6 +42,7 @@ public class PizzaDelivery(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 1,
   )
   @JvmField
   public val address: String = "",
@@ -49,6 +51,7 @@ public class PizzaDelivery(
     tag = 4,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 3,
   )
   @JvmField
   public val promotion: AnyMessage? = null,
@@ -57,6 +60,7 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#DURATION",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "deliveredWithinOrFree",
+    schemaIndex = 4,
   )
   @JvmField
   public val delivered_within_or_free: Duration? = null,
@@ -66,6 +70,7 @@ public class PizzaDelivery(
     adapter = "com.squareup.wire.ProtoAdapter#INSTANT",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "orderedAt",
+    schemaIndex = 6,
   )
   @JvmField
   public val ordered_at: Instant? = null,
@@ -75,6 +80,7 @@ public class PizzaDelivery(
     tag = 3,
     adapter = "squareup.proto3.Pizza#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 2,
   )
   @JvmField
   public val pizzas: List<Pizza> = immutableCopyOf("pizzas", pizzas)
@@ -83,6 +89,7 @@ public class PizzaDelivery(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRUCT_MAP",
     label = WireField.Label.OMIT_IDENTITY,
+    schemaIndex = 5,
   )
   @JvmField
   public val loyalty: Map<String, *>? = immutableCopyOfStruct("loyalty", loyalty)

--- a/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/jvmKotlinAndroidTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -257,6 +257,7 @@ public class Person(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED,
+      schemaIndex = 0,
     )
     public val number: String,
     /**
@@ -265,6 +266,7 @@ public class Person(
     @field:WireField(
       tag = 2,
       adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneType#ADAPTER",
+      schemaIndex = 1,
     )
     public val type: PhoneType? = null,
     unknownFields: ByteString = ByteString.EMPTY,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/ModelEvaluation.kt
@@ -41,12 +41,14 @@ public class ModelEvaluation(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   @JvmField
   public val name: String? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 1,
   )
   @JvmField
   public val score: Double? = null,
@@ -57,6 +59,7 @@ public class ModelEvaluation(
     tag = 3,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "ModelEvaluation#ADAPTER",
+    schemaIndex = 2,
   )
   @JvmField
   public val models: Map<String, ModelEvaluation> = immutableCopyOf("models", models)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -38,6 +38,7 @@ public class FooBar(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val foo: Int? = null,
@@ -45,6 +46,7 @@ public class FooBar(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 1,
   )
   @JvmField
   public val bar: String? = null,
@@ -52,6 +54,7 @@ public class FooBar(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}Nested#ADAPTER",
+    schemaIndex = 2,
   )
   @JvmField
   public val baz: Nested? = null,
@@ -71,6 +74,7 @@ public class FooBar(
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 3,
   )
   @JvmField
   public val qux: Long? = null,
@@ -78,6 +82,7 @@ public class FooBar(
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 5,
   )
   @JvmField
   public val daisy: Double? = null,
@@ -88,6 +93,7 @@ public class FooBar(
   @field:WireField(
     tag = 150,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 7,
   )
   @JvmField
   public val more_string: String? = null,
@@ -97,6 +103,7 @@ public class FooBar(
   @field:WireField(
     tag = 101,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
+    schemaIndex = 8,
   )
   @JvmField
   public val ext: FooBarBazEnum? = null,
@@ -108,6 +115,7 @@ public class FooBar(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 4,
   )
   @JvmField
   public val fred: List<Float> = immutableCopyOf("fred", fred)
@@ -117,6 +125,7 @@ public class FooBar(
     adapter = "com.squareup.wire.protos.custom_options.FooBar#ADAPTER",
     label = WireField.Label.REPEATED,
     redacted = true,
+    schemaIndex = 6,
   )
   @JvmField
   public val nested: List<FooBar> = immutableCopyOf("nested", nested)
@@ -128,6 +137,7 @@ public class FooBar(
     tag = 102,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 9,
   )
   @JvmField
   public val rep: List<FooBarBazEnum> = immutableCopyOf("rep", rep)
@@ -429,6 +439,7 @@ public class FooBar(
       tag = 1,
       adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}FooBarBazEnum#ADAPTER",
       declaredName = "value",
+      schemaIndex = 0,
     )
     @JvmField
     public val value_: FooBarBazEnum? = null,
@@ -544,6 +555,7 @@ public class FooBar(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
       label = WireField.Label.REPEATED,
+      schemaIndex = 0,
     )
     @JvmField
     public val serial: List<Int> = immutableCopyOf("serial", serial)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/DeprecatedProto.kt
@@ -25,6 +25,7 @@ public class DeprecatedProto(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   @JvmField
   public val foo: String? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Form.kt
@@ -605,6 +605,7 @@ public class Form(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
+      schemaIndex = 0,
     )
     @JvmField
     public val text: String? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/MessageUsingMultipleEnums.kt
@@ -25,12 +25,14 @@ public class MessageUsingMultipleEnums(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.protos.kotlin.MessageWithStatus${'$'}Status#ADAPTER",
+    schemaIndex = 0,
   )
   @JvmField
   public val a: MessageWithStatus.Status? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.OtherMessageWithStatus${'$'}Status#ADAPTER",
+    schemaIndex = 1,
   )
   @JvmField
   public val b: OtherMessageWithStatus.Status? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/OneOfMessage.kt
@@ -31,6 +31,7 @@ public class OneOfMessage(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     oneofName = "choice",
+    schemaIndex = 0,
   )
   @JvmField
   public val foo: Int? = null,
@@ -41,6 +42,7 @@ public class OneOfMessage(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     oneofName = "choice",
+    schemaIndex = 1,
   )
   @JvmField
   public val bar: String? = null,
@@ -51,6 +53,7 @@ public class OneOfMessage(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     oneofName = "choice",
+    schemaIndex = 2,
   )
   @JvmField
   public val baz: String? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/Percents.kt
@@ -26,6 +26,7 @@ public class Percents(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   @JvmField
   public val text: String? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/alltypes/AllTypes.kt
@@ -68,102 +68,119 @@ public class AllTypes(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val opt_int32: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 1,
   )
   @JvmField
   public val opt_uint32: Int? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 2,
   )
   @JvmField
   public val opt_sint32: Int? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 3,
   )
   @JvmField
   public val opt_fixed32: Int? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 4,
   )
   @JvmField
   public val opt_sfixed32: Int? = null,
   @field:WireField(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 5,
   )
   @JvmField
   public val opt_int64: Long? = null,
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 6,
   )
   @JvmField
   public val opt_uint64: Long? = null,
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 7,
   )
   @JvmField
   public val opt_sint64: Long? = null,
   @field:WireField(
     tag = 9,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 8,
   )
   @JvmField
   public val opt_fixed64: Long? = null,
   @field:WireField(
     tag = 10,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 9,
   )
   @JvmField
   public val opt_sfixed64: Long? = null,
   @field:WireField(
     tag = 11,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 10,
   )
   @JvmField
   public val opt_bool: Boolean? = null,
   @field:WireField(
     tag = 12,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 11,
   )
   @JvmField
   public val opt_float: Float? = null,
   @field:WireField(
     tag = 13,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 12,
   )
   @JvmField
   public val opt_double: Double? = null,
   @field:WireField(
     tag = 14,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 13,
   )
   @JvmField
   public val opt_string: String? = null,
   @field:WireField(
     tag = 15,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 14,
   )
   @JvmField
   public val opt_bytes: ByteString? = null,
   @field:WireField(
     tag = 16,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 15,
   )
   @JvmField
   public val opt_nested_enum: NestedEnum? = null,
   @field:WireField(
     tag = 17,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 16,
   )
   @JvmField
   public val opt_nested_message: NestedMessage? = null,
@@ -171,6 +188,7 @@ public class AllTypes(
     tag = 101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 17,
   )
   @JvmField
   public val req_int32: Int,
@@ -178,6 +196,7 @@ public class AllTypes(
     tag = 102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 18,
   )
   @JvmField
   public val req_uint32: Int,
@@ -185,6 +204,7 @@ public class AllTypes(
     tag = 103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 19,
   )
   @JvmField
   public val req_sint32: Int,
@@ -192,6 +212,7 @@ public class AllTypes(
     tag = 104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 20,
   )
   @JvmField
   public val req_fixed32: Int,
@@ -199,6 +220,7 @@ public class AllTypes(
     tag = 105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 21,
   )
   @JvmField
   public val req_sfixed32: Int,
@@ -206,6 +228,7 @@ public class AllTypes(
     tag = 106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 22,
   )
   @JvmField
   public val req_int64: Long,
@@ -213,6 +236,7 @@ public class AllTypes(
     tag = 107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 23,
   )
   @JvmField
   public val req_uint64: Long,
@@ -220,6 +244,7 @@ public class AllTypes(
     tag = 108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 24,
   )
   @JvmField
   public val req_sint64: Long,
@@ -227,6 +252,7 @@ public class AllTypes(
     tag = 109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 25,
   )
   @JvmField
   public val req_fixed64: Long,
@@ -234,6 +260,7 @@ public class AllTypes(
     tag = 110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 26,
   )
   @JvmField
   public val req_sfixed64: Long,
@@ -241,6 +268,7 @@ public class AllTypes(
     tag = 111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 27,
   )
   @JvmField
   public val req_bool: Boolean,
@@ -248,6 +276,7 @@ public class AllTypes(
     tag = 112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 28,
   )
   @JvmField
   public val req_float: Float,
@@ -255,6 +284,7 @@ public class AllTypes(
     tag = 113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 29,
   )
   @JvmField
   public val req_double: Double,
@@ -262,6 +292,7 @@ public class AllTypes(
     tag = 114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 30,
   )
   @JvmField
   public val req_string: String,
@@ -269,6 +300,7 @@ public class AllTypes(
     tag = 115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 31,
   )
   @JvmField
   public val req_bytes: ByteString,
@@ -276,6 +308,7 @@ public class AllTypes(
     tag = 116,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 32,
   )
   @JvmField
   public val req_nested_enum: NestedEnum,
@@ -283,6 +316,7 @@ public class AllTypes(
     tag = 117,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 33,
   )
   @JvmField
   public val req_nested_message: NestedMessage,
@@ -320,96 +354,112 @@ public class AllTypes(
   @field:WireField(
     tag = 401,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 65,
   )
   @JvmField
   public val default_int32: Int? = null,
   @field:WireField(
     tag = 402,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 66,
   )
   @JvmField
   public val default_uint32: Int? = null,
   @field:WireField(
     tag = 403,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 67,
   )
   @JvmField
   public val default_sint32: Int? = null,
   @field:WireField(
     tag = 404,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 68,
   )
   @JvmField
   public val default_fixed32: Int? = null,
   @field:WireField(
     tag = 405,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 69,
   )
   @JvmField
   public val default_sfixed32: Int? = null,
   @field:WireField(
     tag = 406,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 70,
   )
   @JvmField
   public val default_int64: Long? = null,
   @field:WireField(
     tag = 407,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 71,
   )
   @JvmField
   public val default_uint64: Long? = null,
   @field:WireField(
     tag = 408,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 72,
   )
   @JvmField
   public val default_sint64: Long? = null,
   @field:WireField(
     tag = 409,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 73,
   )
   @JvmField
   public val default_fixed64: Long? = null,
   @field:WireField(
     tag = 410,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 74,
   )
   @JvmField
   public val default_sfixed64: Long? = null,
   @field:WireField(
     tag = 411,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 75,
   )
   @JvmField
   public val default_bool: Boolean? = null,
   @field:WireField(
     tag = 412,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 76,
   )
   @JvmField
   public val default_float: Float? = null,
   @field:WireField(
     tag = 413,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 77,
   )
   @JvmField
   public val default_double: Double? = null,
   @field:WireField(
     tag = 414,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 78,
   )
   @JvmField
   public val default_string: String? = null,
   @field:WireField(
     tag = 415,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 79,
   )
   @JvmField
   public val default_bytes: ByteString? = null,
   @field:WireField(
     tag = 416,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 80,
   )
   @JvmField
   public val default_nested_enum: NestedEnum? = null,
@@ -421,6 +471,7 @@ public class AllTypes(
     tag = 601,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 85,
   )
   @JvmField
   public val array_int32: IntArray = intArrayOf(),
@@ -428,6 +479,7 @@ public class AllTypes(
     tag = 602,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 86,
   )
   @JvmField
   public val array_uint32: IntArray = intArrayOf(),
@@ -435,6 +487,7 @@ public class AllTypes(
     tag = 603,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 87,
   )
   @JvmField
   public val array_sint32: IntArray = intArrayOf(),
@@ -442,6 +495,7 @@ public class AllTypes(
     tag = 604,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 88,
   )
   @JvmField
   public val array_fixed32: IntArray = intArrayOf(),
@@ -449,6 +503,7 @@ public class AllTypes(
     tag = 605,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 89,
   )
   @JvmField
   public val array_sfixed32: IntArray = intArrayOf(),
@@ -456,6 +511,7 @@ public class AllTypes(
     tag = 606,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 90,
   )
   @JvmField
   public val array_int64: LongArray = longArrayOf(),
@@ -463,6 +519,7 @@ public class AllTypes(
     tag = 607,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 91,
   )
   @JvmField
   public val array_uint64: LongArray = longArrayOf(),
@@ -470,6 +527,7 @@ public class AllTypes(
     tag = 608,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 92,
   )
   @JvmField
   public val array_sint64: LongArray = longArrayOf(),
@@ -477,6 +535,7 @@ public class AllTypes(
     tag = 609,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 93,
   )
   @JvmField
   public val array_fixed64: LongArray = longArrayOf(),
@@ -484,6 +543,7 @@ public class AllTypes(
     tag = 610,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 94,
   )
   @JvmField
   public val array_sfixed64: LongArray = longArrayOf(),
@@ -491,6 +551,7 @@ public class AllTypes(
     tag = 611,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 95,
   )
   @JvmField
   public val array_float: FloatArray = floatArrayOf(),
@@ -498,6 +559,7 @@ public class AllTypes(
     tag = 612,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 96,
   )
   @JvmField
   public val array_double: DoubleArray = doubleArrayOf(),
@@ -507,6 +569,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_001,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 97,
   )
   @JvmField
   public val ext_opt_int32: Int? = null,
@@ -516,6 +579,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_002,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
+    schemaIndex = 98,
   )
   @JvmField
   public val ext_opt_uint32: Int? = null,
@@ -525,6 +589,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_003,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
+    schemaIndex = 99,
   )
   @JvmField
   public val ext_opt_sint32: Int? = null,
@@ -534,6 +599,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_004,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 100,
   )
   @JvmField
   public val ext_opt_fixed32: Int? = null,
@@ -543,6 +609,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_005,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
+    schemaIndex = 101,
   )
   @JvmField
   public val ext_opt_sfixed32: Int? = null,
@@ -552,6 +619,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_006,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
+    schemaIndex = 102,
   )
   @JvmField
   public val ext_opt_int64: Long? = null,
@@ -561,6 +629,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_007,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
+    schemaIndex = 103,
   )
   @JvmField
   public val ext_opt_uint64: Long? = null,
@@ -570,6 +639,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_008,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 104,
   )
   @JvmField
   public val ext_opt_sint64: Long? = null,
@@ -579,6 +649,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_009,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 105,
   )
   @JvmField
   public val ext_opt_fixed64: Long? = null,
@@ -588,6 +659,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_010,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
+    schemaIndex = 106,
   )
   @JvmField
   public val ext_opt_sfixed64: Long? = null,
@@ -597,6 +669,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_011,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    schemaIndex = 107,
   )
   @JvmField
   public val ext_opt_bool: Boolean? = null,
@@ -606,6 +679,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_012,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 108,
   )
   @JvmField
   public val ext_opt_float: Float? = null,
@@ -615,6 +689,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_013,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
+    schemaIndex = 109,
   )
   @JvmField
   public val ext_opt_double: Double? = null,
@@ -624,6 +699,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_014,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 110,
   )
   @JvmField
   public val ext_opt_string: String? = null,
@@ -633,6 +709,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_015,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 111,
   )
   @JvmField
   public val ext_opt_bytes: ByteString? = null,
@@ -642,6 +719,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_016,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 112,
   )
   @JvmField
   public val ext_opt_nested_enum: NestedEnum? = null,
@@ -651,6 +729,7 @@ public class AllTypes(
   @field:WireField(
     tag = 1_017,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 113,
   )
   @JvmField
   public val ext_opt_nested_message: NestedMessage? = null,
@@ -691,6 +770,7 @@ public class AllTypes(
     tag = 201,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 34,
   )
   @JvmField
   public val rep_int32: List<Int> = immutableCopyOf("rep_int32", rep_int32)
@@ -699,6 +779,7 @@ public class AllTypes(
     tag = 202,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 35,
   )
   @JvmField
   public val rep_uint32: List<Int> = immutableCopyOf("rep_uint32", rep_uint32)
@@ -707,6 +788,7 @@ public class AllTypes(
     tag = 203,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 36,
   )
   @JvmField
   public val rep_sint32: List<Int> = immutableCopyOf("rep_sint32", rep_sint32)
@@ -715,6 +797,7 @@ public class AllTypes(
     tag = 204,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 37,
   )
   @JvmField
   public val rep_fixed32: List<Int> = immutableCopyOf("rep_fixed32", rep_fixed32)
@@ -723,6 +806,7 @@ public class AllTypes(
     tag = 205,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 38,
   )
   @JvmField
   public val rep_sfixed32: List<Int> = immutableCopyOf("rep_sfixed32", rep_sfixed32)
@@ -731,6 +815,7 @@ public class AllTypes(
     tag = 206,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 39,
   )
   @JvmField
   public val rep_int64: List<Long> = immutableCopyOf("rep_int64", rep_int64)
@@ -739,6 +824,7 @@ public class AllTypes(
     tag = 207,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 40,
   )
   @JvmField
   public val rep_uint64: List<Long> = immutableCopyOf("rep_uint64", rep_uint64)
@@ -747,6 +833,7 @@ public class AllTypes(
     tag = 208,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 41,
   )
   @JvmField
   public val rep_sint64: List<Long> = immutableCopyOf("rep_sint64", rep_sint64)
@@ -755,6 +842,7 @@ public class AllTypes(
     tag = 209,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 42,
   )
   @JvmField
   public val rep_fixed64: List<Long> = immutableCopyOf("rep_fixed64", rep_fixed64)
@@ -763,6 +851,7 @@ public class AllTypes(
     tag = 210,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 43,
   )
   @JvmField
   public val rep_sfixed64: List<Long> = immutableCopyOf("rep_sfixed64", rep_sfixed64)
@@ -771,6 +860,7 @@ public class AllTypes(
     tag = 211,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
+    schemaIndex = 44,
   )
   @JvmField
   public val rep_bool: List<Boolean> = immutableCopyOf("rep_bool", rep_bool)
@@ -779,6 +869,7 @@ public class AllTypes(
     tag = 212,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 45,
   )
   @JvmField
   public val rep_float: List<Float> = immutableCopyOf("rep_float", rep_float)
@@ -787,6 +878,7 @@ public class AllTypes(
     tag = 213,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 46,
   )
   @JvmField
   public val rep_double: List<Double> = immutableCopyOf("rep_double", rep_double)
@@ -795,6 +887,7 @@ public class AllTypes(
     tag = 214,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 47,
   )
   @JvmField
   public val rep_string: List<String> = immutableCopyOf("rep_string", rep_string)
@@ -803,6 +896,7 @@ public class AllTypes(
     tag = 215,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
+    schemaIndex = 48,
   )
   @JvmField
   public val rep_bytes: List<ByteString> = immutableCopyOf("rep_bytes", rep_bytes)
@@ -811,6 +905,7 @@ public class AllTypes(
     tag = 216,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 49,
   )
   @JvmField
   public val rep_nested_enum: List<NestedEnum> = immutableCopyOf("rep_nested_enum", rep_nested_enum)
@@ -819,6 +914,7 @@ public class AllTypes(
     tag = 217,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 50,
   )
   @JvmField
   public val rep_nested_message: List<NestedMessage> = immutableCopyOf("rep_nested_message",
@@ -828,6 +924,7 @@ public class AllTypes(
     tag = 301,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 51,
   )
   @JvmField
   public val pack_int32: List<Int> = immutableCopyOf("pack_int32", pack_int32)
@@ -836,6 +933,7 @@ public class AllTypes(
     tag = 302,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 52,
   )
   @JvmField
   public val pack_uint32: List<Int> = immutableCopyOf("pack_uint32", pack_uint32)
@@ -844,6 +942,7 @@ public class AllTypes(
     tag = 303,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 53,
   )
   @JvmField
   public val pack_sint32: List<Int> = immutableCopyOf("pack_sint32", pack_sint32)
@@ -852,6 +951,7 @@ public class AllTypes(
     tag = 304,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 54,
   )
   @JvmField
   public val pack_fixed32: List<Int> = immutableCopyOf("pack_fixed32", pack_fixed32)
@@ -860,6 +960,7 @@ public class AllTypes(
     tag = 305,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 55,
   )
   @JvmField
   public val pack_sfixed32: List<Int> = immutableCopyOf("pack_sfixed32", pack_sfixed32)
@@ -868,6 +969,7 @@ public class AllTypes(
     tag = 306,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 56,
   )
   @JvmField
   public val pack_int64: List<Long> = immutableCopyOf("pack_int64", pack_int64)
@@ -876,6 +978,7 @@ public class AllTypes(
     tag = 307,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 57,
   )
   @JvmField
   public val pack_uint64: List<Long> = immutableCopyOf("pack_uint64", pack_uint64)
@@ -884,6 +987,7 @@ public class AllTypes(
     tag = 308,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 58,
   )
   @JvmField
   public val pack_sint64: List<Long> = immutableCopyOf("pack_sint64", pack_sint64)
@@ -892,6 +996,7 @@ public class AllTypes(
     tag = 309,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 59,
   )
   @JvmField
   public val pack_fixed64: List<Long> = immutableCopyOf("pack_fixed64", pack_fixed64)
@@ -900,6 +1005,7 @@ public class AllTypes(
     tag = 310,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 60,
   )
   @JvmField
   public val pack_sfixed64: List<Long> = immutableCopyOf("pack_sfixed64", pack_sfixed64)
@@ -908,6 +1014,7 @@ public class AllTypes(
     tag = 311,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
+    schemaIndex = 61,
   )
   @JvmField
   public val pack_bool: List<Boolean> = immutableCopyOf("pack_bool", pack_bool)
@@ -916,6 +1023,7 @@ public class AllTypes(
     tag = 312,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 62,
   )
   @JvmField
   public val pack_float: List<Float> = immutableCopyOf("pack_float", pack_float)
@@ -924,6 +1032,7 @@ public class AllTypes(
     tag = 313,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 63,
   )
   @JvmField
   public val pack_double: List<Double> = immutableCopyOf("pack_double", pack_double)
@@ -932,6 +1041,7 @@ public class AllTypes(
     tag = 316,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
+    schemaIndex = 64,
   )
   @JvmField
   public val pack_nested_enum: List<NestedEnum> = immutableCopyOf("pack_nested_enum",
@@ -941,6 +1051,7 @@ public class AllTypes(
     tag = 501,
     keyAdapter = "com.squareup.wire.ProtoAdapter#INT32",
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 81,
   )
   @JvmField
   public val map_int32_int32: Map<Int, Int> = immutableCopyOf("map_int32_int32", map_int32_int32)
@@ -949,6 +1060,7 @@ public class AllTypes(
     tag = 502,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 82,
   )
   @JvmField
   public val map_string_string: Map<String, String> = immutableCopyOf("map_string_string",
@@ -958,6 +1070,7 @@ public class AllTypes(
     tag = 503,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 83,
   )
   @JvmField
   public val map_string_message: Map<String, NestedMessage> = immutableCopyOf("map_string_message",
@@ -967,6 +1080,7 @@ public class AllTypes(
     tag = 504,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 84,
   )
   @JvmField
   public val map_string_enum: Map<String, NestedEnum> = immutableCopyOf("map_string_enum",
@@ -979,6 +1093,7 @@ public class AllTypes(
     tag = 1_101,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 114,
   )
   @JvmField
   public val ext_rep_int32: List<Int> = immutableCopyOf("ext_rep_int32", ext_rep_int32)
@@ -990,6 +1105,7 @@ public class AllTypes(
     tag = 1_102,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 115,
   )
   @JvmField
   public val ext_rep_uint32: List<Int> = immutableCopyOf("ext_rep_uint32", ext_rep_uint32)
@@ -1001,6 +1117,7 @@ public class AllTypes(
     tag = 1_103,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 116,
   )
   @JvmField
   public val ext_rep_sint32: List<Int> = immutableCopyOf("ext_rep_sint32", ext_rep_sint32)
@@ -1012,6 +1129,7 @@ public class AllTypes(
     tag = 1_104,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 117,
   )
   @JvmField
   public val ext_rep_fixed32: List<Int> = immutableCopyOf("ext_rep_fixed32", ext_rep_fixed32)
@@ -1023,6 +1141,7 @@ public class AllTypes(
     tag = 1_105,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 118,
   )
   @JvmField
   public val ext_rep_sfixed32: List<Int> = immutableCopyOf("ext_rep_sfixed32", ext_rep_sfixed32)
@@ -1034,6 +1153,7 @@ public class AllTypes(
     tag = 1_106,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 119,
   )
   @JvmField
   public val ext_rep_int64: List<Long> = immutableCopyOf("ext_rep_int64", ext_rep_int64)
@@ -1045,6 +1165,7 @@ public class AllTypes(
     tag = 1_107,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 120,
   )
   @JvmField
   public val ext_rep_uint64: List<Long> = immutableCopyOf("ext_rep_uint64", ext_rep_uint64)
@@ -1056,6 +1177,7 @@ public class AllTypes(
     tag = 1_108,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 121,
   )
   @JvmField
   public val ext_rep_sint64: List<Long> = immutableCopyOf("ext_rep_sint64", ext_rep_sint64)
@@ -1067,6 +1189,7 @@ public class AllTypes(
     tag = 1_109,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 122,
   )
   @JvmField
   public val ext_rep_fixed64: List<Long> = immutableCopyOf("ext_rep_fixed64", ext_rep_fixed64)
@@ -1078,6 +1201,7 @@ public class AllTypes(
     tag = 1_110,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.REPEATED,
+    schemaIndex = 123,
   )
   @JvmField
   public val ext_rep_sfixed64: List<Long> = immutableCopyOf("ext_rep_sfixed64", ext_rep_sfixed64)
@@ -1089,6 +1213,7 @@ public class AllTypes(
     tag = 1_111,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.REPEATED,
+    schemaIndex = 124,
   )
   @JvmField
   public val ext_rep_bool: List<Boolean> = immutableCopyOf("ext_rep_bool", ext_rep_bool)
@@ -1100,6 +1225,7 @@ public class AllTypes(
     tag = 1_112,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.REPEATED,
+    schemaIndex = 125,
   )
   @JvmField
   public val ext_rep_float: List<Float> = immutableCopyOf("ext_rep_float", ext_rep_float)
@@ -1111,6 +1237,7 @@ public class AllTypes(
     tag = 1_113,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 126,
   )
   @JvmField
   public val ext_rep_double: List<Double> = immutableCopyOf("ext_rep_double", ext_rep_double)
@@ -1122,6 +1249,7 @@ public class AllTypes(
     tag = 1_114,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 127,
   )
   @JvmField
   public val ext_rep_string: List<String> = immutableCopyOf("ext_rep_string", ext_rep_string)
@@ -1133,6 +1261,7 @@ public class AllTypes(
     tag = 1_115,
     adapter = "com.squareup.wire.ProtoAdapter#BYTES",
     label = WireField.Label.REPEATED,
+    schemaIndex = 128,
   )
   @JvmField
   public val ext_rep_bytes: List<ByteString> = immutableCopyOf("ext_rep_bytes", ext_rep_bytes)
@@ -1144,6 +1273,7 @@ public class AllTypes(
     tag = 1_116,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 129,
   )
   @JvmField
   public val ext_rep_nested_enum: List<NestedEnum> = immutableCopyOf("ext_rep_nested_enum",
@@ -1156,6 +1286,7 @@ public class AllTypes(
     tag = 1_117,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 130,
   )
   @JvmField
   public val ext_rep_nested_message: List<NestedMessage> = immutableCopyOf("ext_rep_nested_message",
@@ -1168,6 +1299,7 @@ public class AllTypes(
     tag = 1_201,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 131,
   )
   @JvmField
   public val ext_pack_int32: List<Int> = immutableCopyOf("ext_pack_int32", ext_pack_int32)
@@ -1179,6 +1311,7 @@ public class AllTypes(
     tag = 1_202,
     adapter = "com.squareup.wire.ProtoAdapter#UINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 132,
   )
   @JvmField
   public val ext_pack_uint32: List<Int> = immutableCopyOf("ext_pack_uint32", ext_pack_uint32)
@@ -1190,6 +1323,7 @@ public class AllTypes(
     tag = 1_203,
     adapter = "com.squareup.wire.ProtoAdapter#SINT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 133,
   )
   @JvmField
   public val ext_pack_sint32: List<Int> = immutableCopyOf("ext_pack_sint32", ext_pack_sint32)
@@ -1201,6 +1335,7 @@ public class AllTypes(
     tag = 1_204,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 134,
   )
   @JvmField
   public val ext_pack_fixed32: List<Int> = immutableCopyOf("ext_pack_fixed32", ext_pack_fixed32)
@@ -1212,6 +1347,7 @@ public class AllTypes(
     tag = 1_205,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED32",
     label = WireField.Label.PACKED,
+    schemaIndex = 135,
   )
   @JvmField
   public val ext_pack_sfixed32: List<Int> = immutableCopyOf("ext_pack_sfixed32", ext_pack_sfixed32)
@@ -1223,6 +1359,7 @@ public class AllTypes(
     tag = 1_206,
     adapter = "com.squareup.wire.ProtoAdapter#INT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 136,
   )
   @JvmField
   public val ext_pack_int64: List<Long> = immutableCopyOf("ext_pack_int64", ext_pack_int64)
@@ -1234,6 +1371,7 @@ public class AllTypes(
     tag = 1_207,
     adapter = "com.squareup.wire.ProtoAdapter#UINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 137,
   )
   @JvmField
   public val ext_pack_uint64: List<Long> = immutableCopyOf("ext_pack_uint64", ext_pack_uint64)
@@ -1245,6 +1383,7 @@ public class AllTypes(
     tag = 1_208,
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
     label = WireField.Label.PACKED,
+    schemaIndex = 138,
   )
   @JvmField
   public val ext_pack_sint64: List<Long> = immutableCopyOf("ext_pack_sint64", ext_pack_sint64)
@@ -1256,6 +1395,7 @@ public class AllTypes(
     tag = 1_209,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 139,
   )
   @JvmField
   public val ext_pack_fixed64: List<Long> = immutableCopyOf("ext_pack_fixed64", ext_pack_fixed64)
@@ -1267,6 +1407,7 @@ public class AllTypes(
     tag = 1_210,
     adapter = "com.squareup.wire.ProtoAdapter#SFIXED64",
     label = WireField.Label.PACKED,
+    schemaIndex = 140,
   )
   @JvmField
   public val ext_pack_sfixed64: List<Long> = immutableCopyOf("ext_pack_sfixed64", ext_pack_sfixed64)
@@ -1278,6 +1419,7 @@ public class AllTypes(
     tag = 1_211,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.PACKED,
+    schemaIndex = 141,
   )
   @JvmField
   public val ext_pack_bool: List<Boolean> = immutableCopyOf("ext_pack_bool", ext_pack_bool)
@@ -1289,6 +1431,7 @@ public class AllTypes(
     tag = 1_212,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
     label = WireField.Label.PACKED,
+    schemaIndex = 142,
   )
   @JvmField
   public val ext_pack_float: List<Float> = immutableCopyOf("ext_pack_float", ext_pack_float)
@@ -1300,6 +1443,7 @@ public class AllTypes(
     tag = 1_213,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.PACKED,
+    schemaIndex = 143,
   )
   @JvmField
   public val ext_pack_double: List<Double> = immutableCopyOf("ext_pack_double", ext_pack_double)
@@ -1311,6 +1455,7 @@ public class AllTypes(
     tag = 1_216,
     adapter = "com.squareup.wire.protos.kotlin.alltypes.AllTypes${'$'}NestedEnum#ADAPTER",
     label = WireField.Label.PACKED,
+    schemaIndex = 144,
   )
   @JvmField
   public val ext_pack_nested_enum: List<NestedEnum> = immutableCopyOf("ext_pack_nested_enum",
@@ -4804,6 +4949,7 @@ public class AllTypes(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0,
     )
     @JvmField
     public val a: Int? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/foreign/ForeignMessage.kt
@@ -22,6 +22,7 @@ public class ForeignMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val i: Int? = null,
@@ -31,6 +32,7 @@ public class ForeignMessage(
   @field:WireField(
     tag = 100,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   @JvmField
   public val j: Int? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Mappy.kt
@@ -30,6 +30,7 @@ public class Mappy(
     tag = 1,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER",
+    schemaIndex = 0,
   )
   @JvmField
   public val things: Map<String, Thing> = immutableCopyOf("things", things)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/MappyTwo.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/MappyTwo.kt
@@ -36,6 +36,7 @@ public class MappyTwo(
     tag = 1,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.protos.kotlin.map.MappyTwo${'$'}ValueEnum#ADAPTER",
+    schemaIndex = 0,
   )
   @JvmField
   public val string_enums: Map<String, ValueEnum> = immutableCopyOf("string_enums", string_enums)
@@ -44,6 +45,7 @@ public class MappyTwo(
     tag = 2,
     keyAdapter = "com.squareup.wire.ProtoAdapter#SINT64",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER",
+    schemaIndex = 1,
   )
   @JvmField
   public val int_things: Map<Long, Thing> = immutableCopyOf("int_things", int_things)
@@ -52,6 +54,7 @@ public class MappyTwo(
     tag = 3,
     keyAdapter = "com.squareup.wire.ProtoAdapter#STRING",
     adapter = "com.squareup.wire.ProtoAdapter#SINT64",
+    schemaIndex = 2,
   )
   @JvmField
   public val string_ints: Map<String, Long> = immutableCopyOf("string_ints", string_ints)
@@ -60,6 +63,7 @@ public class MappyTwo(
     tag = 4,
     keyAdapter = "com.squareup.wire.ProtoAdapter#SINT32",
     adapter = "com.squareup.wire.protos.kotlin.map.Thing#ADAPTER",
+    schemaIndex = 3,
   )
   @JvmField
   public val int_things_two: Map<Int, Thing> = immutableCopyOf("int_things_two", int_things_two)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/map/Thing.kt
@@ -23,6 +23,7 @@ public class Thing(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   @JvmField
   public val name: String? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/person/Person.kt
@@ -324,6 +324,7 @@ public class Person(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#STRING",
       label = WireField.Label.REQUIRED,
+      schemaIndex = 0,
     )
     @JvmField
     public val number: String,
@@ -333,6 +334,7 @@ public class Person(
     @field:WireField(
       tag = 2,
       adapter = "com.squareup.wire.protos.kotlin.person.Person${'$'}PhoneType#ADAPTER",
+      schemaIndex = 1,
     )
     @JvmField
     public val type: PhoneType? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/redacted/RedactedOneOf.kt
@@ -24,6 +24,7 @@ public class RedactedOneOf(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     oneofName = "a",
+    schemaIndex = 0,
   )
   @JvmField
   public val b: Int? = null,
@@ -32,6 +33,7 @@ public class RedactedOneOf(
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     redacted = true,
     oneofName = "a",
+    schemaIndex = 1,
   )
   @JvmField
   public val c: String? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Repeated.kt
@@ -30,6 +30,7 @@ public class Repeated(
     tag = 1,
     adapter = "com.squareup.wire.protos.kotlin.repeated.Thing#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 0,
   )
   @JvmField
   public val things: List<Thing> = immutableCopyOf("things", things)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/repeated/Thing.kt
@@ -23,6 +23,7 @@ public class Thing(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 0,
   )
   @JvmField
   public val name: String? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/ExternalMessage.kt
@@ -26,6 +26,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",
+    schemaIndex = 0,
   )
   @JvmField
   public val f: Float? = null,
@@ -36,6 +37,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 126,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 2,
   )
   @JvmField
   public val barext: Int? = null,
@@ -45,6 +47,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 127,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 3,
   )
   @JvmField
   public val bazext: Int? = null,
@@ -54,6 +57,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 128,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 4,
   )
   @JvmField
   public val nested_message_ext: SimpleMessage.NestedMessage? = null,
@@ -63,6 +67,7 @@ public class ExternalMessage(
   @field:WireField(
     tag = 129,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 5,
   )
   @JvmField
   public val nested_enum_ext: SimpleMessage.NestedEnum? = null,
@@ -75,6 +80,7 @@ public class ExternalMessage(
     tag = 125,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   @JvmField
   public val fooext: List<Int> = immutableCopyOf("fooext", fooext)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/simple/SimpleMessage.kt
@@ -39,6 +39,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val optional_int32: Int? = null,
@@ -49,6 +50,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedMessage#ADAPTER",
+    schemaIndex = 1,
   )
   @JvmField
   public val optional_nested_msg: NestedMessage? = null,
@@ -58,12 +60,14 @@ public class SimpleMessage(
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.protos.kotlin.simple.ExternalMessage#ADAPTER",
+    schemaIndex = 2,
   )
   @JvmField
   public val optional_external_msg: ExternalMessage? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.protos.kotlin.simple.SimpleMessage${'$'}NestedEnum#ADAPTER",
+    schemaIndex = 3,
   )
   @JvmField
   public val default_nested_enum: NestedEnum? = null,
@@ -74,6 +78,7 @@ public class SimpleMessage(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.REQUIRED,
+    schemaIndex = 4,
   )
   @JvmField
   public val required_int32: Int,
@@ -84,6 +89,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.foreign.ForeignEnum#ADAPTER",
+    schemaIndex = 6,
   )
   @JvmField
   public val default_foreign_enum: ForeignEnum? = null,
@@ -93,6 +99,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.protos.kotlin.foreign.ForeignEnum#ADAPTER",
+    schemaIndex = 7,
   )
   @JvmField
   public val no_default_foreign_enum: ForeignEnum? = null,
@@ -103,6 +110,7 @@ public class SimpleMessage(
     tag = 9,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     declaredName = "package",
+    schemaIndex = 8,
   )
   @JvmField
   public val package_: String? = null,
@@ -112,6 +120,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 10,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 9,
   )
   @JvmField
   public val result: String? = null,
@@ -121,6 +130,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 11,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 10,
   )
   @JvmField
   public val other: String? = null,
@@ -130,6 +140,7 @@ public class SimpleMessage(
   @field:WireField(
     tag = 12,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 11,
   )
   @JvmField
   public val o: String? = null,
@@ -143,6 +154,7 @@ public class SimpleMessage(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#DOUBLE",
     label = WireField.Label.REPEATED,
+    schemaIndex = 5,
   )
   @JvmField
   public val repeated_double: List<Double> = immutableCopyOf("repeated_double", repeated_double)
@@ -538,6 +550,7 @@ public class SimpleMessage(
     @field:WireField(
       tag = 1,
       adapter = "com.squareup.wire.ProtoAdapter#INT32",
+      schemaIndex = 0,
     )
     @JvmField
     public val bb: Int? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionOne.kt
@@ -22,6 +22,7 @@ public class NestedVersionOne(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val i: Int? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/NestedVersionTwo.kt
@@ -26,30 +26,35 @@ public class NestedVersionTwo(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val i: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   @JvmField
   public val v2_i: Int? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   @JvmField
   public val v2_s: String? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 3,
   )
   @JvmField
   public val v2_f32: Int? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 4,
   )
   @JvmField
   public val v2_f64: Long? = null,
@@ -60,6 +65,7 @@ public class NestedVersionTwo(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 5,
   )
   @JvmField
   public val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionOne.kt
@@ -22,18 +22,21 @@ public class VersionOne(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val i: Int? = null,
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.NestedVersionOne#ADAPTER",
+    schemaIndex = 1,
   )
   @JvmField
   public val obj: NestedVersionOne? = null,
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.EnumVersionOne#ADAPTER",
+    schemaIndex = 2,
   )
   @JvmField
   public val en: EnumVersionOne? = null,

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/kotlin/unknownfields/VersionTwo.kt
@@ -26,30 +26,35 @@ public class VersionTwo(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val i: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   @JvmField
   public val v2_i: Int? = null,
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
+    schemaIndex = 2,
   )
   @JvmField
   public val v2_s: String? = null,
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED32",
+    schemaIndex = 3,
   )
   @JvmField
   public val v2_f32: Int? = null,
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FIXED64",
+    schemaIndex = 4,
   )
   @JvmField
   public val v2_f64: Long? = null,
@@ -57,12 +62,14 @@ public class VersionTwo(
   @field:WireField(
     tag = 7,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.NestedVersionTwo#ADAPTER",
+    schemaIndex = 6,
   )
   @JvmField
   public val obj: NestedVersionTwo? = null,
   @field:WireField(
     tag = 8,
     adapter = "com.squareup.wire.protos.kotlin.unknownfields.EnumVersionTwo#ADAPTER",
+    schemaIndex = 7,
   )
   @JvmField
   public val en: EnumVersionTwo? = null,
@@ -72,6 +79,7 @@ public class VersionTwo(
     tag = 6,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
+    schemaIndex = 5,
   )
   @JvmField
   public val v2_rs: List<String> = immutableCopyOf("v2_rs", v2_rs)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/usesany/UsesAny.kt
@@ -27,6 +27,7 @@ public class UsesAny(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
+    schemaIndex = 0,
   )
   @JvmField
   public val just_one: AnyMessage? = null,
@@ -37,6 +38,7 @@ public class UsesAny(
     tag = 2,
     adapter = "com.squareup.wire.AnyMessage#ADAPTER",
     label = WireField.Label.REPEATED,
+    schemaIndex = 1,
   )
   @JvmField
   public val many_anys: List<AnyMessage> = immutableCopyOf("many_anys", many_anys)

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/EmbeddedMessage.kt
@@ -26,6 +26,7 @@ public class EmbeddedMessage(
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 1,
   )
   @JvmField
   public val inner_number_after: Int? = null,
@@ -35,6 +36,7 @@ public class EmbeddedMessage(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     label = WireField.Label.PACKED,
+    schemaIndex = 0,
   )
   @JvmField
   public val inner_repeated_number: List<Int> = immutableCopyOf("inner_repeated_number",

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/protos/packed_encoding/OuterMessage.kt
@@ -22,12 +22,14 @@ public class OuterMessage(
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
+    schemaIndex = 0,
   )
   @JvmField
   public val outer_number_before: Int? = null,
   @field:WireField(
     tag = 2,
     adapter = "squareup.protos.packed_encoding.EmbeddedMessage#ADAPTER",
+    schemaIndex = 1,
   )
   @JvmField
   public val embedded_message: EmbeddedMessage? = null,


### PR DESCRIPTION
Because reflexion is unpredictable. Unfortunate but I don't see another real option here.
This is actually only required by Kotlin since Java will use the builders. I removed it all together from java generator.

Check the first commit for logic change.
Fixes #2432 for real.