### PR TITLE
Add serialVersionUID to AndroidMessage

### DIFF
--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/AndroidMessage.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/AndroidMessage.kt
@@ -42,6 +42,8 @@ abstract class AndroidMessage<M : Message<M, B>, B : Message.Builder<M, B>> prot
   }
 
   companion object {
+    private const val serialVersionUID = 0L
+
     /** Creates a new [Parcelable.Creator] using `adapter` for serialization. */
     @JvmStatic fun <E> newCreator(adapter: ProtoAdapter<E>): Parcelable.Creator<E> {
       return ProtoAdapterCreator(adapter)


### PR DESCRIPTION
Message defines it but it looks like even if the parent defines it, it will not be used by the serialization process. So we're adding one. Fixes #2247