### PR TITLE
Only add ProtoTarget output to resources, not sources

### DIFF
--- a/wire-gradle-plugin-playground/build.gradle.kts
+++ b/wire-gradle-plugin-playground/build.gradle.kts
@@ -13,6 +13,8 @@ class MyEventListenerFactory : EventListener.Factory {
 }
 
 wire {
+  protoLibrary = true
+
   sourcePath {
     srcDir("src/main/proto")
   }

--- a/wire-gradle-plugin/api/wire-gradle-plugin.api
+++ b/wire-gradle-plugin/api/wire-gradle-plugin.api
@@ -200,6 +200,7 @@ public abstract class com/squareup/wire/gradle/WireTask : org/gradle/api/tasks/S
 	public final fun getPermitPackageCycles ()Lorg/gradle/api/provider/Property;
 	public final fun getPluginVersion ()Lorg/gradle/api/provider/Property;
 	public abstract fun getProjectDirProperty ()Lorg/gradle/api/file/DirectoryProperty;
+	public abstract fun getProtoLibraryOutput ()Lorg/gradle/api/file/DirectoryProperty;
 	public abstract fun getPrunes ()Lorg/gradle/api/provider/ListProperty;
 	public final fun getRejectUnusedRootsOrPrunes ()Lorg/gradle/api/provider/Property;
 	public abstract fun getRoots ()Lorg/gradle/api/provider/ListProperty;

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -37,6 +37,7 @@ import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectories
+import org.gradle.api.tasks.OutputDirectory
 import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.SkipWhenEmpty
@@ -48,6 +49,10 @@ abstract class WireTask @Inject constructor(objects: ObjectFactory) : SourceTask
 
   @get:OutputDirectories
   abstract val outputDirectories: ConfigurableFileCollection
+
+  @get:Optional
+  @get:OutputDirectory
+  abstract val protoLibraryOutput: DirectoryProperty
 
   @get:Input
   val pluginVersion: Property<String> = objects.property(String::class.java)


### PR DESCRIPTION
And vice versa. Should fix a bunch a bugs where one of the folder were treated in the other form and the IDE would go red and not resolve anything.

![image](https://github.com/square/wire/assets/1767669/b906a4c0-7630-4db3-83af-f5fa49d954be)
