### PR TITLE
Swift: remove unused variables

### DIFF
--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -1017,8 +1017,6 @@ class SwiftGenerator private constructor(
       }
       val default = field.default
       if (default != null) {
-        val typeName = type.typeName
-        val fieldName = field.name
         val defaultValue = defaultFieldInitializer(field.type!!, default)
         property.addAttribute(AttributeSpec.builder(defaulted).addArgument("defaultValue: $defaultValue").build())
       }


### PR DESCRIPTION
Fixes two warnings for unused variables:

> wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt:1020:13 Variable 'typeName' is never used
> 
> wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt:1021:13 Variable 'fieldName' is never used