### PR TITLE
Add explicit overloads for getters/setters

### DIFF
--- a/wire-runtime-swift/src/main/swift/propertyWrappers/CopyOnWrite.swift
+++ b/wire-runtime-swift/src/main/swift/propertyWrappers/CopyOnWrite.swift
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// A property wrapper which allows easily implementing Copy-on-Write for value types.
+@propertyWrapper
+public struct CopyOnWrite<Value> {
+
+    /// The underlying value represented by the property wrapper.
+    ///
+    /// When writing to the the property, the property wrapper will
+    /// perform copy-on-write by utilizing `isKnownUniquelyReferenced`
+    /// to make a copy of the underlying storage.
+    public var wrappedValue: Value {
+        get {
+            storage.value
+        }
+
+        set {
+            if isKnownUniquelyReferenced(&storage) {
+                storage.value = newValue
+            } else {
+                storage = Storage(newValue)
+            }
+        }
+    }
+
+    /// The reference type which holds onto our data.
+    private var storage: Storage
+
+    /// Creates a new property wrapper with the provided value.
+    public init(wrappedValue: Value) {
+        storage = Storage(wrappedValue)
+    }
+}
+
+// MARK: - Equatable
+
+extension CopyOnWrite : Equatable where Value : Equatable {
+    public static func == (lhs: CopyOnWrite, rhs: CopyOnWrite) -> Bool {
+        lhs.wrappedValue == rhs.wrappedValue
+    }
+}
+
+// MARK: - Hashable
+
+extension CopyOnWrite : Hashable where Value : Hashable {
+    public func hash(into hasher: inout Hasher) {
+        wrappedValue.hash(into: &hasher)
+    }
+}
+
+#if swift(>=5.5)
+
+extension CopyOnWrite : Sendable where Value : Sendable {
+}
+
+#endif
+
+// MARK: - Storage
+
+private extension CopyOnWrite {
+    final class Storage {
+        var value: Value
+
+        init(_ value: Value) {
+            self.value = value
+        }
+    }
+}
+
+#if swift(>=5.5)
+
+extension CopyOnWrite.Storage : @unchecked Sendable where Value : Sendable {
+}
+
+#endif

--- a/wire-runtime-swift/src/main/swift/propertyWrappers/CopyOnWrite.swift
+++ b/wire-runtime-swift/src/main/swift/propertyWrappers/CopyOnWrite.swift
@@ -16,6 +16,12 @@
 import Foundation
 
 /// A property wrapper which allows easily implementing Copy-on-Write for value types.
