### PR TITLE
Swift: Manually keep track of imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Change Log
 ==========
 
+Version 4.9.0
+-------------
+
+_2023-09-20_
+
+* Fix: Swift generates all Storage properties. This mitigates performance issues with dynamicMemberLookup
+* Change: Swift codegen was reordered for readability
+* New: Swift propertyWrapper @CopyOnWrite. @Heap is now deprecated and will be removed in November 2024.
+* Change: Several dependency updates
+
 Version 4.8.1
 -------------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Version ???
+-----------
+
+_Unreleased_
+
+* Fix: Missing Swift imports
+
 Version 4.9.0
 -------------
 

--- a/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -187,7 +187,6 @@ data class SwiftTarget(
         val modulePath = context.outDirectory
         val typeName = generator.generatedTypeName(type)
         val swiftFile = SwiftFileSpec.builder(typeName.moduleName, typeName.simpleName)
-          .addImport("Foundation")
           .addComment(WireCompiler.CODE_GENERATED_BY_WIRE)
           .addComment("\nSource: %L in %L", type.type, type.location.withPathOnly())
           .indent("    ")


### PR DESCRIPTION
Types defined in an extension seem to get lost by current versions of SwiftPoet.
This manually tracks imports and emits them as appropriate.