### PR TITLE
Adding explicit deps to javadoc from metadata to please plugin publish

### DIFF
--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -82,6 +82,12 @@ if (project.rootProject.name == "wire") {
   }
 }
 
+  tasks.all {
+    if (name == "generateMetadataFileForPluginMavenPublication") {
+      dependsOn("simpleJavadocJar")
+    }
+  }
+
 buildConfig {
   useKotlinOutput {
     internalVisibility = true

--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -84,6 +84,7 @@ if (project.rootProject.name == "wire") {
 
   tasks.all {
     if (name == "generateMetadataFileForPluginMavenPublication") {
+      // We please the plugin-publish plugin which complains about missing explicit dependency between the two tasks.
       dependsOn("simpleJavadocJar")
     }
   }


### PR DESCRIPTION
To address
```
* What went wrong:
A problem was found with the configuration of task ':wire-gradle-plugin:simpleJavadocJar' (type 'JavadocJar').
  - Gradle detected a problem with the following location: '/Users/runner/work/wire/wire/wire-gradle-plugin/build/libs/wire-gradle-plugin-4.9.0-SNAPSHOT-javadoc.jar'.
    
    Reason: Task ':wire-gradle-plugin:generateMetadataFileForPluginMavenPublication' uses this output of task ':wire-gradle-plugin:simpleJavadocJar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':wire-gradle-plugin:simpleJavadocJar' as an input of ':wire-gradle-plugin:generateMetadataFileForPluginMavenPublication'.
      2. Declare an explicit dependency on ':wire-gradle-plugin:simpleJavadocJar' from ':wire-gradle-plugin:generateMetadataFileForPluginMavenPublication' using Task#dependsOn.
      3. Declare an explicit dependency on ':wire-gradle-plugin:simpleJavadocJar' from ':wire-gradle-plugin:generateMetadataFileForPluginMavenPublication' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.3/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.
```