### PR TITLE
Fix import for CancellableException

### DIFF
--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcCall.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcCall.kt
@@ -15,7 +15,7 @@
  */
 package com.squareup.wire
 
-import kotlinx.coroutines.CancellationException
+import kotlin.coroutines.cancellation.CancellationException
 import okio.IOException
 import okio.Timeout
 


### PR DESCRIPTION
It would complain with the current import
![image](https://github.com/square/wire/assets/1767669/1831b11f-fd4c-429e-ba8a-2a6c3187d8a3)
