### PR TITLE
Disable Dokka

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -6,8 +6,8 @@ buildscript {
   dependencies {
     classpath(libs.pluginz.kotlin)
     classpath(libs.vanniktechPublishPlugin)
-    classpath(libs.dokka.core)
-    classpath(libs.dokka.gradlePlugin)
+    // classpath(libs.dokka.core)
+    // classpath(libs.dokka.gradlePlugin)
     classpath(libs.pluginz.buildConfig)
     classpath(libs.pluginz.spotless)
     classpath(libs.pluginz.kotlinSerialization)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,15 +8,15 @@ import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
-import org.jetbrains.dokka.gradle.DokkaTask
+// import org.jetbrains.dokka.gradle.DokkaTask
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootExtension
 import org.jetbrains.kotlin.gradle.targets.js.nodejs.NodeJsRootPlugin
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   dependencies {
-    classpath(libs.dokka.core)
-    classpath(libs.dokka.gradlePlugin)
+    // classpath(libs.dokka.core)
+    // classpath(libs.dokka.gradlePlugin)
     classpath(libs.pluginz.android)
     classpath(libs.pluginz.binaryCompatibilityValidator)
     classpath(libs.pluginz.kotlin)
@@ -165,20 +165,20 @@ allprojects {
     }
   }
 
-  tasks.withType<DokkaTask>().configureEach {
-    dokkaSourceSets.configureEach {
-      reportUndocumented.set(false)
-      skipDeprecated.set(true)
-      jdkVersion.set(8)
-      perPackageOption {
-        matchingRegex.set("com\\.squareup\\.wire\\.internal.*")
-        suppress.set(true)
-      }
-    }
-    if (name == "dokkaGfm") {
-      outputDirectory.set(project.file("${project.rootDir}/docs/3.x"))
-    }
-  }
+  // tasks.withType<DokkaTask>().configureEach {
+  //   dokkaSourceSets.configureEach {
+  //     reportUndocumented.set(false)
+  //     skipDeprecated.set(true)
+  //     jdkVersion.set(8)
+  //     perPackageOption {
+  //       matchingRegex.set("com\\.squareup\\.wire\\.internal.*")
+  //       suppress.set(true)
+  //     }
+  //   }
+  //   if (name == "dokkaGfm") {
+  //     outputDirectory.set(project.file("${project.rootDir}/docs/3.x"))
+  //   }
+  // }
 
   plugins.withId("com.vanniktech.maven.publish.base") {
     configure<PublishingExtension> {

--- a/wire-compiler/build.gradle.kts
+++ b/wire-compiler/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -7,7 +7,8 @@ plugins {
   application
   kotlin("jvm")
   id("org.jetbrains.kotlin.plugin.serialization")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.github.johnrengelman.shadow").apply(false)
   id("com.vanniktech.maven.publish.base").apply(false)
 }
@@ -45,7 +46,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.gradle.publish.PluginBundleExtension
 import com.vanniktech.maven.publish.GradlePlugin
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -16,7 +16,8 @@ plugins {
   id("com.github.gmazzo.buildconfig")
   id("java-gradle-plugin")
   id("com.gradle.plugin-publish").version("0.18.0").apply(false)
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -87,7 +88,7 @@ val test by tasks.getting(Test::class) {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      GradlePlugin(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      GradlePlugin(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-grpc-client/build.gradle.kts
+++ b/wire-grpc-client/build.gradle.kts
@@ -1,10 +1,11 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("multiplatform")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -91,7 +92,7 @@ repositories.whenObjectAdded {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
+      KotlinMultiplatform(javadocJar = Javadoc())
     )
   }
 }

--- a/wire-grpc-server-generator/build.gradle.kts
+++ b/wire-grpc-server-generator/build.gradle.kts
@@ -1,12 +1,13 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   id("java-library")
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -39,7 +40,7 @@ sourceSets {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-grpc-server/build.gradle.kts
+++ b/wire-grpc-server/build.gradle.kts
@@ -1,11 +1,12 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   id("java-library")
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -37,7 +38,7 @@ sourceSets {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-gson-support/build.gradle.kts
+++ b/wire-gson-support/build.gradle.kts
@@ -1,11 +1,12 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -15,7 +16,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-java-generator/build.gradle.kts
+++ b/wire-java-generator/build.gradle.kts
@@ -1,11 +1,12 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   id("java-library")
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -31,7 +32,7 @@ dependencies {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-kotlin-generator/build.gradle.kts
+++ b/wire-kotlin-generator/build.gradle.kts
@@ -1,11 +1,12 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   id("java-library")
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -30,7 +31,7 @@ dependencies {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-moshi-adapter/build.gradle.kts
+++ b/wire-moshi-adapter/build.gradle.kts
@@ -1,11 +1,12 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -15,7 +16,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-reflector/build.gradle.kts
+++ b/wire-reflector/build.gradle.kts
@@ -1,11 +1,12 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   id("java-library")
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -15,7 +16,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }

--- a/wire-runtime/build.gradle.kts
+++ b/wire-runtime/build.gradle.kts
@@ -1,12 +1,13 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("multiplatform")
   id("com.github.gmazzo.buildconfig")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -156,7 +157,7 @@ buildConfig {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
+      KotlinMultiplatform(javadocJar = Javadoc())
     )
   }
 

--- a/wire-schema-tests/build.gradle.kts
+++ b/wire-schema-tests/build.gradle.kts
@@ -1,11 +1,12 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("multiplatform")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -68,7 +69,7 @@ kotlin {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
+      KotlinMultiplatform(javadocJar = Javadoc())
     )
   }
 }

--- a/wire-schema/build.gradle.kts
+++ b/wire-schema/build.gradle.kts
@@ -1,11 +1,12 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("multiplatform")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -74,7 +75,7 @@ kotlin {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
+      KotlinMultiplatform(javadocJar = Javadoc())
     )
   }
 

--- a/wire-swift-generator/build.gradle.kts
+++ b/wire-swift-generator/build.gradle.kts
@@ -1,11 +1,12 @@
-import com.vanniktech.maven.publish.JavadocJar.Dokka
+import com.vanniktech.maven.publish.JavadocJar.Javadoc
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   id("java-library")
   kotlin("jvm")
-  id("org.jetbrains.dokka")
+  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
+  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 
@@ -22,7 +23,7 @@ dependencies {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
+      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
     )
   }
 }


### PR DESCRIPTION
Probably related to https://github.com/Kotlin/dokka/issues/2977

We're getting errors like

```
* What went wrong:
A problem was found with the configuration of task ':wire-gradle-plugin:dokkaJavadocJar' (type 'JavadocJar').
  - Gradle detected a problem with the following location: '/Users/runner/work/wire/wire/docs/3.x'.
    
    Reason: Task ':wire-gradle-plugin:dokkaJavadocJar' uses this output of task ':wire-compiler:dokkaGfm' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':wire-compiler:dokkaGfm' as an input of ':wire-gradle-plugin:dokkaJavadocJar'.
      2. Declare an explicit dependency on ':wire-compiler:dokkaGfm' from ':wire-gradle-plugin:dokkaJavadocJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':wire-compiler:dokkaGfm' from ':wire-gradle-plugin:dokkaJavadocJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.2.1/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.

* Try:
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org./

* Exception is:
org.gradle.internal.execution.WorkValidationException: A problem was found with the configuration of task ':wire-gradle-plugin:dokkaJavadocJar' (type 'JavadocJar').
  - Gradle detected a problem with the following location: '/Users/runner/work/wire/wire/docs/3.x'.
    
    Reason: Task ':wire-gradle-plugin:dokkaJavadocJar' uses this output of task ':wire-compiler:dokkaGfm' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':wire-compiler:dokkaGfm' as an input of ':wire-gradle-plugin:dokkaJavadocJar'.
      2. Declare an explicit dependency on ':wire-compiler:dokkaGfm' from ':wire-gradle-plugin:dokkaJavadocJar' using Task#dependsOn.
      3. Declare an explicit dependency on ':wire-compiler:dokkaGfm' from ':wire-gradle-plugin:dokkaJavadocJar' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.2.1/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
	at org.gradle.internal.execution.WorkValidationException$BuilderWithSummary.build(WorkValidationException.java:133)
```