### PR TITLE
feat: adds  CoroutineContext parameter into BindableAdapter constructor

### DIFF
--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
@@ -62,9 +62,10 @@ object BindableAdapterGenerator {
                   // via a context parameter.
                   this.addParameter(
                     ParameterSpec.builder("context", CoroutineContext::class)
-                      .defaultValue("kotlin.coroutines.EmptyCoroutineContext")
+                      .defaultValue("%T", ClassName("kotlin.coroutines", "EmptyCoroutineContext"))
                       .build(),
                   )
+                  this.addAnnotation(JvmOverloads::class)
                 }
               }
               .apply { addRpcConstructorParameters(generator, this, service, options) }

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
@@ -58,7 +58,8 @@ object BindableAdapterGenerator {
                     type = ExecutorService::class,
                   )
                 } else {
-                  // suspending calls optionally allow for adding to the CoroutineContext
+                  // For suspending calls, optionally allow for adding to the CoroutineContext
+                  // via a context parameter.
                   this.addParameter(
                     ParameterSpec.builder("context", CoroutineContext::class)
                       .defaultValue("kotlin.coroutines.EmptyCoroutineContext")

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterGenerator.kt
@@ -20,12 +20,14 @@ import com.squareup.kotlinpoet.CodeBlock
 import com.squareup.kotlinpoet.FunSpec
 import com.squareup.kotlinpoet.KModifier
 import com.squareup.kotlinpoet.LambdaTypeName
+import com.squareup.kotlinpoet.ParameterSpec
 import com.squareup.kotlinpoet.ParameterizedTypeName.Companion.parameterizedBy
 import com.squareup.kotlinpoet.PropertySpec
 import com.squareup.kotlinpoet.TypeSpec
 import com.squareup.wire.kotlin.grpcserver.ImplBaseGenerator.addImplBaseRpcSignature
 import com.squareup.wire.schema.Service
 import java.util.concurrent.ExecutorService
+import kotlin.coroutines.CoroutineContext
 
 object BindableAdapterGenerator {
 
@@ -55,6 +57,13 @@ object BindableAdapterGenerator {
                     name = "streamExecutor",
                     type = ExecutorService::class,
                   )
+                } else {
+                  // suspending calls optionally allow for adding to the CoroutineContext
+                  this.addParameter(
+                    ParameterSpec.builder("context", CoroutineContext::class)
+                      .defaultValue("kotlin.coroutines.EmptyCoroutineContext")
+                      .build(),
+                  )
                 }
               }
               .apply { addRpcConstructorParameters(generator, this, service, options) }
@@ -66,6 +75,12 @@ object BindableAdapterGenerator {
                 PropertySpec.builder("streamExecutor", ExecutorService::class)
                   .addModifiers(KModifier.PRIVATE)
                   .initializer("streamExecutor")
+                  .build(),
+              )
+            } else {
+              superclassConstructorParameters.add(
+                CodeBlock.builder()
+                  .add("context")
                   .build(),
               )
             }

--- a/wire-grpc-server-generator/src/test/golden/unitService.kt
+++ b/wire-grpc-server-generator/src/test/golden/unitService.kt
@@ -128,8 +128,9 @@ public object MyServiceWireGrpc {
   }
 
   public class BindableAdapter(
+    context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
     private val service: () -> MyServiceServer,
-  ) : MyServiceImplBase() {
+  ) : MyServiceImplBase(context) {
     override suspend fun doSomething(request: Unit): Unit = service().doSomething(request)
   }
 

--- a/wire-grpc-server-generator/src/test/golden/unitService.kt
+++ b/wire-grpc-server-generator/src/test/golden/unitService.kt
@@ -20,6 +20,8 @@ import kotlin.Unit
 import kotlin.collections.Map
 import kotlin.collections.Set
 import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.jvm.JvmOverloads
 import kotlin.jvm.Volatile
 
 public object MyServiceWireGrpc {
@@ -127,8 +129,8 @@ public object MyServiceWireGrpc {
     }
   }
 