+///
+/// When applied to a field, the corresponding value will always be heap-allocated.
+// This happens because this wrapper is a class and classes are always heap-allocated.
+///
+/// Use of this wrapper is required on large value types
+/// because they can overflow the Swift runtime stack.
 @propertyWrapper
 public struct CopyOnWrite<Value> {
 

--- a/wire-runtime-swift/src/main/swift/propertyWrappers/Defaulted.swift
+++ b/wire-runtime-swift/src/main/swift/propertyWrappers/Defaulted.swift
@@ -20,27 +20,29 @@ import Foundation
  or the default value set.
  */
 @propertyWrapper
-public struct Defaulted<T> {
+public struct Defaulted<Value> {
 
-    public var wrappedValue: T?
-    let defaultValue: T
+    public var wrappedValue: Value?
+    let defaultValue: Value
 
-    public init(defaultValue: T) {
+    public init(defaultValue: Value) {
         self.defaultValue = defaultValue
     }
 
-    public var projectedValue: T {
+    public var projectedValue: Value {
         wrappedValue ?? defaultValue
     }
 }
 
-extension Defaulted : Equatable where T : Equatable {
+extension Defaulted : Equatable where Value : Equatable {
 }
 
-extension Defaulted : Hashable where T : Hashable {
+extension Defaulted : Hashable where Value : Hashable {
 }
 
 #if swift(>=5.5)
-extension Defaulted : Sendable where T : Sendable {
+
+extension Defaulted : Sendable where Value : Sendable {
 }
+
 #endif

--- a/wire-runtime-swift/src/main/swift/propertyWrappers/Heap.swift
+++ b/wire-runtime-swift/src/main/swift/propertyWrappers/Heap.swift
@@ -22,6 +22,7 @@ import Foundation
  Use of this wrapper is required on large protobuf messages because large (and especially
  recursive) structs can overflow the Swift runtime stack.
  */
+@available(*, deprecated, message: "Replace with CopyOnWrite. Note that property wrapper has different semantics")
 @propertyWrapper
 public final class Heap<T> {
 

--- a/wire-runtime-swift/src/main/swift/propertyWrappers/Indirect.swift
+++ b/wire-runtime-swift/src/main/swift/propertyWrappers/Indirect.swift
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 @propertyWrapper
-public enum Indirect<T : ProtoCodable> {
+public enum Indirect<Value : ProtoCodable> {
     // Dedicated .none case for nil means the runtime size of this case is equal to a single
     // pointer rather than the two for the .some case.
     case none
 
-    indirect case some(T)
+    indirect case some(Value)
 
-    public init(wrappedValue: T?) {
+    public init(wrappedValue: Value?) {
         if let value = wrappedValue {
           self = .some(value)
         } else {
@@ -29,7 +29,7 @@ public enum Indirect<T : ProtoCodable> {
         }
     }
 
-    public var wrappedValue: T? {
+    public var wrappedValue: Value? {
         get {
             switch self {
             case .none: return nil
@@ -46,10 +46,10 @@ public enum Indirect<T : ProtoCodable> {
     }
 }
 
-extension Indirect : Codable where T : Codable {
+extension Indirect : Codable where Value : Codable {
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()
-        self.init(wrappedValue: try container.decode(T.self))
+        self.init(wrappedValue: try container.decode(Value.self))
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -57,13 +57,15 @@ extension Indirect : Codable where T : Codable {
     }
 }
 
-extension Indirect : Equatable where T : Equatable {
+extension Indirect : Equatable where Value : Equatable {
 }
 
-extension Indirect : Hashable where T : Hashable {
+extension Indirect : Hashable where Value : Hashable {
 }
 
 #if swift(>=5.5)
-extension Indirect : Sendable where T : Sendable {
+
+extension Indirect : Sendable where Value : Sendable {
 }
+
 #endif

--- a/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
+++ b/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
@@ -18,7 +18,7 @@ public struct Dinosaur {
     public var period: Period?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -1336,7 +1336,7 @@ class SwiftGenerator private constructor(
       .build()
 
     val subscript = PropertySpec.subscriptBuilder(signature)
-      .addDoc("Access the underlying storage")
+      .addDoc("Access the underlying storage\n")
       .addModifiers(PUBLIC)
       .getter(
         FunctionSpec.getterBuilder()
@@ -1404,13 +1404,12 @@ class SwiftGenerator private constructor(
       PropertySpec.varBuilder("unknownFields", FOUNDATION_DATA, PUBLIC)
         .getter(
           FunctionSpec.getterBuilder()
-            .addStatement("%N.unknownFields", storageName)
+            .addStatement("self[dynamicMember: \\.unknownFields]")
             .build(),
         )
         .setter(
           FunctionSpec.setterBuilder()
-            .addStatement("copyStorage()")
-            .addStatement("%N.unknownFields = newValue", storageName)
+            .addStatement("self[dynamicMember: \\.unknownFields] = newValue")
             .build(),
         )
         .build(),

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -50,6 +50,7 @@ import io.outfoxx.swiftpoet.FunctionTypeName
 import io.outfoxx.swiftpoet.INT
 import io.outfoxx.swiftpoet.INT32
 import io.outfoxx.swiftpoet.INT64
+import io.outfoxx.swiftpoet.Modifier
 import io.outfoxx.swiftpoet.Modifier.FILEPRIVATE
 import io.outfoxx.swiftpoet.Modifier.MUTATING
 import io.outfoxx.swiftpoet.Modifier.PRIVATE
@@ -103,6 +104,8 @@ class SwiftGenerator private constructor(
   private val writableKeyPath = DeclaredTypeName.typeName("Swift.WritableKeyPath")
 
   private val deprecated = AttributeSpec.builder("available").addArguments("*", "deprecated").build()
+
+  private val storageVisibility: Modifier = PUBLIC
 
   private val ProtoType.typeName
     get() = nameToTypeName.getValue(this)
@@ -289,7 +292,7 @@ class SwiftGenerator private constructor(
               .build(),
           )
 
-          generateMessageStoragePropertyDelegates(type, storageName, storageType)
+          generateMessageStoragePropertyDelegates(type, storageName, storageType, oneOfEnumNames)
           generateMessageStorageDelegateConstructor(type, storageName, structType, storageType, oneOfEnumNames, fileMembers)
 
           addFunction(
@@ -304,17 +307,10 @@ class SwiftGenerator private constructor(
           generateMessageProperties(type, oneOfEnumNames)
           generateMessageConstructor(type, structType, oneOfEnumNames, fileMembers)
         }
-
-        generateMessageOneOfs(type, oneOfEnumNames, fileMembers)
-
-        type.nestedTypes.forEach { nestedType ->
-          generateType(nestedType, fileMembers).forEach {
-            addType(it)
-          }
-        }
       }
       .build()
 
+    // Generate common Foundation types
     val structEquatableExtension = ExtensionSpec.builder(structType)
       .addSuperType(equatable)
       .build()
@@ -341,8 +337,11 @@ class SwiftGenerator private constructor(
       .addGuard("swift(>=5.5)")
       .build()
 
-    val redactionExtension = if (type.fields.any { it.isRedacted }) {
-      ExtensionSpec.builder(structType)
+    // Add redaction, which is potentially delegated
+    val requiresRedaction = type.fields.any { it.isRedacted }
+
+    if (requiresRedaction) {
+      val redactionExtension = ExtensionSpec.builder(structType)
         .addSuperType(redactable)
         .addType(
           TypeSpec.enumBuilder("RedactedKeys")
@@ -358,24 +357,27 @@ class SwiftGenerator private constructor(
             }
             .build(),
         )
-    } else {
-      null
-    }
 
-    if (type.isHeapAllocated) {
-      val storageExtension = ExtensionSpec.builder(structType)
-        .addType(
-          TypeSpec.structBuilder(storageType)
+      if (type.isHeapAllocated) {
+        redactionExtension.addProperty(
+          PropertySpec.varBuilder("description", STRING)
             .addModifiers(PUBLIC)
-            .apply {
-              generateMessageProperties(type, oneOfEnumNames, forStorageType = true)
-              generateMessageConstructor(type, storageType, oneOfEnumNames, fileMembers, includeMemberwiseDefaults = false)
-            }
+            .getter(
+              FunctionSpec.getterBuilder()
+                .addStatement("return %N.description", storageName)
+                .build(),
+            )
             .build(),
         )
-        .build()
-      fileMembers += FileMemberSpec.builder(storageExtension).build()
+      }
 
+      fileMembers += FileMemberSpec.builder(redactionExtension.build())
+        .addGuard("!$FLAG_REMOVE_REDACTABLE")
+        .build()
+    }
+
+    // Add {Proto/Foundation} Codable methods, which may delegate to Storage
+    if (type.isHeapAllocated) {
       val structProtoCodableExtension = ExtensionSpec.builder(structType)
         .addSuperType(type.protoCodableType)
         .addFunction(
@@ -397,26 +399,67 @@ class SwiftGenerator private constructor(
         .build()
       fileMembers += FileMemberSpec.builder(structProtoCodableExtension).build()
 
-      val storageMessageConformanceExtension = ExtensionSpec.builder(storageType)
-        .messageConformanceExtension(type)
-        .build()
-      fileMembers += FileMemberSpec.builder(storageMessageConformanceExtension).build()
-
-      val storageProtoCodableExtension = ExtensionSpec.builder(storageType)
-        .messageProtoCodableExtension(type, structType, oneOfEnumNames, propertyNames)
-        .build()
-      fileMembers += FileMemberSpec.builder(storageProtoCodableExtension).build()
-
       val structCodableExtension = heapCodableExtension(structType, storageName, storageType)
       fileMembers += FileMemberSpec.builder(structCodableExtension)
         .addGuard("!$FLAG_REMOVE_CODABLE")
         .build()
+    } else {
+      val messageConformanceExtension = ExtensionSpec.builder(structType)
+        .messageConformanceExtension(type)
+        .build()
+      fileMembers += FileMemberSpec.builder(messageConformanceExtension).build()
 
-      val storageCodableExtension = messageCodableExtension(type, storageType)
-      fileMembers += FileMemberSpec.builder(storageCodableExtension)
-        .addGuard("!$FLAG_REMOVE_CODABLE")
+      val protoCodableExtension = ExtensionSpec.builder(structType)
+        .messageProtoCodableExtension(type, structType, oneOfEnumNames, propertyNames)
+        .build()
+      fileMembers += FileMemberSpec.builder(protoCodableExtension).build()
+
+      if (!type.needsCustomCodable) {
+        fileMembers += FileMemberSpec.builder(messageCodableExtension(type, structType))
+          .addGuard("!$FLAG_REMOVE_CODABLE")
+          .build()
+      }
+    }
+
+    // Generate One-Ofs and Nested Types
+    if (type.oneOfs.isNotEmpty() || type.nestedTypes.isNotEmpty()) {
+      val nestedFileMembers = mutableListOf<FileMemberSpec>()
+
+      val nestedExtension = ExtensionSpec.builder(structType)
+        .addDoc("Subtypes within %T\n", structType)
+        .apply {
+          generateMessageOneOfs(type, oneOfEnumNames, nestedFileMembers)
+        }
+        .apply {
+          type.nestedTypes.forEach { nestedType ->
+            generateType(nestedType, nestedFileMembers).forEach {
+              addType(it)
+            }
+          }
+        }
         .build()
 
+      fileMembers += FileMemberSpec.builder(nestedExtension).build()
+      fileMembers += nestedFileMembers
+    }
+
+    // Generate Storage
+    if (type.isHeapAllocated) {
+      val storageExtension = ExtensionSpec.builder(structType)
+        .addType(
+          TypeSpec.structBuilder(storageType)
+            .addDoc("Underlying storage for %T\n", structType)
+            .addModifiers(storageVisibility)
+            .apply {
+              generateMessageProperties(type, oneOfEnumNames, forStorageType = true)
+              generateMessageConstructor(type, storageType, oneOfEnumNames, fileMembers, forStorageType = true)
+            }
+            .build(),
+        )
+        .build()
+      fileMembers += FileMemberSpec.builder(storageExtension).build()
+
+      // Generate common Foundation types
       val storageEquatableExtension = ExtensionSpec.builder(storageType)
         .addSuperType(equatable)
         .build()
@@ -438,23 +481,13 @@ class SwiftGenerator private constructor(
         .addGuard("swift(>=5.5)")
         .build()
 
-      if (redactionExtension != null) {
-        redactionExtension.addProperty(
-          PropertySpec.varBuilder("description", STRING)
-            .addModifiers(PUBLIC)
-            .getter(
-              FunctionSpec.getterBuilder()
-                .addStatement("return %N.description", storageName)
-                .build(),
-            )
-            .build(),
-        )
-
+      // Add redaction
+      if (requiresRedaction) {
         val storageRedactableExtension = ExtensionSpec.builder(storageType)
           .addSuperType(redactable)
           .addType(
             TypeAliasSpec.builder("RedactedKeys", structType.nestedType("RedactedKeys"))
-              .addModifiers(PUBLIC)
+              .addModifiers(storageVisibility)
               .build(),
           )
           .build()
@@ -462,27 +495,21 @@ class SwiftGenerator private constructor(
           .addGuard("!$FLAG_REMOVE_REDACTABLE")
           .build()
       }
-    } else {
-      val messageConformanceExtension = ExtensionSpec.builder(structType)
-        .messageConformanceExtension(type)
+
+      // Add {Proto/Foundation} Codable methods
+      val storageMessageConformanceExtension = ExtensionSpec.builder(storageType)
+        .messageConformanceExtension(type, forStorageType = true)
         .build()
-      fileMembers += FileMemberSpec.builder(messageConformanceExtension).build()
+      fileMembers += FileMemberSpec.builder(storageMessageConformanceExtension).build()
 
-      val protoCodableExtension = ExtensionSpec.builder(structType)
-        .messageProtoCodableExtension(type, structType, oneOfEnumNames, propertyNames)
+      val storageProtoCodableExtension = ExtensionSpec.builder(storageType)
+        .messageProtoCodableExtension(type, structType, oneOfEnumNames, propertyNames, forStorageType = true)
         .build()
-      fileMembers += FileMemberSpec.builder(protoCodableExtension).build()
+      fileMembers += FileMemberSpec.builder(storageProtoCodableExtension).build()
 
-      if (!type.needsCustomCodable) {
-        fileMembers += FileMemberSpec.builder(messageCodableExtension(type, structType))
-          .addGuard("!$FLAG_REMOVE_CODABLE")
-          .build()
-      }
-    }
-
-    if (redactionExtension != null) {
-      fileMembers += FileMemberSpec.builder(redactionExtension.build())
-        .addGuard("!$FLAG_REMOVE_REDACTABLE")
+      val storageCodableExtension = messageCodableExtension(type, storageType, forStorageType = true)
+      fileMembers += FileMemberSpec.builder(storageCodableExtension)
+        .addGuard("!$FLAG_REMOVE_CODABLE")
         .build()
     }
 
@@ -494,7 +521,14 @@ class SwiftGenerator private constructor(
     structType: DeclaredTypeName,
     oneOfEnumNames: Map<OneOf, DeclaredTypeName>,
     propertyNames: Collection<String>,
+    forStorageType: Boolean = false,
   ): ExtensionSpec.Builder = apply {
+    val visibility: Modifier = if (forStorageType) {
+      storageVisibility
+    } else {
+      PUBLIC
+    }
+
     addSuperType(type.protoCodableType)
 
     val reader = if ("protoReader" in propertyNames) "_protoReader" else "protoReader"
@@ -502,7 +536,7 @@ class SwiftGenerator private constructor(
     val tag = if ("tag" in propertyNames) "_tag" else "tag"
     addFunction(
       FunctionSpec.constructorBuilder()
-        .addModifiers(PUBLIC)
+        .addModifiers(visibility)
         .addParameter("from", reader, protoReader)
         .throws(true)
         .apply {
@@ -629,7 +663,7 @@ class SwiftGenerator private constructor(
     val writer = if ("protoWriter" in propertyNames) "_protoWriter" else "protoWriter"
     addFunction(
       FunctionSpec.builder("encode")
-        .addModifiers(PUBLIC)
+        .addModifiers(visibility)
         .addParameter("to", writer, protoWriter)
         .throws(true)
         .apply {
@@ -667,12 +701,19 @@ class SwiftGenerator private constructor(
 
   private fun ExtensionSpec.Builder.messageConformanceExtension(
     type: MessageType,
+    forStorageType: Boolean = false,
   ): ExtensionSpec.Builder = apply {
+    val visibility: Modifier = if (forStorageType) {
+      storageVisibility
+    } else {
+      PUBLIC
+    }
+
     addSuperType(protoMessage)
     addFunction(
       FunctionSpec.builder("protoMessageTypeURL")
         .returns(STRING)
-        .addModifiers(PUBLIC)
+        .addModifiers(visibility)
         .addModifiers(STATIC)
         .addStatement("return \"%N\"", type.type.typeUrl!!)
         .build(),
@@ -718,7 +759,14 @@ class SwiftGenerator private constructor(
   private fun messageCodableExtension(
     type: MessageType,
     structType: DeclaredTypeName,
+    forStorageType: Boolean = false,
   ): ExtensionSpec {
+    val visibility: Modifier = if (forStorageType) {
+      storageVisibility
+    } else {
+      PUBLIC
+    }
+
     return ExtensionSpec.builder(structType)
       .addSuperType(codable)
       .apply {
@@ -735,7 +783,7 @@ class SwiftGenerator private constructor(
             // in order to compile.
 
             TypeSpec.enumBuilder(codingKeys)
-              .addModifiers(PUBLIC)
+              .addModifiers(visibility)
               .addSuperType(codingKey)
               .build(),
           )
@@ -746,7 +794,7 @@ class SwiftGenerator private constructor(
           addFunction(
             FunctionSpec.constructorBuilder()
               .addParameter("from", "decoder", decoder)
-              .addModifiers(PUBLIC)
+              .addModifiers(visibility)
               .throws(true)
               .addStatement("let container = try decoder.container(keyedBy: %T.self)", codingKeys)
               .apply {
@@ -830,7 +878,7 @@ class SwiftGenerator private constructor(
           addFunction(
             FunctionSpec.builder("encode")
               .addParameter("to", "encoder", encoder)
-              .addModifiers(PUBLIC)
+              .addModifiers(visibility)
               .throws(true)
               .addStatement("var container = encoder.container(keyedBy: %T.self)", codingKeys)
               .apply {
@@ -1057,13 +1105,20 @@ class SwiftGenerator private constructor(
     structType: DeclaredTypeName,
     oneOfEnumNames: Map<OneOf, DeclaredTypeName>,
     fileMembers: MutableList<FileMemberSpec>,
-    includeMemberwiseDefaults: Boolean = true,
+    forStorageType: Boolean = false,
   ) {
+    val includeMemberwiseDefaults = !forStorageType
     val needsConfigure = type.fields.any { !it.isRequiredParameter } || type.oneOfs.isNotEmpty()
+
+    val visibility: Modifier = if (forStorageType) {
+      storageVisibility
+    } else {
+      PUBLIC
+    }
 
     addFunction(
       FunctionSpec.constructorBuilder()
-        .addModifiers(PUBLIC)
+        .addModifiers(visibility)
         .addParameters(
           type,
           oneOfEnumNames,
@@ -1107,7 +1162,7 @@ class SwiftGenerator private constructor(
     val memberwiseExtension = ExtensionSpec.builder(structType)
       .addFunction(
         FunctionSpec.constructorBuilder()
-          .addModifiers(PUBLIC)
+          .addModifiers(visibility)
           .addParameters(type, oneOfEnumNames, includeDefaults = includeMemberwiseDefaults)
           .addAttribute(AttributeSpec.builder("_disfavoredOverload").build())
           .addAttribute(deprecated)
@@ -1136,8 +1191,14 @@ class SwiftGenerator private constructor(
     oneOfEnumNames: Map<OneOf, DeclaredTypeName>,
     forStorageType: Boolean = false,
   ) {
+    val visibility: Modifier = if (forStorageType) {
+      storageVisibility
+    } else {
+      PUBLIC
+    }
+
     type.fields.forEach { field ->
-      val property = PropertySpec.varBuilder(field.name, field.typeName, PUBLIC)
+      val property = PropertySpec.varBuilder(field.name, field.typeName, visibility)
       if (!forStorageType && field.documentation.isNotBlank()) {
         property.addDoc("%L\n", field.documentation.sanitizeDoc())
       }
@@ -1166,7 +1227,7 @@ class SwiftGenerator private constructor(
       val enumName = oneOfEnumNames.getValue(oneOf)
 
       addProperty(
-        PropertySpec.varBuilder(oneOf.name, enumName.makeOptional(), PUBLIC)
+        PropertySpec.varBuilder(oneOf.name, enumName.makeOptional(), visibility)
           .apply {
             if (oneOf.documentation.isNotBlank()) {
               addDoc("%N\n", oneOf.documentation.sanitizeDoc())
@@ -1177,7 +1238,7 @@ class SwiftGenerator private constructor(
     }
 
     addProperty(
-      PropertySpec.varBuilder("unknownFields", FOUNDATION_DATA, PUBLIC)
+      PropertySpec.varBuilder("unknownFields", FOUNDATION_DATA, visibility)
         .initializer(".init()")
         .build(),
     )
@@ -1257,24 +1318,25 @@ class SwiftGenerator private constructor(
     type: MessageType,
     storageName: String,
     storageType: DeclaredTypeName,
+    oneOfEnumNames: Map<OneOf, DeclaredTypeName>,
   ) {
     if (!type.isHeapAllocated) {
       println("Generating storage property delegates for a non-heap allocated type?!")
     }
 
     val propertyVariable = TypeVariableName.typeVariable("Property")
+    val signature = FunctionSignatureSpec.builder()
+      .addTypeVariable(propertyVariable)
+      .addParameter(
+        "dynamicMember",
+        "keyPath",
+        writableKeyPath.parameterizedBy(storageType, propertyVariable),
+      )
+      .returns(propertyVariable)
+      .build()
 
-    val subscript = PropertySpec.subscriptBuilder(
-      FunctionSignatureSpec.builder()
-        .addTypeVariable(propertyVariable)
-        .addParameter(
-          "dynamicMember",
-          "keyPath",
-          writableKeyPath.parameterizedBy(storageType, propertyVariable),
-        )
-        .returns(propertyVariable)
-        .build(),
-    )
+    val subscript = PropertySpec.subscriptBuilder(signature)
+      .addDoc("Access the underlying storage")
       .addModifiers(PUBLIC)
       .getter(
         FunctionSpec.getterBuilder()
@@ -1288,11 +1350,74 @@ class SwiftGenerator private constructor(
           .build(),
       )
       .build()
-
     addProperty(subscript)
+
+    type.fields.forEach { field ->
+      val property = PropertySpec.varBuilder(field.name, field.typeName, PUBLIC)
+        .getter(
+          FunctionSpec.getterBuilder()
+            .addStatement("self[dynamicMember: \\.%N]", field.name)
+            .build(),
+        )
+        .setter(
+          FunctionSpec.setterBuilder()
+            .addStatement("self[dynamicMember: \\.%N] = newValue", field.name)
+            .build(),
+        )
+
+      if (field.documentation.isNotBlank()) {
+        property.addDoc("%L\n", field.documentation.sanitizeDoc())
+      }
+      if (field.isDeprecated) {
+        property.addAttribute(deprecated)
+      }
+
+      addProperty(property.build())
+    }
+
+    type.oneOfs.forEach { oneOf ->
+      val enumName = oneOfEnumNames.getValue(oneOf)
+
+      addProperty(
+        PropertySpec.varBuilder(oneOf.name, enumName.makeOptional(), PUBLIC)
+          .getter(
+            FunctionSpec.getterBuilder()
+              .addStatement("%N.%N", storageName, oneOf.name)
+              .build(),
+          )
+          .setter(
+            FunctionSpec.setterBuilder()
+              .addStatement("copyStorage()")
+              .addStatement("%N.%N = newValue", storageName, oneOf.name)
+              .build(),
+          )
+          .apply {
+            if (oneOf.documentation.isNotBlank()) {
+              addDoc("%N\n", oneOf.documentation.sanitizeDoc())
+            }
+          }
+          .build(),
+      )
+    }
+
+    addProperty(
+      PropertySpec.varBuilder("unknownFields", FOUNDATION_DATA, PUBLIC)
+        .getter(
+          FunctionSpec.getterBuilder()
+            .addStatement("%N.unknownFields", storageName)
+            .build(),
+        )
+        .setter(
+          FunctionSpec.setterBuilder()
+            .addStatement("copyStorage()")
+            .addStatement("%N.unknownFields = newValue", storageName)
+            .build(),
+        )
+        .build(),
+    )
   }
 
-  private fun TypeSpec.Builder.generateMessageOneOfs(
+  private fun ExtensionSpec.Builder.generateMessageOneOfs(
     type: MessageType,
     oneOfEnumNames: Map<OneOf, DeclaredTypeName>,
     fileMembers: MutableList<FileMemberSpec>,

--- a/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
@@ -8,7 +8,7 @@ public struct ContainsDuration {
     public var duration: Duration?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
@@ -8,7 +8,7 @@ public struct ContainsTimestamp {
     public var timestamp: Timestamp?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -6,7 +6,7 @@ import Wire
 @dynamicMemberLookup
 public struct AllTypes {
 
-    @Heap
+    @CopyOnWrite
     private var storage: AllTypes.Storage
     /**
      * Access the underlying storage
@@ -16,1176 +16,1175 @@ public struct AllTypes {
             storage[keyPath: keyPath]
         }
         set {
-            copyStorage()
             storage[keyPath: keyPath] = newValue
         }
     }
     public var opt_int32: Int32? {
         get {
-            self[dynamicMember: \.opt_int32]
+            storage.opt_int32
         }
         set {
-            self[dynamicMember: \.opt_int32] = newValue
+            storage.opt_int32 = newValue
         }
     }
     public var opt_uint32: UInt32? {
         get {
-            self[dynamicMember: \.opt_uint32]
+            storage.opt_uint32
         }
         set {
-            self[dynamicMember: \.opt_uint32] = newValue
+            storage.opt_uint32 = newValue
         }
     }
     public var opt_sint32: Int32? {
         get {
-            self[dynamicMember: \.opt_sint32]
+            storage.opt_sint32
         }
         set {
-            self[dynamicMember: \.opt_sint32] = newValue
+            storage.opt_sint32 = newValue
         }
     }
     public var opt_fixed32: UInt32? {
         get {
-            self[dynamicMember: \.opt_fixed32]
+            storage.opt_fixed32
         }
         set {
-            self[dynamicMember: \.opt_fixed32] = newValue
+            storage.opt_fixed32 = newValue
         }
     }
     public var opt_sfixed32: Int32? {
         get {
-            self[dynamicMember: \.opt_sfixed32]
+            storage.opt_sfixed32
         }
         set {
-            self[dynamicMember: \.opt_sfixed32] = newValue
+            storage.opt_sfixed32 = newValue
         }
     }
     public var opt_int64: Int64? {
         get {
-            self[dynamicMember: \.opt_int64]
+            storage.opt_int64
         }
         set {
-            self[dynamicMember: \.opt_int64] = newValue
+            storage.opt_int64 = newValue
         }
     }
     public var opt_uint64: UInt64? {
         get {
-            self[dynamicMember: \.opt_uint64]
+            storage.opt_uint64
         }
         set {
-            self[dynamicMember: \.opt_uint64] = newValue
+            storage.opt_uint64 = newValue
         }
     }
     public var opt_sint64: Int64? {
         get {
-            self[dynamicMember: \.opt_sint64]
+            storage.opt_sint64
         }
         set {
-            self[dynamicMember: \.opt_sint64] = newValue
+            storage.opt_sint64 = newValue
         }
     }
     public var opt_fixed64: UInt64? {
         get {
-            self[dynamicMember: \.opt_fixed64]
+            storage.opt_fixed64
         }
         set {
-            self[dynamicMember: \.opt_fixed64] = newValue
+            storage.opt_fixed64 = newValue
         }
     }
     public var opt_sfixed64: Int64? {
         get {
-            self[dynamicMember: \.opt_sfixed64]
+            storage.opt_sfixed64
         }
         set {
-            self[dynamicMember: \.opt_sfixed64] = newValue
+            storage.opt_sfixed64 = newValue
         }
     }
     public var opt_bool: Bool? {
         get {
-            self[dynamicMember: \.opt_bool]
+            storage.opt_bool
         }
         set {
-            self[dynamicMember: \.opt_bool] = newValue
+            storage.opt_bool = newValue
         }
     }
     public var opt_float: Float? {
         get {
-            self[dynamicMember: \.opt_float]
+            storage.opt_float
         }
         set {
-            self[dynamicMember: \.opt_float] = newValue
+            storage.opt_float = newValue
         }
     }
     public var opt_double: Double? {
         get {
-            self[dynamicMember: \.opt_double]
+            storage.opt_double
         }
         set {
-            self[dynamicMember: \.opt_double] = newValue
+            storage.opt_double = newValue
         }
     }
     public var opt_string: String? {
         get {
-            self[dynamicMember: \.opt_string]
+            storage.opt_string
         }
         set {
-            self[dynamicMember: \.opt_string] = newValue
+            storage.opt_string = newValue
         }
     }
     public var opt_bytes: Foundation.Data? {
         get {
-            self[dynamicMember: \.opt_bytes]
+            storage.opt_bytes
         }
         set {
-            self[dynamicMember: \.opt_bytes] = newValue
+            storage.opt_bytes = newValue
         }
     }
     public var opt_nested_enum: AllTypes.NestedEnum? {
         get {
-            self[dynamicMember: \.opt_nested_enum]
+            storage.opt_nested_enum
         }
         set {
-            self[dynamicMember: \.opt_nested_enum] = newValue
+            storage.opt_nested_enum = newValue
         }
     }
     public var opt_nested_message: AllTypes.NestedMessage? {
         get {
-            self[dynamicMember: \.opt_nested_message]
+            storage.opt_nested_message
         }
         set {
-            self[dynamicMember: \.opt_nested_message] = newValue
+            storage.opt_nested_message = newValue
         }
     }
     public var req_int32: Int32 {
         get {
-            self[dynamicMember: \.req_int32]
+            storage.req_int32
         }
         set {
-            self[dynamicMember: \.req_int32] = newValue
+            storage.req_int32 = newValue
         }
     }
     public var req_uint32: UInt32 {
         get {
-            self[dynamicMember: \.req_uint32]
+            storage.req_uint32
         }
         set {
-            self[dynamicMember: \.req_uint32] = newValue
+            storage.req_uint32 = newValue
         }
     }
     public var req_sint32: Int32 {
         get {
-            self[dynamicMember: \.req_sint32]
+            storage.req_sint32
         }
         set {
-            self[dynamicMember: \.req_sint32] = newValue
+            storage.req_sint32 = newValue
         }
     }
     public var req_fixed32: UInt32 {
         get {
-            self[dynamicMember: \.req_fixed32]
+            storage.req_fixed32
         }
         set {
-            self[dynamicMember: \.req_fixed32] = newValue
+            storage.req_fixed32 = newValue
         }
     }
     public var req_sfixed32: Int32 {
         get {
-            self[dynamicMember: \.req_sfixed32]
+            storage.req_sfixed32
         }
         set {
-            self[dynamicMember: \.req_sfixed32] = newValue
+            storage.req_sfixed32 = newValue
         }
     }
     public var req_int64: Int64 {
         get {
-            self[dynamicMember: \.req_int64]
+            storage.req_int64
         }
         set {
-            self[dynamicMember: \.req_int64] = newValue
+            storage.req_int64 = newValue
         }
     }
     public var req_uint64: UInt64 {
         get {
-            self[dynamicMember: \.req_uint64]
+            storage.req_uint64
         }
         set {
-            self[dynamicMember: \.req_uint64] = newValue
+            storage.req_uint64 = newValue
         }
     }
     public var req_sint64: Int64 {
         get {
-            self[dynamicMember: \.req_sint64]
+            storage.req_sint64
         }
         set {
-            self[dynamicMember: \.req_sint64] = newValue
+            storage.req_sint64 = newValue
         }
     }
     public var req_fixed64: UInt64 {
         get {
-            self[dynamicMember: \.req_fixed64]
+            storage.req_fixed64
         }
         set {
-            self[dynamicMember: \.req_fixed64] = newValue
+            storage.req_fixed64 = newValue
         }
     }
     public var req_sfixed64: Int64 {
         get {
-            self[dynamicMember: \.req_sfixed64]
+            storage.req_sfixed64
         }
         set {
-            self[dynamicMember: \.req_sfixed64] = newValue
+            storage.req_sfixed64 = newValue
         }
     }
     public var req_bool: Bool {
         get {
-            self[dynamicMember: \.req_bool]
+            storage.req_bool
         }
         set {
-            self[dynamicMember: \.req_bool] = newValue
+            storage.req_bool = newValue
         }
     }
     public var req_float: Float {
         get {
-            self[dynamicMember: \.req_float]
+            storage.req_float
         }
         set {
-            self[dynamicMember: \.req_float] = newValue
+            storage.req_float = newValue
         }
     }
     public var req_double: Double {
         get {
-            self[dynamicMember: \.req_double]
+            storage.req_double
         }
         set {
-            self[dynamicMember: \.req_double] = newValue
+            storage.req_double = newValue
         }
     }
     public var req_string: String {
         get {
-            self[dynamicMember: \.req_string]
+            storage.req_string
         }
         set {
-            self[dynamicMember: \.req_string] = newValue
+            storage.req_string = newValue
         }
     }
     public var req_bytes: Foundation.Data {
         get {
-            self[dynamicMember: \.req_bytes]
+            storage.req_bytes
         }
         set {
-            self[dynamicMember: \.req_bytes] = newValue
+            storage.req_bytes = newValue
         }
     }
     public var req_nested_enum: AllTypes.NestedEnum {
         get {
-            self[dynamicMember: \.req_nested_enum]
+            storage.req_nested_enum
         }
         set {
-            self[dynamicMember: \.req_nested_enum] = newValue
+            storage.req_nested_enum = newValue
         }
     }
     public var req_nested_message: AllTypes.NestedMessage {
         get {
-            self[dynamicMember: \.req_nested_message]
+            storage.req_nested_message
         }
         set {
-            self[dynamicMember: \.req_nested_message] = newValue
+            storage.req_nested_message = newValue
         }
     }
     public var rep_int32: [Int32] {
         get {
-            self[dynamicMember: \.rep_int32]
+            storage.rep_int32
         }
         set {
-            self[dynamicMember: \.rep_int32] = newValue
+            storage.rep_int32 = newValue
         }
     }
     public var rep_uint32: [UInt32] {
         get {
-            self[dynamicMember: \.rep_uint32]
+            storage.rep_uint32
         }
         set {
-            self[dynamicMember: \.rep_uint32] = newValue
+            storage.rep_uint32 = newValue
         }
     }
     public var rep_sint32: [Int32] {
         get {
-            self[dynamicMember: \.rep_sint32]
+            storage.rep_sint32
         }
         set {
-            self[dynamicMember: \.rep_sint32] = newValue
+            storage.rep_sint32 = newValue
         }
     }
     public var rep_fixed32: [UInt32] {
         get {
-            self[dynamicMember: \.rep_fixed32]
+            storage.rep_fixed32
         }
         set {
-            self[dynamicMember: \.rep_fixed32] = newValue
+            storage.rep_fixed32 = newValue
         }
     }
     public var rep_sfixed32: [Int32] {
         get {
-            self[dynamicMember: \.rep_sfixed32]
+            storage.rep_sfixed32
         }
         set {
-            self[dynamicMember: \.rep_sfixed32] = newValue
+            storage.rep_sfixed32 = newValue
         }
     }
     public var rep_int64: [Int64] {
         get {
-            self[dynamicMember: \.rep_int64]
+            storage.rep_int64
         }
         set {
-            self[dynamicMember: \.rep_int64] = newValue
+            storage.rep_int64 = newValue
         }
     }
     public var rep_uint64: [UInt64] {
         get {
-            self[dynamicMember: \.rep_uint64]
+            storage.rep_uint64
         }
         set {
-            self[dynamicMember: \.rep_uint64] = newValue
+            storage.rep_uint64 = newValue
         }
     }
     public var rep_sint64: [Int64] {
         get {
-            self[dynamicMember: \.rep_sint64]
+            storage.rep_sint64
         }
         set {
-            self[dynamicMember: \.rep_sint64] = newValue
+            storage.rep_sint64 = newValue
         }
     }
     public var rep_fixed64: [UInt64] {
         get {
-            self[dynamicMember: \.rep_fixed64]
+            storage.rep_fixed64
         }
         set {
-            self[dynamicMember: \.rep_fixed64] = newValue
+            storage.rep_fixed64 = newValue
         }
     }
     public var rep_sfixed64: [Int64] {
         get {
-            self[dynamicMember: \.rep_sfixed64]
+            storage.rep_sfixed64
         }
         set {
-            self[dynamicMember: \.rep_sfixed64] = newValue
+            storage.rep_sfixed64 = newValue
         }
     }
     public var rep_bool: [Bool] {
         get {
-            self[dynamicMember: \.rep_bool]
+            storage.rep_bool
         }
         set {
-            self[dynamicMember: \.rep_bool] = newValue
+            storage.rep_bool = newValue
         }
     }
     public var rep_float: [Float] {
         get {
-            self[dynamicMember: \.rep_float]
+            storage.rep_float
         }
         set {
-            self[dynamicMember: \.rep_float] = newValue
+            storage.rep_float = newValue
         }
     }
     public var rep_double: [Double] {
         get {
-            self[dynamicMember: \.rep_double]
+            storage.rep_double
         }
         set {
-            self[dynamicMember: \.rep_double] = newValue
+            storage.rep_double = newValue
         }
     }
     public var rep_string: [String] {
         get {
-            self[dynamicMember: \.rep_string]
+            storage.rep_string
         }
         set {
-            self[dynamicMember: \.rep_string] = newValue
+            storage.rep_string = newValue
         }
     }
     public var rep_bytes: [Foundation.Data] {
         get {
-            self[dynamicMember: \.rep_bytes]
+            storage.rep_bytes
         }
         set {
-            self[dynamicMember: \.rep_bytes] = newValue
+            storage.rep_bytes = newValue
         }
     }
     public var rep_nested_enum: [AllTypes.NestedEnum] {
         get {
-            self[dynamicMember: \.rep_nested_enum]
+            storage.rep_nested_enum
         }
         set {
-            self[dynamicMember: \.rep_nested_enum] = newValue
+            storage.rep_nested_enum = newValue
         }
     }
     public var rep_nested_message: [AllTypes.NestedMessage] {
         get {
-            self[dynamicMember: \.rep_nested_message]
+            storage.rep_nested_message
         }
         set {
-            self[dynamicMember: \.rep_nested_message] = newValue
+            storage.rep_nested_message = newValue
         }
     }
     public var pack_int32: [Int32] {
         get {
-            self[dynamicMember: \.pack_int32]
+            storage.pack_int32
         }
         set {
-            self[dynamicMember: \.pack_int32] = newValue
+            storage.pack_int32 = newValue
         }
     }
     public var pack_uint32: [UInt32] {
         get {
-            self[dynamicMember: \.pack_uint32]
+            storage.pack_uint32
         }
         set {
-            self[dynamicMember: \.pack_uint32] = newValue
+            storage.pack_uint32 = newValue
         }
     }
     public var pack_sint32: [Int32] {
         get {
-            self[dynamicMember: \.pack_sint32]
+            storage.pack_sint32
         }
         set {
-            self[dynamicMember: \.pack_sint32] = newValue
+            storage.pack_sint32 = newValue
         }
     }
     public var pack_fixed32: [UInt32] {
         get {
-            self[dynamicMember: \.pack_fixed32]
+            storage.pack_fixed32
         }
         set {
-            self[dynamicMember: \.pack_fixed32] = newValue
+            storage.pack_fixed32 = newValue
         }
     }
     public var pack_sfixed32: [Int32] {
         get {
-            self[dynamicMember: \.pack_sfixed32]
+            storage.pack_sfixed32
         }
         set {
-            self[dynamicMember: \.pack_sfixed32] = newValue
+            storage.pack_sfixed32 = newValue
         }
     }
     public var pack_int64: [Int64] {
         get {
-            self[dynamicMember: \.pack_int64]
+            storage.pack_int64
         }
         set {
-            self[dynamicMember: \.pack_int64] = newValue
+            storage.pack_int64 = newValue
         }
     }
     public var pack_uint64: [UInt64] {
         get {
-            self[dynamicMember: \.pack_uint64]
+            storage.pack_uint64
         }
         set {
-            self[dynamicMember: \.pack_uint64] = newValue
+            storage.pack_uint64 = newValue
         }
     }
     public var pack_sint64: [Int64] {
         get {
-            self[dynamicMember: \.pack_sint64]
+            storage.pack_sint64
         }
         set {
-            self[dynamicMember: \.pack_sint64] = newValue
+            storage.pack_sint64 = newValue
         }
     }
     public var pack_fixed64: [UInt64] {
         get {
-            self[dynamicMember: \.pack_fixed64]
+            storage.pack_fixed64
         }
         set {
-            self[dynamicMember: \.pack_fixed64] = newValue
+            storage.pack_fixed64 = newValue
         }
     }
     public var pack_sfixed64: [Int64] {
         get {
-            self[dynamicMember: \.pack_sfixed64]
+            storage.pack_sfixed64
         }
         set {
-            self[dynamicMember: \.pack_sfixed64] = newValue
+            storage.pack_sfixed64 = newValue
         }
     }
     public var pack_bool: [Bool] {
         get {
-            self[dynamicMember: \.pack_bool]
+            storage.pack_bool
         }
         set {
-            self[dynamicMember: \.pack_bool] = newValue
+            storage.pack_bool = newValue
         }
     }
     public var pack_float: [Float] {
         get {
-            self[dynamicMember: \.pack_float]
+            storage.pack_float
         }
         set {
-            self[dynamicMember: \.pack_float] = newValue
+            storage.pack_float = newValue
         }
     }
     public var pack_double: [Double] {
         get {
-            self[dynamicMember: \.pack_double]
+            storage.pack_double
         }
         set {
-            self[dynamicMember: \.pack_double] = newValue
+            storage.pack_double = newValue
         }
     }
     public var pack_nested_enum: [AllTypes.NestedEnum] {
         get {
-            self[dynamicMember: \.pack_nested_enum]
+            storage.pack_nested_enum
         }
         set {
-            self[dynamicMember: \.pack_nested_enum] = newValue
+            storage.pack_nested_enum = newValue
         }
     }
     public var default_int32: Int32? {
         get {
-            self[dynamicMember: \.default_int32]
+            storage.default_int32
         }
         set {
-            self[dynamicMember: \.default_int32] = newValue
+            storage.default_int32 = newValue
         }
     }
     public var default_uint32: UInt32? {
         get {
-            self[dynamicMember: \.default_uint32]
+            storage.default_uint32
         }
         set {
-            self[dynamicMember: \.default_uint32] = newValue
+            storage.default_uint32 = newValue
         }
     }
     public var default_sint32: Int32? {
         get {
-            self[dynamicMember: \.default_sint32]
+            storage.default_sint32
         }
         set {
-            self[dynamicMember: \.default_sint32] = newValue
+            storage.default_sint32 = newValue
         }
     }
     public var default_fixed32: UInt32? {
         get {
-            self[dynamicMember: \.default_fixed32]
+            storage.default_fixed32
         }
         set {
-            self[dynamicMember: \.default_fixed32] = newValue
+            storage.default_fixed32 = newValue
         }
     }
     public var default_sfixed32: Int32? {
         get {
-            self[dynamicMember: \.default_sfixed32]
+            storage.default_sfixed32
         }
         set {
-            self[dynamicMember: \.default_sfixed32] = newValue
+            storage.default_sfixed32 = newValue
         }
     }
     public var default_int64: Int64? {
         get {
-            self[dynamicMember: \.default_int64]
+            storage.default_int64
         }
         set {
-            self[dynamicMember: \.default_int64] = newValue
+            storage.default_int64 = newValue
         }
     }
     public var default_uint64: UInt64? {
         get {
-            self[dynamicMember: \.default_uint64]
+            storage.default_uint64
         }
         set {
-            self[dynamicMember: \.default_uint64] = newValue
+            storage.default_uint64 = newValue
         }
     }
     public var default_sint64: Int64? {
         get {
-            self[dynamicMember: \.default_sint64]
+            storage.default_sint64
         }
         set {
-            self[dynamicMember: \.default_sint64] = newValue
+            storage.default_sint64 = newValue
         }
     }
     public var default_fixed64: UInt64? {
         get {
-            self[dynamicMember: \.default_fixed64]
+            storage.default_fixed64
         }
         set {
-            self[dynamicMember: \.default_fixed64] = newValue
+            storage.default_fixed64 = newValue
         }
     }
     public var default_sfixed64: Int64? {
         get {
-            self[dynamicMember: \.default_sfixed64]
+            storage.default_sfixed64
         }
         set {
-            self[dynamicMember: \.default_sfixed64] = newValue
+            storage.default_sfixed64 = newValue
         }
     }
     public var default_bool: Bool? {
         get {
-            self[dynamicMember: \.default_bool]
+            storage.default_bool
         }
         set {
-            self[dynamicMember: \.default_bool] = newValue
+            storage.default_bool = newValue
         }
     }
     public var default_float: Float? {
         get {
-            self[dynamicMember: \.default_float]
+            storage.default_float
         }
         set {
-            self[dynamicMember: \.default_float] = newValue
+            storage.default_float = newValue
         }
     }
     public var default_double: Double? {
         get {
-            self[dynamicMember: \.default_double]
+            storage.default_double
         }
         set {
-            self[dynamicMember: \.default_double] = newValue
+            storage.default_double = newValue
         }
     }
     public var default_string: String? {
         get {
-            self[dynamicMember: \.default_string]
+            storage.default_string
         }
         set {
-            self[dynamicMember: \.default_string] = newValue
+            storage.default_string = newValue
         }
     }
     public var default_bytes: Foundation.Data? {
         get {
-            self[dynamicMember: \.default_bytes]
+            storage.default_bytes
         }
         set {
-            self[dynamicMember: \.default_bytes] = newValue
+            storage.default_bytes = newValue
         }
     }
     public var default_nested_enum: AllTypes.NestedEnum? {
         get {
-            self[dynamicMember: \.default_nested_enum]
+            storage.default_nested_enum
         }
         set {
-            self[dynamicMember: \.default_nested_enum] = newValue
+            storage.default_nested_enum = newValue
         }
     }
     public var map_int32_int32: [Int32 : Int32] {
         get {
-            self[dynamicMember: \.map_int32_int32]
+            storage.map_int32_int32
         }
         set {
-            self[dynamicMember: \.map_int32_int32] = newValue
+            storage.map_int32_int32 = newValue
         }
     }
     public var map_string_string: [String : String] {
         get {
-            self[dynamicMember: \.map_string_string]
+            storage.map_string_string
         }
         set {
-            self[dynamicMember: \.map_string_string] = newValue
+            storage.map_string_string = newValue
         }
     }
     public var map_string_message: [String : AllTypes.NestedMessage] {
         get {
-            self[dynamicMember: \.map_string_message]
+            storage.map_string_message
         }
         set {
-            self[dynamicMember: \.map_string_message] = newValue
+            storage.map_string_message = newValue
         }
     }
     public var map_string_enum: [String : AllTypes.NestedEnum] {
         get {
-            self[dynamicMember: \.map_string_enum]
+            storage.map_string_enum
         }
         set {
-            self[dynamicMember: \.map_string_enum] = newValue
+            storage.map_string_enum = newValue
         }
     }
     public var array_int32: [Int32] {
         get {
-            self[dynamicMember: \.array_int32]
+            storage.array_int32
         }
         set {
-            self[dynamicMember: \.array_int32] = newValue
+            storage.array_int32 = newValue
         }
     }
     public var array_uint32: [UInt32] {
         get {
-            self[dynamicMember: \.array_uint32]
+            storage.array_uint32
         }
         set {
-            self[dynamicMember: \.array_uint32] = newValue
+            storage.array_uint32 = newValue
         }
     }
     public var array_sint32: [Int32] {
         get {
-            self[dynamicMember: \.array_sint32]
+            storage.array_sint32
         }
         set {
-            self[dynamicMember: \.array_sint32] = newValue
+            storage.array_sint32 = newValue
         }
     }
     public var array_fixed32: [UInt32] {
         get {
-            self[dynamicMember: \.array_fixed32]
+            storage.array_fixed32
         }
         set {
-            self[dynamicMember: \.array_fixed32] = newValue
+            storage.array_fixed32 = newValue
         }
     }
     public var array_sfixed32: [Int32] {
         get {
-            self[dynamicMember: \.array_sfixed32]
+            storage.array_sfixed32
         }
         set {
-            self[dynamicMember: \.array_sfixed32] = newValue
+            storage.array_sfixed32 = newValue
         }
     }
     public var array_int64: [Int64] {
         get {
-            self[dynamicMember: \.array_int64]
+            storage.array_int64
         }
         set {
-            self[dynamicMember: \.array_int64] = newValue
+            storage.array_int64 = newValue
         }
     }
     public var array_uint64: [UInt64] {
         get {
-            self[dynamicMember: \.array_uint64]
+            storage.array_uint64
         }
         set {
-            self[dynamicMember: \.array_uint64] = newValue
+            storage.array_uint64 = newValue
         }
     }
     public var array_sint64: [Int64] {
         get {
-            self[dynamicMember: \.array_sint64]
+            storage.array_sint64
         }
         set {
-            self[dynamicMember: \.array_sint64] = newValue
+            storage.array_sint64 = newValue
         }
     }
     public var array_fixed64: [UInt64] {
         get {
-            self[dynamicMember: \.array_fixed64]
+            storage.array_fixed64
         }
         set {
-            self[dynamicMember: \.array_fixed64] = newValue
+            storage.array_fixed64 = newValue
         }
     }
     public var array_sfixed64: [Int64] {
         get {
-            self[dynamicMember: \.array_sfixed64]
+            storage.array_sfixed64
         }
         set {
-            self[dynamicMember: \.array_sfixed64] = newValue
+            storage.array_sfixed64 = newValue
         }
     }
     public var array_float: [Float] {
         get {
-            self[dynamicMember: \.array_float]
+            storage.array_float
         }
         set {
-            self[dynamicMember: \.array_float] = newValue
+            storage.array_float = newValue
         }
     }
     public var array_double: [Double] {
         get {
-            self[dynamicMember: \.array_double]
+            storage.array_double
         }
         set {
-            self[dynamicMember: \.array_double] = newValue
+            storage.array_double = newValue
         }
     }
     public var ext_opt_int32: Int32? {
         get {
-            self[dynamicMember: \.ext_opt_int32]
+            storage.ext_opt_int32
         }
         set {
-            self[dynamicMember: \.ext_opt_int32] = newValue
+            storage.ext_opt_int32 = newValue
         }
     }
     public var ext_opt_uint32: UInt32? {
         get {
-            self[dynamicMember: \.ext_opt_uint32]
+            storage.ext_opt_uint32
         }
         set {
-            self[dynamicMember: \.ext_opt_uint32] = newValue
+            storage.ext_opt_uint32 = newValue
         }
     }
     public var ext_opt_sint32: Int32? {
         get {
-            self[dynamicMember: \.ext_opt_sint32]
+            storage.ext_opt_sint32
         }
         set {
-            self[dynamicMember: \.ext_opt_sint32] = newValue
+            storage.ext_opt_sint32 = newValue
         }
     }
     public var ext_opt_fixed32: UInt32? {
         get {
-            self[dynamicMember: \.ext_opt_fixed32]
+            storage.ext_opt_fixed32
         }
         set {
-            self[dynamicMember: \.ext_opt_fixed32] = newValue
+            storage.ext_opt_fixed32 = newValue
         }
     }
     public var ext_opt_sfixed32: Int32? {
         get {
-            self[dynamicMember: \.ext_opt_sfixed32]
+            storage.ext_opt_sfixed32
         }
         set {
-            self[dynamicMember: \.ext_opt_sfixed32] = newValue
+            storage.ext_opt_sfixed32 = newValue
         }
     }
     public var ext_opt_int64: Int64? {
         get {
-            self[dynamicMember: \.ext_opt_int64]
+            storage.ext_opt_int64
         }
         set {
-            self[dynamicMember: \.ext_opt_int64] = newValue
+            storage.ext_opt_int64 = newValue
         }
     }
     public var ext_opt_uint64: UInt64? {
         get {
-            self[dynamicMember: \.ext_opt_uint64]
+            storage.ext_opt_uint64
         }
         set {
-            self[dynamicMember: \.ext_opt_uint64] = newValue
+            storage.ext_opt_uint64 = newValue
         }
     }
     public var ext_opt_sint64: Int64? {
         get {
-            self[dynamicMember: \.ext_opt_sint64]
+            storage.ext_opt_sint64
         }
         set {
-            self[dynamicMember: \.ext_opt_sint64] = newValue
+            storage.ext_opt_sint64 = newValue
         }
     }
     public var ext_opt_fixed64: UInt64? {
         get {
-            self[dynamicMember: \.ext_opt_fixed64]
+            storage.ext_opt_fixed64
         }
         set {
-            self[dynamicMember: \.ext_opt_fixed64] = newValue
+            storage.ext_opt_fixed64 = newValue
         }
     }
     public var ext_opt_sfixed64: Int64? {
         get {
-            self[dynamicMember: \.ext_opt_sfixed64]
+            storage.ext_opt_sfixed64
         }
         set {
-            self[dynamicMember: \.ext_opt_sfixed64] = newValue
+            storage.ext_opt_sfixed64 = newValue
         }
     }
     public var ext_opt_bool: Bool? {
         get {
-            self[dynamicMember: \.ext_opt_bool]
+            storage.ext_opt_bool
         }
         set {
-            self[dynamicMember: \.ext_opt_bool] = newValue
+            storage.ext_opt_bool = newValue
         }
     }
     public var ext_opt_float: Float? {
         get {
-            self[dynamicMember: \.ext_opt_float]
+            storage.ext_opt_float
         }
         set {
-            self[dynamicMember: \.ext_opt_float] = newValue
+            storage.ext_opt_float = newValue
         }
     }
     public var ext_opt_double: Double? {
         get {
-            self[dynamicMember: \.ext_opt_double]
+            storage.ext_opt_double
         }
         set {
-            self[dynamicMember: \.ext_opt_double] = newValue
+            storage.ext_opt_double = newValue
         }
     }
     public var ext_opt_string: String? {
         get {
-            self[dynamicMember: \.ext_opt_string]
+            storage.ext_opt_string
         }
         set {
-            self[dynamicMember: \.ext_opt_string] = newValue
+            storage.ext_opt_string = newValue
         }
     }
     public var ext_opt_bytes: Foundation.Data? {
         get {
-            self[dynamicMember: \.ext_opt_bytes]
+            storage.ext_opt_bytes
         }
         set {
-            self[dynamicMember: \.ext_opt_bytes] = newValue
+            storage.ext_opt_bytes = newValue
         }
     }
     public var ext_opt_nested_enum: AllTypes.NestedEnum? {
         get {
-            self[dynamicMember: \.ext_opt_nested_enum]
+            storage.ext_opt_nested_enum
         }
         set {
-            self[dynamicMember: \.ext_opt_nested_enum] = newValue
+            storage.ext_opt_nested_enum = newValue
         }
     }
     public var ext_opt_nested_message: AllTypes.NestedMessage? {
         get {
-            self[dynamicMember: \.ext_opt_nested_message]
+            storage.ext_opt_nested_message
         }
         set {
-            self[dynamicMember: \.ext_opt_nested_message] = newValue
+            storage.ext_opt_nested_message = newValue
         }
     }
     public var ext_rep_int32: [Int32] {
         get {
-            self[dynamicMember: \.ext_rep_int32]
+            storage.ext_rep_int32
         }
         set {
-            self[dynamicMember: \.ext_rep_int32] = newValue
+            storage.ext_rep_int32 = newValue
         }
     }
     public var ext_rep_uint32: [UInt32] {
         get {
-            self[dynamicMember: \.ext_rep_uint32]
+            storage.ext_rep_uint32
         }
         set {
-            self[dynamicMember: \.ext_rep_uint32] = newValue
+            storage.ext_rep_uint32 = newValue
         }
     }
     public var ext_rep_sint32: [Int32] {
         get {
-            self[dynamicMember: \.ext_rep_sint32]
+            storage.ext_rep_sint32
         }
         set {
-            self[dynamicMember: \.ext_rep_sint32] = newValue
+            storage.ext_rep_sint32 = newValue
         }
     }
     public var ext_rep_fixed32: [UInt32] {
         get {
-            self[dynamicMember: \.ext_rep_fixed32]
+            storage.ext_rep_fixed32
         }
         set {
-            self[dynamicMember: \.ext_rep_fixed32] = newValue
+            storage.ext_rep_fixed32 = newValue
         }
     }
     public var ext_rep_sfixed32: [Int32] {
         get {
-            self[dynamicMember: \.ext_rep_sfixed32]
+            storage.ext_rep_sfixed32
         }
         set {
-            self[dynamicMember: \.ext_rep_sfixed32] = newValue
+            storage.ext_rep_sfixed32 = newValue
         }
     }
     public var ext_rep_int64: [Int64] {
         get {
-            self[dynamicMember: \.ext_rep_int64]
+            storage.ext_rep_int64
         }
         set {
-            self[dynamicMember: \.ext_rep_int64] = newValue
+            storage.ext_rep_int64 = newValue
         }
     }
     public var ext_rep_uint64: [UInt64] {
         get {
-            self[dynamicMember: \.ext_rep_uint64]
+            storage.ext_rep_uint64
         }
         set {
-            self[dynamicMember: \.ext_rep_uint64] = newValue
+            storage.ext_rep_uint64 = newValue
         }
     }
     public var ext_rep_sint64: [Int64] {
         get {
-            self[dynamicMember: \.ext_rep_sint64]
+            storage.ext_rep_sint64
         }
         set {
-            self[dynamicMember: \.ext_rep_sint64] = newValue
+            storage.ext_rep_sint64 = newValue
         }
     }
     public var ext_rep_fixed64: [UInt64] {
         get {
-            self[dynamicMember: \.ext_rep_fixed64]
+            storage.ext_rep_fixed64
         }
         set {
-            self[dynamicMember: \.ext_rep_fixed64] = newValue
+            storage.ext_rep_fixed64 = newValue
         }
     }
     public var ext_rep_sfixed64: [Int64] {
         get {
-            self[dynamicMember: \.ext_rep_sfixed64]
+            storage.ext_rep_sfixed64
         }
         set {
-            self[dynamicMember: \.ext_rep_sfixed64] = newValue
+            storage.ext_rep_sfixed64 = newValue
         }
     }
     public var ext_rep_bool: [Bool] {
         get {
-            self[dynamicMember: \.ext_rep_bool]
+            storage.ext_rep_bool
         }
         set {
-            self[dynamicMember: \.ext_rep_bool] = newValue
+            storage.ext_rep_bool = newValue
         }
     }
     public var ext_rep_float: [Float] {
         get {
-            self[dynamicMember: \.ext_rep_float]
+            storage.ext_rep_float
         }
         set {
-            self[dynamicMember: \.ext_rep_float] = newValue
+            storage.ext_rep_float = newValue
         }
     }
     public var ext_rep_double: [Double] {
         get {
-            self[dynamicMember: \.ext_rep_double]
+            storage.ext_rep_double
         }
         set {
-            self[dynamicMember: \.ext_rep_double] = newValue
+            storage.ext_rep_double = newValue
         }
     }
     public var ext_rep_string: [String] {
         get {
-            self[dynamicMember: \.ext_rep_string]
+            storage.ext_rep_string
         }
         set {
-            self[dynamicMember: \.ext_rep_string] = newValue
+            storage.ext_rep_string = newValue
         }
     }
     public var ext_rep_bytes: [Foundation.Data] {
         get {
-            self[dynamicMember: \.ext_rep_bytes]
+            storage.ext_rep_bytes
         }
         set {
-            self[dynamicMember: \.ext_rep_bytes] = newValue
+            storage.ext_rep_bytes = newValue
         }
     }
     public var ext_rep_nested_enum: [AllTypes.NestedEnum] {
         get {
-            self[dynamicMember: \.ext_rep_nested_enum]
+            storage.ext_rep_nested_enum
         }
         set {
-            self[dynamicMember: \.ext_rep_nested_enum] = newValue
+            storage.ext_rep_nested_enum = newValue
         }
     }
     public var ext_rep_nested_message: [AllTypes.NestedMessage] {
         get {
-            self[dynamicMember: \.ext_rep_nested_message]
+            storage.ext_rep_nested_message
         }
         set {
-            self[dynamicMember: \.ext_rep_nested_message] = newValue
+            storage.ext_rep_nested_message = newValue
         }
     }
     public var ext_pack_int32: [Int32] {
         get {
-            self[dynamicMember: \.ext_pack_int32]
+            storage.ext_pack_int32
         }
         set {
-            self[dynamicMember: \.ext_pack_int32] = newValue
+            storage.ext_pack_int32 = newValue
         }
     }
     public var ext_pack_uint32: [UInt32] {
         get {
-            self[dynamicMember: \.ext_pack_uint32]
+            storage.ext_pack_uint32
         }
         set {
-            self[dynamicMember: \.ext_pack_uint32] = newValue
+            storage.ext_pack_uint32 = newValue
         }
     }
     public var ext_pack_sint32: [Int32] {
         get {
-            self[dynamicMember: \.ext_pack_sint32]
+            storage.ext_pack_sint32
         }
         set {
-            self[dynamicMember: \.ext_pack_sint32] = newValue
+            storage.ext_pack_sint32 = newValue
         }
     }
     public var ext_pack_fixed32: [UInt32] {
         get {
-            self[dynamicMember: \.ext_pack_fixed32]
+            storage.ext_pack_fixed32
         }
         set {
-            self[dynamicMember: \.ext_pack_fixed32] = newValue
+            storage.ext_pack_fixed32 = newValue
         }
     }
     public var ext_pack_sfixed32: [Int32] {
         get {
-            self[dynamicMember: \.ext_pack_sfixed32]
+            storage.ext_pack_sfixed32
         }
         set {
-            self[dynamicMember: \.ext_pack_sfixed32] = newValue
+            storage.ext_pack_sfixed32 = newValue
         }
     }
     public var ext_pack_int64: [Int64] {
         get {
-            self[dynamicMember: \.ext_pack_int64]
+            storage.ext_pack_int64
         }
         set {
-            self[dynamicMember: \.ext_pack_int64] = newValue
+            storage.ext_pack_int64 = newValue
         }
     }
     public var ext_pack_uint64: [UInt64] {
         get {
-            self[dynamicMember: \.ext_pack_uint64]
+            storage.ext_pack_uint64
         }
         set {
-            self[dynamicMember: \.ext_pack_uint64] = newValue
+            storage.ext_pack_uint64 = newValue
         }
     }
     public var ext_pack_sint64: [Int64] {
         get {
-            self[dynamicMember: \.ext_pack_sint64]
+            storage.ext_pack_sint64
         }
         set {
-            self[dynamicMember: \.ext_pack_sint64] = newValue
+            storage.ext_pack_sint64 = newValue
         }
     }
     public var ext_pack_fixed64: [UInt64] {
         get {
-            self[dynamicMember: \.ext_pack_fixed64]
+            storage.ext_pack_fixed64
         }
         set {
-            self[dynamicMember: \.ext_pack_fixed64] = newValue
+            storage.ext_pack_fixed64 = newValue
         }
     }
     public var ext_pack_sfixed64: [Int64] {
         get {
-            self[dynamicMember: \.ext_pack_sfixed64]
+            storage.ext_pack_sfixed64
         }
         set {
-            self[dynamicMember: \.ext_pack_sfixed64] = newValue
+            storage.ext_pack_sfixed64 = newValue
         }
     }
     public var ext_pack_bool: [Bool] {
         get {
-            self[dynamicMember: \.ext_pack_bool]
+            storage.ext_pack_bool
         }
         set {
-            self[dynamicMember: \.ext_pack_bool] = newValue
+            storage.ext_pack_bool = newValue
         }
     }
     public var ext_pack_float: [Float] {
         get {
-            self[dynamicMember: \.ext_pack_float]
+            storage.ext_pack_float
         }
         set {
-            self[dynamicMember: \.ext_pack_float] = newValue
+            storage.ext_pack_float = newValue
         }
     }
     public var ext_pack_double: [Double] {
         get {
-            self[dynamicMember: \.ext_pack_double]
+            storage.ext_pack_double
         }
         set {
-            self[dynamicMember: \.ext_pack_double] = newValue
+            storage.ext_pack_double = newValue
         }
     }
     public var ext_pack_nested_enum: [AllTypes.NestedEnum] {
         get {
-            self[dynamicMember: \.ext_pack_nested_enum]
+            storage.ext_pack_nested_enum
         }
         set {
-            self[dynamicMember: \.ext_pack_nested_enum] = newValue
+            storage.ext_pack_nested_enum = newValue
         }
     }
     public var unknownFields: Foundation.Data {
         get {
-            self[dynamicMember: \.unknownFields]
+            storage.unknownFields
         }
         set {
-            self[dynamicMember: \.unknownFields] = newValue
+            storage.unknownFields = newValue
         }
     }
 
@@ -1207,7 +1206,7 @@ public struct AllTypes {
         req_bytes: Foundation.Data,
         req_nested_enum: AllTypes.NestedEnum,
         req_nested_message: AllTypes.NestedMessage,
-        configure: (inout Self.Storage) -> Void = { _ in }
+        configure: (inout Self.Storage) -> Swift.Void = { _ in }
     ) {
         self.storage = AllTypes.Storage(
                 req_int32: req_int32,
@@ -1229,12 +1228,6 @@ public struct AllTypes {
                 req_nested_message: req_nested_message,
                 configure: configure
                 )
-    }
-
-    private mutating func copyStorage() {
-        if !isKnownUniquelyReferenced(&_storage) {
-            _storage = Heap(wrappedValue: storage)
-        }
     }
 
 }
@@ -1554,7 +1547,7 @@ extension AllTypes : Hashable {
 #endif
 
 #if swift(>=5.5)
-extension AllTypes : @unchecked Sendable {
+extension AllTypes : Sendable {
 }
 #endif
 

--- a/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -9,7 +9,8 @@ public struct AllTypes {
     @Heap
     private var storage: AllTypes.Storage
     /**
-     * Access the underlying storage */
+     * Access the underlying storage
+     */
     public subscript<Property>(dynamicMember keyPath: WritableKeyPath<AllTypes.Storage, Property>) -> Property {
         get {
             storage[keyPath: keyPath]
@@ -1181,11 +1182,10 @@ public struct AllTypes {
     }
     public var unknownFields: Foundation.Data {
         get {
-            storage.unknownFields
+            self[dynamicMember: \.unknownFields]
         }
         set {
-            copyStorage()
-            storage.unknownFields = newValue
+            self[dynamicMember: \.unknownFields] = newValue
         }
     }
 

--- a/wire-tests-swift/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/src/main/swift/AllTypes.swift
@@ -8,6 +8,8 @@ public struct AllTypes {
 
     @Heap
     private var storage: AllTypes.Storage
+    /**
+     * Access the underlying storage */
     public subscript<Property>(dynamicMember keyPath: WritableKeyPath<AllTypes.Storage, Property>) -> Property {
         get {
             storage[keyPath: keyPath]
@@ -15,6 +17,1175 @@ public struct AllTypes {
         set {
             copyStorage()
             storage[keyPath: keyPath] = newValue
+        }
+    }
+    public var opt_int32: Int32? {
+        get {
+            self[dynamicMember: \.opt_int32]
+        }
+        set {
+            self[dynamicMember: \.opt_int32] = newValue
+        }
+    }
+    public var opt_uint32: UInt32? {
+        get {
+            self[dynamicMember: \.opt_uint32]
+        }
+        set {
+            self[dynamicMember: \.opt_uint32] = newValue
+        }
+    }
+    public var opt_sint32: Int32? {
+        get {
+            self[dynamicMember: \.opt_sint32]
+        }
+        set {
+            self[dynamicMember: \.opt_sint32] = newValue
+        }
+    }
+    public var opt_fixed32: UInt32? {
+        get {
+            self[dynamicMember: \.opt_fixed32]
+        }
+        set {
+            self[dynamicMember: \.opt_fixed32] = newValue
+        }
+    }
+    public var opt_sfixed32: Int32? {
+        get {
+            self[dynamicMember: \.opt_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.opt_sfixed32] = newValue
+        }
+    }
+    public var opt_int64: Int64? {
+        get {
+            self[dynamicMember: \.opt_int64]
+        }
+        set {
+            self[dynamicMember: \.opt_int64] = newValue
+        }
+    }
+    public var opt_uint64: UInt64? {
+        get {
+            self[dynamicMember: \.opt_uint64]
+        }
+        set {
+            self[dynamicMember: \.opt_uint64] = newValue
+        }
+    }
+    public var opt_sint64: Int64? {
+        get {
+            self[dynamicMember: \.opt_sint64]
+        }
+        set {
+            self[dynamicMember: \.opt_sint64] = newValue
+        }
+    }
+    public var opt_fixed64: UInt64? {
+        get {
+            self[dynamicMember: \.opt_fixed64]
+        }
+        set {
+            self[dynamicMember: \.opt_fixed64] = newValue
+        }
+    }
+    public var opt_sfixed64: Int64? {
+        get {
+            self[dynamicMember: \.opt_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.opt_sfixed64] = newValue
+        }
+    }
+    public var opt_bool: Bool? {
+        get {
+            self[dynamicMember: \.opt_bool]
+        }
+        set {
+            self[dynamicMember: \.opt_bool] = newValue
+        }
+    }
+    public var opt_float: Float? {
+        get {
+            self[dynamicMember: \.opt_float]
+        }
+        set {
+            self[dynamicMember: \.opt_float] = newValue
+        }
+    }
+    public var opt_double: Double? {
+        get {
+            self[dynamicMember: \.opt_double]
+        }
+        set {
+            self[dynamicMember: \.opt_double] = newValue
+        }
+    }
+    public var opt_string: String? {
+        get {
+            self[dynamicMember: \.opt_string]
+        }
+        set {
+            self[dynamicMember: \.opt_string] = newValue
+        }
+    }
+    public var opt_bytes: Foundation.Data? {
+        get {
+            self[dynamicMember: \.opt_bytes]
+        }
+        set {
+            self[dynamicMember: \.opt_bytes] = newValue
+        }
+    }
+    public var opt_nested_enum: AllTypes.NestedEnum? {
+        get {
+            self[dynamicMember: \.opt_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.opt_nested_enum] = newValue
+        }
+    }
+    public var opt_nested_message: AllTypes.NestedMessage? {
+        get {
+            self[dynamicMember: \.opt_nested_message]
+        }
+        set {
+            self[dynamicMember: \.opt_nested_message] = newValue
+        }
+    }
+    public var req_int32: Int32 {
+        get {
+            self[dynamicMember: \.req_int32]
+        }
+        set {
+            self[dynamicMember: \.req_int32] = newValue
+        }
+    }
+    public var req_uint32: UInt32 {
+        get {
+            self[dynamicMember: \.req_uint32]
+        }
+        set {
+            self[dynamicMember: \.req_uint32] = newValue
+        }
+    }
+    public var req_sint32: Int32 {
+        get {
+            self[dynamicMember: \.req_sint32]
+        }
+        set {
+            self[dynamicMember: \.req_sint32] = newValue
+        }
+    }
+    public var req_fixed32: UInt32 {
+        get {
+            self[dynamicMember: \.req_fixed32]
+        }
+        set {
+            self[dynamicMember: \.req_fixed32] = newValue
+        }
+    }
+    public var req_sfixed32: Int32 {
+        get {
+            self[dynamicMember: \.req_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.req_sfixed32] = newValue
+        }
+    }
+    public var req_int64: Int64 {
+        get {
+            self[dynamicMember: \.req_int64]
+        }
+        set {
+            self[dynamicMember: \.req_int64] = newValue
+        }
+    }
+    public var req_uint64: UInt64 {
+        get {
+            self[dynamicMember: \.req_uint64]
+        }
+        set {
+            self[dynamicMember: \.req_uint64] = newValue
+        }
+    }
+    public var req_sint64: Int64 {
+        get {
+            self[dynamicMember: \.req_sint64]
+        }
+        set {
+            self[dynamicMember: \.req_sint64] = newValue
+        }
+    }
+    public var req_fixed64: UInt64 {
+        get {
+            self[dynamicMember: \.req_fixed64]
+        }
+        set {
+            self[dynamicMember: \.req_fixed64] = newValue
+        }
+    }
+    public var req_sfixed64: Int64 {
+        get {
+            self[dynamicMember: \.req_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.req_sfixed64] = newValue
+        }
+    }
+    public var req_bool: Bool {
+        get {
+            self[dynamicMember: \.req_bool]
+        }
+        set {
+            self[dynamicMember: \.req_bool] = newValue
+        }
+    }
+    public var req_float: Float {
+        get {
+            self[dynamicMember: \.req_float]
+        }
+        set {
+            self[dynamicMember: \.req_float] = newValue
+        }
+    }
+    public var req_double: Double {
+        get {
+            self[dynamicMember: \.req_double]
+        }
+        set {
+            self[dynamicMember: \.req_double] = newValue
+        }
+    }
+    public var req_string: String {
+        get {
+            self[dynamicMember: \.req_string]
+        }
+        set {
+            self[dynamicMember: \.req_string] = newValue
+        }
+    }
+    public var req_bytes: Foundation.Data {
+        get {
+            self[dynamicMember: \.req_bytes]
+        }
+        set {
+            self[dynamicMember: \.req_bytes] = newValue
+        }
+    }
+    public var req_nested_enum: AllTypes.NestedEnum {
+        get {
+            self[dynamicMember: \.req_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.req_nested_enum] = newValue
+        }
+    }
+    public var req_nested_message: AllTypes.NestedMessage {
+        get {
+            self[dynamicMember: \.req_nested_message]
+        }
+        set {
+            self[dynamicMember: \.req_nested_message] = newValue
+        }
+    }
+    public var rep_int32: [Int32] {
+        get {
+            self[dynamicMember: \.rep_int32]
+        }
+        set {
+            self[dynamicMember: \.rep_int32] = newValue
+        }
+    }
+    public var rep_uint32: [UInt32] {
+        get {
+            self[dynamicMember: \.rep_uint32]
+        }
+        set {
+            self[dynamicMember: \.rep_uint32] = newValue
+        }
+    }
+    public var rep_sint32: [Int32] {
+        get {
+            self[dynamicMember: \.rep_sint32]
+        }
+        set {
+            self[dynamicMember: \.rep_sint32] = newValue
+        }
+    }
+    public var rep_fixed32: [UInt32] {
+        get {
+            self[dynamicMember: \.rep_fixed32]
+        }
+        set {
+            self[dynamicMember: \.rep_fixed32] = newValue
+        }
+    }
+    public var rep_sfixed32: [Int32] {
+        get {
+            self[dynamicMember: \.rep_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.rep_sfixed32] = newValue
+        }
+    }
+    public var rep_int64: [Int64] {
+        get {
+            self[dynamicMember: \.rep_int64]
+        }
+        set {
+            self[dynamicMember: \.rep_int64] = newValue
+        }
+    }
+    public var rep_uint64: [UInt64] {
+        get {
+            self[dynamicMember: \.rep_uint64]
+        }
+        set {
+            self[dynamicMember: \.rep_uint64] = newValue
+        }
+    }
+    public var rep_sint64: [Int64] {
+        get {
+            self[dynamicMember: \.rep_sint64]
+        }
+        set {
+            self[dynamicMember: \.rep_sint64] = newValue
+        }
+    }
+    public var rep_fixed64: [UInt64] {
+        get {
+            self[dynamicMember: \.rep_fixed64]
+        }
+        set {
+            self[dynamicMember: \.rep_fixed64] = newValue
+        }
+    }
+    public var rep_sfixed64: [Int64] {
+        get {
+            self[dynamicMember: \.rep_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.rep_sfixed64] = newValue
+        }
+    }
+    public var rep_bool: [Bool] {
+        get {
+            self[dynamicMember: \.rep_bool]
+        }
+        set {
+            self[dynamicMember: \.rep_bool] = newValue
+        }
+    }
+    public var rep_float: [Float] {
+        get {
+            self[dynamicMember: \.rep_float]
+        }
+        set {
+            self[dynamicMember: \.rep_float] = newValue
+        }
+    }
+    public var rep_double: [Double] {
+        get {
+            self[dynamicMember: \.rep_double]
+        }
+        set {
+            self[dynamicMember: \.rep_double] = newValue
+        }
+    }
+    public var rep_string: [String] {
+        get {
+            self[dynamicMember: \.rep_string]
+        }
+        set {
+            self[dynamicMember: \.rep_string] = newValue
+        }
+    }
+    public var rep_bytes: [Foundation.Data] {
+        get {
+            self[dynamicMember: \.rep_bytes]
+        }
+        set {
+            self[dynamicMember: \.rep_bytes] = newValue
+        }
+    }
+    public var rep_nested_enum: [AllTypes.NestedEnum] {
+        get {
+            self[dynamicMember: \.rep_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.rep_nested_enum] = newValue
+        }
+    }
+    public var rep_nested_message: [AllTypes.NestedMessage] {
+        get {
+            self[dynamicMember: \.rep_nested_message]
+        }
+        set {
+            self[dynamicMember: \.rep_nested_message] = newValue
+        }
+    }
+    public var pack_int32: [Int32] {
+        get {
+            self[dynamicMember: \.pack_int32]
+        }
+        set {
+            self[dynamicMember: \.pack_int32] = newValue
+        }
+    }
+    public var pack_uint32: [UInt32] {
+        get {
+            self[dynamicMember: \.pack_uint32]
+        }
+        set {
+            self[dynamicMember: \.pack_uint32] = newValue
+        }
+    }
+    public var pack_sint32: [Int32] {
+        get {
+            self[dynamicMember: \.pack_sint32]
+        }
+        set {
+            self[dynamicMember: \.pack_sint32] = newValue
+        }
+    }
+    public var pack_fixed32: [UInt32] {
+        get {
+            self[dynamicMember: \.pack_fixed32]
+        }
+        set {
+            self[dynamicMember: \.pack_fixed32] = newValue
+        }
+    }
+    public var pack_sfixed32: [Int32] {
+        get {
+            self[dynamicMember: \.pack_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.pack_sfixed32] = newValue
+        }
+    }
+    public var pack_int64: [Int64] {
+        get {
+            self[dynamicMember: \.pack_int64]
+        }
+        set {
+            self[dynamicMember: \.pack_int64] = newValue
+        }
+    }
+    public var pack_uint64: [UInt64] {
+        get {
+            self[dynamicMember: \.pack_uint64]
+        }
+        set {
+            self[dynamicMember: \.pack_uint64] = newValue
+        }
+    }
+    public var pack_sint64: [Int64] {
+        get {
+            self[dynamicMember: \.pack_sint64]
+        }
+        set {
+            self[dynamicMember: \.pack_sint64] = newValue
+        }
+    }
+    public var pack_fixed64: [UInt64] {
+        get {
+            self[dynamicMember: \.pack_fixed64]
+        }
+        set {
+            self[dynamicMember: \.pack_fixed64] = newValue
+        }
+    }
+    public var pack_sfixed64: [Int64] {
+        get {
+            self[dynamicMember: \.pack_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.pack_sfixed64] = newValue
+        }
+    }
+    public var pack_bool: [Bool] {
+        get {
+            self[dynamicMember: \.pack_bool]
+        }
+        set {
+            self[dynamicMember: \.pack_bool] = newValue
+        }
+    }
+    public var pack_float: [Float] {
+        get {
+            self[dynamicMember: \.pack_float]
+        }
+        set {
+            self[dynamicMember: \.pack_float] = newValue
+        }
+    }
+    public var pack_double: [Double] {
+        get {
+            self[dynamicMember: \.pack_double]
+        }
+        set {
+            self[dynamicMember: \.pack_double] = newValue
+        }
+    }
+    public var pack_nested_enum: [AllTypes.NestedEnum] {
+        get {
+            self[dynamicMember: \.pack_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.pack_nested_enum] = newValue
+        }
+    }
+    public var default_int32: Int32? {
+        get {
+            self[dynamicMember: \.default_int32]
+        }
+        set {
+            self[dynamicMember: \.default_int32] = newValue
+        }
+    }
+    public var default_uint32: UInt32? {
+        get {
+            self[dynamicMember: \.default_uint32]
+        }
+        set {
+            self[dynamicMember: \.default_uint32] = newValue
+        }
+    }
+    public var default_sint32: Int32? {
+        get {
+            self[dynamicMember: \.default_sint32]
+        }
+        set {
+            self[dynamicMember: \.default_sint32] = newValue
+        }
+    }
+    public var default_fixed32: UInt32? {
+        get {
+            self[dynamicMember: \.default_fixed32]
+        }
+        set {
+            self[dynamicMember: \.default_fixed32] = newValue
+        }
+    }
+    public var default_sfixed32: Int32? {
+        get {
+            self[dynamicMember: \.default_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.default_sfixed32] = newValue
+        }
+    }
+    public var default_int64: Int64? {
+        get {
+            self[dynamicMember: \.default_int64]
+        }
+        set {
+            self[dynamicMember: \.default_int64] = newValue
+        }
+    }
+    public var default_uint64: UInt64? {
+        get {
+            self[dynamicMember: \.default_uint64]
+        }
+        set {
+            self[dynamicMember: \.default_uint64] = newValue
+        }
+    }
+    public var default_sint64: Int64? {
+        get {
+            self[dynamicMember: \.default_sint64]
+        }
+        set {
+            self[dynamicMember: \.default_sint64] = newValue
+        }
+    }
+    public var default_fixed64: UInt64? {
+        get {
+            self[dynamicMember: \.default_fixed64]
+        }
+        set {
+            self[dynamicMember: \.default_fixed64] = newValue
+        }
+    }
+    public var default_sfixed64: Int64? {
+        get {
+            self[dynamicMember: \.default_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.default_sfixed64] = newValue
+        }
+    }
+    public var default_bool: Bool? {
+        get {
+            self[dynamicMember: \.default_bool]
+        }
+        set {
+            self[dynamicMember: \.default_bool] = newValue
+        }
+    }
+    public var default_float: Float? {
+        get {
+            self[dynamicMember: \.default_float]
+        }
+        set {
+            self[dynamicMember: \.default_float] = newValue
+        }
+    }
+    public var default_double: Double? {
+        get {
+            self[dynamicMember: \.default_double]
+        }
+        set {
+            self[dynamicMember: \.default_double] = newValue
+        }
+    }
+    public var default_string: String? {
+        get {
+            self[dynamicMember: \.default_string]
+        }
+        set {
+            self[dynamicMember: \.default_string] = newValue
+        }
+    }
+    public var default_bytes: Foundation.Data? {
+        get {
+            self[dynamicMember: \.default_bytes]
+        }
+        set {
+            self[dynamicMember: \.default_bytes] = newValue
+        }
+    }
+    public var default_nested_enum: AllTypes.NestedEnum? {
+        get {
+            self[dynamicMember: \.default_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.default_nested_enum] = newValue
+        }
+    }
+    public var map_int32_int32: [Int32 : Int32] {
+        get {
+            self[dynamicMember: \.map_int32_int32]
+        }
+        set {
+            self[dynamicMember: \.map_int32_int32] = newValue
+        }
+    }
+    public var map_string_string: [String : String] {
+        get {
+            self[dynamicMember: \.map_string_string]
+        }
+        set {
+            self[dynamicMember: \.map_string_string] = newValue
+        }
+    }
+    public var map_string_message: [String : AllTypes.NestedMessage] {
+        get {
+            self[dynamicMember: \.map_string_message]
+        }
+        set {
+            self[dynamicMember: \.map_string_message] = newValue
+        }
+    }
+    public var map_string_enum: [String : AllTypes.NestedEnum] {
+        get {
+            self[dynamicMember: \.map_string_enum]
+        }
+        set {
+            self[dynamicMember: \.map_string_enum] = newValue
+        }
+    }
+    public var array_int32: [Int32] {
+        get {
+            self[dynamicMember: \.array_int32]
+        }
+        set {
+            self[dynamicMember: \.array_int32] = newValue
+        }
+    }
+    public var array_uint32: [UInt32] {
+        get {
+            self[dynamicMember: \.array_uint32]
+        }
+        set {
+            self[dynamicMember: \.array_uint32] = newValue
+        }
+    }
+    public var array_sint32: [Int32] {
+        get {
+            self[dynamicMember: \.array_sint32]
+        }
+        set {
+            self[dynamicMember: \.array_sint32] = newValue
+        }
+    }
+    public var array_fixed32: [UInt32] {
+        get {
+            self[dynamicMember: \.array_fixed32]
+        }
+        set {
+            self[dynamicMember: \.array_fixed32] = newValue
+        }
+    }
+    public var array_sfixed32: [Int32] {
+        get {
+            self[dynamicMember: \.array_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.array_sfixed32] = newValue
+        }
+    }
+    public var array_int64: [Int64] {
+        get {
+            self[dynamicMember: \.array_int64]
+        }
+        set {
+            self[dynamicMember: \.array_int64] = newValue
+        }
+    }
+    public var array_uint64: [UInt64] {
+        get {
+            self[dynamicMember: \.array_uint64]
+        }
+        set {
+            self[dynamicMember: \.array_uint64] = newValue
+        }
+    }
+    public var array_sint64: [Int64] {
+        get {
+            self[dynamicMember: \.array_sint64]
+        }
+        set {
+            self[dynamicMember: \.array_sint64] = newValue
+        }
+    }
+    public var array_fixed64: [UInt64] {
+        get {
+            self[dynamicMember: \.array_fixed64]
+        }
+        set {
+            self[dynamicMember: \.array_fixed64] = newValue
+        }
+    }
+    public var array_sfixed64: [Int64] {
+        get {
+            self[dynamicMember: \.array_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.array_sfixed64] = newValue
+        }
+    }
+    public var array_float: [Float] {
+        get {
+            self[dynamicMember: \.array_float]
+        }
+        set {
+            self[dynamicMember: \.array_float] = newValue
+        }
+    }
+    public var array_double: [Double] {
+        get {
+            self[dynamicMember: \.array_double]
+        }
+        set {
+            self[dynamicMember: \.array_double] = newValue
+        }
+    }
+    public var ext_opt_int32: Int32? {
+        get {
+            self[dynamicMember: \.ext_opt_int32]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_int32] = newValue
+        }
+    }
+    public var ext_opt_uint32: UInt32? {
+        get {
+            self[dynamicMember: \.ext_opt_uint32]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_uint32] = newValue
+        }
+    }
+    public var ext_opt_sint32: Int32? {
+        get {
+            self[dynamicMember: \.ext_opt_sint32]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_sint32] = newValue
+        }
+    }
+    public var ext_opt_fixed32: UInt32? {
+        get {
+            self[dynamicMember: \.ext_opt_fixed32]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_fixed32] = newValue
+        }
+    }
+    public var ext_opt_sfixed32: Int32? {
+        get {
+            self[dynamicMember: \.ext_opt_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_sfixed32] = newValue
+        }
+    }
+    public var ext_opt_int64: Int64? {
+        get {
+            self[dynamicMember: \.ext_opt_int64]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_int64] = newValue
+        }
+    }
+    public var ext_opt_uint64: UInt64? {
+        get {
+            self[dynamicMember: \.ext_opt_uint64]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_uint64] = newValue
+        }
+    }
+    public var ext_opt_sint64: Int64? {
+        get {
+            self[dynamicMember: \.ext_opt_sint64]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_sint64] = newValue
+        }
+    }
+    public var ext_opt_fixed64: UInt64? {
+        get {
+            self[dynamicMember: \.ext_opt_fixed64]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_fixed64] = newValue
+        }
+    }
+    public var ext_opt_sfixed64: Int64? {
+        get {
+            self[dynamicMember: \.ext_opt_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_sfixed64] = newValue
+        }
+    }
+    public var ext_opt_bool: Bool? {
+        get {
+            self[dynamicMember: \.ext_opt_bool]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_bool] = newValue
+        }
+    }
+    public var ext_opt_float: Float? {
+        get {
+            self[dynamicMember: \.ext_opt_float]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_float] = newValue
+        }
+    }
+    public var ext_opt_double: Double? {
+        get {
+            self[dynamicMember: \.ext_opt_double]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_double] = newValue
+        }
+    }
+    public var ext_opt_string: String? {
+        get {
+            self[dynamicMember: \.ext_opt_string]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_string] = newValue
+        }
+    }
+    public var ext_opt_bytes: Foundation.Data? {
+        get {
+            self[dynamicMember: \.ext_opt_bytes]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_bytes] = newValue
+        }
+    }
+    public var ext_opt_nested_enum: AllTypes.NestedEnum? {
+        get {
+            self[dynamicMember: \.ext_opt_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_nested_enum] = newValue
+        }
+    }
+    public var ext_opt_nested_message: AllTypes.NestedMessage? {
+        get {
+            self[dynamicMember: \.ext_opt_nested_message]
+        }
+        set {
+            self[dynamicMember: \.ext_opt_nested_message] = newValue
+        }
+    }
+    public var ext_rep_int32: [Int32] {
+        get {
+            self[dynamicMember: \.ext_rep_int32]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_int32] = newValue
+        }
+    }
+    public var ext_rep_uint32: [UInt32] {
+        get {
+            self[dynamicMember: \.ext_rep_uint32]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_uint32] = newValue
+        }
+    }
+    public var ext_rep_sint32: [Int32] {
+        get {
+            self[dynamicMember: \.ext_rep_sint32]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_sint32] = newValue
+        }
+    }
+    public var ext_rep_fixed32: [UInt32] {
+        get {
+            self[dynamicMember: \.ext_rep_fixed32]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_fixed32] = newValue
+        }
+    }
+    public var ext_rep_sfixed32: [Int32] {
+        get {
+            self[dynamicMember: \.ext_rep_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_sfixed32] = newValue
+        }
+    }
+    public var ext_rep_int64: [Int64] {
+        get {
+            self[dynamicMember: \.ext_rep_int64]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_int64] = newValue
+        }
+    }
+    public var ext_rep_uint64: [UInt64] {
+        get {
+            self[dynamicMember: \.ext_rep_uint64]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_uint64] = newValue
+        }
+    }
+    public var ext_rep_sint64: [Int64] {
+        get {
+            self[dynamicMember: \.ext_rep_sint64]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_sint64] = newValue
+        }
+    }
+    public var ext_rep_fixed64: [UInt64] {
+        get {
+            self[dynamicMember: \.ext_rep_fixed64]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_fixed64] = newValue
+        }
+    }
+    public var ext_rep_sfixed64: [Int64] {
+        get {
+            self[dynamicMember: \.ext_rep_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_sfixed64] = newValue
+        }
+    }
+    public var ext_rep_bool: [Bool] {
+        get {
+            self[dynamicMember: \.ext_rep_bool]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_bool] = newValue
+        }
+    }
+    public var ext_rep_float: [Float] {
+        get {
+            self[dynamicMember: \.ext_rep_float]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_float] = newValue
+        }
+    }
+    public var ext_rep_double: [Double] {
+        get {
+            self[dynamicMember: \.ext_rep_double]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_double] = newValue
+        }
+    }
+    public var ext_rep_string: [String] {
+        get {
+            self[dynamicMember: \.ext_rep_string]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_string] = newValue
+        }
+    }
+    public var ext_rep_bytes: [Foundation.Data] {
+        get {
+            self[dynamicMember: \.ext_rep_bytes]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_bytes] = newValue
+        }
+    }
+    public var ext_rep_nested_enum: [AllTypes.NestedEnum] {
+        get {
+            self[dynamicMember: \.ext_rep_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_nested_enum] = newValue
+        }
+    }
+    public var ext_rep_nested_message: [AllTypes.NestedMessage] {
+        get {
+            self[dynamicMember: \.ext_rep_nested_message]
+        }
+        set {
+            self[dynamicMember: \.ext_rep_nested_message] = newValue
+        }
+    }
+    public var ext_pack_int32: [Int32] {
+        get {
+            self[dynamicMember: \.ext_pack_int32]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_int32] = newValue
+        }
+    }
+    public var ext_pack_uint32: [UInt32] {
+        get {
+            self[dynamicMember: \.ext_pack_uint32]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_uint32] = newValue
+        }
+    }
+    public var ext_pack_sint32: [Int32] {
+        get {
+            self[dynamicMember: \.ext_pack_sint32]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_sint32] = newValue
+        }
+    }
+    public var ext_pack_fixed32: [UInt32] {
+        get {
+            self[dynamicMember: \.ext_pack_fixed32]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_fixed32] = newValue
+        }
+    }
+    public var ext_pack_sfixed32: [Int32] {
+        get {
+            self[dynamicMember: \.ext_pack_sfixed32]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_sfixed32] = newValue
+        }
+    }
+    public var ext_pack_int64: [Int64] {
+        get {
+            self[dynamicMember: \.ext_pack_int64]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_int64] = newValue
+        }
+    }
+    public var ext_pack_uint64: [UInt64] {
+        get {
+            self[dynamicMember: \.ext_pack_uint64]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_uint64] = newValue
+        }
+    }
+    public var ext_pack_sint64: [Int64] {
+        get {
+            self[dynamicMember: \.ext_pack_sint64]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_sint64] = newValue
+        }
+    }
+    public var ext_pack_fixed64: [UInt64] {
+        get {
+            self[dynamicMember: \.ext_pack_fixed64]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_fixed64] = newValue
+        }
+    }
+    public var ext_pack_sfixed64: [Int64] {
+        get {
+            self[dynamicMember: \.ext_pack_sfixed64]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_sfixed64] = newValue
+        }
+    }
+    public var ext_pack_bool: [Bool] {
+        get {
+            self[dynamicMember: \.ext_pack_bool]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_bool] = newValue
+        }
+    }
+    public var ext_pack_float: [Float] {
+        get {
+            self[dynamicMember: \.ext_pack_float]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_float] = newValue
+        }
+    }
+    public var ext_pack_double: [Double] {
+        get {
+            self[dynamicMember: \.ext_pack_double]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_double] = newValue
+        }
+    }
+    public var ext_pack_nested_enum: [AllTypes.NestedEnum] {
+        get {
+            self[dynamicMember: \.ext_pack_nested_enum]
+        }
+        set {
+            self[dynamicMember: \.ext_pack_nested_enum] = newValue
+        }
+    }
+    public var unknownFields: Foundation.Data {
+        get {
+            storage.unknownFields
+        }
+        set {
+            copyStorage()
+            storage.unknownFields = newValue
         }
     }
 
@@ -64,31 +1235,6 @@ public struct AllTypes {
         if !isKnownUniquelyReferenced(&_storage) {
             _storage = Heap(wrappedValue: storage)
         }
-    }
-
-    public enum NestedEnum : UInt32, CaseIterable, ProtoEnum {
-
-        case UNKNOWN = 0
-        case A = 1
-
-        public var description: String {
-            switch self {
-            case .UNKNOWN: return "UNKNOWN"
-            case .A: return "A"
-            }
-        }
-
-    }
-
-    public struct NestedMessage {
-
-        public var a: Int32?
-        public var unknownFields: Foundation.Data = .init()
-
-        public init(configure: (inout Self) -> Void = { _ in }) {
-            configure(&self)
-        }
-
     }
 
 }
@@ -397,6 +1543,81 @@ extension AllTypes {
 }
 #endif
 
+#if !WIRE_REMOVE_EQUATABLE
+extension AllTypes : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension AllTypes : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension AllTypes : @unchecked Sendable {
+}
+#endif
+
+extension AllTypes : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        self.storage = try Storage(from: protoReader)
+    }
+
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try storage.encode(to: protoWriter)
+    }
+
+}
+
+#if !WIRE_REMOVE_CODABLE
+extension AllTypes : Codable {
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self.storage = try container.decode(Storage.self)
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(storage)
+    }
+
+}
+#endif
+
+/**
+ * Subtypes within AllTypes
+ */
+extension AllTypes {
+
+    public enum NestedEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+
+        case UNKNOWN = 0
+        case A = 1
+
+        public var description: Swift.String {
+            switch self {
+            case .UNKNOWN: return "UNKNOWN"
+            case .A: return "A"
+            }
+        }
+
+    }
+
+    public struct NestedMessage {
+
+        public var a: Swift.Int32?
+        public var unknownFields: Foundation.Data = .init()
+
+        public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+            configure(&self)
+        }
+
+    }
+
+}
+
 #if swift(>=5.5)
 extension AllTypes.NestedEnum : Sendable {
 }
@@ -475,21 +1696,6 @@ extension AllTypes.NestedMessage : Codable {
         try container.encodeIfPresent(self.a, forKey: "a")
     }
 
-}
-#endif
-
-#if !WIRE_REMOVE_EQUATABLE
-extension AllTypes : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension AllTypes : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension AllTypes : @unchecked Sendable {
 }
 #endif
 
@@ -797,6 +2003,9 @@ extension AllTypes.Storage {
 
 extension AllTypes {
 
+    /**
+     * Underlying storage for AllTypes
+     */
     public struct Storage {
 
         public var opt_int32: Swift.Int32?
@@ -1006,17 +2215,20 @@ extension AllTypes {
 
 }
 
-extension AllTypes : Proto2Codable {
-
-    public init(from protoReader: Wire.ProtoReader) throws {
-        self.storage = try Storage(from: protoReader)
-    }
-
-    public func encode(to protoWriter: Wire.ProtoWriter) throws {
-        try storage.encode(to: protoWriter)
-    }
-
+#if !WIRE_REMOVE_EQUATABLE
+extension AllTypes.Storage : Equatable {
 }
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension AllTypes.Storage : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension AllTypes.Storage : Sendable {
+}
+#endif
 
 extension AllTypes.Storage : ProtoMessage {
 
@@ -1627,22 +2839,6 @@ extension AllTypes.Storage : Proto2Codable {
 }
 
 #if !WIRE_REMOVE_CODABLE
-extension AllTypes : Codable {
-
-    public init(from decoder: Swift.Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self.storage = try container.decode(Storage.self)
-    }
-
-    public func encode(to encoder: Swift.Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(storage)
-    }
-
-}
-#endif
-
-#if !WIRE_REMOVE_CODABLE
 extension AllTypes.Storage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
@@ -2134,20 +3330,5 @@ extension AllTypes.Storage : Codable {
         }
     }
 
-}
-#endif
-
-#if !WIRE_REMOVE_EQUATABLE
-extension AllTypes.Storage : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension AllTypes.Storage : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension AllTypes.Storage : Sendable {
 }
 #endif

--- a/wire-tests-swift/src/main/swift/DeprecatedProto.swift
+++ b/wire-tests-swift/src/main/swift/DeprecatedProto.swift
@@ -9,7 +9,7 @@ public struct DeprecatedProto {
     public var foo: String?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
+++ b/wire-tests-swift/src/main/swift/EmbeddedMessage.swift
@@ -9,7 +9,7 @@ public struct EmbeddedMessage {
     public var inner_number_after: Int32?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/ExternalMessage.swift
+++ b/wire-tests-swift/src/main/swift/ExternalMessage.swift
@@ -9,7 +9,7 @@ public struct ExternalMessage {
     public var f: Float?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/src/main/swift/FooBar.swift
@@ -17,7 +17,7 @@ public struct FooBar {
     public var more_string: String?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/src/main/swift/FooBar.swift
@@ -21,44 +21,6 @@ public struct FooBar {
         configure(&self)
     }
 
-    public struct Nested {
-
-        public var value: FooBar.FooBarBazEnum?
-        public var unknownFields: Foundation.Data = .init()
-
-        public init(configure: (inout Self) -> Void = { _ in }) {
-            configure(&self)
-        }
-
-    }
-
-    public struct More {
-
-        public var serial: [Int32] = []
-        public var unknownFields: Foundation.Data = .init()
-
-        public init(configure: (inout Self) -> Void = { _ in }) {
-            configure(&self)
-        }
-
-    }
-
-    public enum FooBarBazEnum : UInt32, CaseIterable, ProtoEnum {
-
-        case FOO = 1
-        case BAR = 2
-        case BAZ = 3
-
-        public var description: String {
-            switch self {
-            case .FOO: return "FOO"
-            case .BAR: return "BAR"
-            case .BAZ: return "BAZ"
-            }
-        }
-
-    }
-
 }
 
 #if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
@@ -92,6 +54,189 @@ extension FooBar {
 
 }
 #endif
+
+#if !WIRE_REMOVE_EQUATABLE
+extension FooBar : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension FooBar : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension FooBar : Sendable {
+}
+#endif
+
+#if !WIRE_REMOVE_REDACTABLE
+extension FooBar : Redactable {
+
+    public enum RedactedKeys : Swift.String, Wire.RedactedKey {
+
+        case nested
+
+    }
+
+}
+#endif
+
+extension FooBar : ProtoMessage {
+
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/squareup.protos.custom_options.FooBar"
+    }
+
+}
+
+extension FooBar : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var foo: Swift.Int32? = nil
+        var bar: Swift.String? = nil
+        var baz: FooBar.Nested? = nil
+        var qux: Swift.UInt64? = nil
+        var fred: [Swift.Float] = []
+        var daisy: Swift.Double? = nil
+        var nested: [FooBar] = []
+        var ext: FooBar.FooBarBazEnum? = nil
+        var rep: [FooBar.FooBarBazEnum] = []
+        var more_string: Swift.String? = nil
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
+            switch tag {
+            case 1: foo = try protoReader.decode(Swift.Int32.self)
+            case 2: bar = try protoReader.decode(Swift.String.self)
+            case 3: baz = try protoReader.decode(FooBar.Nested.self)
+            case 4: qux = try protoReader.decode(Swift.UInt64.self)
+            case 5: try protoReader.decode(into: &fred)
+            case 6: daisy = try protoReader.decode(Swift.Double.self)
+            case 7: try protoReader.decode(into: &nested)
+            case 101: ext = try protoReader.decode(FooBar.FooBarBazEnum.self)
+            case 102: try protoReader.decode(into: &rep)
+            case 150: more_string = try protoReader.decode(Swift.String.self)
+            default: try protoReader.readUnknownField(tag: tag)
+            }
+        }
+        self.unknownFields = try protoReader.endMessage(token: token)
+
+        self.foo = foo
+        self.bar = bar
+        self.baz = baz
+        self.qux = qux
+        self.fred = fred
+        self.daisy = daisy
+        self.nested = nested
+        self.ext = ext
+        self.rep = rep
+        self.more_string = more_string
+    }
+
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.foo)
+        try protoWriter.encode(tag: 2, value: self.bar)
+        try protoWriter.encode(tag: 3, value: self.baz)
+        try protoWriter.encode(tag: 4, value: self.qux)
+        try protoWriter.encode(tag: 5, value: self.fred)
+        try protoWriter.encode(tag: 6, value: self.daisy)
+        try protoWriter.encode(tag: 7, value: self.nested)
+        try protoWriter.encode(tag: 101, value: self.ext)
+        try protoWriter.encode(tag: 102, value: self.rep)
+        try protoWriter.encode(tag: 150, value: self.more_string)
+        try protoWriter.writeUnknownFields(unknownFields)
+    }
+
+}
+
+#if !WIRE_REMOVE_CODABLE
+extension FooBar : Codable {
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.foo = try container.decodeIfPresent(Swift.Int32.self, forKey: "foo")
+        self.bar = try container.decodeIfPresent(Swift.String.self, forKey: "bar")
+        self.baz = try container.decodeIfPresent(FooBar.Nested.self, forKey: "baz")
+        self.qux = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, forKey: "qux")
+        self.fred = try container.decodeProtoArray(Swift.Float.self, forKey: "fred")
+        self.daisy = try container.decodeIfPresent(Swift.Double.self, forKey: "daisy")
+        self.nested = try container.decodeProtoArray(FooBar.self, forKey: "nested")
+        self.ext = try container.decodeIfPresent(FooBar.FooBarBazEnum.self, forKey: "ext")
+        self.rep = try container.decodeProtoArray(FooBar.FooBarBazEnum.self, forKey: "rep")
+        self.more_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "moreString", "more_string")
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
+        let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
+
+        try container.encodeIfPresent(self.foo, forKey: "foo")
+        try container.encodeIfPresent(self.bar, forKey: "bar")
+        try container.encodeIfPresent(self.baz, forKey: "baz")
+        try container.encodeIfPresent(stringEncoded: self.qux, forKey: "qux")
+        if includeDefaults || !self.fred.isEmpty {
+            try container.encodeProtoArray(self.fred, forKey: "fred")
+        }
+        try container.encodeIfPresent(self.daisy, forKey: "daisy")
+        if includeDefaults || !self.nested.isEmpty {
+            try container.encodeProtoArray(self.nested, forKey: "nested")
+        }
+        try container.encodeIfPresent(self.ext, forKey: "ext")
+        if includeDefaults || !self.rep.isEmpty {
+            try container.encodeProtoArray(self.rep, forKey: "rep")
+        }
+        try container.encodeIfPresent(self.more_string, forKey: preferCamelCase ? "moreString" : "more_string")
+    }
+
+}
+#endif
+
+/**
+ * Subtypes within FooBar
+ */
+extension FooBar {
+
+    public struct Nested {
+
+        public var value: FooBar.FooBarBazEnum?
+        public var unknownFields: Foundation.Data = .init()
+
+        public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+            configure(&self)
+        }
+
+    }
+
+    public struct More {
+
+        public var serial: [Swift.Int32] = []
+        public var unknownFields: Foundation.Data = .init()
+
+        public init(configure: (inout Self) -> Swift.Void = { _ in }) {
+            configure(&self)
+        }
+
+    }
+
+    public enum FooBarBazEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+
+        case FOO = 1
+        case BAR = 2
+        case BAZ = 3
+
+        public var description: Swift.String {
+            switch self {
+            case .FOO: return "FOO"
+            case .BAR: return "BAR"
+            case .BAZ: return "BAZ"
+            }
+        }
+
+    }
+
+}
 
 #if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
 extension FooBar.Nested {
@@ -250,143 +395,5 @@ extension FooBar.More : Codable {
 
 #if swift(>=5.5)
 extension FooBar.FooBarBazEnum : Sendable {
-}
-#endif
-
-#if !WIRE_REMOVE_EQUATABLE
-extension FooBar : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension FooBar : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension FooBar : Sendable {
-}
-#endif
-
-extension FooBar : ProtoMessage {
-
-    public static func protoMessageTypeURL() -> Swift.String {
-        return "type.googleapis.com/squareup.protos.custom_options.FooBar"
-    }
-
-}
-
-extension FooBar : Proto2Codable {
-
-    public init(from protoReader: Wire.ProtoReader) throws {
-        var foo: Swift.Int32? = nil
-        var bar: Swift.String? = nil
-        var baz: FooBar.Nested? = nil
-        var qux: Swift.UInt64? = nil
-        var fred: [Swift.Float] = []
-        var daisy: Swift.Double? = nil
-        var nested: [FooBar] = []
-        var ext: FooBar.FooBarBazEnum? = nil
-        var rep: [FooBar.FooBarBazEnum] = []
-        var more_string: Swift.String? = nil
-
-        let token = try protoReader.beginMessage()
-        while let tag = try protoReader.nextTag(token: token) {
-            switch tag {
-            case 1: foo = try protoReader.decode(Swift.Int32.self)
-            case 2: bar = try protoReader.decode(Swift.String.self)
-            case 3: baz = try protoReader.decode(FooBar.Nested.self)
-            case 4: qux = try protoReader.decode(Swift.UInt64.self)
-            case 5: try protoReader.decode(into: &fred)
-            case 6: daisy = try protoReader.decode(Swift.Double.self)
-            case 7: try protoReader.decode(into: &nested)
-            case 101: ext = try protoReader.decode(FooBar.FooBarBazEnum.self)
-            case 102: try protoReader.decode(into: &rep)
-            case 150: more_string = try protoReader.decode(Swift.String.self)
-            default: try protoReader.readUnknownField(tag: tag)
-            }
-        }
-        self.unknownFields = try protoReader.endMessage(token: token)
-
-        self.foo = foo
-        self.bar = bar
-        self.baz = baz
-        self.qux = qux
-        self.fred = fred
-        self.daisy = daisy
-        self.nested = nested
-        self.ext = ext
-        self.rep = rep
-        self.more_string = more_string
-    }
-
-    public func encode(to protoWriter: Wire.ProtoWriter) throws {
-        try protoWriter.encode(tag: 1, value: self.foo)
-        try protoWriter.encode(tag: 2, value: self.bar)
-        try protoWriter.encode(tag: 3, value: self.baz)
-        try protoWriter.encode(tag: 4, value: self.qux)
-        try protoWriter.encode(tag: 5, value: self.fred)
-        try protoWriter.encode(tag: 6, value: self.daisy)
-        try protoWriter.encode(tag: 7, value: self.nested)
-        try protoWriter.encode(tag: 101, value: self.ext)
-        try protoWriter.encode(tag: 102, value: self.rep)
-        try protoWriter.encode(tag: 150, value: self.more_string)
-        try protoWriter.writeUnknownFields(unknownFields)
-    }
-
-}
-
-#if !WIRE_REMOVE_CODABLE
-extension FooBar : Codable {
-
-    public init(from decoder: Swift.Decoder) throws {
-        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.foo = try container.decodeIfPresent(Swift.Int32.self, forKey: "foo")
-        self.bar = try container.decodeIfPresent(Swift.String.self, forKey: "bar")
-        self.baz = try container.decodeIfPresent(FooBar.Nested.self, forKey: "baz")
-        self.qux = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, forKey: "qux")
-        self.fred = try container.decodeProtoArray(Swift.Float.self, forKey: "fred")
-        self.daisy = try container.decodeIfPresent(Swift.Double.self, forKey: "daisy")
-        self.nested = try container.decodeProtoArray(FooBar.self, forKey: "nested")
-        self.ext = try container.decodeIfPresent(FooBar.FooBarBazEnum.self, forKey: "ext")
-        self.rep = try container.decodeProtoArray(FooBar.FooBarBazEnum.self, forKey: "rep")
-        self.more_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "moreString", "more_string")
-    }
-
-    public func encode(to encoder: Swift.Encoder) throws {
-        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
-        let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
-
-        try container.encodeIfPresent(self.foo, forKey: "foo")
-        try container.encodeIfPresent(self.bar, forKey: "bar")
-        try container.encodeIfPresent(self.baz, forKey: "baz")
-        try container.encodeIfPresent(stringEncoded: self.qux, forKey: "qux")
-        if includeDefaults || !self.fred.isEmpty {
-            try container.encodeProtoArray(self.fred, forKey: "fred")
-        }
-        try container.encodeIfPresent(self.daisy, forKey: "daisy")
-        if includeDefaults || !self.nested.isEmpty {
-            try container.encodeProtoArray(self.nested, forKey: "nested")
-        }
-        try container.encodeIfPresent(self.ext, forKey: "ext")
-        if includeDefaults || !self.rep.isEmpty {
-            try container.encodeProtoArray(self.rep, forKey: "rep")
-        }
-        try container.encodeIfPresent(self.more_string, forKey: preferCamelCase ? "moreString" : "more_string")
-    }
-
-}
-#endif
-
-#if !WIRE_REMOVE_REDACTABLE
-extension FooBar : Redactable {
-
-    public enum RedactedKeys : Swift.String, Wire.RedactedKey {
-
-        case nested
-
-    }
-
 }
 #endif

--- a/wire-tests-swift/src/main/swift/ForeignMessage.swift
+++ b/wire-tests-swift/src/main/swift/ForeignMessage.swift
@@ -8,7 +8,7 @@ public struct ForeignMessage {
     public var i: Int32?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-tests-swift/src/main/swift/Form.swift
@@ -5,13 +5,218 @@ import Wire
 
 public struct Form {
 
-    public var choice: Choice?
-    public var decision: Decision?
+    public var choice: Form.Choice?
+    public var decision: Form.Decision?
     public var unknownFields: Foundation.Data = .init()
 
     public init(configure: (inout Self) -> Void = { _ in }) {
         configure(&self)
     }
+
+}
+
+#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
+extension Form {
+
+    @_disfavoredOverload
+    @available(*, deprecated)
+    public init(choice: Choice? = nil, decision: Decision? = nil) {
+        self.choice = choice
+        self.decision = decision
+    }
+
+}
+#endif
+
+#if !WIRE_REMOVE_EQUATABLE
+extension Form : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension Form : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension Form : Sendable {
+}
+#endif
+
+extension Form : ProtoMessage {
+
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/squareup.protos.kotlin.oneof.Form"
+    }
+
+}
+
+extension Form : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var choice: Choice? = nil
+        var decision: Decision? = nil
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
+            switch tag {
+            case 1: choice = .button_element(try protoReader.decode(Form.ButtonElement.self))
+            case 2: choice = .local_image_element(try protoReader.decode(Form.LocalImageElement.self))
+            case 3: choice = .remote_image_element(try protoReader.decode(Form.RemoteImageElement.self))
+            case 4: choice = .money_element(try protoReader.decode(Form.MoneyElement.self))
+            case 5: choice = .spacer_element(try protoReader.decode(Form.SpacerElement.self))
+            case 6: choice = .text_element(try protoReader.decode(Form.TextElement.self))
+            case 7: choice = .customized_card_element(try protoReader.decode(Form.CustomizedCardElement.self))
+            case 8: choice = .address_element(try protoReader.decode(Form.AddressElement.self))
+            case 9: choice = .text_input_element(try protoReader.decode(Form.TextInputElement.self))
+            case 10: choice = .option_picker_element(try protoReader.decode(Form.OptionPickerElement.self))
+            case 11: choice = .detail_row_element(try protoReader.decode(Form.DetailRowElement.self))
+            case 12: choice = .currency_conversion_flags_element(try protoReader.decode(Form.CurrencyConversionFlagsElement.self))
+            case 101: decision = .a(try protoReader.decode(Swift.String.self))
+            case 102: decision = .b(try protoReader.decode(Swift.String.self))
+            case 103: decision = .c(try protoReader.decode(Swift.String.self))
+            case 104: decision = .d(try protoReader.decode(Swift.String.self))
+            case 105: decision = .e(try protoReader.decode(Swift.String.self))
+            case 106: decision = .f(try protoReader.decode(Swift.String.self))
+            case 107: decision = .g(try protoReader.decode(Swift.String.self))
+            case 108: decision = .h(try protoReader.decode(Swift.String.self))
+            default: try protoReader.readUnknownField(tag: tag)
+            }
+        }
+        self.unknownFields = try protoReader.endMessage(token: token)
+
+        self.choice = choice
+        self.decision = decision
+    }
+
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        if let choice = self.choice {
+            try choice.encode(to: protoWriter)
+        }
+        if let decision = self.decision {
+            try decision.encode(to: protoWriter)
+        }
+        try protoWriter.writeUnknownFields(unknownFields)
+    }
+
+}
+
+#if !WIRE_REMOVE_CODABLE
+extension Form : Codable {
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        if let button_element = try container.decodeIfPresent(Form.ButtonElement.self, forKey: "buttonElement") {
+            self.choice = .button_element(button_element)
+        } else if let button_element = try container.decodeIfPresent(Form.ButtonElement.self, forKey: "button_element") {
+            self.choice = .button_element(button_element)
+        } else if let local_image_element = try container.decodeIfPresent(Form.LocalImageElement.self, forKey: "localImageElement") {
+            self.choice = .local_image_element(local_image_element)
+        } else if let local_image_element = try container.decodeIfPresent(Form.LocalImageElement.self, forKey: "local_image_element") {
+            self.choice = .local_image_element(local_image_element)
+        } else if let remote_image_element = try container.decodeIfPresent(Form.RemoteImageElement.self, forKey: "remoteImageElement") {
+            self.choice = .remote_image_element(remote_image_element)
+        } else if let remote_image_element = try container.decodeIfPresent(Form.RemoteImageElement.self, forKey: "remote_image_element") {
+            self.choice = .remote_image_element(remote_image_element)
+        } else if let money_element = try container.decodeIfPresent(Form.MoneyElement.self, forKey: "moneyElement") {
+            self.choice = .money_element(money_element)
+        } else if let money_element = try container.decodeIfPresent(Form.MoneyElement.self, forKey: "money_element") {
+            self.choice = .money_element(money_element)
+        } else if let spacer_element = try container.decodeIfPresent(Form.SpacerElement.self, forKey: "spacerElement") {
+            self.choice = .spacer_element(spacer_element)
+        } else if let spacer_element = try container.decodeIfPresent(Form.SpacerElement.self, forKey: "spacer_element") {
+            self.choice = .spacer_element(spacer_element)
+        } else if let text_element = try container.decodeIfPresent(Form.TextElement.self, forKey: "textElement") {
+            self.choice = .text_element(text_element)
+        } else if let text_element = try container.decodeIfPresent(Form.TextElement.self, forKey: "text_element") {
+            self.choice = .text_element(text_element)
+        } else if let customized_card_element = try container.decodeIfPresent(Form.CustomizedCardElement.self, forKey: "customizedCardElement") {
+            self.choice = .customized_card_element(customized_card_element)
+        } else if let customized_card_element = try container.decodeIfPresent(Form.CustomizedCardElement.self, forKey: "customized_card_element") {
+            self.choice = .customized_card_element(customized_card_element)
+        } else if let address_element = try container.decodeIfPresent(Form.AddressElement.self, forKey: "addressElement") {
+            self.choice = .address_element(address_element)
+        } else if let address_element = try container.decodeIfPresent(Form.AddressElement.self, forKey: "address_element") {
+            self.choice = .address_element(address_element)
+        } else if let text_input_element = try container.decodeIfPresent(Form.TextInputElement.self, forKey: "textInputElement") {
+            self.choice = .text_input_element(text_input_element)
+        } else if let text_input_element = try container.decodeIfPresent(Form.TextInputElement.self, forKey: "text_input_element") {
+            self.choice = .text_input_element(text_input_element)
+        } else if let option_picker_element = try container.decodeIfPresent(Form.OptionPickerElement.self, forKey: "optionPickerElement") {
+            self.choice = .option_picker_element(option_picker_element)
+        } else if let option_picker_element = try container.decodeIfPresent(Form.OptionPickerElement.self, forKey: "option_picker_element") {
+            self.choice = .option_picker_element(option_picker_element)
+        } else if let detail_row_element = try container.decodeIfPresent(Form.DetailRowElement.self, forKey: "detailRowElement") {
+            self.choice = .detail_row_element(detail_row_element)
+        } else if let detail_row_element = try container.decodeIfPresent(Form.DetailRowElement.self, forKey: "detail_row_element") {
+            self.choice = .detail_row_element(detail_row_element)
+        } else if let currency_conversion_flags_element = try container.decodeIfPresent(Form.CurrencyConversionFlagsElement.self, forKey: "currencyConversionFlagsElement") {
+            self.choice = .currency_conversion_flags_element(currency_conversion_flags_element)
+        } else if let currency_conversion_flags_element = try container.decodeIfPresent(Form.CurrencyConversionFlagsElement.self, forKey: "currency_conversion_flags_element") {
+            self.choice = .currency_conversion_flags_element(currency_conversion_flags_element)
+        } else {
+            self.choice = nil
+        }
+        if let a = try container.decodeIfPresent(Swift.String.self, forKey: "a") {
+            self.decision = .a(a)
+        } else if let b = try container.decodeIfPresent(Swift.String.self, forKey: "b") {
+            self.decision = .b(b)
+        } else if let c = try container.decodeIfPresent(Swift.String.self, forKey: "c") {
+            self.decision = .c(c)
+        } else if let d = try container.decodeIfPresent(Swift.String.self, forKey: "d") {
+            self.decision = .d(d)
+        } else if let e = try container.decodeIfPresent(Swift.String.self, forKey: "e") {
+            self.decision = .e(e)
+        } else if let f = try container.decodeIfPresent(Swift.String.self, forKey: "f") {
+            self.decision = .f(f)
+        } else if let g = try container.decodeIfPresent(Swift.String.self, forKey: "g") {
+            self.decision = .g(g)
+        } else if let h = try container.decodeIfPresent(Swift.String.self, forKey: "h") {
+            self.decision = .h(h)
+        } else {
+            self.decision = nil
+        }
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
+
+        switch self.choice {
+        case .button_element(let button_element): try container.encode(button_element, forKey: preferCamelCase ? "buttonElement" : "button_element")
+        case .local_image_element(let local_image_element): try container.encode(local_image_element, forKey: preferCamelCase ? "localImageElement" : "local_image_element")
+        case .remote_image_element(let remote_image_element): try container.encode(remote_image_element, forKey: preferCamelCase ? "remoteImageElement" : "remote_image_element")
+        case .money_element(let money_element): try container.encode(money_element, forKey: preferCamelCase ? "moneyElement" : "money_element")
+        case .spacer_element(let spacer_element): try container.encode(spacer_element, forKey: preferCamelCase ? "spacerElement" : "spacer_element")
+        case .text_element(let text_element): try container.encode(text_element, forKey: preferCamelCase ? "textElement" : "text_element")
+        case .customized_card_element(let customized_card_element): try container.encode(customized_card_element, forKey: preferCamelCase ? "customizedCardElement" : "customized_card_element")
+        case .address_element(let address_element): try container.encode(address_element, forKey: preferCamelCase ? "addressElement" : "address_element")
+        case .text_input_element(let text_input_element): try container.encode(text_input_element, forKey: preferCamelCase ? "textInputElement" : "text_input_element")
+        case .option_picker_element(let option_picker_element): try container.encode(option_picker_element, forKey: preferCamelCase ? "optionPickerElement" : "option_picker_element")
+        case .detail_row_element(let detail_row_element): try container.encode(detail_row_element, forKey: preferCamelCase ? "detailRowElement" : "detail_row_element")
+        case .currency_conversion_flags_element(let currency_conversion_flags_element): try container.encode(currency_conversion_flags_element, forKey: preferCamelCase ? "currencyConversionFlagsElement" : "currency_conversion_flags_element")
+        case Swift.Optional.none: break
+        }
+        switch self.decision {
+        case .a(let a): try container.encode(a, forKey: "a")
+        case .b(let b): try container.encode(b, forKey: "b")
+        case .c(let c): try container.encode(c, forKey: "c")
+        case .d(let d): try container.encode(d, forKey: "d")
+        case .e(let e): try container.encode(e, forKey: "e")
+        case .f(let f): try container.encode(f, forKey: "f")
+        case .g(let g): try container.encode(g, forKey: "g")
+        case .h(let h): try container.encode(h, forKey: "h")
+        case Swift.Optional.none: break
+        }
+    }
+
+}
+#endif
+
+/**
+ * Subtypes within Form
+ */
+extension Form {
 
     public enum Choice {
 
@@ -29,7 +234,7 @@ public struct Form {
         case detail_row_element(Form.DetailRowElement)
         case currency_conversion_flags_element(Form.CurrencyConversionFlagsElement)
 
-        fileprivate func encode(to protoWriter: ProtoWriter) throws {
+        fileprivate func encode(to protoWriter: Wire.ProtoWriter) throws {
             switch self {
             case .button_element(let button_element): try protoWriter.encode(tag: 1, value: button_element)
             case .local_image_element(let local_image_element): try protoWriter.encode(tag: 2, value: local_image_element)
@@ -50,16 +255,16 @@ public struct Form {
 
     public enum Decision {
 
-        case a(String)
-        case b(String)
-        case c(String)
-        case d(String)
-        case e(String)
-        case f(String)
-        case g(String)
-        case h(String)
+        case a(Swift.String)
+        case b(Swift.String)
+        case c(Swift.String)
+        case d(Swift.String)
+        case e(Swift.String)
+        case f(Swift.String)
+        case g(Swift.String)
+        case h(Swift.String)
 
-        fileprivate func encode(to protoWriter: ProtoWriter) throws {
+        fileprivate func encode(to protoWriter: Wire.ProtoWriter) throws {
             switch self {
             case .a(let a): try protoWriter.encode(tag: 101, value: a)
             case .b(let b): try protoWriter.encode(tag: 102, value: b)
@@ -121,10 +326,10 @@ public struct Form {
 
     public struct TextElement {
 
-        public var text: String?
+        public var text: Swift.String?
         public var unknownFields: Foundation.Data = .init()
 
-        public init(configure: (inout Self) -> Void = { _ in }) {
+        public init(configure: (inout Self) -> Swift.Void = { _ in }) {
             configure(&self)
         }
 
@@ -185,19 +390,6 @@ public struct Form {
     }
 
 }
-
-#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
-extension Form {
-
-    @_disfavoredOverload
-    @available(*, deprecated)
-    public init(choice: Choice? = nil, decision: Decision? = nil) {
-        self.choice = choice
-        self.decision = decision
-    }
-
-}
-#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension Form.Choice : Equatable {
@@ -873,191 +1065,6 @@ extension Form.CurrencyConversionFlagsElement : Proto2Codable {
 extension Form.CurrencyConversionFlagsElement : Codable {
 
     public enum CodingKeys : Swift.CodingKey {
-    }
-
-}
-#endif
-
-#if !WIRE_REMOVE_EQUATABLE
-extension Form : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension Form : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension Form : Sendable {
-}
-#endif
-
-extension Form : ProtoMessage {
-
-    public static func protoMessageTypeURL() -> Swift.String {
-        return "type.googleapis.com/squareup.protos.kotlin.oneof.Form"
-    }
-
-}
-
-extension Form : Proto2Codable {
-
-    public init(from protoReader: Wire.ProtoReader) throws {
-        var choice: Choice? = nil
-        var decision: Decision? = nil
-
-        let token = try protoReader.beginMessage()
-        while let tag = try protoReader.nextTag(token: token) {
-            switch tag {
-            case 1: choice = .button_element(try protoReader.decode(Form.ButtonElement.self))
-            case 2: choice = .local_image_element(try protoReader.decode(Form.LocalImageElement.self))
-            case 3: choice = .remote_image_element(try protoReader.decode(Form.RemoteImageElement.self))
-            case 4: choice = .money_element(try protoReader.decode(Form.MoneyElement.self))
-            case 5: choice = .spacer_element(try protoReader.decode(Form.SpacerElement.self))
-            case 6: choice = .text_element(try protoReader.decode(Form.TextElement.self))
-            case 7: choice = .customized_card_element(try protoReader.decode(Form.CustomizedCardElement.self))
-            case 8: choice = .address_element(try protoReader.decode(Form.AddressElement.self))
-            case 9: choice = .text_input_element(try protoReader.decode(Form.TextInputElement.self))
-            case 10: choice = .option_picker_element(try protoReader.decode(Form.OptionPickerElement.self))
-            case 11: choice = .detail_row_element(try protoReader.decode(Form.DetailRowElement.self))
-            case 12: choice = .currency_conversion_flags_element(try protoReader.decode(Form.CurrencyConversionFlagsElement.self))
-            case 101: decision = .a(try protoReader.decode(Swift.String.self))
-            case 102: decision = .b(try protoReader.decode(Swift.String.self))
-            case 103: decision = .c(try protoReader.decode(Swift.String.self))
-            case 104: decision = .d(try protoReader.decode(Swift.String.self))
-            case 105: decision = .e(try protoReader.decode(Swift.String.self))
-            case 106: decision = .f(try protoReader.decode(Swift.String.self))
-            case 107: decision = .g(try protoReader.decode(Swift.String.self))
-            case 108: decision = .h(try protoReader.decode(Swift.String.self))
-            default: try protoReader.readUnknownField(tag: tag)
-            }
-        }
-        self.unknownFields = try protoReader.endMessage(token: token)
-
-        self.choice = choice
-        self.decision = decision
-    }
-
-    public func encode(to protoWriter: Wire.ProtoWriter) throws {
-        if let choice = self.choice {
-            try choice.encode(to: protoWriter)
-        }
-        if let decision = self.decision {
-            try decision.encode(to: protoWriter)
-        }
-        try protoWriter.writeUnknownFields(unknownFields)
-    }
-
-}
-
-#if !WIRE_REMOVE_CODABLE
-extension Form : Codable {
-
-    public init(from decoder: Swift.Decoder) throws {
-        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        if let button_element = try container.decodeIfPresent(Form.ButtonElement.self, forKey: "buttonElement") {
-            self.choice = .button_element(button_element)
-        } else if let button_element = try container.decodeIfPresent(Form.ButtonElement.self, forKey: "button_element") {
-            self.choice = .button_element(button_element)
-        } else if let local_image_element = try container.decodeIfPresent(Form.LocalImageElement.self, forKey: "localImageElement") {
-            self.choice = .local_image_element(local_image_element)
-        } else if let local_image_element = try container.decodeIfPresent(Form.LocalImageElement.self, forKey: "local_image_element") {
-            self.choice = .local_image_element(local_image_element)
-        } else if let remote_image_element = try container.decodeIfPresent(Form.RemoteImageElement.self, forKey: "remoteImageElement") {
-            self.choice = .remote_image_element(remote_image_element)
-        } else if let remote_image_element = try container.decodeIfPresent(Form.RemoteImageElement.self, forKey: "remote_image_element") {
-            self.choice = .remote_image_element(remote_image_element)
-        } else if let money_element = try container.decodeIfPresent(Form.MoneyElement.self, forKey: "moneyElement") {
-            self.choice = .money_element(money_element)
-        } else if let money_element = try container.decodeIfPresent(Form.MoneyElement.self, forKey: "money_element") {
-            self.choice = .money_element(money_element)
-        } else if let spacer_element = try container.decodeIfPresent(Form.SpacerElement.self, forKey: "spacerElement") {
-            self.choice = .spacer_element(spacer_element)
-        } else if let spacer_element = try container.decodeIfPresent(Form.SpacerElement.self, forKey: "spacer_element") {
-            self.choice = .spacer_element(spacer_element)
-        } else if let text_element = try container.decodeIfPresent(Form.TextElement.self, forKey: "textElement") {
-            self.choice = .text_element(text_element)
-        } else if let text_element = try container.decodeIfPresent(Form.TextElement.self, forKey: "text_element") {
-            self.choice = .text_element(text_element)
-        } else if let customized_card_element = try container.decodeIfPresent(Form.CustomizedCardElement.self, forKey: "customizedCardElement") {
-            self.choice = .customized_card_element(customized_card_element)
-        } else if let customized_card_element = try container.decodeIfPresent(Form.CustomizedCardElement.self, forKey: "customized_card_element") {
-            self.choice = .customized_card_element(customized_card_element)
-        } else if let address_element = try container.decodeIfPresent(Form.AddressElement.self, forKey: "addressElement") {
-            self.choice = .address_element(address_element)
-        } else if let address_element = try container.decodeIfPresent(Form.AddressElement.self, forKey: "address_element") {
-            self.choice = .address_element(address_element)
-        } else if let text_input_element = try container.decodeIfPresent(Form.TextInputElement.self, forKey: "textInputElement") {
-            self.choice = .text_input_element(text_input_element)
-        } else if let text_input_element = try container.decodeIfPresent(Form.TextInputElement.self, forKey: "text_input_element") {
-            self.choice = .text_input_element(text_input_element)
-        } else if let option_picker_element = try container.decodeIfPresent(Form.OptionPickerElement.self, forKey: "optionPickerElement") {
-            self.choice = .option_picker_element(option_picker_element)
-        } else if let option_picker_element = try container.decodeIfPresent(Form.OptionPickerElement.self, forKey: "option_picker_element") {
-            self.choice = .option_picker_element(option_picker_element)
-        } else if let detail_row_element = try container.decodeIfPresent(Form.DetailRowElement.self, forKey: "detailRowElement") {
-            self.choice = .detail_row_element(detail_row_element)
-        } else if let detail_row_element = try container.decodeIfPresent(Form.DetailRowElement.self, forKey: "detail_row_element") {
-            self.choice = .detail_row_element(detail_row_element)
-        } else if let currency_conversion_flags_element = try container.decodeIfPresent(Form.CurrencyConversionFlagsElement.self, forKey: "currencyConversionFlagsElement") {
-            self.choice = .currency_conversion_flags_element(currency_conversion_flags_element)
-        } else if let currency_conversion_flags_element = try container.decodeIfPresent(Form.CurrencyConversionFlagsElement.self, forKey: "currency_conversion_flags_element") {
-            self.choice = .currency_conversion_flags_element(currency_conversion_flags_element)
-        } else {
-            self.choice = nil
-        }
-        if let a = try container.decodeIfPresent(Swift.String.self, forKey: "a") {
-            self.decision = .a(a)
-        } else if let b = try container.decodeIfPresent(Swift.String.self, forKey: "b") {
-            self.decision = .b(b)
-        } else if let c = try container.decodeIfPresent(Swift.String.self, forKey: "c") {
-            self.decision = .c(c)
-        } else if let d = try container.decodeIfPresent(Swift.String.self, forKey: "d") {
-            self.decision = .d(d)
-        } else if let e = try container.decodeIfPresent(Swift.String.self, forKey: "e") {
-            self.decision = .e(e)
-        } else if let f = try container.decodeIfPresent(Swift.String.self, forKey: "f") {
-            self.decision = .f(f)
-        } else if let g = try container.decodeIfPresent(Swift.String.self, forKey: "g") {
-            self.decision = .g(g)
-        } else if let h = try container.decodeIfPresent(Swift.String.self, forKey: "h") {
-            self.decision = .h(h)
-        } else {
-            self.decision = nil
-        }
-    }
-
-    public func encode(to encoder: Swift.Encoder) throws {
-        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
-
-        switch self.choice {
-        case .button_element(let button_element): try container.encode(button_element, forKey: preferCamelCase ? "buttonElement" : "button_element")
-        case .local_image_element(let local_image_element): try container.encode(local_image_element, forKey: preferCamelCase ? "localImageElement" : "local_image_element")
-        case .remote_image_element(let remote_image_element): try container.encode(remote_image_element, forKey: preferCamelCase ? "remoteImageElement" : "remote_image_element")
-        case .money_element(let money_element): try container.encode(money_element, forKey: preferCamelCase ? "moneyElement" : "money_element")
-        case .spacer_element(let spacer_element): try container.encode(spacer_element, forKey: preferCamelCase ? "spacerElement" : "spacer_element")
-        case .text_element(let text_element): try container.encode(text_element, forKey: preferCamelCase ? "textElement" : "text_element")
-        case .customized_card_element(let customized_card_element): try container.encode(customized_card_element, forKey: preferCamelCase ? "customizedCardElement" : "customized_card_element")
-        case .address_element(let address_element): try container.encode(address_element, forKey: preferCamelCase ? "addressElement" : "address_element")
-        case .text_input_element(let text_input_element): try container.encode(text_input_element, forKey: preferCamelCase ? "textInputElement" : "text_input_element")
-        case .option_picker_element(let option_picker_element): try container.encode(option_picker_element, forKey: preferCamelCase ? "optionPickerElement" : "option_picker_element")
-        case .detail_row_element(let detail_row_element): try container.encode(detail_row_element, forKey: preferCamelCase ? "detailRowElement" : "detail_row_element")
-        case .currency_conversion_flags_element(let currency_conversion_flags_element): try container.encode(currency_conversion_flags_element, forKey: preferCamelCase ? "currencyConversionFlagsElement" : "currency_conversion_flags_element")
-        case Swift.Optional.none: break
-        }
-        switch self.decision {
-        case .a(let a): try container.encode(a, forKey: "a")
-        case .b(let b): try container.encode(b, forKey: "b")
-        case .c(let c): try container.encode(c, forKey: "c")
-        case .d(let d): try container.encode(d, forKey: "d")
-        case .e(let e): try container.encode(e, forKey: "e")
-        case .f(let f): try container.encode(f, forKey: "f")
-        case .g(let g): try container.encode(g, forKey: "g")
-        case .h(let h): try container.encode(h, forKey: "h")
-        case Swift.Optional.none: break
-        }
     }
 
 }

--- a/wire-tests-swift/src/main/swift/Form.swift
+++ b/wire-tests-swift/src/main/swift/Form.swift
@@ -9,7 +9,7 @@ public struct Form {
     public var decision: Form.Decision?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/Mappy.swift
+++ b/wire-tests-swift/src/main/swift/Mappy.swift
@@ -8,7 +8,7 @@ public struct Mappy {
     public var things: [String : Thing] = [:]
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/MappyTwo.swift
+++ b/wire-tests-swift/src/main/swift/MappyTwo.swift
@@ -15,22 +15,6 @@ public struct MappyTwo {
         configure(&self)
     }
 
-    public enum ValueEnum : UInt32, CaseIterable, ProtoEnum {
-
-        case DEFAULT = 0
-        case FOO = 1
-        case BAR = 2
-
-        public var description: String {
-            switch self {
-            case .DEFAULT: return "DEFAULT"
-            case .FOO: return "FOO"
-            case .BAR: return "BAR"
-            }
-        }
-
-    }
-
 }
 
 #if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
@@ -50,11 +34,6 @@ extension MappyTwo {
         self.int_things_two = int_things_two
     }
 
-}
-#endif
-
-#if swift(>=5.5)
-extension MappyTwo.ValueEnum : Sendable {
 }
 #endif
 
@@ -147,5 +126,33 @@ extension MappyTwo : Codable {
         }
     }
 
+}
+#endif
+
+/**
+ * Subtypes within MappyTwo
+ */
+extension MappyTwo {
+
+    public enum ValueEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+
+        case DEFAULT = 0
+        case FOO = 1
+        case BAR = 2
+
+        public var description: Swift.String {
+            switch self {
+            case .DEFAULT: return "DEFAULT"
+            case .FOO: return "FOO"
+            case .BAR: return "BAR"
+            }
+        }
+
+    }
+
+}
+
+#if swift(>=5.5)
+extension MappyTwo.ValueEnum : Sendable {
 }
 #endif

--- a/wire-tests-swift/src/main/swift/MappyTwo.swift
+++ b/wire-tests-swift/src/main/swift/MappyTwo.swift
@@ -11,7 +11,7 @@ public struct MappyTwo {
     public var int_things_two: [Int32 : Thing] = [:]
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-tests-swift/src/main/swift/MessageUsingMultipleEnums.swift
@@ -12,7 +12,7 @@ public struct MessageUsingMultipleEnums {
     public var b: OtherMessageWithStatus.Status?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/MessageWithStatus.swift
+++ b/wire-tests-swift/src/main/swift/MessageWithStatus.swift
@@ -10,24 +10,7 @@ public struct MessageWithStatus {
     public init() {
     }
 
-    public enum Status : UInt32, CaseIterable, ProtoEnum {
-
-        case A = 1
-
-        public var description: String {
-            switch self {
-            case .A: return "A"
-            }
-        }
-
-    }
-
 }
-
-#if swift(>=5.5)
-extension MessageWithStatus.Status : Sendable {
-}
-#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension MessageWithStatus : Equatable {
@@ -77,5 +60,29 @@ extension MessageWithStatus : Codable {
     public enum CodingKeys : Swift.CodingKey {
     }
 
+}
+#endif
+
+/**
+ * Subtypes within MessageWithStatus
+ */
+extension MessageWithStatus {
+
+    public enum Status : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+
+        case A = 1
+
+        public var description: Swift.String {
+            switch self {
+            case .A: return "A"
+            }
+        }
+
+    }
+
+}
+
+#if swift(>=5.5)
+extension MessageWithStatus.Status : Sendable {
 }
 #endif

--- a/wire-tests-swift/src/main/swift/ModelEvaluation.swift
+++ b/wire-tests-swift/src/main/swift/ModelEvaluation.swift
@@ -25,7 +25,7 @@ public struct ModelEvaluation {
     public var models: [String : ModelEvaluation] = [:]
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/NestedVersionOne.swift
+++ b/wire-tests-swift/src/main/swift/NestedVersionOne.swift
@@ -8,7 +8,7 @@ public struct NestedVersionOne {
     public var i: Int32?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
+++ b/wire-tests-swift/src/main/swift/NestedVersionTwo.swift
@@ -13,7 +13,7 @@ public struct NestedVersionTwo {
     public var v2_rs: [String] = []
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -14,7 +14,7 @@ public struct OneOfMessage {
     public var choice: OneOfMessage.Choice?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/OneOfMessage.swift
+++ b/wire-tests-swift/src/main/swift/OneOfMessage.swift
@@ -11,36 +11,11 @@ public struct OneOfMessage {
     /**
      * Must have a foo or a bar or a baz.
      */
-    public var choice: Choice?
+    public var choice: OneOfMessage.Choice?
     public var unknownFields: Foundation.Data = .init()
 
     public init(configure: (inout Self) -> Void = { _ in }) {
         configure(&self)
-    }
-
-    public enum Choice {
-
-        /**
-         * What foo.
-         */
-        case foo(Int32)
-        /**
-         * Such bar.
-         */
-        case bar(String)
-        /**
-         * Nice baz.
-         */
-        case baz(String)
-
-        fileprivate func encode(to protoWriter: ProtoWriter) throws {
-            switch self {
-            case .foo(let foo): try protoWriter.encode(tag: 1, value: foo)
-            case .bar(let bar): try protoWriter.encode(tag: 3, value: bar)
-            case .baz(let baz): try protoWriter.encode(tag: 4, value: baz)
-            }
-        }
-
     }
 
 }
@@ -54,21 +29,6 @@ extension OneOfMessage {
         self.choice = choice
     }
 
-}
-#endif
-
-#if !WIRE_REMOVE_EQUATABLE
-extension OneOfMessage.Choice : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension OneOfMessage.Choice : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension OneOfMessage.Choice : Sendable {
 }
 #endif
 
@@ -150,5 +110,52 @@ extension OneOfMessage : Codable {
         }
     }
 
+}
+#endif
+
+/**
+ * Subtypes within OneOfMessage
+ */
+extension OneOfMessage {
+
+    public enum Choice {
+
+        /**
+         * What foo.
+         */
+        case foo(Swift.Int32)
+        /**
+         * Such bar.
+         */
+        case bar(Swift.String)
+        /**
+         * Nice baz.
+         */
+        case baz(Swift.String)
+
+        fileprivate func encode(to protoWriter: Wire.ProtoWriter) throws {
+            switch self {
+            case .foo(let foo): try protoWriter.encode(tag: 1, value: foo)
+            case .bar(let bar): try protoWriter.encode(tag: 3, value: bar)
+            case .baz(let baz): try protoWriter.encode(tag: 4, value: baz)
+            }
+        }
+
+    }
+
+}
+
+#if !WIRE_REMOVE_EQUATABLE
+extension OneOfMessage.Choice : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension OneOfMessage.Choice : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension OneOfMessage.Choice : Sendable {
 }
 #endif

--- a/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -12,20 +12,6 @@ public struct OptionalEnumUser {
         configure(&self)
     }
 
-    public enum OptionalEnum : UInt32, CaseIterable, ProtoEnum {
-
-        case FOO = 1
-        case BAR = 2
-
-        public var description: String {
-            switch self {
-            case .FOO: return "FOO"
-            case .BAR: return "BAR"
-            }
-        }
-
-    }
-
 }
 
 #if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
@@ -37,11 +23,6 @@ extension OptionalEnumUser {
         self.optional_enum = optional_enum
     }
 
-}
-#endif
-
-#if swift(>=5.5)
-extension OptionalEnumUser.OptionalEnum : Sendable {
 }
 #endif
 
@@ -107,5 +88,31 @@ extension OptionalEnumUser : Codable {
         try container.encodeIfPresent(self.optional_enum, forKey: preferCamelCase ? "optionalEnum" : "optional_enum")
     }
 
+}
+#endif
+
+/**
+ * Subtypes within OptionalEnumUser
+ */
+extension OptionalEnumUser {
+
+    public enum OptionalEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+
+        case FOO = 1
+        case BAR = 2
+
+        public var description: Swift.String {
+            switch self {
+            case .FOO: return "FOO"
+            case .BAR: return "BAR"
+            }
+        }
+
+    }
+
+}
+
+#if swift(>=5.5)
+extension OptionalEnumUser.OptionalEnum : Sendable {
 }
 #endif

--- a/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
+++ b/wire-tests-swift/src/main/swift/OptionalEnumUser.swift
@@ -8,7 +8,7 @@ public struct OptionalEnumUser {
     public var optional_enum: OptionalEnumUser.OptionalEnum?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-tests-swift/src/main/swift/OtherMessageWithStatus.swift
@@ -10,24 +10,7 @@ public struct OtherMessageWithStatus {
     public init() {
     }
 
-    public enum Status : UInt32, CaseIterable, ProtoEnum {
-
-        case A = 1
-
-        public var description: String {
-            switch self {
-            case .A: return "A"
-            }
-        }
-
-    }
-
 }
-
-#if swift(>=5.5)
-extension OtherMessageWithStatus.Status : Sendable {
-}
-#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension OtherMessageWithStatus : Equatable {
@@ -77,5 +60,29 @@ extension OtherMessageWithStatus : Codable {
     public enum CodingKeys : Swift.CodingKey {
     }
 
+}
+#endif
+
+/**
+ * Subtypes within OtherMessageWithStatus
+ */
+extension OtherMessageWithStatus {
+
+    public enum Status : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+
+        case A = 1
+
+        public var description: Swift.String {
+            switch self {
+            case .A: return "A"
+            }
+        }
+
+    }
+
+}
+
+#if swift(>=5.5)
+extension OtherMessageWithStatus.Status : Sendable {
 }
 #endif

--- a/wire-tests-swift/src/main/swift/OuterMessage.swift
+++ b/wire-tests-swift/src/main/swift/OuterMessage.swift
@@ -9,7 +9,7 @@ public struct OuterMessage {
     public var embedded_message: EmbeddedMessage?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/Percents.swift
+++ b/wire-tests-swift/src/main/swift/Percents.swift
@@ -11,7 +11,7 @@ public struct Percents {
     public var text: String?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-tests-swift/src/main/swift/Person.swift
@@ -37,48 +37,6 @@ public struct Person {
         configure(&self)
     }
 
-    /**
-     * Represents the type of the phone number: mobile, home or work.
-     */
-    public enum PhoneType : UInt32, CaseIterable, ProtoEnum {
-
-        case MOBILE = 0
-        case HOME = 1
-        /**
-         * Could be phone or fax.
-         */
-        case WORK = 2
-
-        public var description: String {
-            switch self {
-            case .MOBILE: return "MOBILE"
-            case .HOME: return "HOME"
-            case .WORK: return "WORK"
-            }
-        }
-
-    }
-
-    public struct PhoneNumber {
-
-        /**
-         * The customer's phone number.
-         */
-        public var number: String
-        /**
-         * The type of phone stored here.
-         */
-        @Defaulted(defaultValue: Person.PhoneType.HOME)
-        public var type: Person.PhoneType?
-        public var unknownFields: Foundation.Data = .init()
-
-        public init(number: String, configure: (inout Self) -> Void = { _ in }) {
-            self.number = number
-            configure(&self)
-        }
-
-    }
-
 }
 
 #if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
@@ -98,97 +56,6 @@ extension Person {
         self.email = email
         self.phone = phone
         self.aliases = aliases
-    }
-
-}
-#endif
-
-#if swift(>=5.5)
-extension Person.PhoneType : Sendable {
-}
-#endif
-
-#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
-extension Person.PhoneNumber {
-
-    @_disfavoredOverload
-    @available(*, deprecated)
-    public init(number: Swift.String, type: Person.PhoneType? = nil) {
-        self.number = number
-        _type.wrappedValue = type
-    }
-
-}
-#endif
-
-#if !WIRE_REMOVE_EQUATABLE
-extension Person.PhoneNumber : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension Person.PhoneNumber : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension Person.PhoneNumber : Sendable {
-}
-#endif
-
-extension Person.PhoneNumber : ProtoMessage {
-
-    public static func protoMessageTypeURL() -> Swift.String {
-        return "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
-    }
-
-}
-
-extension Person.PhoneNumber : Proto2Codable {
-
-    public init(from protoReader: Wire.ProtoReader) throws {
-        var number: Swift.String? = nil
-        var type: Person.PhoneType? = nil
-
-        let token = try protoReader.beginMessage()
-        while let tag = try protoReader.nextTag(token: token) {
-            switch tag {
-            case 1: number = try protoReader.decode(Swift.String.self)
-            case 2: type = try protoReader.decode(Person.PhoneType.self)
-            default: try protoReader.readUnknownField(tag: tag)
-            }
-        }
-        self.unknownFields = try protoReader.endMessage(token: token)
-
-        self.number = try Person.PhoneNumber.checkIfMissing(number, "number")
-        _type.wrappedValue = type
-    }
-
-    public func encode(to protoWriter: Wire.ProtoWriter) throws {
-        try protoWriter.encode(tag: 1, value: self.number)
-        try protoWriter.encode(tag: 2, value: self.type)
-        try protoWriter.writeUnknownFields(unknownFields)
-    }
-
-}
-
-#if !WIRE_REMOVE_CODABLE
-extension Person.PhoneNumber : Codable {
-
-    public init(from decoder: Swift.Decoder) throws {
-        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.number = try container.decode(Swift.String.self, forKey: "number")
-        _type.wrappedValue = try container.decodeIfPresent(Person.PhoneType.self, forKey: "type")
-    }
-
-    public func encode(to encoder: Swift.Encoder) throws {
-        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
-
-        if includeDefaults || !self.number.isEmpty {
-            try container.encode(self.number, forKey: "number")
-        }
-        try container.encodeIfPresent(self.type, forKey: "type")
     }
 
 }
@@ -286,6 +153,146 @@ extension Person : Codable {
         if includeDefaults || !self.aliases.isEmpty {
             try container.encodeProtoArray(self.aliases, forKey: "aliases")
         }
+    }
+
+}
+#endif
+
+/**
+ * Subtypes within Person
+ */
+extension Person {
+
+    /**
+     * Represents the type of the phone number: mobile, home or work.
+     */
+    public enum PhoneType : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+
+        case MOBILE = 0
+        case HOME = 1
+        /**
+         * Could be phone or fax.
+         */
+        case WORK = 2
+
+        public var description: Swift.String {
+            switch self {
+            case .MOBILE: return "MOBILE"
+            case .HOME: return "HOME"
+            case .WORK: return "WORK"
+            }
+        }
+
+    }
+
+    public struct PhoneNumber {
+
+        /**
+         * The customer's phone number.
+         */
+        public var number: Swift.String
+        /**
+         * The type of phone stored here.
+         */
+        @Wire.Defaulted(defaultValue: Person.PhoneType.HOME)
+        public var type: Person.PhoneType?
+        public var unknownFields: Foundation.Data = .init()
+
+        public init(number: Swift.String, configure: (inout Self) -> Swift.Void = { _ in }) {
+            self.number = number
+            configure(&self)
+        }
+
+    }
+
+}
+
+#if swift(>=5.5)
+extension Person.PhoneType : Sendable {
+}
+#endif
+
+#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
+extension Person.PhoneNumber {
+
+    @_disfavoredOverload
+    @available(*, deprecated)
+    public init(number: Swift.String, type: Person.PhoneType? = nil) {
+        self.number = number
+        _type.wrappedValue = type
+    }
+
+}
+#endif
+
+#if !WIRE_REMOVE_EQUATABLE
+extension Person.PhoneNumber : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension Person.PhoneNumber : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension Person.PhoneNumber : Sendable {
+}
+#endif
+
+extension Person.PhoneNumber : ProtoMessage {
+
+    public static func protoMessageTypeURL() -> Swift.String {
+        return "type.googleapis.com/squareup.protos.kotlin.person.Person.PhoneNumber"
+    }
+
+}
+
+extension Person.PhoneNumber : Proto2Codable {
+
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var number: Swift.String? = nil
+        var type: Person.PhoneType? = nil
+
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
+            switch tag {
+            case 1: number = try protoReader.decode(Swift.String.self)
+            case 2: type = try protoReader.decode(Person.PhoneType.self)
+            default: try protoReader.readUnknownField(tag: tag)
+            }
+        }
+        self.unknownFields = try protoReader.endMessage(token: token)
+
+        self.number = try Person.PhoneNumber.checkIfMissing(number, "number")
+        _type.wrappedValue = type
+    }
+
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.number)
+        try protoWriter.encode(tag: 2, value: self.type)
+        try protoWriter.writeUnknownFields(unknownFields)
+    }
+
+}
+
+#if !WIRE_REMOVE_CODABLE
+extension Person.PhoneNumber : Codable {
+
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self.number = try container.decode(Swift.String.self, forKey: "number")
+        _type.wrappedValue = try container.decodeIfPresent(Person.PhoneType.self, forKey: "type")
+    }
+
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
+
+        if includeDefaults || !self.number.isEmpty {
+            try container.encode(self.number, forKey: "number")
+        }
+        try container.encodeIfPresent(self.type, forKey: "type")
     }
 
 }

--- a/wire-tests-swift/src/main/swift/Person.swift
+++ b/wire-tests-swift/src/main/swift/Person.swift
@@ -30,7 +30,7 @@ public struct Person {
     public init(
         id: Int32,
         name: String,
-        configure: (inout Self) -> Void = { _ in }
+        configure: (inout Self) -> Swift.Void = { _ in }
     ) {
         self.id = id
         self.name = name

--- a/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -8,7 +8,7 @@ public struct RedactedOneOf {
     public var a: RedactedOneOf.A?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/RedactedOneOf.swift
+++ b/wire-tests-swift/src/main/swift/RedactedOneOf.swift
@@ -5,25 +5,11 @@ import Wire
 
 public struct RedactedOneOf {
 
-    public var a: A?
+    public var a: RedactedOneOf.A?
     public var unknownFields: Foundation.Data = .init()
 
     public init(configure: (inout Self) -> Void = { _ in }) {
         configure(&self)
-    }
-
-    public enum A {
-
-        case b(Int32)
-        case c(String)
-
-        fileprivate func encode(to protoWriter: ProtoWriter) throws {
-            switch self {
-            case .b(let b): try protoWriter.encode(tag: 1, value: b)
-            case .c(let c): try protoWriter.encode(tag: 2, value: c)
-            }
-        }
-
     }
 
 }
@@ -35,33 +21,6 @@ extension RedactedOneOf {
     @available(*, deprecated)
     public init(a: A? = nil) {
         self.a = a
-    }
-
-}
-#endif
-
-#if !WIRE_REMOVE_EQUATABLE
-extension RedactedOneOf.A : Equatable {
-}
-#endif
-
-#if !WIRE_REMOVE_HASHABLE
-extension RedactedOneOf.A : Hashable {
-}
-#endif
-
-#if swift(>=5.5)
-extension RedactedOneOf.A : Sendable {
-}
-#endif
-
-#if !WIRE_REMOVE_REDACTABLE
-extension RedactedOneOf.A : Redactable {
-
-    public enum RedactedKeys : Swift.String, Wire.RedactedKey {
-
-        case c
-
     }
 
 }
@@ -139,6 +98,54 @@ extension RedactedOneOf : Codable {
         case .c(let c): try container.encode(c, forKey: "c")
         case Swift.Optional.none: break
         }
+    }
+
+}
+#endif
+
+/**
+ * Subtypes within RedactedOneOf
+ */
+extension RedactedOneOf {
+
+    public enum A {
+
+        case b(Swift.Int32)
+        case c(Swift.String)
+
+        fileprivate func encode(to protoWriter: Wire.ProtoWriter) throws {
+            switch self {
+            case .b(let b): try protoWriter.encode(tag: 1, value: b)
+            case .c(let c): try protoWriter.encode(tag: 2, value: c)
+            }
+        }
+
+    }
+
+}
+
+#if !WIRE_REMOVE_EQUATABLE
+extension RedactedOneOf.A : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension RedactedOneOf.A : Hashable {
+}
+#endif
+
+#if swift(>=5.5)
+extension RedactedOneOf.A : Sendable {
+}
+#endif
+
+#if !WIRE_REMOVE_REDACTABLE
+extension RedactedOneOf.A : Redactable {
+
+    public enum RedactedKeys : Swift.String, Wire.RedactedKey {
+
+        case c
+
     }
 
 }

--- a/wire-tests-swift/src/main/swift/Thing.swift
+++ b/wire-tests-swift/src/main/swift/Thing.swift
@@ -8,7 +8,7 @@ public struct Thing {
     public var name: String?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/VersionOne.swift
+++ b/wire-tests-swift/src/main/swift/VersionOne.swift
@@ -10,7 +10,7 @@ public struct VersionOne {
     public var en: EnumVersionOne?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/VersionTwo.swift
+++ b/wire-tests-swift/src/main/swift/VersionTwo.swift
@@ -15,7 +15,7 @@ public struct VersionTwo {
     public var en: EnumVersionTwo?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 

--- a/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-tests-swift/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -11,7 +11,7 @@ public struct VeryLongProtoNameCausingBrokenLineBreaks {
     public var foo: String?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 


### PR DESCRIPTION
There's two things here:

* Reordering the structures in a consistent order
    * Public object
    * Public object conformances
    * Object Sub-types
    * Object Sub-type conformances
    * Storage object
    * Storage object conformances
* Adding explicit overloads for getters/setters which _should_ improve performance
    * If needed I can unwind it further and call storage directly

I could not remove `dynamicMemberLookup` without breaking `@Defaulteded`