### PR TITLE
Add options to OneOf

### DIFF
--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -491,17 +491,21 @@ public final class com/squareup/wire/schema/MessageType$Companion {
 
 public final class com/squareup/wire/schema/OneOf {
 	public static final field Companion Lcom/squareup/wire/schema/OneOf$Companion;
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/squareup/wire/schema/Location;Lcom/squareup/wire/schema/Options;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/squareup/wire/schema/OneOf;
-	public static synthetic fun copy$default (Lcom/squareup/wire/schema/OneOf;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/squareup/wire/schema/OneOf;
+	public final fun component4 ()Lcom/squareup/wire/schema/Location;
+	public final fun component5 ()Lcom/squareup/wire/schema/Options;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/squareup/wire/schema/Location;Lcom/squareup/wire/schema/Options;)Lcom/squareup/wire/schema/OneOf;
+	public static synthetic fun copy$default (Lcom/squareup/wire/schema/OneOf;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/squareup/wire/schema/Location;Lcom/squareup/wire/schema/Options;ILjava/lang/Object;)Lcom/squareup/wire/schema/OneOf;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromElements (Ljava/util/List;Ljava/util/List;)Ljava/util/List;
 	public final fun getDocumentation ()Ljava/lang/String;
 	public final fun getFields ()Ljava/util/List;
+	public final fun getLocation ()Lcom/squareup/wire/schema/Location;
 	public final fun getName ()Ljava/lang/String;
+	public final fun getOptions ()Lcom/squareup/wire/schema/Options;
 	public fun hashCode ()I
 	public final fun link (Lcom/squareup/wire/schema/Linker;)V
 	public final fun linkOptions (Lcom/squareup/wire/schema/Linker;Lcom/squareup/wire/schema/SyntaxRules;Z)V
@@ -1270,19 +1274,21 @@ public final class com/squareup/wire/schema/internal/parser/MessageElement : com
 }
 
 public final class com/squareup/wire/schema/internal/parser/OneOfElement {
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/squareup/wire/schema/Location;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/squareup/wire/schema/Location;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/util/List;
 	public final fun component4 ()Ljava/util/List;
 	public final fun component5 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;)Lcom/squareup/wire/schema/internal/parser/OneOfElement;
-	public static synthetic fun copy$default (Lcom/squareup/wire/schema/internal/parser/OneOfElement;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;ILjava/lang/Object;)Lcom/squareup/wire/schema/internal/parser/OneOfElement;
+	public final fun component6 ()Lcom/squareup/wire/schema/Location;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/squareup/wire/schema/Location;)Lcom/squareup/wire/schema/internal/parser/OneOfElement;
+	public static synthetic fun copy$default (Lcom/squareup/wire/schema/internal/parser/OneOfElement;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Lcom/squareup/wire/schema/Location;ILjava/lang/Object;)Lcom/squareup/wire/schema/internal/parser/OneOfElement;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getDocumentation ()Ljava/lang/String;
 	public final fun getFields ()Ljava/util/List;
 	public final fun getGroups ()Ljava/util/List;
+	public final fun getLocation ()Lcom/squareup/wire/schema/Location;
 	public final fun getName ()Ljava/lang/String;
 	public final fun getOptions ()Ljava/util/List;
 	public fun hashCode ()I

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OneOfElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/OneOfElement.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire.schema.internal.parser
 
+import com.squareup.wire.schema.Location
 import com.squareup.wire.schema.internal.appendDocumentation
 import com.squareup.wire.schema.internal.appendIndented
 
