### PR TITLE
Open GrpcClient

### DIFF
--- a/wire-grpc-client/api/wire-grpc-client.api
+++ b/wire-grpc-client/api/wire-grpc-client.api
@@ -23,12 +23,12 @@ public final class com/squareup/wire/GrpcCalls {
 	public static final fun grpcStreamingCall (Lkotlin/jvm/functions/Function3;)Lcom/squareup/wire/GrpcStreamingCall;
 }
 
-public final class com/squareup/wire/GrpcClient {
+public abstract class com/squareup/wire/GrpcClient {
 	public synthetic fun <init> (Lokhttp3/Call$Factory;Lokhttp3/HttpUrl;JLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun create (Lkotlin/reflect/KClass;)Lcom/squareup/wire/Service;
 	public final fun newBuilder ()Lcom/squareup/wire/GrpcClient$Builder;
-	public final fun newCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcCall;
-	public final fun newStreamingCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcStreamingCall;
+	public abstract fun newCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcCall;
+	public abstract fun newStreamingCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcStreamingCall;
 }
 
 public final class com/squareup/wire/GrpcClient$Builder {

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.wire
 
-expect class GrpcClient {
-  fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
-  fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
+expect abstract class GrpcClient {
+  abstract fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
+  abstract fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
 }

--- a/wire-grpc-client/src/jsMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/jsMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -15,14 +15,7 @@
  */
 package com.squareup.wire
 
-actual class GrpcClient {
-  actual fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R> {
-    throw UnsupportedOperationException("wire-grpc-client doesn't support JS yet.")
-  }
-
-  actual fun <S : Any, R : Any> newStreamingCall(
-    method: GrpcMethod<S, R>
-  ): GrpcStreamingCall<S, R> {
-    throw UnsupportedOperationException("wire-grpc-client doesn't support JS yet.")
-  }
+actual abstract class GrpcClient {
+  actual abstract fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
+  actual abstract fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
 }

--- a/wire-grpc-client/src/nativeMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/nativeMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -15,14 +15,7 @@
  */
 package com.squareup.wire
 
-actual class GrpcClient {
-  actual fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R> {
-    throw UnsupportedOperationException("wire-grpc-client doesn't support Native yet.")
-  }
-
-  actual fun <S : Any, R : Any> newStreamingCall(
-    method: GrpcMethod<S, R>
-  ): GrpcStreamingCall<S, R> {
-    throw UnsupportedOperationException("wire-grpc-client doesn't support Native yet.")
-  }
+actual abstract class GrpcClient {
+  actual abstract fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
+  actual abstract fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
 }


### PR DESCRIPTION
So that people can inject their own implementation. Fixes #2484
Would that be a bad idea to do so?

For info, Wire currently generates something like this for an RPC:

```kotlin
public class GrpcWhiteboardClient(
  private val client: GrpcClient,
) : WhiteboardClient {
  override fun Whiteboard(): GrpcStreamingCall<WhiteboardCommand, WhiteboardUpdate> =
      client.newStreamingCall(GrpcMethod(
      path = "/com.squareup.wire.whiteboard.Whiteboard/Whiteboard",
      requestAdapter = WhiteboardCommand.ADAPTER,
      responseAdapter = WhiteboardUpdate.ADAPTER
  ))
}
```