-  public class BindableAdapter(
-    context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
+  public class BindableAdapter @JvmOverloads constructor(
+    context: CoroutineContext = EmptyCoroutineContext,
     private val service: () -> MyServiceServer,
   ) : MyServiceImplBase(context) {
     override suspend fun doSomething(request: Unit): Unit = service().doSomething(request)

--- a/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterTest.kt
+++ b/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterTest.kt
@@ -70,12 +70,14 @@ class BindableAdapterTest {
       package test
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
+      import kotlin.coroutines.CoroutineContext
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
         public class BindableAdapter(
+          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
           private val service: () -> TestServiceServer,
-        ) : TestServiceWireGrpc.TestServiceImplBase() {
+        ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override fun TestRPC(request: Test): Flow<Test> = FlowAdapter.serverStream(context, request,
               service()::TestRPC)
         }
@@ -105,12 +107,14 @@ class BindableAdapterTest {
       package test
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
+      import kotlin.coroutines.CoroutineContext
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
         public class BindableAdapter(
+          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
           private val service: () -> TestServiceServer,
-        ) : TestServiceWireGrpc.TestServiceImplBase() {
+        ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override suspend fun TestRPC(request: Flow<Test>): Test = FlowAdapter.clientStream(context,
               request, service()::TestRPC)
         }
@@ -140,12 +144,14 @@ class BindableAdapterTest {
       package test
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
+      import kotlin.coroutines.CoroutineContext
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
         public class BindableAdapter(
+          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
           private val service: () -> TestServiceServer,
-        ) : TestServiceWireGrpc.TestServiceImplBase() {
+        ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override fun TestRPC(request: Flow<Test>): Flow<Test> = FlowAdapter.bidiStream(context, request,
               service()::TestRPC)
         }
@@ -179,12 +185,14 @@ class BindableAdapterTest {
       package test
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
+      import kotlin.coroutines.CoroutineContext
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
         public class BindableAdapter(
+          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
           private val TestRPC: () -> TestServiceTestRPCServer,
-        ) : TestServiceWireGrpc.TestServiceImplBase() {
+        ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override fun TestRPC(request: Flow<Test>): Flow<Test> = FlowAdapter.bidiStream(context, request,
               TestRPC()::TestRPC)
         }

--- a/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterTest.kt
+++ b/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/BindableAdapterTest.kt
@@ -71,11 +71,13 @@ class BindableAdapterTest {
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
       import kotlin.coroutines.CoroutineContext
+      import kotlin.coroutines.EmptyCoroutineContext
+      import kotlin.jvm.JvmOverloads
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
-        public class BindableAdapter(
-          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
+        public class BindableAdapter @JvmOverloads constructor(
+          context: CoroutineContext = EmptyCoroutineContext,
           private val service: () -> TestServiceServer,
         ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override fun TestRPC(request: Test): Flow<Test> = FlowAdapter.serverStream(context, request,
@@ -108,11 +110,13 @@ class BindableAdapterTest {
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
       import kotlin.coroutines.CoroutineContext
+      import kotlin.coroutines.EmptyCoroutineContext
+      import kotlin.jvm.JvmOverloads
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
-        public class BindableAdapter(
-          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
+        public class BindableAdapter @JvmOverloads constructor(
+          context: CoroutineContext = EmptyCoroutineContext,
           private val service: () -> TestServiceServer,
         ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override suspend fun TestRPC(request: Flow<Test>): Test = FlowAdapter.clientStream(context,
@@ -145,11 +149,13 @@ class BindableAdapterTest {
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
       import kotlin.coroutines.CoroutineContext
+      import kotlin.coroutines.EmptyCoroutineContext
+      import kotlin.jvm.JvmOverloads
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
-        public class BindableAdapter(
-          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
+        public class BindableAdapter @JvmOverloads constructor(
+          context: CoroutineContext = EmptyCoroutineContext,
           private val service: () -> TestServiceServer,
         ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override fun TestRPC(request: Flow<Test>): Flow<Test> = FlowAdapter.bidiStream(context, request,
@@ -186,11 +192,13 @@ class BindableAdapterTest {
 
       import com.squareup.wire.kotlin.grpcserver.FlowAdapter
       import kotlin.coroutines.CoroutineContext
+      import kotlin.coroutines.EmptyCoroutineContext
+      import kotlin.jvm.JvmOverloads
       import kotlinx.coroutines.flow.Flow
 
       public class TestServiceWireGrpc {
-        public class BindableAdapter(
-          context: CoroutineContext = kotlin.coroutines.EmptyCoroutineContext,
+        public class BindableAdapter @JvmOverloads constructor(
+          context: CoroutineContext = EmptyCoroutineContext,
           private val TestRPC: () -> TestServiceTestRPCServer,
         ) : TestServiceWireGrpc.TestServiceImplBase(context) {
           override fun TestRPC(request: Flow<Test>): Flow<Test> = FlowAdapter.bidiStream(context, request,


### PR DESCRIPTION
The BindableAdapter currently does not visibility into the base <service>Impl class in order to set a custom CoroutineContext. This exposes a context parameter with, with an empty default, that passes it through to the underlying pass impl class. This is only generated if suspendingCalls is enabled

This should be backward compatible, since it has a default value and generates `@JvmOverloads`. It also keeps the lambda as the last parameter. 