### PR TITLE
Swift: exclude generated test fixtures from Spotless

### DIFF
--- a/wire-runtime-swift/build.gradle.kts
+++ b/wire-runtime-swift/build.gradle.kts
@@ -152,6 +152,7 @@ configure<SpotlessExtension> {
   format("Swift") {
     targetExclude(
       "src/main/swift/wellknowntypes/*.swift",
+      "src/test/swift/gen/*.swift",
       "src/test/swift/sample/*.swift",
     )
   }


### PR DESCRIPTION
Follow up to https://github.com/square/wire/pull/2533 that excludes generated test fixtures.

```
Can't parse copyright year '// Code generated by Wire protocol buffer compiler, do not edit.
// Source: A in cycles.proto
', defaulting to 2023

Execution failed for task ':wire-runtime-swift:spotlessSwiftCheck'.
> The following files had format violations:
      src/test/swift/gen/A.swift
...
```