### PR TITLE
feat: Adjust Gradle plugin `outputs` to be computed lazily

### DIFF
--- a/wire-gradle-plugin-playground/build.gradle.kts
+++ b/wire-gradle-plugin-playground/build.gradle.kts
@@ -8,9 +8,12 @@ plugins {
 
 class MyEventListenerFactory : EventListener.Factory {
   override fun create(): EventListener {
-    return object: EventListener() {}
+    return object : EventListener() {}
   }
 }
+
+val outputDirectory = objects.property<String>()
+outputDirectory.set("$buildDir/something-wrong")
 
 wire {
   protoLibrary = true
@@ -22,8 +25,11 @@ wire {
   eventListenerFactory(MyEventListenerFactory())
 
   kotlin {
+    out = outputDirectory.orNull
   }
 }
+
+outputDirectory.set(null as String?)
 
 dependencies {
   implementation(projects.wireGrpcClient)

--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -53,12 +53,15 @@ if (project.rootProject.name == "wire") {
 }
 
 dependencies {
+  implementation(gradleKotlinDsl())
+
   implementation(projects.wireCompiler)
   implementation(projects.wireKotlinGenerator)
   implementation(libs.swiftpoet)
   implementation(libs.okio.fakefilesystem)
 
   compileOnly(gradleApi())
+
   implementation(libs.pluginz.kotlin)
   compileOnly(libs.pluginz.android)
 
@@ -87,7 +90,7 @@ val test by tasks.getting(Test::class) {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      GradlePlugin(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      GradlePlugin(javadocJar = Dokka("dokkaGfm"), sourcesJar = true),
     )
   }
 }

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -31,7 +31,7 @@ import javax.inject.Inject
  * as destination directories and configuration options). This includes registering output
  * directories with the project so they can be compiled after they are generated.
  */
-abstract class WireOutput {
+sealed class WireOutput {
   /** Set this to override the default output directory for this [WireOutput]. */
   var out: String? = null
 

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -67,7 +67,8 @@ class WirePluginTest {
     getOutputDirectories(File("src/test/projects")).forEach(::unsafeDelete)
   }
 
-  @Test fun versionIsExposed() {
+  @Test
+  fun versionIsExposed() {
     assertThat(VERSION).isNotNull()
   }
 
@@ -1322,6 +1323,30 @@ class WirePluginTest {
     assertThat(notExpected).doesNotExist()
 
     ZipFile(File(fixtureRoot, "geology/build/libs/geology.jar")).use {
+      assertThat(it.getEntry("squareup/geology/period.proto")).isNotNull()
+    }
+  }
+
+  @Test
+  fun allowLazySetOutputDirectory() {
+    val fixtureRoot = File("src/test/projects/lazy-set-target-out-from-property")
+
+    val result = gradleRunner.runFixture(fixtureRoot) {
+      withArguments("build", "--stacktrace", "--info").build()
+    }
+
+    assertThat(result.task(":generateMainProtos")?.outcome)
+      .isIn(TaskOutcome.SUCCESS, TaskOutcome.UP_TO_DATE)
+    val generatedProto1 = fixtureRoot.resolve("build/right/com/squareup/dinosaurs/Dinosaur.kt")
+    val generatedProto2 = fixtureRoot.resolve("build/right/com/squareup/geology/Period.kt")
+    assertThat(generatedProto1).exists()
+    assertThat(generatedProto2).exists()
+
+    val notExpected = fixtureRoot.resolve("build/wrong")
+    assertThat(notExpected).doesNotExist()
+
+    ZipFile(fixtureRoot.resolve("build/libs/lazy-set-target-out-from-property.jar")).use {
+      assertThat(it.getEntry("squareup/dinosaurs/dinosaur.proto")).isNotNull()
       assertThat(it.getEntry("squareup/geology/period.proto")).isNotNull()
     }
   }

--- a/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/build.gradle
@@ -1,0 +1,37 @@
+plugins {
+    id 'application'
+    id 'org.jetbrains.kotlin.jvm'
+    id 'com.squareup.wire'
+}
+
+mainClassName = 'com.squareup.dinosaurs.Sample'
+
+repositories {
+    maven {
+        url "file://${projectDir.absolutePath}/../../../../../build/localMaven"
+    }
+    mavenCentral()
+}
+
+dependencies {
+    implementation "com.squareup.wire:wire-runtime:$VERSION_NAME"
+}
+
+def outputLocation = objects.property(String)
+outputLocation.set("$buildDir/wrong")
+
+wire {
+    protoLibrary = true
+
+    kotlin {
+        out = outputLocation.orNull
+    }
+}
+
+outputLocation.set("$buildDir/right")
+
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}

--- a/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/src/main/java/com/squareup/dinosaurs/Sample.kt
+++ b/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/src/main/java/com/squareup/dinosaurs/Sample.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.dinosaurs
+
+import com.squareup.geology.Period
+import java.io.IOException
+import okio.ByteString.Companion.toByteString
+
+class Sample {
+  @Throws(IOException::class)
+  fun run() {
+    // Create an immutable value object with the Builder API.
+    val stegosaurus = Dinosaur(
+      name = "Stegosaurus",
+      period = Period.JURASSIC,
+      length_meters = 9.0,
+      mass_kilograms = 5_000.0,
+      picture_urls = listOf("http://goo.gl/LD5KY5", "http://goo.gl/VYRM67"),
+    )
+    // Encode that value to bytes, and print that as base64.
+    val stegosaurusEncoded = Dinosaur.ADAPTER.encode(stegosaurus)
+    println(stegosaurusEncoded.toByteString().base64())
+  }
+
+  companion object {
+    @Throws(IOException::class)
+    @JvmStatic
+    fun main(args: Array<String>) {
+      Sample().run()
+    }
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/src/main/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/src/main/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/lazy-set-target-out-from-property/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
At Faire, we have Gradle convention plugins in use to share common configuration of our many (~50) protobuf projects. To do this, we leverage a [Gradle Convention plugin](https://docs.gradle.org/current/samples/sample_convention_plugins.html) to wrap our common settings. One issue we have is that we want to make the `out` directory configurable by scripts, but due to how Wire requires computation at wire configuration time, it is not possible.

This PR moves the computation of targets to be wrapped in a `ListProperty<>` and pushes the execution of `Action<>` to be when tasks are configured. The `plugin-playground` project shows a simplified case.

All of the non-test changes are to lazily compute values via providers.