### PR TITLE
fix: support Unit values in grpc-server-generator

### DIFF
--- a/wire-grpc-server-generator/src/test/golden/unitService.kt
+++ b/wire-grpc-server-generator/src/test/golden/unitService.kt
@@ -1,0 +1,146 @@
+import com.google.protobuf.DescriptorProtos
+import com.google.protobuf.Descriptors
+import com.squareup.wire.kotlin.grpcserver.WireBindableService
+import com.squareup.wire.kotlin.grpcserver.WireMethodMarshaller
+import io.grpc.CallOptions
+import io.grpc.Channel
+import io.grpc.MethodDescriptor
+import io.grpc.ServerServiceDefinition
+import io.grpc.ServiceDescriptor
+import io.grpc.ServiceDescriptor.newBuilder
+import io.grpc.kotlin.AbstractCoroutineStub
+import io.grpc.kotlin.ClientCalls.unaryRpc
+import java.io.InputStream
+import java.lang.Class
+import java.lang.UnsupportedOperationException
+import kotlin.Array
+import kotlin.String
+import kotlin.Unit
+import kotlin.collections.Map
+import kotlin.collections.Set
+import kotlin.coroutines.CoroutineContext
+import kotlin.jvm.Volatile
+
+public object MyServiceWireGrpc {
+  public val SERVICE_NAME: String = "MyService"
+
+  @Volatile
+  private var serviceDescriptor: ServiceDescriptor? = null
+
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
+    "service.proto" to descriptorFor(arrayOf(
+      "Cg1zZXJ2aWNlLnByb3RvGhtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8ySgoJTXlTZXJ2aWNlEj0K",
+      "C2RvU29tZXRoaW5nEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5",
+      "YgZwcm90bzM=",
+    )),
+    "google/protobuf/empty.proto" to descriptorFor(arrayOf(
+      "Chtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiIHCgVFbXB0eWIGcHJv",
+      "dG8z",
+    )),
+  )
+
+
+  @Volatile
+  private var getdoSomethingMethod: MethodDescriptor<Unit, Unit>? = null
+
+  private fun descriptorFor(`data`: Array<String>): DescriptorProtos.FileDescriptorProto {
+    val str = data.fold(java.lang.StringBuilder()) { b, s -> b.append(s) }.toString()
+    val bytes = java.util.Base64.getDecoder().decode(str)
+    return DescriptorProtos.FileDescriptorProto.parseFrom(bytes)
+  }
+
+  private fun fileDescriptor(path: String, visited: Set<String>): Descriptors.FileDescriptor {
+    val proto = descriptorMap[path]!!
+    val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
+        visited + path) }
+    return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
+
+  public fun getServiceDescriptor(): ServiceDescriptor? {
+    var result = serviceDescriptor
+    if (result == null) {
+      synchronized(MyServiceWireGrpc::class) {
+        result = serviceDescriptor
+        if (result == null) {
+          result = newBuilder(SERVICE_NAME)
+          .addMethod(getdoSomethingMethod())
+          .setSchemaDescriptor(io.grpc.protobuf.ProtoFileDescriptorSupplier {
+                fileDescriptor("service.proto", emptySet())
+              })
+          .build()
+          serviceDescriptor = result
+        }
+      }
+    }
+    return result
+  }
+
+  public fun getdoSomethingMethod(): MethodDescriptor<Unit, Unit> {
+    var result: MethodDescriptor<Unit, Unit>? = getdoSomethingMethod
+    if (result == null) {
+      synchronized(MyServiceWireGrpc::class) {
+        result = getdoSomethingMethod
+        if (result == null) {
+          getdoSomethingMethod = MethodDescriptor.newBuilder<Unit, Unit>()
+            .setType(MethodDescriptor.MethodType.UNARY)
+            .setFullMethodName(
+              MethodDescriptor.generateFullMethodName(
+                "MyService", "doSomething"
+              )
+            )
+            .setSampledToLocalTracing(true)
+            .setRequestMarshaller(MyServiceImplBase.EmptyMarshaller())
+            .setResponseMarshaller(MyServiceImplBase.EmptyMarshaller())
+            .build()
+        }
+      }
+    }
+    return getdoSomethingMethod!!
+  }
+
+  public fun newStub(channel: Channel): MyServiceStub = MyServiceStub(channel)
+
+  public abstract class MyServiceImplBase(
+    protected val context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext
+    ,
+  ) : WireBindableService {
+    public open suspend fun doSomething(request: Unit): Unit = throw UnsupportedOperationException()
+
+    override fun bindService(): ServerServiceDefinition =
+        ServerServiceDefinition.builder(getServiceDescriptor()).addMethod(
+               io.grpc.kotlin.ServerCalls.unaryServerMethodDefinition(
+                 context = context,
+                 descriptor = getdoSomethingMethod(),
+                 implementation = this@MyServiceImplBase::doSomething,
+               )
+             ).build()
+
+    public class EmptyMarshaller : WireMethodMarshaller<Unit> {
+      override fun stream(`value`: Unit): InputStream =
+          com.squareup.wire.ProtoAdapter.EMPTY.encode(value).inputStream()
+
+      override fun marshalledClass(): Class<Unit> = Unit::class.java
+
+      override fun parse(stream: InputStream): Unit =
+          com.squareup.wire.ProtoAdapter.EMPTY.decode(stream)
+    }
+  }
+
+  public class BindableAdapter(
+    private val service: () -> MyServiceServer,
+  ) : MyServiceImplBase() {
+    override suspend fun doSomething(request: Unit): Unit = service().doSomething(request)
+  }
+
+  public class MyServiceStub : AbstractCoroutineStub<MyServiceStub> {
+    internal constructor(channel: Channel) : super(channel)
+
+    internal constructor(channel: Channel, callOptions: CallOptions) : super(channel, callOptions)
+
+    override fun build(channel: Channel, callOptions: CallOptions): MyServiceStub =
+        MyServiceStub(channel, callOptions)
+
+    public suspend fun doSomething(request: Unit): Unit = unaryRpc(channel, getdoSomethingMethod(),
+        request, callOptions)
+  }
+}

