### PR TITLE
Remove Vanniktech per module configuration

### DIFF
--- a/build-support/build.gradle.kts
+++ b/build-support/build.gradle.kts
@@ -6,8 +6,7 @@ buildscript {
   dependencies {
     classpath(libs.pluginz.kotlin)
     classpath(libs.vanniktechPublishPlugin)
-    // classpath(libs.dokka.core)
-    // classpath(libs.dokka.gradlePlugin)
+    classpath(libs.pluginz.dokka)
     classpath(libs.pluginz.buildConfig)
     classpath(libs.pluginz.spotless)
     classpath(libs.pluginz.kotlinSerialization)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ import kotlinx.validation.ApiValidationExtension
 import org.gradle.api.tasks.testing.logging.TestExceptionFormat
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.PASSED
+import org.jetbrains.dokka.gradle.DokkaTaskPartial
 import org.gradle.api.tasks.testing.logging.TestLogEvent.SKIPPED
 import org.gradle.api.tasks.testing.logging.TestLogEvent.STARTED
 // import org.jetbrains.dokka.gradle.DokkaTask
@@ -15,8 +16,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 buildscript {
   dependencies {
-    // classpath(libs.dokka.core)
-    // classpath(libs.dokka.gradlePlugin)
+    classpath(libs.pluginz.dokka)
     classpath(libs.pluginz.android)
     classpath(libs.pluginz.binaryCompatibilityValidator)
     classpath(libs.pluginz.kotlin)
@@ -45,6 +45,7 @@ rootProject.plugins.withType(NodeJsRootPlugin::class) {
 }
 
 apply(plugin = "com.vanniktech.maven.publish.base")
+apply(plugin = "org.jetbrains.dokka")
 
 allprojects {
   group = project.property("GROUP") as String
@@ -153,6 +154,21 @@ subprojects {
         sourceSets = listOf(project.extensions.getByType<SourceSetContainer>()["main"])
       }
     }
+
+    apply(plugin = "org.jetbrains.dokka")
+
+    tasks.withType<DokkaTaskPartial>().configureEach {
+      outputDirectory.set(project.file("${project.rootDir}/docs/3.x"))
+      dokkaSourceSets.configureEach {
+          reportUndocumented.set(false)
+          skipDeprecated.set(true)
+          jdkVersion.set(8)
+          perPackageOption {
+            matchingRegex.set("com\\.squareup\\.wire.*\\.internal.*")
+            suppress.set(true)
+          }
+      }
+    }
   }
 }
 
@@ -165,27 +181,12 @@ allprojects {
     }
   }
 
-  // tasks.withType<DokkaTask>().configureEach {
-  //   dokkaSourceSets.configureEach {
-  //     reportUndocumented.set(false)
-  //     skipDeprecated.set(true)
-  //     jdkVersion.set(8)
-  //     perPackageOption {
-  //       matchingRegex.set("com\\.squareup\\.wire\\.internal.*")
-  //       suppress.set(true)
-  //     }
-  //   }
-  //   if (name == "dokkaGfm") {
-  //     outputDirectory.set(project.file("${project.rootDir}/docs/3.x"))
-  //   }
-  // }
-
   plugins.withId("com.vanniktech.maven.publish.base") {
     configure<PublishingExtension> {
       repositories {
         maven {
           name = "test"
-          setUrl("file://${project.rootProject.buildDir}/localMaven")
+          setUrl("file://${project.rootProject.layout.buildDirectory.dir("localMaven").get().asFile.path}")
         }
         /**
          * Want to push to an internal repository for testing?

--- a/deploy_website.sh
+++ b/deploy_website.sh
@@ -21,17 +21,7 @@ git clone $REPO $DIR
 cd $DIR
 
 # Generate the API docs
-./gradlew \
-    :wire-grpc-client:dokkaGfm \
-    :wire-moshi-adapter:dokkaGfm \
-    :wire-runtime:dokkaGfm \
-    :wire-compiler:dokkaGfm \
-    :wire-gson-support:dokkaGfm \
-    :wire-java-generator:dokkaGfm \
-    :wire-kotlin-generator:dokkaGfm \
-    :wire-reflector:dokkaGfm \
-    :wire-schema:dokkaGfm \
-    :wire-swift-generator:dokkaGfm
+./gradlew dokkaGfmMultiModule
 
 # Fix *.md links to point to where the docs live under Mkdocs.
 # Linux
@@ -44,7 +34,6 @@ sed -i "" 's/docs\/wire_grpc.md/wire_grpc/' README.md
 cat README.md | grep -v 'project website' > docs/index.md
 cp CHANGELOG.md docs/changelog.md
 cp CONTRIBUTING.md docs/contributing.md
-cp RELEASING.md docs/releasing.md
 
 # Build the site and push the new files up to GitHub
 mkdocs gh-deploy

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,8 +32,6 @@ androidx-ktx = { module = "androidx.core:core-ktx", version = "1.10.1" }
 assertj = { module = "org.assertj:assertj-core", version.ref = "assertj" }
 checker-qual = { module = "org.checkerframework:checker-qual", version.ref = "checkerQual" }
 contour = { module = "app.cash.contour:contour", version = "1.1.0" }
-dokka-core = { module = "org.jetbrains.dokka:dokka-core", version.ref = "dokka" }
-dokka-gradlePlugin = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 googleJavaFormat = "com.google.googlejavaformat:google-java-format:1.17.0"
 grpc-genJava = { module = "io.grpc:protoc-gen-grpc-java", version.ref = "grpc" }
 grpc-netty = { module = "io.grpc:grpc-netty", version.ref = "grpc" }
@@ -73,6 +71,7 @@ okio-fakefilesystem = { module = "com.squareup.okio:okio-fakefilesystem", versio
 #  if we ever wanna migrate to this.
 pluginz-android = { module = "com.android.tools.build:gradle", version = "8.1.1" }
 pluginz-binaryCompatibilityValidator = { module = "org.jetbrains.kotlinx.binary-compatibility-validator:org.jetbrains.kotlinx.binary-compatibility-validator.gradle.plugin", version = "0.13.2" }
+pluginz-dokka = { module = "org.jetbrains.dokka:dokka-gradle-plugin", version.ref = "dokka" }
 pluginz-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin" }
 pluginz-kotlinSerialization = { module = "org.jetbrains.kotlin:kotlin-serialization", version.ref = "kotlin" }
 pluginz-shadow = { module = "com.github.johnrengelman:shadow", version = "8.1.1" }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -5,7 +5,7 @@ site_description: "gRPC and protocol buffers for Android, Kotlin, and Java."
 site_author: Square, Inc.
 remote_branch: gh-pages
 
-copyright: 'Copyright &copy; 2019 Square, Inc.'
+copyright: 'Copyright &copy; 2023 Square, Inc.'
 
 theme:
   name: 'material'
@@ -42,15 +42,17 @@ nav:
   - 'Stack Overflow ⏏': https://stackoverflow.com/questions/tagged/square-wire?sort=active
   - '3.x API':
     - 'wire-compiler': 3.x/wire-compiler/com.squareup.wire/index.md
+    - 'wire-gradle-plugin': 3.x/wire-gradle-plugin/com.squareup.wire.gradle/index.md
     - 'wire-grpc-client': 3.x/wire-grpc-client/com.squareup.wire/index.md
     - 'wire-gson-support': 3.x/wire-gson-support/com.squareup.wire/index.md
-    - 'wire-java-generator': 3.x/wire-java-generator/com.squareup.wire/index.md
-    - 'wire-kotlin-generator': 3.x/wire-kotlin-generator/com.squareup.wire/index.md
+    - 'wire-java-generator': 3.x/wire-java-generator/com.squareup.wire.java/index.md
+    - 'wire-kotlin-generator': 3.x/wire-kotlin-generator/com.squareup.wire.kotlin/index.md
     - 'wire-moshi-adapter': 3.x/wire-moshi-adapter/com.squareup.wire/index.md
-    - 'wire-reflector': 3.x/wire-reflector/com.squareup.wire/index.md
+    - 'wire-reflector': 3.x/wire-reflector/com.squareup.wire.reflector/index.md
     - 'wire-runtime': 3.x/wire-runtime/com.squareup.wire/index.md
-    - 'wire-schema': 3.x/wire-schema/com.squareup.wire/index.md
-    - 'wire-swift-generator': 3.x/wire-swift-generator/com.squareup.wire/index.md
+    - 'wire-schema': 3.x/wire-schema/com.squareup.wire.schema/index.md
+    - 'wire-schema-tests': 3.x/wire-schema-tests/com.squareup.wire/index.md
+    - 'wire-swift-generator': 3.x/wire-swift-generator/com.squareup.wire.swift/index.md
   - '2.x API':
     - 'wire-gson-support ⏏': https://square.github.io/wire/2.x/wire-gson-support/
     - 'wire-runtime ⏏': https://square.github.io/wire/2.x/wire-runtime/

--- a/wire-compiler/build.gradle.kts
+++ b/wire-compiler/build.gradle.kts
@@ -7,8 +7,6 @@ plugins {
   application
   kotlin("jvm")
   id("org.jetbrains.kotlin.plugin.serialization")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.github.johnrengelman.shadow").apply(false)
   id("com.vanniktech.maven.publish.base").apply(false)
 }

--- a/wire-compiler/build.gradle.kts
+++ b/wire-compiler/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -43,7 +43,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -1,6 +1,6 @@
 import com.gradle.publish.PluginBundleExtension
 import com.vanniktech.maven.publish.GradlePlugin
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
@@ -71,21 +71,6 @@ val test by tasks.getting(Test::class) {
   systemProperty("kjs", System.getProperty("kjs"))
   systemProperty("knative", System.getProperty("knative"))
 }
-
-if (project.rootProject.name == "wire") {
-  configure<MavenPublishBaseExtension> {
-    configure(
-      GradlePlugin(javadocJar = Javadoc(), sourcesJar = true)
-    )
-  }
-}
-
-  tasks.all {
-    if (name == "generateMetadataFileForPluginMavenPublication") {
-      // We please the plugin-publish plugin which complains about missing explicit dependency between the two tasks.
-      dependsOn("simpleJavadocJar")
-    }
-  }
 
 buildConfig {
   useKotlinOutput {

--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -16,8 +16,6 @@ plugins {
   id("com.github.gmazzo.buildconfig")
   id("java-gradle-plugin")
   id("com.gradle.plugin-publish").version("1.2.1").apply(false)
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-grpc-client/build.gradle.kts
+++ b/wire-grpc-client/build.gradle.kts
@@ -4,8 +4,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("multiplatform")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-grpc-client/build.gradle.kts
+++ b/wire-grpc-client/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -90,7 +90,7 @@ repositories.whenObjectAdded {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Javadoc())
+      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
     )
   }
 }

--- a/wire-grpc-server-generator/build.gradle.kts
+++ b/wire-grpc-server-generator/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -38,7 +38,7 @@ sourceSets {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-grpc-server-generator/build.gradle.kts
+++ b/wire-grpc-server-generator/build.gradle.kts
@@ -6,8 +6,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
   id("java-library")
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-grpc-server/build.gradle.kts
+++ b/wire-grpc-server/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -37,7 +37,7 @@ sourceSets {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-grpc-server/build.gradle.kts
+++ b/wire-grpc-server/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
   id("java-library")
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-gson-support/build.gradle.kts
+++ b/wire-gson-support/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -14,7 +14,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-gson-support/build.gradle.kts
+++ b/wire-gson-support/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-java-generator/build.gradle.kts
+++ b/wire-java-generator/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -30,7 +30,7 @@ dependencies {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-java-generator/build.gradle.kts
+++ b/wire-java-generator/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
   id("java-library")
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-kotlin-generator/build.gradle.kts
+++ b/wire-kotlin-generator/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
   id("java-library")
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-kotlin-generator/build.gradle.kts
+++ b/wire-kotlin-generator/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -28,7 +28,7 @@ dependencies {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-moshi-adapter/build.gradle.kts
+++ b/wire-moshi-adapter/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -14,7 +14,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-moshi-adapter/build.gradle.kts
+++ b/wire-moshi-adapter/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-reflector/build.gradle.kts
+++ b/wire-reflector/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
   id("java-library")
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-reflector/build.gradle.kts
+++ b/wire-reflector/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -14,7 +14,7 @@ if (project.rootProject.name == "wire") {
 
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-runtime/build.gradle.kts
+++ b/wire-runtime/build.gradle.kts
@@ -6,8 +6,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
   kotlin("multiplatform")
   id("com.github.gmazzo.buildconfig")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-runtime/build.gradle.kts
+++ b/wire-runtime/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -155,7 +155,7 @@ buildConfig {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Javadoc())
+      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
     )
   }
 

--- a/wire-schema-tests/build.gradle.kts
+++ b/wire-schema-tests/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("multiplatform")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-schema-tests/build.gradle.kts
+++ b/wire-schema-tests/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
@@ -67,7 +67,7 @@ kotlin {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Javadoc())
+      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
     )
   }
 }

--- a/wire-schema/build.gradle.kts
+++ b/wire-schema/build.gradle.kts
@@ -1,5 +1,5 @@
 import com.diffplug.gradle.spotless.SpotlessExtension
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -73,7 +73,7 @@ kotlin {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinMultiplatform(javadocJar = Javadoc())
+      KotlinMultiplatform(javadocJar = Dokka("dokkaGfm"))
     )
   }
 

--- a/wire-schema/build.gradle.kts
+++ b/wire-schema/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
 plugins {
   kotlin("multiplatform")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 

--- a/wire-swift-generator/build.gradle.kts
+++ b/wire-swift-generator/build.gradle.kts
@@ -1,4 +1,4 @@
-import com.vanniktech.maven.publish.JavadocJar.Javadoc
+import com.vanniktech.maven.publish.JavadocJar.Dokka
 import com.vanniktech.maven.publish.KotlinJvm
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
 
@@ -21,7 +21,7 @@ dependencies {
 if (project.rootProject.name == "wire") {
   configure<MavenPublishBaseExtension> {
     configure(
-      KotlinJvm(javadocJar = Javadoc(), sourcesJar = true)
+      KotlinJvm(javadocJar = Dokka("dokkaGfm"), sourcesJar = true)
     )
   }
 }

--- a/wire-swift-generator/build.gradle.kts
+++ b/wire-swift-generator/build.gradle.kts
@@ -5,8 +5,6 @@ import com.vanniktech.maven.publish.MavenPublishBaseExtension
 plugins {
   id("java-library")
   kotlin("jvm")
-  // TODO(Benoit)  Re-enable dokka when it works again. Probably related to https://github.com/Kotlin/dokka/issues/2977
-  // id("org.jetbrains.dokka")
   id("com.vanniktech.maven.publish.base").apply(false)
 }
 


### PR DESCRIPTION
I don't think we need them? And the one in gradle-plugin was making the plugin publishing fail. Removing for now, and we'll add again if it happened to be needed