### PR TITLE
Allow setting up a custom logger in WireCompiler

### DIFF
--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -12,6 +12,10 @@ public final class com/squareup/wire/WireLogger$Companion {
 	public final fun getNONE ()Lcom/squareup/wire/WireLogger;
 }
 
+public abstract interface class com/squareup/wire/WireLogger$Factory : java/io/Serializable {
+	public abstract fun create ()Lcom/squareup/wire/WireLogger;
+}
+
 public final class com/squareup/wire/schema/AdapterConstant {
 	public static final field Companion Lcom/squareup/wire/schema/AdapterConstant$Companion;
 	public final field javaClassName Lcom/squareup/javapoet/ClassName;
@@ -974,6 +978,10 @@ public final class com/squareup/wire/schema/Type$Companion {
 	public final fun fromElements (Ljava/lang/String;Ljava/util/List;Lcom/squareup/wire/Syntax;)Ljava/util/List;
 	public final fun get (Ljava/util/List;Lcom/squareup/wire/schema/ProtoType;Lcom/squareup/wire/schema/internal/parser/TypeElement;Lcom/squareup/wire/Syntax;)Lcom/squareup/wire/schema/Type;
 	public final fun toElements (Ljava/util/List;)Ljava/util/List;
+}
+
+public final class com/squareup/wire/schema/WireLoggersKt {
+	public static final fun newLoggerFactory (Ljava/lang/String;)Lcom/squareup/wire/WireLogger$Factory;
 }
 
 public final class com/squareup/wire/schema/WireRun {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/WireLogger.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/WireLogger.kt
@@ -15,6 +15,7 @@
  */
 package com.squareup.wire
 
+import com.squareup.wire.internal.Serializable
 import com.squareup.wire.schema.ProtoType
 import okio.Path
 
@@ -93,6 +94,11 @@ interface WireLogger {
    */
   // TODO(Benoit) We could pass the target name or something which makes it identifiable.
   fun unusedExcludesInTarget(unusedExcludes: Set<String>)
+
+  /** Implementations of this interface must have a no-arguments public constructor. */
+  fun interface Factory : Serializable {
+    fun create(): WireLogger
+  }
 
   companion object {
     val NONE = object : WireLogger {

--- a/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/WireLoggers.kt
+++ b/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/WireLoggers.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import com.squareup.wire.WireLogger
+
+/**
+ * Create and return an instance of [WireLogger.Factory].
+ *
+ * @param loggerFactoryClass a fully qualified class name for a class that implements [WireLogger.Factory]. The
+ * class must have a no-arguments public constructor.
+ */
+fun newLoggerFactory(loggerFactoryClass: String): WireLogger.Factory {
+  return ClassNameLoggerFactory(loggerFactoryClass)
+}
+
+/**
+ * This logger factory is serializable (so Gradle can cache targets that use it). It works even if the delegate logger
+ * class is itself not serializable.
+ */
+private class ClassNameLoggerFactory(
+  private val loggerFactoryClass: String,
+) : WireLogger.Factory {
+  @Transient
+  private var cachedDelegate: WireLogger.Factory? = null
+
+  private val delegate: WireLogger.Factory
+    get() {
+      val cachedResult = cachedDelegate
+      if (cachedResult != null) return cachedResult
+
+      val wireLoggerType = try {
+        Class.forName(loggerFactoryClass)
+      } catch (exception: ClassNotFoundException) {
+        throw IllegalArgumentException("Couldn't find LoggerClass '$loggerFactoryClass'")
+      }
+
+      val constructor = try {
+        wireLoggerType.getConstructor()
+      } catch (exception: NoSuchMethodException) {
+        throw IllegalArgumentException("No public constructor on $loggerFactoryClass")
+      }
+
+      val result = constructor.newInstance() as? WireLogger.Factory
+        ?: throw IllegalArgumentException("$loggerFactoryClass does not implement WireLogger.Factory")
+      this.cachedDelegate = result
+      return result
+    }
+
+  override fun create(): WireLogger {
+    return delegate.create()
+  }
+}


### PR DESCRIPTION
Brought back some code of #2486 which got reverted later on.
Dimitris needs it for the Bazel integration.