--- a/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/GrpcGeneratorHelpers.kt
+++ b/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/GrpcGeneratorHelpers.kt
@@ -18,7 +18,9 @@ internal fun buildClassMap(schema: Schema, service: Service): Map<ProtoType, Cla
         types.flatMap { getNestedTypes(javaPackage(schema), null, listOf(it)) }
       servicesToName + typesToName
     }
-    .toMap()
+    .toMap() + mapOf(
+      ProtoType.EMPTY to ClassName("kotlin", "Unit"),
+    )
 
 private fun getNestedTypes(
   kotlinPackage: String,

--- a/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
+++ b/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/KotlinGrpcGeneratorTest.kt
@@ -93,4 +93,27 @@ internal class KotlinGrpcGeneratorTest {
     assertThat(output.toString())
       .isEqualTo(File("src/test/golden/singleMethodService.kt").source().buffer().readUtf8())
   }
+
+  @Test
+  fun `correctly generates adapters for Unit return values`() {
+    val path = "service.proto".toPath()
+    val schema = buildSchema { add(path, """
+      syntax = "proto3";
+      import "google/protobuf/empty.proto";
+
+      service MyService {
+        rpc doSomething(google.protobuf.Empty) returns (google.protobuf.Empty);
+      }
+    """.trimIndent()) }
+    val service = schema.getService("MyService")
+    val (_, typeSpec) = KotlinGrpcGenerator(
+      buildClassMap(schema, service!!),
+      singleMethodServices = false,
+      suspendingCalls = true
+    ).generateGrpcServer(service, schema.protoFile(path), schema)
+    val output = FileSpec.get("", typeSpec)
+
+    assertThat(output.toString())
+      .isEqualTo(File("src/test/golden/unitService.kt").source().buffer().readUtf8())
+  }
 }


### PR DESCRIPTION
Adds a special case for returning `Empty` from a grpc call in the grpc service compatibility generator. 

We map `Empty` to `kotlin.Unit` which does not have `ADAPTER` and previously resulted in invalid generated code.
Here we return a null stream as the InputStream instead, and when parsing a stream, always return `Unit` immediately. 

Also fixes similar issue with returning timestamps, durations, structs, and some primitive value messages.