### PR TITLE
Allow configuring Maven host URL during pod publishing

### DIFF
--- a/WireCompiler.podspec
+++ b/WireCompiler.podspec
@@ -15,7 +15,7 @@ Pod::Spec.new do |s|
   s.osx.deployment_target  = '10.15'
 
   s.prepare_command = <<-CMD
-    curl https://repo.maven.apache.org/maven2/com/squareup/wire/wire-compiler/#{version}/wire-compiler-#{version}-jar-with-dependencies.jar --output compiler.jar
+    curl -L #{get_maven_host}/com/squareup/wire/wire-compiler/#{version}/wire-compiler-#{version}-jar-with-dependencies.jar --output compiler.jar
     if ! jar tf compiler.jar >/dev/null 2>&1; then
       echo "[WireCompiler] The compiler.jar file is invalid or corrupted."
       exit 1

--- a/wire-runtime-swift/pod_helpers.rb
+++ b/wire-runtime-swift/pod_helpers.rb
@@ -19,6 +19,9 @@ def get_version
   raise error_message
 end
 
+def get_maven_host
+  return ENV['POD_MAVEN_HOST'] || 'https://repo.maven.apache.org/maven2'
+end
 
 private def git_root
   `git rev-parse --show-toplevel`.strip


### PR DESCRIPTION
If we wish to do an internally hosted pre-release of Wire we cannot publish the podspec today because the `curl` command is hardcoded to the publicly hosted maven global.

A new env variable can be used to adjust this for performing internal releases. We wish not expose our internal URL so configuring it via ENV variable makes sense.

It's best for folks who wish to do internal releases of Wire to use `--use-json` always instead of publishing the Ruby podspec as it won't work today.