### PR TITLE
Never prune descriptor.proto fileOptions if internal types are marked

### DIFF
--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -422,6 +422,8 @@ public final class com/squareup/wire/schema/Location$Companion {
 public final class com/squareup/wire/schema/MarkSet {
 	public static final field Companion Lcom/squareup/wire/schema/MarkSet$Companion;
 	public fun <init> (Lcom/squareup/wire/schema/PruningRules;)V
+	public fun <init> (Lcom/squareup/wire/schema/PruningRules;Lcom/squareup/wire/schema/Schema;)V
+	public synthetic fun <init> (Lcom/squareup/wire/schema/PruningRules;Lcom/squareup/wire/schema/Schema;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun contains (Lcom/squareup/wire/schema/ProtoMember;)Z
 	public final fun contains (Lcom/squareup/wire/schema/ProtoType;)Z
 	public final fun getMembers ()Ljava/util/Map;


### PR DESCRIPTION
Some repo were pruning `descriptor.proto` and add it to a Jar (whatever) but Wire would produce corrupted files where all types were not resolvable. Now, we don't let this happen.