@@ -24,6 +25,7 @@ data class OneOfElement(
   val fields: List<FieldElement> = emptyList(),
   val groups: List<GroupElement> = emptyList(),
   val options: List<OptionElement> = emptyList(),
+  val location: Location,
 ) {
   fun toSchema() = buildString {
     appendDocumentation(documentation)

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
@@ -154,7 +154,7 @@ class ProtoParser internal constructor(
       }
 
       label == "oneof" && context.permitsOneOf() -> {
-        readOneOf(documentation)
+        readOneOf(location, documentation)
       }
 
       label == "extensions" && context.permitsExtensions() -> {
@@ -408,7 +408,7 @@ class ProtoParser internal constructor(
     return result
   }
 
-  private fun readOneOf(documentation: String): OneOfElement {
+  private fun readOneOf(location: Location, documentation: String): OneOfElement {
     val name = reader.readName()
     val fields = mutableListOf<FieldElement>()
     val groups = mutableListOf<GroupElement>()
@@ -436,6 +436,7 @@ class ProtoParser internal constructor(
       fields = fields,
       groups = groups,
       options = options,
+      location = location,
     )
   }
 

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1075,6 +1075,37 @@ class PrunerTest {
   }
 
   @Test
+  fun excludeOneOfOptions() {
+    val schema = buildSchema {
+      add(
+        "service.proto".toPath(),
+        """
+             |syntax = "proto3";
+             |import "google/protobuf/descriptor.proto";
+             |extend google.protobuf.OneofOptions {
+             |  string my_oneof_option = 22101;
+             |}
+             |message Message {
+             |  oneof choice {
+             |    option (my_oneof_option) = "Well done";
+             |
+             |    string one = 1;
+             |    string two = 2;
+             |  }
+             |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .prune("google.protobuf.OneofOptions")
+        .build(),
+    )
+    val oneOf = (pruned.getType("Message") as MessageType).oneOfs[0]
+    assertThat(oneOf.options.map).isEmpty()
+  }
+
+  @Test
   fun excludeRepeatedOptions() {
     val schema = buildSchema {
       add(

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/RootTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/RootTest.kt
@@ -34,7 +34,7 @@ class RootTest {
 
     val location = Location.get("sample/src/main/proto", "squareup/dinosaurs/dinosaur.proto")
     val roots = location.roots(fs)
-    assertThat(roots.size == 1)
+    assertThat(roots.size == 1).isTrue()
 
     // Standalone files resolve because we have a base directory.
     assertThat(roots[0].resolve("squareup/dinosaurs/dinosaur.proto")).isEqualTo(roots[0])

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaTest.kt
@@ -19,6 +19,7 @@ package com.squareup.wire.schema
 
 import com.squareup.wire.buildSchema
 import com.squareup.wire.schema.Options.Companion.FIELD_OPTIONS
+import com.squareup.wire.schema.Options.Companion.ONEOF_OPTIONS
 import com.squareup.wire.schema.internal.isValidTag
 import com.squareup.wire.schema.internal.parser.OptionElement
 import okio.Path.Companion.toPath
@@ -2065,6 +2066,10 @@ class SchemaTest {
     assertThat(fieldOptions.extensionField("my_oneof_option")!!.type).isEqualTo(
       ProtoType.get("string"),
     )
+    val choiceOneOf = (schema.getType("Message") as MessageType).oneOfs[0]
+    assertThat(choiceOneOf.name).isEqualTo("choice")
+    assertThat(choiceOneOf.options.get(ProtoMember.get(ONEOF_OPTIONS, "my_oneof_option")))
+      .isEqualTo("Well done")
   }
 
   @Test

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/MessageElementTest.kt
@@ -282,6 +282,7 @@ class MessageElementTest {
       name = "Message",
       oneOfs = listOf(
         OneOfElement(
+          location = location,
           name = "hi",
           fields = listOf(
             FieldElement(
@@ -312,6 +313,7 @@ class MessageElementTest {
       name = "Message",
       oneOfs = listOf(
         OneOfElement(
+          location = location,
           name = "hi",
           fields = listOf(
             FieldElement(
@@ -368,6 +370,7 @@ class MessageElementTest {
   @Test
   fun addMultipleOneOfs() {
     val hi = OneOfElement(
+      location = location,
       name = "hi",
       fields = listOf(
         FieldElement(
@@ -379,6 +382,7 @@ class MessageElementTest {
       ),
     )
     val hey = OneOfElement(
+      location = location,
       name = "hey",
       fields = listOf(
         FieldElement(
@@ -494,6 +498,7 @@ class MessageElementTest {
     )
 
     val oneOf1 = OneOfElement(
+      location = location,
       name = "thingy",
       fields = listOf(oneOf1Field1, oneOf1Field2),
     )
@@ -511,6 +516,7 @@ class MessageElementTest {
       tag = 4,
     )
     val oneOf2 = OneOfElement(
+      location = location,
       name = "thinger",
       fields = listOf(oneOf2Field),
     )
@@ -696,6 +702,7 @@ class MessageElementTest {
         |
     """.trimMargin()
     val oneOf = OneOfElement(
+      location = location,
       name = "page_info",
       fields = listOf(
         FieldElement(

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/OneOfElementTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/OneOfElementTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema.internal.parser
+
+import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.internal.parser.OptionElement.Kind.STRING
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+
+class OneOfElementTest {
+  internal var location = Location.get("file.proto")
+
+  @Test fun oneOfWithOptions() {
+    // spotless:off because spotless will remove the indents (trailing spaces) in the oneof block.
+    val elementAsString = """
+      |message Message {
+      |  // You have to take one.
+      |  oneof choice {
+      |    option (my_oneof_option) = "Well done";
+      |    option (my_other_oneof_option) = "Yet again";
+      |  
+      |    string one = 1;
+      |    string two = 2;
+      |  }
+      |}
+      |""".trimMargin()
+    // spotless:on
+
+    val expectedElement = MessageElement(
+      location = location.at(1, 1),
+      name = "Message",
+      oneOfs = listOf(
+        OneOfElement(
+          location = location.at(3, 3),
+          name = "choice",
+          documentation = "You have to take one.",
+          fields = listOf(
+            FieldElement(location.at(7, 5), type = "string", name = "one", tag = 1),
+            FieldElement(location.at(8, 5), type = "string", name = "two", tag = 2),
+          ),
+          options = listOf(
+            OptionElement(name = "my_oneof_option", kind = STRING, value = "Well done", isParenthesized = true),
+            OptionElement(name = "my_other_oneof_option", kind = STRING, value = "Yet again", isParenthesized = true),
+          ),
+        ),
+      ),
+    )
+    val element = ProtoParser.parse(location, elementAsString).types[0] as MessageElement
+    assertThat(element).isEqualTo(expectedElement)
+    assertThat(element.toSchema()).isEqualTo(elementAsString)
+  }
+}

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -1074,6 +1074,7 @@ class ProtoParserTest {
           ),
           oneOfs = listOf(
             OneOfElement(
+              location = location.at(3, 3),
               name = "page_info",
               fields = listOf(
                 FieldElement(
@@ -1128,6 +1129,7 @@ class ProtoParserTest {
           ),
           oneOfs = listOf(
             OneOfElement(
+              location = location.at(3, 3),
               name = "page_info",
               fields = listOf(
                 FieldElement(
@@ -3103,6 +3105,7 @@ class ProtoParserTest {
           ),
           oneOfs = listOf(
             OneOfElement(
+              location = location.at(3, 3),
               name = "page_info",
               fields = listOf(
                 FieldElement(


### PR DESCRIPTION
And thus allow the reading of its values.

There are few breaking APIs but it's kinda low-level. I wonder if many people instantiate `OneOfElement` or `OneOf` manually.

Fixes #2503