### PR TITLE
[swift] Provide a default value for sub fields and common types as per proto spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ plugin*.xml
 
 # SPM
 .build
+.swiftpm
 
 # Special Mkdocs files
 docs/3.x

--- a/README.md
+++ b/README.md
@@ -571,42 +571,24 @@ public struct Dinosaur {
     /**
      * Common name of this dinosaur, like "Stegosaurus".
      */
+    @ProtoDefaulted
     public var name: String?
     /**
      * URLs with images of this dinosaur.
      */
     public var picture_urls: [String] = []
+    @ProtoDefaulted
     public var length_meters: Double?
+    @ProtoDefaulted
     public var mass_kilograms: Double?
     public var period: Period?
     public var unknownFields: Foundation.Data = .init()
 
-    public init(configure: (inout Self) -> Void = { _ in }) {
+    public init(configure: (inout Self) -> Swift.Void = { _ in }) {
         configure(&self)
     }
 
 }
-
-#if WIRE_INCLUDE_MEMBERWISE_INITIALIZER
-extension Dinosaur {
-
-    @_disfavoredOverload
-    public init(
-        name: String? = nil,
-        picture_urls: [String] = [],
-        length_meters: Double? = nil,
-        mass_kilograms: Double? = nil,
-        period: Period? = nil
-    ) {
-        self.name = name
-        self.picture_urls = picture_urls
-        self.length_meters = length_meters
-        self.mass_kilograms = mass_kilograms
-        self.period = period
-    }
-
-}
-#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension Dinosaur : Equatable {
@@ -623,9 +605,16 @@ extension Dinosaur : Sendable {
 }
 #endif
 
+extension Dinosaur : ProtoDefaultedValue {
+
+    public static var defaultedValue: Dinosaur {
+        Dinosaur()
+    }
+}
+
 extension Dinosaur : ProtoMessage {
 
-    public static func protoMessageTypeURL() -> String {
+    public static func protoMessageTypeURL() -> Swift.String {
         return "type.googleapis.com/squareup.dinosaurs.Dinosaur"
     }
 
@@ -633,40 +622,40 @@ extension Dinosaur : ProtoMessage {
 
 extension Dinosaur : Proto2Codable {
 
-    public init(from reader: ProtoReader) throws {
-        var name: String? = nil
-        var picture_urls: [String] = []
-        var length_meters: Double? = nil
-        var mass_kilograms: Double? = nil
+    public init(from protoReader: Wire.ProtoReader) throws {
+        var name: Swift.String? = nil
+        var picture_urls: [Swift.String] = []
+        var length_meters: Swift.Double? = nil
+        var mass_kilograms: Swift.Double? = nil
         var period: Period? = nil
 
-        let token = try reader.beginMessage()
-        while let tag = try reader.nextTag(token: token) {
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
             switch tag {
-            case 1: name = try reader.decode(String.self)
-            case 2: try reader.decode(into: &picture_urls)
-            case 3: length_meters = try reader.decode(Double.self)
-            case 4: mass_kilograms = try reader.decode(Double.self)
-            case 5: period = try reader.decode(Period.self)
-            default: try reader.readUnknownField(tag: tag)
+            case 1: name = try protoReader.decode(Swift.String.self)
+            case 2: try protoReader.decode(into: &picture_urls)
+            case 3: length_meters = try protoReader.decode(Swift.Double.self)
+            case 4: mass_kilograms = try protoReader.decode(Swift.Double.self)
+            case 5: period = try protoReader.decode(Period.self)
+            default: try protoReader.readUnknownField(tag: tag)
             }
         }
-        self.unknownFields = try reader.endMessage(token: token)
+        self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.name = name
+        self._name.wrappedValue = name
         self.picture_urls = picture_urls
-        self.length_meters = length_meters
-        self.mass_kilograms = mass_kilograms
+        self._length_meters.wrappedValue = length_meters
+        self._mass_kilograms.wrappedValue = mass_kilograms
         self.period = period
     }
 
-    public func encode(to writer: ProtoWriter) throws {
-        try writer.encode(tag: 1, value: self.name)
-        try writer.encode(tag: 2, value: self.picture_urls)
-        try writer.encode(tag: 3, value: self.length_meters)
-        try writer.encode(tag: 4, value: self.mass_kilograms)
-        try writer.encode(tag: 5, value: self.period)
-        try writer.writeUnknownFields(unknownFields)
+    public func encode(to protoWriter: Wire.ProtoWriter) throws {
+        try protoWriter.encode(tag: 1, value: self.name)
+        try protoWriter.encode(tag: 2, value: self.picture_urls)
+        try protoWriter.encode(tag: 3, value: self.length_meters)
+        try protoWriter.encode(tag: 4, value: self.mass_kilograms)
+        try protoWriter.encode(tag: 5, value: self.period)
+        try protoWriter.writeUnknownFields(unknownFields)
     }
 
 }
@@ -674,17 +663,17 @@ extension Dinosaur : Proto2Codable {
 #if !WIRE_REMOVE_CODABLE
 extension Dinosaur : Codable {
 
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(String.self, forKey: "name")
-        self.picture_urls = try container.decodeProtoArray(String.self, firstOfKeys: "pictureUrls", "picture_urls")
-        self.length_meters = try container.decodeIfPresent(Double.self, firstOfKeys: "lengthMeters", "length_meters")
-        self.mass_kilograms = try container.decodeIfPresent(Double.self, firstOfKeys: "massKilograms", "mass_kilograms")
+    public init(from decoder: Swift.Decoder) throws {
+        let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
+        self._name.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self.picture_urls = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "pictureUrls", "picture_urls")
+        self._length_meters.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "lengthMeters", "length_meters")
+        self._mass_kilograms.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "massKilograms", "mass_kilograms")
         self.period = try container.decodeIfPresent(Period.self, forKey: "period")
     }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: StringLiteralCodingKeys.self)
+    public func encode(to encoder: Swift.Encoder) throws {
+        var container = encoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         let preferCamelCase = encoder.protoKeyNameEncodingStrategy == .camelCase
         let includeDefaults = encoder.protoDefaultValuesEncodingStrategy == .include
 

--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoCodable+Implementations.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoCodable+Implementations.swift
@@ -17,7 +17,13 @@ import Foundation
 
 // MARK: -
 
-extension Bool : ProtoCodable {
+extension Bool : ProtoCodable, ProtoDefaultedValue {
+    
+    // MARK: - ProtoDefaultedValue
+    
+    public static var defaultedValue: Bool {
+        false
+    }
 
     // MARK: - ProtoDecodable
 
@@ -40,7 +46,13 @@ extension Bool : ProtoCodable {
 
 // MARK: -
 
-extension Data : ProtoCodable {
+extension Data : ProtoCodable, ProtoDefaultedValue {
+    
+    // MARK: - ProtoDefaultedValue
+    
+    public static var defaultedValue: Data {
+        Data()
+    }
 
     // MARK: - ProtoDecodable
 
@@ -61,7 +73,7 @@ extension Data : ProtoCodable {
 
 // MARK: -
 
-extension Double : ProtoCodable {
+extension Double : ProtoCodable, ProtoDefaultedValue {
 
     // MARK: - ProtoDecodable
 
@@ -84,7 +96,7 @@ extension Double : ProtoCodable {
 
 // MARK: -
 
-extension Float : ProtoCodable {
+extension Float : ProtoCodable, ProtoDefaultedValue {
 
     // MARK: - ProtoDecodable
 
@@ -107,7 +119,13 @@ extension Float : ProtoCodable {
 
 // MARK: -
 
-extension String : ProtoCodable {
+extension String : ProtoCodable, ProtoDefaultedValue {
+    
+    // MARK: - ProtoDefaultedValue
+    
+    public static var defaultedValue: String {
+        ""
+    }
 
     // MARK: - ProtoDecodable
 

--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoIntCodable+Implementations.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoIntCodable+Implementations.swift
@@ -17,7 +17,7 @@ import Foundation
 
 // MARK: -
 
-extension Int32: ProtoIntCodable {
+extension Int32: ProtoIntCodable, ProtoDefaultedValue {
 
     // MARK: - ProtoIntDecodable
 
@@ -56,7 +56,7 @@ extension Int32: ProtoIntCodable {
 
 // MARK: -
 
-extension UInt32: ProtoIntCodable {
+extension UInt32: ProtoIntCodable, ProtoDefaultedValue {
 
     // MARK: - ProtoIntDecodable
 
@@ -93,7 +93,7 @@ extension UInt32: ProtoIntCodable {
 
 // MARK: -
 
-extension Int64: ProtoIntCodable {
+extension Int64: ProtoIntCodable, ProtoDefaultedValue {
 
     // MARK: - ProtoIntDecodable
 
@@ -132,7 +132,7 @@ extension Int64: ProtoIntCodable {
 
 // MARK: -
 
-extension UInt64: ProtoIntCodable {
+extension UInt64: ProtoIntCodable, ProtoDefaultedValue {
 
     // MARK: - ProtoIntDecodable
 

--- a/wire-runtime-swift/src/main/swift/Redactable.swift
+++ b/wire-runtime-swift/src/main/swift/Redactable.swift
@@ -44,16 +44,20 @@ extension Redactable {
             guard let label = label else {
                 return "\(value)"
             }
-            if RedactedKeys(rawValue: label) != nil {
+            var strippedLabel = label
+            if (label.hasPrefix("_")) {
+                strippedLabel = String(label.dropFirst(1))
+            }
+            if RedactedKeys(rawValue: strippedLabel) != nil {
                 // This is a redacted field, but if it's nil then that's ok to print
                 if "\(value)" != "nil" {
-                    return "\(label): <redacted>"
+                    return "\(strippedLabel): <redacted>"
                 }
             }
             if value is String {
-                return "\(label): \"\(value)\""
+                return "\(strippedLabel): \"\(value)\""
             }
-            return "\(label): \(value)"
+            return "\(strippedLabel): \(value)"
         }
 
         if fields.count > 0 {

--- a/wire-runtime-swift/src/main/swift/propertyWrappers/CustomDefaulted.swift
+++ b/wire-runtime-swift/src/main/swift/propertyWrappers/CustomDefaulted.swift
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2023 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+@available(*, deprecated, message: "Replace with CustomDefaulted")
+public typealias Defaulted = CustomDefaulted
+
+/**
+ When applied to field a projected value is provided for accessing the real value
+ or the default value set.
+ */
+@propertyWrapper
+public struct CustomDefaulted<Value> {
+
+    public var wrappedValue: Value?
+    let defaultValue: Value
+
+    public init(defaultValue: Value) {
+        self.defaultValue = defaultValue
+    }
+
+    public var projectedValue: Value {
+        wrappedValue ?? defaultValue
+    }
+}
+
+extension CustomDefaulted : Equatable where Value : Equatable {
+}
+
+extension CustomDefaulted : Hashable where Value : Hashable {
+}
+
+#if swift(>=5.5)
+
+extension CustomDefaulted : Sendable where Value : Sendable {
+}
+
+#endif

--- a/wire-runtime-swift/src/main/swift/propertyWrappers/ProtoDefaulted.swift
+++ b/wire-runtime-swift/src/main/swift/propertyWrappers/ProtoDefaulted.swift
@@ -13,36 +13,41 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import Foundation
+public protocol ProtoDefaultedValue {
+    static var defaultedValue: Self { get }
+}
 
-/**
- When applied to field a projected value is provided for accessing the real value
- or the default value set.
- */
+// MARK: - ProtoDefaultedValue
+
+extension Numeric where Self: ProtoDefaultedValue {
+    public static var defaultedValue: Self {
+        .zero
+    }
+}
+
+// MARK: - ProtoDefaulted
+
 @propertyWrapper
-public struct Defaulted<Value> {
-
+public struct ProtoDefaulted<Value: ProtoDefaultedValue> {
     public var wrappedValue: Value?
-    let defaultValue: Value
 
-    public init(defaultValue: Value) {
-        self.defaultValue = defaultValue
+    public init() {
     }
 
     public var projectedValue: Value {
-        wrappedValue ?? defaultValue
+        wrappedValue ?? Value.defaultedValue
     }
 }
 
-extension Defaulted : Equatable where Value : Equatable {
+extension ProtoDefaulted : Equatable where Value : Equatable {
 }
 
-extension Defaulted : Hashable where Value : Hashable {
+extension ProtoDefaulted : Hashable where Value : Hashable {
 }
 
 #if swift(>=5.5)
 
-extension Defaulted : Sendable where Value : Sendable {
+extension ProtoDefaulted : Sendable where Value : Sendable {
 }
 
 #endif

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -26,6 +26,13 @@ extension OneofOptions : Sendable {
 }
 #endif
 
+extension OneofOptions : ProtoDefaultedValue {
+
+    public static var defaultedValue: OneofOptions {
+        OneofOptions()
+    }
+}
+
 extension OneofOptions : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-runtime-swift/src/test/swift/DefaultedTests.swift
+++ b/wire-runtime-swift/src/test/swift/DefaultedTests.swift
@@ -18,6 +18,11 @@ import Wire
 import XCTest
 
 final class DefaultedTests: XCTestCase {
+    func testMessageIdentityValue() throws {
+        let d: D = D()
+        XCTAssertNotNil(d.$a)
+    }
+    
     func testProjectedValueIsDefaultValue() throws {
         let phoneNumber = Person.PhoneNumber(number: "1234567890")
         XCTAssertNil(phoneNumber.type)

--- a/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
+++ b/wire-runtime-swift/src/test/swift/sample/Dinosaur.swift
@@ -8,12 +8,15 @@ public struct Dinosaur {
     /**
      * Common name of this dinosaur, like "Stegosaurus".
      */
+    @ProtoDefaulted
     public var name: String?
     /**
      * URLs with images of this dinosaur.
      */
     public var picture_urls: [String] = []
+    @ProtoDefaulted
     public var length_meters: Double?
+    @ProtoDefaulted
     public var mass_kilograms: Double?
     public var period: Period?
     public var unknownFields: Foundation.Data = .init()
@@ -36,10 +39,10 @@ extension Dinosaur {
         mass_kilograms: Swift.Double? = nil,
         period: Period? = nil
     ) {
-        self.name = name
+        self._name.wrappedValue = name
         self.picture_urls = picture_urls
-        self.length_meters = length_meters
-        self.mass_kilograms = mass_kilograms
+        self._length_meters.wrappedValue = length_meters
+        self._mass_kilograms.wrappedValue = mass_kilograms
         self.period = period
     }
 
@@ -60,6 +63,13 @@ extension Dinosaur : Hashable {
 extension Dinosaur : Sendable {
 }
 #endif
+
+extension Dinosaur : ProtoDefaultedValue {
+
+    public static var defaultedValue: Dinosaur {
+        Dinosaur()
+    }
+}
 
 extension Dinosaur : ProtoMessage {
 
@@ -91,10 +101,10 @@ extension Dinosaur : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.name = name
+        self._name.wrappedValue = name
         self.picture_urls = picture_urls
-        self.length_meters = length_meters
-        self.mass_kilograms = mass_kilograms
+        self._length_meters.wrappedValue = length_meters
+        self._mass_kilograms.wrappedValue = mass_kilograms
         self.period = period
     }
 
@@ -114,10 +124,10 @@ extension Dinosaur : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self._name.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "name")
         self.picture_urls = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "pictureUrls", "picture_urls")
-        self.length_meters = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "lengthMeters", "length_meters")
-        self.mass_kilograms = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "massKilograms", "mass_kilograms")
+        self._length_meters.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "lengthMeters", "length_meters")
+        self._mass_kilograms.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "massKilograms", "mass_kilograms")
         self.period = try container.decodeIfPresent(Period.self, forKey: "period")
     }
 

--- a/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsDuration.swift
@@ -41,6 +41,13 @@ extension ContainsDuration : Sendable {
 }
 #endif
 
+extension ContainsDuration : ProtoDefaultedValue {
+
+    public static var defaultedValue: ContainsDuration {
+        ContainsDuration()
+    }
+}
+
 extension ContainsDuration : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
+++ b/wire-tests-proto3-swift/src/main/swift/ContainsTimestamp.swift
@@ -41,6 +41,13 @@ extension ContainsTimestamp : Sendable {
 }
 #endif
 
+extension ContainsTimestamp : ProtoDefaultedValue {
+
+    public static var defaultedValue: ContainsTimestamp {
+        ContainsTimestamp()
+    }
+}
+
 extension ContainsTimestamp : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/manifest/module_one/SwiftModuleOneType.swift
+++ b/wire-tests-swift/manifest/module_one/SwiftModuleOneType.swift
@@ -3,12 +3,15 @@
 import Foundation
 import Wire
 
-public enum SwiftModuleOneType : UInt32, CaseIterable, ProtoEnum {
+public enum SwiftModuleOneType : UInt32, CaseIterable, ProtoEnum, ProtoDefaultedValue {
 
     case DO_NOT_USE = 0
     case ONE = 1
     case TWO = 2
 
+    public static var defaultedValue: SwiftModuleOneType {
+        SwiftModuleOneType.DO_NOT_USE
+    }
     public var description: String {
         switch self {
         case .DO_NOT_USE: return "DO_NOT_USE"

--- a/wire-tests-swift/manifest/module_three/SwiftModuleThreeMessage.swift
+++ b/wire-tests-swift/manifest/module_three/SwiftModuleThreeMessage.swift
@@ -6,6 +6,7 @@ import module_one
 
 public struct SwiftModuleThreeMessage {
 
+    @ProtoDefaulted
     public var name: String?
     public var unknownFields: Foundation.Data = .init()
 
@@ -21,7 +22,7 @@ extension SwiftModuleThreeMessage {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(name: Swift.String? = nil) {
-        self.name = name
+        self._name.wrappedValue = name
     }
 
 }
@@ -41,6 +42,13 @@ extension SwiftModuleThreeMessage : Hashable {
 extension SwiftModuleThreeMessage : Sendable {
 }
 #endif
+
+extension SwiftModuleThreeMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: SwiftModuleThreeMessage {
+        SwiftModuleThreeMessage()
+    }
+}
 
 extension SwiftModuleThreeMessage : ProtoMessage {
 
@@ -64,7 +72,7 @@ extension SwiftModuleThreeMessage : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.name = name
+        self._name.wrappedValue = name
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -79,7 +87,7 @@ extension SwiftModuleThreeMessage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self._name.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "name")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {
@@ -135,6 +143,13 @@ extension SwiftModuleThreeMessage.NestedMessage : Hashable {
 extension SwiftModuleThreeMessage.NestedMessage : Sendable {
 }
 #endif
+
+extension SwiftModuleThreeMessage.NestedMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: SwiftModuleThreeMessage.NestedMessage {
+        SwiftModuleThreeMessage.NestedMessage()
+    }
+}
 
 extension SwiftModuleThreeMessage.NestedMessage : ProtoMessage {
 

--- a/wire-tests-swift/manifest/module_two/SwiftModuleTwoMessage.swift
+++ b/wire-tests-swift/manifest/module_two/SwiftModuleTwoMessage.swift
@@ -6,6 +6,7 @@ import module_one
 
 public struct SwiftModuleTwoMessage {
 
+    @ProtoDefaulted
     public var name: String?
     public var unknownFields: Foundation.Data = .init()
 
@@ -21,7 +22,7 @@ extension SwiftModuleTwoMessage {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(name: Swift.String? = nil) {
-        self.name = name
+        self._name.wrappedValue = name
     }
 
 }
@@ -41,6 +42,13 @@ extension SwiftModuleTwoMessage : Hashable {
 extension SwiftModuleTwoMessage : Sendable {
 }
 #endif
+
+extension SwiftModuleTwoMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: SwiftModuleTwoMessage {
+        SwiftModuleTwoMessage()
+    }
+}
 
 extension SwiftModuleTwoMessage : ProtoMessage {
 
@@ -64,7 +72,7 @@ extension SwiftModuleTwoMessage : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.name = name
+        self._name.wrappedValue = name
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -79,7 +87,7 @@ extension SwiftModuleTwoMessage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self._name.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "name")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {
@@ -135,6 +143,13 @@ extension SwiftModuleTwoMessage.NestedMessage : Hashable {
 extension SwiftModuleTwoMessage.NestedMessage : Sendable {
 }
 #endif
+
+extension SwiftModuleTwoMessage.NestedMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: SwiftModuleTwoMessage.NestedMessage {
+        SwiftModuleTwoMessage.NestedMessage()
+    }
+}
 
 extension SwiftModuleTwoMessage.NestedMessage : ProtoMessage {
 

--- a/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
@@ -1584,11 +1584,15 @@ extension AllTypes : Codable {
  */
 extension AllTypes {
 
-    public enum NestedEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+    public enum NestedEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum,
+            Wire.ProtoDefaultedValue {
 
         case UNKNOWN = 0
         case A = 1
 
+        public static var defaultedValue: AllTypes.NestedEnum {
+            AllTypes.NestedEnum.UNKNOWN
+        }
         public var description: Swift.String {
             switch self {
             case .UNKNOWN: return "UNKNOWN"
@@ -1600,6 +1604,7 @@ extension AllTypes {
 
     public struct NestedMessage {
 
+        @Wire.ProtoDefaulted
         public var a: Swift.Int32?
         public var unknownFields: Foundation.Data = .init()
 
@@ -1622,7 +1627,7 @@ extension AllTypes.NestedMessage {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(a: Swift.Int32? = nil) {
-        self.a = a
+        self._a.wrappedValue = a
     }
 
 }
@@ -1642,6 +1647,13 @@ extension AllTypes.NestedMessage : Hashable {
 extension AllTypes.NestedMessage : Sendable {
 }
 #endif
+
+extension AllTypes.NestedMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: AllTypes.NestedMessage {
+        AllTypes.NestedMessage()
+    }
+}
 
 extension AllTypes.NestedMessage : ProtoMessage {
 
@@ -1665,7 +1677,7 @@ extension AllTypes.NestedMessage : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.a = a
+        self._a.wrappedValue = a
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -1680,7 +1692,7 @@ extension AllTypes.NestedMessage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.a = try container.decodeIfPresent(Swift.Int32.self, forKey: "a")
+        self._a.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, forKey: "a")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {
@@ -1844,23 +1856,23 @@ extension AllTypes.Storage {
         ext_pack_double: [Swift.Double],
         ext_pack_nested_enum: [AllTypes.NestedEnum]
     ) {
-        self.opt_int32 = opt_int32
-        self.opt_uint32 = opt_uint32
-        self.opt_sint32 = opt_sint32
-        self.opt_fixed32 = opt_fixed32
-        self.opt_sfixed32 = opt_sfixed32
-        self.opt_int64 = opt_int64
-        self.opt_uint64 = opt_uint64
-        self.opt_sint64 = opt_sint64
-        self.opt_fixed64 = opt_fixed64
-        self.opt_sfixed64 = opt_sfixed64
-        self.opt_bool = opt_bool
-        self.opt_float = opt_float
-        self.opt_double = opt_double
-        self.opt_string = opt_string
-        self.opt_bytes = opt_bytes
-        self.opt_nested_enum = opt_nested_enum
-        self.opt_nested_message = opt_nested_message
+        self._opt_int32.wrappedValue = opt_int32
+        self._opt_uint32.wrappedValue = opt_uint32
+        self._opt_sint32.wrappedValue = opt_sint32
+        self._opt_fixed32.wrappedValue = opt_fixed32
+        self._opt_sfixed32.wrappedValue = opt_sfixed32
+        self._opt_int64.wrappedValue = opt_int64
+        self._opt_uint64.wrappedValue = opt_uint64
+        self._opt_sint64.wrappedValue = opt_sint64
+        self._opt_fixed64.wrappedValue = opt_fixed64
+        self._opt_sfixed64.wrappedValue = opt_sfixed64
+        self._opt_bool.wrappedValue = opt_bool
+        self._opt_float.wrappedValue = opt_float
+        self._opt_double.wrappedValue = opt_double
+        self._opt_string.wrappedValue = opt_string
+        self._opt_bytes.wrappedValue = opt_bytes
+        self._opt_nested_enum.wrappedValue = opt_nested_enum
+        self._opt_nested_message.wrappedValue = opt_nested_message
         self.req_int32 = req_int32
         self.req_uint32 = req_uint32
         self.req_sint32 = req_sint32
@@ -1909,22 +1921,22 @@ extension AllTypes.Storage {
         self.pack_float = pack_float
         self.pack_double = pack_double
         self.pack_nested_enum = pack_nested_enum
-        _default_int32.wrappedValue = default_int32
-        _default_uint32.wrappedValue = default_uint32
-        _default_sint32.wrappedValue = default_sint32
-        _default_fixed32.wrappedValue = default_fixed32
-        _default_sfixed32.wrappedValue = default_sfixed32
-        _default_int64.wrappedValue = default_int64
-        _default_uint64.wrappedValue = default_uint64
-        _default_sint64.wrappedValue = default_sint64
-        _default_fixed64.wrappedValue = default_fixed64
-        _default_sfixed64.wrappedValue = default_sfixed64
-        _default_bool.wrappedValue = default_bool
-        _default_float.wrappedValue = default_float
-        _default_double.wrappedValue = default_double
-        _default_string.wrappedValue = default_string
-        _default_bytes.wrappedValue = default_bytes
-        _default_nested_enum.wrappedValue = default_nested_enum
+        self._default_int32.wrappedValue = default_int32
+        self._default_uint32.wrappedValue = default_uint32
+        self._default_sint32.wrappedValue = default_sint32
+        self._default_fixed32.wrappedValue = default_fixed32
+        self._default_sfixed32.wrappedValue = default_sfixed32
+        self._default_int64.wrappedValue = default_int64
+        self._default_uint64.wrappedValue = default_uint64
+        self._default_sint64.wrappedValue = default_sint64
+        self._default_fixed64.wrappedValue = default_fixed64
+        self._default_sfixed64.wrappedValue = default_sfixed64
+        self._default_bool.wrappedValue = default_bool
+        self._default_float.wrappedValue = default_float
+        self._default_double.wrappedValue = default_double
+        self._default_string.wrappedValue = default_string
+        self._default_bytes.wrappedValue = default_bytes
+        self._default_nested_enum.wrappedValue = default_nested_enum
         self.map_int32_int32 = map_int32_int32
         self.map_string_string = map_string_string
         self.map_string_message = map_string_message
@@ -1941,23 +1953,23 @@ extension AllTypes.Storage {
         self.array_sfixed64 = array_sfixed64
         self.array_float = array_float
         self.array_double = array_double
-        self.ext_opt_int32 = ext_opt_int32
-        self.ext_opt_uint32 = ext_opt_uint32
-        self.ext_opt_sint32 = ext_opt_sint32
-        self.ext_opt_fixed32 = ext_opt_fixed32
-        self.ext_opt_sfixed32 = ext_opt_sfixed32
-        self.ext_opt_int64 = ext_opt_int64
-        self.ext_opt_uint64 = ext_opt_uint64
-        self.ext_opt_sint64 = ext_opt_sint64
-        self.ext_opt_fixed64 = ext_opt_fixed64
-        self.ext_opt_sfixed64 = ext_opt_sfixed64
-        self.ext_opt_bool = ext_opt_bool
-        self.ext_opt_float = ext_opt_float
-        self.ext_opt_double = ext_opt_double
-        self.ext_opt_string = ext_opt_string
-        self.ext_opt_bytes = ext_opt_bytes
-        self.ext_opt_nested_enum = ext_opt_nested_enum
-        self.ext_opt_nested_message = ext_opt_nested_message
+        self._ext_opt_int32.wrappedValue = ext_opt_int32
+        self._ext_opt_uint32.wrappedValue = ext_opt_uint32
+        self._ext_opt_sint32.wrappedValue = ext_opt_sint32
+        self._ext_opt_fixed32.wrappedValue = ext_opt_fixed32
+        self._ext_opt_sfixed32.wrappedValue = ext_opt_sfixed32
+        self._ext_opt_int64.wrappedValue = ext_opt_int64
+        self._ext_opt_uint64.wrappedValue = ext_opt_uint64
+        self._ext_opt_sint64.wrappedValue = ext_opt_sint64
+        self._ext_opt_fixed64.wrappedValue = ext_opt_fixed64
+        self._ext_opt_sfixed64.wrappedValue = ext_opt_sfixed64
+        self._ext_opt_bool.wrappedValue = ext_opt_bool
+        self._ext_opt_float.wrappedValue = ext_opt_float
+        self._ext_opt_double.wrappedValue = ext_opt_double
+        self._ext_opt_string.wrappedValue = ext_opt_string
+        self._ext_opt_bytes.wrappedValue = ext_opt_bytes
+        self._ext_opt_nested_enum.wrappedValue = ext_opt_nested_enum
+        self._ext_opt_nested_message.wrappedValue = ext_opt_nested_message
         self.ext_rep_int32 = ext_rep_int32
         self.ext_rep_uint32 = ext_rep_uint32
         self.ext_rep_sint32 = ext_rep_sint32
@@ -2001,22 +2013,39 @@ extension AllTypes {
      */
     public struct Storage {
 
+        @Wire.ProtoDefaulted
         public var opt_int32: Swift.Int32?
+        @Wire.ProtoDefaulted
         public var opt_uint32: Swift.UInt32?
+        @Wire.ProtoDefaulted
         public var opt_sint32: Swift.Int32?
+        @Wire.ProtoDefaulted
         public var opt_fixed32: Swift.UInt32?
+        @Wire.ProtoDefaulted
         public var opt_sfixed32: Swift.Int32?
+        @Wire.ProtoDefaulted
         public var opt_int64: Swift.Int64?
+        @Wire.ProtoDefaulted
         public var opt_uint64: Swift.UInt64?
+        @Wire.ProtoDefaulted
         public var opt_sint64: Swift.Int64?
+        @Wire.ProtoDefaulted
         public var opt_fixed64: Swift.UInt64?
+        @Wire.ProtoDefaulted
         public var opt_sfixed64: Swift.Int64?
+        @Wire.ProtoDefaulted
         public var opt_bool: Swift.Bool?
+        @Wire.ProtoDefaulted
         public var opt_float: Swift.Float?
+        @Wire.ProtoDefaulted
         public var opt_double: Swift.Double?
+        @Wire.ProtoDefaulted
         public var opt_string: Swift.String?
+        @Wire.ProtoDefaulted
         public var opt_bytes: Foundation.Data?
+        @Wire.ProtoDefaulted
         public var opt_nested_enum: AllTypes.NestedEnum?
+        @Wire.ProtoDefaulted
         public var opt_nested_message: AllTypes.NestedMessage?
         public var req_int32: Swift.Int32
         public var req_uint32: Swift.UInt32
@@ -2066,37 +2095,37 @@ extension AllTypes {
         public var pack_float: [Swift.Float] = []
         public var pack_double: [Swift.Double] = []
         public var pack_nested_enum: [AllTypes.NestedEnum] = []
-        @Wire.Defaulted(defaultValue: Swift.Int32.max)
+        @Wire.CustomDefaulted(defaultValue: Swift.Int32.max)
         public var default_int32: Swift.Int32?
-        @Wire.Defaulted(defaultValue: Swift.UInt32.max)
+        @Wire.CustomDefaulted(defaultValue: Swift.UInt32.max)
         public var default_uint32: Swift.UInt32?
-        @Wire.Defaulted(defaultValue: Swift.Int32.min)
+        @Wire.CustomDefaulted(defaultValue: Swift.Int32.min)
         public var default_sint32: Swift.Int32?
-        @Wire.Defaulted(defaultValue: Swift.UInt32.max)
+        @Wire.CustomDefaulted(defaultValue: Swift.UInt32.max)
         public var default_fixed32: Swift.UInt32?
-        @Wire.Defaulted(defaultValue: Swift.Int32.min)
+        @Wire.CustomDefaulted(defaultValue: Swift.Int32.min)
         public var default_sfixed32: Swift.Int32?
-        @Wire.Defaulted(defaultValue: Swift.Int64.max)
+        @Wire.CustomDefaulted(defaultValue: Swift.Int64.max)
         public var default_int64: Swift.Int64?
-        @Wire.Defaulted(defaultValue: Swift.UInt64.max)
+        @Wire.CustomDefaulted(defaultValue: Swift.UInt64.max)
         public var default_uint64: Swift.UInt64?
-        @Wire.Defaulted(defaultValue: Swift.Int64.min)
+        @Wire.CustomDefaulted(defaultValue: Swift.Int64.min)
         public var default_sint64: Swift.Int64?
-        @Wire.Defaulted(defaultValue: Swift.UInt64.max)
+        @Wire.CustomDefaulted(defaultValue: Swift.UInt64.max)
         public var default_fixed64: Swift.UInt64?
-        @Wire.Defaulted(defaultValue: Swift.Int64.min)
+        @Wire.CustomDefaulted(defaultValue: Swift.Int64.min)
         public var default_sfixed64: Swift.Int64?
-        @Wire.Defaulted(defaultValue: true)
+        @Wire.CustomDefaulted(defaultValue: true)
         public var default_bool: Swift.Bool?
-        @Wire.Defaulted(defaultValue: 123.456e7)
+        @Wire.CustomDefaulted(defaultValue: 123.456e7)
         public var default_float: Swift.Float?
-        @Wire.Defaulted(defaultValue: 1.23456E80)
+        @Wire.CustomDefaulted(defaultValue: 1.23456E80)
         public var default_double: Swift.Double?
-        @Wire.Defaulted(defaultValue: "\"çok\\u0007\\b\\u000c\\n\\r\\t\\u000b\\u0001\\u0001\\u0001\\u000f\\u000f~\\u0001\\u0001\\u0011\\u0001\\u0001\\u0011güzel\"")
+        @Wire.CustomDefaulted(defaultValue: "\"çok\\u0007\\b\\u000c\\n\\r\\t\\u000b\\u0001\\u0001\\u0001\\u000f\\u000f~\\u0001\\u0001\\u0011\\u0001\\u0001\\u0011güzel\"")
         public var default_string: Swift.String?
-        @Wire.Defaulted(defaultValue: Foundation.Data(base64Encoded: "529rBwgMCg0JCwEBAQ8PfgEBEQEBEWf8emVs")!)
+        @Wire.CustomDefaulted(defaultValue: Foundation.Data(base64Encoded: "529rBwgMCg0JCwEBAQ8PfgEBEQEBEWf8emVs")!)
         public var default_bytes: Foundation.Data?
-        @Wire.Defaulted(defaultValue: AllTypes.NestedEnum.A)
+        @Wire.CustomDefaulted(defaultValue: AllTypes.NestedEnum.A)
         public var default_nested_enum: AllTypes.NestedEnum?
         public var map_int32_int32: [Swift.Int32 : Swift.Int32] = [:]
         public var map_string_string: [Swift.String : Swift.String] = [:]
@@ -2114,22 +2143,39 @@ extension AllTypes {
         public var array_sfixed64: [Swift.Int64] = []
         public var array_float: [Swift.Float] = []
         public var array_double: [Swift.Double] = []
+        @Wire.ProtoDefaulted
         public var ext_opt_int32: Swift.Int32?
+        @Wire.ProtoDefaulted
         public var ext_opt_uint32: Swift.UInt32?
+        @Wire.ProtoDefaulted
         public var ext_opt_sint32: Swift.Int32?
+        @Wire.ProtoDefaulted
         public var ext_opt_fixed32: Swift.UInt32?
+        @Wire.ProtoDefaulted
         public var ext_opt_sfixed32: Swift.Int32?
+        @Wire.ProtoDefaulted
         public var ext_opt_int64: Swift.Int64?
+        @Wire.ProtoDefaulted
         public var ext_opt_uint64: Swift.UInt64?
+        @Wire.ProtoDefaulted
         public var ext_opt_sint64: Swift.Int64?
+        @Wire.ProtoDefaulted
         public var ext_opt_fixed64: Swift.UInt64?
+        @Wire.ProtoDefaulted
         public var ext_opt_sfixed64: Swift.Int64?
+        @Wire.ProtoDefaulted
         public var ext_opt_bool: Swift.Bool?
+        @Wire.ProtoDefaulted
         public var ext_opt_float: Swift.Float?
+        @Wire.ProtoDefaulted
         public var ext_opt_double: Swift.Double?
+        @Wire.ProtoDefaulted
         public var ext_opt_string: Swift.String?
+        @Wire.ProtoDefaulted
         public var ext_opt_bytes: Foundation.Data?
+        @Wire.ProtoDefaulted
         public var ext_opt_nested_enum: AllTypes.NestedEnum?
+        @Wire.ProtoDefaulted
         public var ext_opt_nested_message: AllTypes.NestedMessage?
         public var ext_rep_int32: [Swift.Int32] = []
         public var ext_rep_uint32: [Swift.UInt32] = []
@@ -2533,23 +2579,23 @@ extension AllTypes.Storage : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.opt_int32 = opt_int32
-        self.opt_uint32 = opt_uint32
-        self.opt_sint32 = opt_sint32
-        self.opt_fixed32 = opt_fixed32
-        self.opt_sfixed32 = opt_sfixed32
-        self.opt_int64 = opt_int64
-        self.opt_uint64 = opt_uint64
-        self.opt_sint64 = opt_sint64
-        self.opt_fixed64 = opt_fixed64
-        self.opt_sfixed64 = opt_sfixed64
-        self.opt_bool = opt_bool
-        self.opt_float = opt_float
-        self.opt_double = opt_double
-        self.opt_string = opt_string
-        self.opt_bytes = opt_bytes
-        self.opt_nested_enum = opt_nested_enum
-        self.opt_nested_message = opt_nested_message
+        self._opt_int32.wrappedValue = opt_int32
+        self._opt_uint32.wrappedValue = opt_uint32
+        self._opt_sint32.wrappedValue = opt_sint32
+        self._opt_fixed32.wrappedValue = opt_fixed32
+        self._opt_sfixed32.wrappedValue = opt_sfixed32
+        self._opt_int64.wrappedValue = opt_int64
+        self._opt_uint64.wrappedValue = opt_uint64
+        self._opt_sint64.wrappedValue = opt_sint64
+        self._opt_fixed64.wrappedValue = opt_fixed64
+        self._opt_sfixed64.wrappedValue = opt_sfixed64
+        self._opt_bool.wrappedValue = opt_bool
+        self._opt_float.wrappedValue = opt_float
+        self._opt_double.wrappedValue = opt_double
+        self._opt_string.wrappedValue = opt_string
+        self._opt_bytes.wrappedValue = opt_bytes
+        self._opt_nested_enum.wrappedValue = opt_nested_enum
+        self._opt_nested_message.wrappedValue = opt_nested_message
         self.req_int32 = try AllTypes.checkIfMissing(req_int32, "req_int32")
         self.req_uint32 = try AllTypes.checkIfMissing(req_uint32, "req_uint32")
         self.req_sint32 = try AllTypes.checkIfMissing(req_sint32, "req_sint32")
@@ -2598,22 +2644,22 @@ extension AllTypes.Storage : Proto2Codable {
         self.pack_float = pack_float
         self.pack_double = pack_double
         self.pack_nested_enum = pack_nested_enum
-        _default_int32.wrappedValue = default_int32
-        _default_uint32.wrappedValue = default_uint32
-        _default_sint32.wrappedValue = default_sint32
-        _default_fixed32.wrappedValue = default_fixed32
-        _default_sfixed32.wrappedValue = default_sfixed32
-        _default_int64.wrappedValue = default_int64
-        _default_uint64.wrappedValue = default_uint64
-        _default_sint64.wrappedValue = default_sint64
-        _default_fixed64.wrappedValue = default_fixed64
-        _default_sfixed64.wrappedValue = default_sfixed64
-        _default_bool.wrappedValue = default_bool
-        _default_float.wrappedValue = default_float
-        _default_double.wrappedValue = default_double
-        _default_string.wrappedValue = default_string
-        _default_bytes.wrappedValue = default_bytes
-        _default_nested_enum.wrappedValue = default_nested_enum
+        self._default_int32.wrappedValue = default_int32
+        self._default_uint32.wrappedValue = default_uint32
+        self._default_sint32.wrappedValue = default_sint32
+        self._default_fixed32.wrappedValue = default_fixed32
+        self._default_sfixed32.wrappedValue = default_sfixed32
+        self._default_int64.wrappedValue = default_int64
+        self._default_uint64.wrappedValue = default_uint64
+        self._default_sint64.wrappedValue = default_sint64
+        self._default_fixed64.wrappedValue = default_fixed64
+        self._default_sfixed64.wrappedValue = default_sfixed64
+        self._default_bool.wrappedValue = default_bool
+        self._default_float.wrappedValue = default_float
+        self._default_double.wrappedValue = default_double
+        self._default_string.wrappedValue = default_string
+        self._default_bytes.wrappedValue = default_bytes
+        self._default_nested_enum.wrappedValue = default_nested_enum
         self.map_int32_int32 = map_int32_int32
         self.map_string_string = map_string_string
         self.map_string_message = map_string_message
@@ -2630,23 +2676,23 @@ extension AllTypes.Storage : Proto2Codable {
         self.array_sfixed64 = array_sfixed64
         self.array_float = array_float
         self.array_double = array_double
-        self.ext_opt_int32 = ext_opt_int32
-        self.ext_opt_uint32 = ext_opt_uint32
-        self.ext_opt_sint32 = ext_opt_sint32
-        self.ext_opt_fixed32 = ext_opt_fixed32
-        self.ext_opt_sfixed32 = ext_opt_sfixed32
-        self.ext_opt_int64 = ext_opt_int64
-        self.ext_opt_uint64 = ext_opt_uint64
-        self.ext_opt_sint64 = ext_opt_sint64
-        self.ext_opt_fixed64 = ext_opt_fixed64
-        self.ext_opt_sfixed64 = ext_opt_sfixed64
-        self.ext_opt_bool = ext_opt_bool
-        self.ext_opt_float = ext_opt_float
-        self.ext_opt_double = ext_opt_double
-        self.ext_opt_string = ext_opt_string
-        self.ext_opt_bytes = ext_opt_bytes
-        self.ext_opt_nested_enum = ext_opt_nested_enum
-        self.ext_opt_nested_message = ext_opt_nested_message
+        self._ext_opt_int32.wrappedValue = ext_opt_int32
+        self._ext_opt_uint32.wrappedValue = ext_opt_uint32
+        self._ext_opt_sint32.wrappedValue = ext_opt_sint32
+        self._ext_opt_fixed32.wrappedValue = ext_opt_fixed32
+        self._ext_opt_sfixed32.wrappedValue = ext_opt_sfixed32
+        self._ext_opt_int64.wrappedValue = ext_opt_int64
+        self._ext_opt_uint64.wrappedValue = ext_opt_uint64
+        self._ext_opt_sint64.wrappedValue = ext_opt_sint64
+        self._ext_opt_fixed64.wrappedValue = ext_opt_fixed64
+        self._ext_opt_sfixed64.wrappedValue = ext_opt_sfixed64
+        self._ext_opt_bool.wrappedValue = ext_opt_bool
+        self._ext_opt_float.wrappedValue = ext_opt_float
+        self._ext_opt_double.wrappedValue = ext_opt_double
+        self._ext_opt_string.wrappedValue = ext_opt_string
+        self._ext_opt_bytes.wrappedValue = ext_opt_bytes
+        self._ext_opt_nested_enum.wrappedValue = ext_opt_nested_enum
+        self._ext_opt_nested_message.wrappedValue = ext_opt_nested_message
         self.ext_rep_int32 = ext_rep_int32
         self.ext_rep_uint32 = ext_rep_uint32
         self.ext_rep_sint32 = ext_rep_sint32
@@ -2836,23 +2882,23 @@ extension AllTypes.Storage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.opt_int32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optInt32", "opt_int32")
-        self.opt_uint32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "optUint32", "opt_uint32")
-        self.opt_sint32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optSint32", "opt_sint32")
-        self.opt_fixed32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "optFixed32", "opt_fixed32")
-        self.opt_sfixed32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optSfixed32", "opt_sfixed32")
-        self.opt_int64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optInt64", "opt_int64")
-        self.opt_uint64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "optUint64", "opt_uint64")
-        self.opt_sint64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optSint64", "opt_sint64")
-        self.opt_fixed64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "optFixed64", "opt_fixed64")
-        self.opt_sfixed64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optSfixed64", "opt_sfixed64")
-        self.opt_bool = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "optBool", "opt_bool")
-        self.opt_float = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "optFloat", "opt_float")
-        self.opt_double = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "optDouble", "opt_double")
-        self.opt_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "optString", "opt_string")
-        self.opt_bytes = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "optBytes", "opt_bytes")
-        self.opt_nested_enum = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "optNestedEnum", "opt_nested_enum")
-        self.opt_nested_message = try container.decodeIfPresent(AllTypes.NestedMessage.self, firstOfKeys: "optNestedMessage", "opt_nested_message")
+        self._opt_int32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optInt32", "opt_int32")
+        self._opt_uint32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "optUint32", "opt_uint32")
+        self._opt_sint32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optSint32", "opt_sint32")
+        self._opt_fixed32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "optFixed32", "opt_fixed32")
+        self._opt_sfixed32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "optSfixed32", "opt_sfixed32")
+        self._opt_int64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optInt64", "opt_int64")
+        self._opt_uint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "optUint64", "opt_uint64")
+        self._opt_sint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optSint64", "opt_sint64")
+        self._opt_fixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "optFixed64", "opt_fixed64")
+        self._opt_sfixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "optSfixed64", "opt_sfixed64")
+        self._opt_bool.wrappedValue = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "optBool", "opt_bool")
+        self._opt_float.wrappedValue = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "optFloat", "opt_float")
+        self._opt_double.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "optDouble", "opt_double")
+        self._opt_string.wrappedValue = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "optString", "opt_string")
+        self._opt_bytes.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "optBytes", "opt_bytes")
+        self._opt_nested_enum.wrappedValue = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "optNestedEnum", "opt_nested_enum")
+        self._opt_nested_message.wrappedValue = try container.decodeIfPresent(AllTypes.NestedMessage.self, firstOfKeys: "optNestedMessage", "opt_nested_message")
         self.req_int32 = try container.decode(Swift.Int32.self, firstOfKeys: "reqInt32", "req_int32")
         self.req_uint32 = try container.decode(Swift.UInt32.self, firstOfKeys: "reqUint32", "req_uint32")
         self.req_sint32 = try container.decode(Swift.Int32.self, firstOfKeys: "reqSint32", "req_sint32")
@@ -2901,22 +2947,22 @@ extension AllTypes.Storage : Codable {
         self.pack_float = try container.decodeProtoArray(Swift.Float.self, firstOfKeys: "packFloat", "pack_float")
         self.pack_double = try container.decodeProtoArray(Swift.Double.self, firstOfKeys: "packDouble", "pack_double")
         self.pack_nested_enum = try container.decodeProtoArray(AllTypes.NestedEnum.self, firstOfKeys: "packNestedEnum", "pack_nested_enum")
-        _default_int32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultInt32", "default_int32")
-        _default_uint32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "defaultUint32", "default_uint32")
-        _default_sint32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultSint32", "default_sint32")
-        _default_fixed32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "defaultFixed32", "default_fixed32")
-        _default_sfixed32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultSfixed32", "default_sfixed32")
-        _default_int64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultInt64", "default_int64")
-        _default_uint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "defaultUint64", "default_uint64")
-        _default_sint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultSint64", "default_sint64")
-        _default_fixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "defaultFixed64", "default_fixed64")
-        _default_sfixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultSfixed64", "default_sfixed64")
-        _default_bool.wrappedValue = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "defaultBool", "default_bool")
-        _default_float.wrappedValue = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "defaultFloat", "default_float")
-        _default_double.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "defaultDouble", "default_double")
-        _default_string.wrappedValue = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "defaultString", "default_string")
-        _default_bytes.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "defaultBytes", "default_bytes")
-        _default_nested_enum.wrappedValue = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "defaultNestedEnum", "default_nested_enum")
+        self._default_int32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultInt32", "default_int32")
+        self._default_uint32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "defaultUint32", "default_uint32")
+        self._default_sint32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultSint32", "default_sint32")
+        self._default_fixed32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "defaultFixed32", "default_fixed32")
+        self._default_sfixed32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "defaultSfixed32", "default_sfixed32")
+        self._default_int64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultInt64", "default_int64")
+        self._default_uint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "defaultUint64", "default_uint64")
+        self._default_sint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultSint64", "default_sint64")
+        self._default_fixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "defaultFixed64", "default_fixed64")
+        self._default_sfixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "defaultSfixed64", "default_sfixed64")
+        self._default_bool.wrappedValue = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "defaultBool", "default_bool")
+        self._default_float.wrappedValue = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "defaultFloat", "default_float")
+        self._default_double.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "defaultDouble", "default_double")
+        self._default_string.wrappedValue = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "defaultString", "default_string")
+        self._default_bytes.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "defaultBytes", "default_bytes")
+        self._default_nested_enum.wrappedValue = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "defaultNestedEnum", "default_nested_enum")
         self.map_int32_int32 = try container.decodeProtoMap([Swift.Int32 : Swift.Int32].self, firstOfKeys: "mapInt32Int32", "map_int32_int32")
         self.map_string_string = try container.decodeProtoMap([Swift.String : Swift.String].self, firstOfKeys: "mapStringString", "map_string_string")
         self.map_string_message = try container.decodeProtoMap([Swift.String : AllTypes.NestedMessage].self, firstOfKeys: "mapStringMessage", "map_string_message")
@@ -2933,23 +2979,23 @@ extension AllTypes.Storage : Codable {
         self.array_sfixed64 = try container.decodeProtoArray(Swift.Int64.self, firstOfKeys: "arraySfixed64", "array_sfixed64")
         self.array_float = try container.decodeProtoArray(Swift.Float.self, firstOfKeys: "arrayFloat", "array_float")
         self.array_double = try container.decodeProtoArray(Swift.Double.self, firstOfKeys: "arrayDouble", "array_double")
-        self.ext_opt_int32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptInt32", "ext_opt_int32")
-        self.ext_opt_uint32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "extOptUint32", "ext_opt_uint32")
-        self.ext_opt_sint32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptSint32", "ext_opt_sint32")
-        self.ext_opt_fixed32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "extOptFixed32", "ext_opt_fixed32")
-        self.ext_opt_sfixed32 = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptSfixed32", "ext_opt_sfixed32")
-        self.ext_opt_int64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptInt64", "ext_opt_int64")
-        self.ext_opt_uint64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "extOptUint64", "ext_opt_uint64")
-        self.ext_opt_sint64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptSint64", "ext_opt_sint64")
-        self.ext_opt_fixed64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "extOptFixed64", "ext_opt_fixed64")
-        self.ext_opt_sfixed64 = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptSfixed64", "ext_opt_sfixed64")
-        self.ext_opt_bool = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "extOptBool", "ext_opt_bool")
-        self.ext_opt_float = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "extOptFloat", "ext_opt_float")
-        self.ext_opt_double = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "extOptDouble", "ext_opt_double")
-        self.ext_opt_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "extOptString", "ext_opt_string")
-        self.ext_opt_bytes = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "extOptBytes", "ext_opt_bytes")
-        self.ext_opt_nested_enum = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "extOptNestedEnum", "ext_opt_nested_enum")
-        self.ext_opt_nested_message = try container.decodeIfPresent(AllTypes.NestedMessage.self, firstOfKeys: "extOptNestedMessage", "ext_opt_nested_message")
+        self._ext_opt_int32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptInt32", "ext_opt_int32")
+        self._ext_opt_uint32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "extOptUint32", "ext_opt_uint32")
+        self._ext_opt_sint32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptSint32", "ext_opt_sint32")
+        self._ext_opt_fixed32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "extOptFixed32", "ext_opt_fixed32")
+        self._ext_opt_sfixed32.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "extOptSfixed32", "ext_opt_sfixed32")
+        self._ext_opt_int64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptInt64", "ext_opt_int64")
+        self._ext_opt_uint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "extOptUint64", "ext_opt_uint64")
+        self._ext_opt_sint64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptSint64", "ext_opt_sint64")
+        self._ext_opt_fixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "extOptFixed64", "ext_opt_fixed64")
+        self._ext_opt_sfixed64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.Int64.self, firstOfKeys: "extOptSfixed64", "ext_opt_sfixed64")
+        self._ext_opt_bool.wrappedValue = try container.decodeIfPresent(Swift.Bool.self, firstOfKeys: "extOptBool", "ext_opt_bool")
+        self._ext_opt_float.wrappedValue = try container.decodeIfPresent(Swift.Float.self, firstOfKeys: "extOptFloat", "ext_opt_float")
+        self._ext_opt_double.wrappedValue = try container.decodeIfPresent(Swift.Double.self, firstOfKeys: "extOptDouble", "ext_opt_double")
+        self._ext_opt_string.wrappedValue = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "extOptString", "ext_opt_string")
+        self._ext_opt_bytes.wrappedValue = try container.decodeIfPresent(stringEncoded: Foundation.Data.self, firstOfKeys: "extOptBytes", "ext_opt_bytes")
+        self._ext_opt_nested_enum.wrappedValue = try container.decodeIfPresent(AllTypes.NestedEnum.self, firstOfKeys: "extOptNestedEnum", "ext_opt_nested_enum")
+        self._ext_opt_nested_message.wrappedValue = try container.decodeIfPresent(AllTypes.NestedMessage.self, firstOfKeys: "extOptNestedMessage", "ext_opt_nested_message")
         self.ext_rep_int32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extRepInt32", "ext_rep_int32")
         self.ext_rep_uint32 = try container.decodeProtoArray(Swift.UInt32.self, firstOfKeys: "extRepUint32", "ext_rep_uint32")
         self.ext_rep_sint32 = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "extRepSint32", "ext_rep_sint32")

--- a/wire-tests-swift/no-manifest/src/main/swift/DeprecatedProto.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/DeprecatedProto.swift
@@ -6,6 +6,7 @@ import Wire
 public struct DeprecatedProto {
 
     @available(*, deprecated)
+    @ProtoDefaulted
     public var foo: String?
     public var unknownFields: Foundation.Data = .init()
 
@@ -21,7 +22,7 @@ extension DeprecatedProto {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(foo: Swift.String? = nil) {
-        self.foo = foo
+        self._foo.wrappedValue = foo
     }
 
 }
@@ -41,6 +42,13 @@ extension DeprecatedProto : Hashable {
 extension DeprecatedProto : Sendable {
 }
 #endif
+
+extension DeprecatedProto : ProtoDefaultedValue {
+
+    public static var defaultedValue: DeprecatedProto {
+        DeprecatedProto()
+    }
+}
 
 extension DeprecatedProto : ProtoMessage {
 
@@ -64,7 +72,7 @@ extension DeprecatedProto : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.foo = foo
+        self._foo.wrappedValue = foo
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -79,7 +87,7 @@ extension DeprecatedProto : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.foo = try container.decodeIfPresent(Swift.String.self, forKey: "foo")
+        self._foo.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "foo")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/EmbeddedMessage.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/EmbeddedMessage.swift
@@ -6,6 +6,7 @@ import Wire
 public struct EmbeddedMessage {
 
     public var inner_repeated_number: [Int32] = []
+    @ProtoDefaulted
     public var inner_number_after: Int32?
     public var unknownFields: Foundation.Data = .init()
 
@@ -22,7 +23,7 @@ extension EmbeddedMessage {
     @available(*, deprecated)
     public init(inner_repeated_number: [Swift.Int32] = [], inner_number_after: Swift.Int32? = nil) {
         self.inner_repeated_number = inner_repeated_number
-        self.inner_number_after = inner_number_after
+        self._inner_number_after.wrappedValue = inner_number_after
     }
 
 }
@@ -42,6 +43,13 @@ extension EmbeddedMessage : Hashable {
 extension EmbeddedMessage : Sendable {
 }
 #endif
+
+extension EmbeddedMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: EmbeddedMessage {
+        EmbeddedMessage()
+    }
+}
 
 extension EmbeddedMessage : ProtoMessage {
 
@@ -68,7 +76,7 @@ extension EmbeddedMessage : Proto2Codable {
         self.unknownFields = try protoReader.endMessage(token: token)
 
         self.inner_repeated_number = inner_repeated_number
-        self.inner_number_after = inner_number_after
+        self._inner_number_after.wrappedValue = inner_number_after
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -85,7 +93,7 @@ extension EmbeddedMessage : Codable {
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.inner_repeated_number = try container.decodeProtoArray(Swift.Int32.self, firstOfKeys: "innerRepeatedNumber", "inner_repeated_number")
-        self.inner_number_after = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "innerNumberAfter", "inner_number_after")
+        self._inner_number_after.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "innerNumberAfter", "inner_number_after")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/ExternalMessage.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ExternalMessage.swift
@@ -5,7 +5,7 @@ import Wire
 
 public struct ExternalMessage {
 
-    @Defaulted(defaultValue: 20)
+    @CustomDefaulted(defaultValue: 20)
     public var f: Float?
     public var unknownFields: Foundation.Data = .init()
 
@@ -21,7 +21,7 @@ extension ExternalMessage {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(f: Swift.Float? = nil) {
-        _f.wrappedValue = f
+        self._f.wrappedValue = f
     }
 
 }
@@ -41,6 +41,13 @@ extension ExternalMessage : Hashable {
 extension ExternalMessage : Sendable {
 }
 #endif
+
+extension ExternalMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: ExternalMessage {
+        ExternalMessage()
+    }
+}
 
 extension ExternalMessage : ProtoMessage {
 
@@ -64,7 +71,7 @@ extension ExternalMessage : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        _f.wrappedValue = f
+        self._f.wrappedValue = f
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -79,7 +86,7 @@ extension ExternalMessage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        _f.wrappedValue = try container.decodeIfPresent(Swift.Float.self, forKey: "f")
+        self._f.wrappedValue = try container.decodeIfPresent(Swift.Float.self, forKey: "f")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
@@ -5,15 +5,21 @@ import Wire
 
 public struct FooBar {
 
+    @ProtoDefaulted
     public var foo: Int32?
+    @ProtoDefaulted
     public var bar: String?
+    @ProtoDefaulted
     public var baz: FooBar.Nested?
+    @ProtoDefaulted
     public var qux: UInt64?
     public var fred: [Float] = []
+    @ProtoDefaulted
     public var daisy: Double?
     public var nested: [FooBar] = []
     public var ext: FooBar.FooBarBazEnum?
     public var rep: [FooBar.FooBarBazEnum] = []
+    @ProtoDefaulted
     public var more_string: String?
     public var unknownFields: Foundation.Data = .init()
 
@@ -40,16 +46,16 @@ extension FooBar {
         rep: [FooBar.FooBarBazEnum] = [],
         more_string: Swift.String? = nil
     ) {
-        self.foo = foo
-        self.bar = bar
-        self.baz = baz
-        self.qux = qux
+        self._foo.wrappedValue = foo
+        self._bar.wrappedValue = bar
+        self._baz.wrappedValue = baz
+        self._qux.wrappedValue = qux
         self.fred = fred
-        self.daisy = daisy
+        self._daisy.wrappedValue = daisy
         self.nested = nested
         self.ext = ext
         self.rep = rep
-        self.more_string = more_string
+        self._more_string.wrappedValue = more_string
     }
 
 }
@@ -69,6 +75,13 @@ extension FooBar : Hashable {
 extension FooBar : Sendable {
 }
 #endif
+
+extension FooBar : ProtoDefaultedValue {
+
+    public static var defaultedValue: FooBar {
+        FooBar()
+    }
+}
 
 #if !WIRE_REMOVE_REDACTABLE
 extension FooBar : Redactable {
@@ -122,16 +135,16 @@ extension FooBar : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.foo = foo
-        self.bar = bar
-        self.baz = baz
-        self.qux = qux
+        self._foo.wrappedValue = foo
+        self._bar.wrappedValue = bar
+        self._baz.wrappedValue = baz
+        self._qux.wrappedValue = qux
         self.fred = fred
-        self.daisy = daisy
+        self._daisy.wrappedValue = daisy
         self.nested = nested
         self.ext = ext
         self.rep = rep
-        self.more_string = more_string
+        self._more_string.wrappedValue = more_string
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -155,16 +168,16 @@ extension FooBar : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.foo = try container.decodeIfPresent(Swift.Int32.self, forKey: "foo")
-        self.bar = try container.decodeIfPresent(Swift.String.self, forKey: "bar")
-        self.baz = try container.decodeIfPresent(FooBar.Nested.self, forKey: "baz")
-        self.qux = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, forKey: "qux")
+        self._foo.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, forKey: "foo")
+        self._bar.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "bar")
+        self._baz.wrappedValue = try container.decodeIfPresent(FooBar.Nested.self, forKey: "baz")
+        self._qux.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, forKey: "qux")
         self.fred = try container.decodeProtoArray(Swift.Float.self, forKey: "fred")
-        self.daisy = try container.decodeIfPresent(Swift.Double.self, forKey: "daisy")
+        self._daisy.wrappedValue = try container.decodeIfPresent(Swift.Double.self, forKey: "daisy")
         self.nested = try container.decodeProtoArray(FooBar.self, forKey: "nested")
         self.ext = try container.decodeIfPresent(FooBar.FooBarBazEnum.self, forKey: "ext")
         self.rep = try container.decodeProtoArray(FooBar.FooBarBazEnum.self, forKey: "rep")
-        self.more_string = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "moreString", "more_string")
+        self._more_string.wrappedValue = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "moreString", "more_string")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {
@@ -265,6 +278,13 @@ extension FooBar.Nested : Sendable {
 }
 #endif
 
+extension FooBar.Nested : ProtoDefaultedValue {
+
+    public static var defaultedValue: FooBar.Nested {
+        FooBar.Nested()
+    }
+}
+
 extension FooBar.Nested : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -340,6 +360,13 @@ extension FooBar.More : Hashable {
 extension FooBar.More : Sendable {
 }
 #endif
+
+extension FooBar.More : ProtoDefaultedValue {
+
+    public static var defaultedValue: FooBar.More {
+        FooBar.More()
+    }
+}
 
 extension FooBar.More : ProtoMessage {
 

--- a/wire-tests-swift/no-manifest/src/main/swift/ForeignEnum.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ForeignEnum.swift
@@ -3,11 +3,14 @@
 import Foundation
 import Wire
 
-public enum ForeignEnum : UInt32, CaseIterable, ProtoEnum {
+public enum ForeignEnum : UInt32, CaseIterable, ProtoEnum, ProtoDefaultedValue {
 
     case BAV = 0
     case BAX = 1
 
+    public static var defaultedValue: ForeignEnum {
+        ForeignEnum.BAV
+    }
     public var description: String {
         switch self {
         case .BAV: return "BAV"

--- a/wire-tests-swift/no-manifest/src/main/swift/ForeignMessage.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ForeignMessage.swift
@@ -5,6 +5,7 @@ import Wire
 
 public struct ForeignMessage {
 
+    @ProtoDefaulted
     public var i: Int32?
     public var unknownFields: Foundation.Data = .init()
 
@@ -20,7 +21,7 @@ extension ForeignMessage {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(i: Swift.Int32? = nil) {
-        self.i = i
+        self._i.wrappedValue = i
     }
 
 }
@@ -40,6 +41,13 @@ extension ForeignMessage : Hashable {
 extension ForeignMessage : Sendable {
 }
 #endif
+
+extension ForeignMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: ForeignMessage {
+        ForeignMessage()
+    }
+}
 
 extension ForeignMessage : ProtoMessage {
 
@@ -63,7 +71,7 @@ extension ForeignMessage : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.i = i
+        self._i.wrappedValue = i
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -78,7 +86,7 @@ extension ForeignMessage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
+        self._i.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/Form.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Form.swift
@@ -43,6 +43,13 @@ extension Form : Sendable {
 }
 #endif
 
+extension Form : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form {
+        Form()
+    }
+}
+
 extension Form : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -326,6 +333,7 @@ extension Form {
 
     public struct TextElement {
 
+        @Wire.ProtoDefaulted
         public var text: Swift.String?
         public var unknownFields: Foundation.Data = .init()
 
@@ -448,6 +456,13 @@ extension Form.ButtonElement : Sendable {
 }
 #endif
 
+extension Form.ButtonElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.ButtonElement {
+        Form.ButtonElement()
+    }
+}
+
 extension Form.ButtonElement : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -498,6 +513,13 @@ extension Form.LocalImageElement : Hashable {
 extension Form.LocalImageElement : Sendable {
 }
 #endif
+
+extension Form.LocalImageElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.LocalImageElement {
+        Form.LocalImageElement()
+    }
+}
 
 extension Form.LocalImageElement : ProtoMessage {
 
@@ -550,6 +572,13 @@ extension Form.RemoteImageElement : Sendable {
 }
 #endif
 
+extension Form.RemoteImageElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.RemoteImageElement {
+        Form.RemoteImageElement()
+    }
+}
+
 extension Form.RemoteImageElement : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -600,6 +629,13 @@ extension Form.MoneyElement : Hashable {
 extension Form.MoneyElement : Sendable {
 }
 #endif
+
+extension Form.MoneyElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.MoneyElement {
+        Form.MoneyElement()
+    }
+}
 
 extension Form.MoneyElement : ProtoMessage {
 
@@ -652,6 +688,13 @@ extension Form.SpacerElement : Sendable {
 }
 #endif
 
+extension Form.SpacerElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.SpacerElement {
+        Form.SpacerElement()
+    }
+}
+
 extension Form.SpacerElement : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -694,7 +737,7 @@ extension Form.TextElement {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(text: Swift.String? = nil) {
-        self.text = text
+        self._text.wrappedValue = text
     }
 
 }
@@ -714,6 +757,13 @@ extension Form.TextElement : Hashable {
 extension Form.TextElement : Sendable {
 }
 #endif
+
+extension Form.TextElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.TextElement {
+        Form.TextElement()
+    }
+}
 
 extension Form.TextElement : ProtoMessage {
 
@@ -737,7 +787,7 @@ extension Form.TextElement : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.text = text
+        self._text.wrappedValue = text
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -752,7 +802,7 @@ extension Form.TextElement : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.text = try container.decodeIfPresent(Swift.String.self, forKey: "text")
+        self._text.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "text")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {
@@ -778,6 +828,13 @@ extension Form.CustomizedCardElement : Hashable {
 extension Form.CustomizedCardElement : Sendable {
 }
 #endif
+
+extension Form.CustomizedCardElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.CustomizedCardElement {
+        Form.CustomizedCardElement()
+    }
+}
 
 extension Form.CustomizedCardElement : ProtoMessage {
 
@@ -830,6 +887,13 @@ extension Form.AddressElement : Sendable {
 }
 #endif
 
+extension Form.AddressElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.AddressElement {
+        Form.AddressElement()
+    }
+}
+
 extension Form.AddressElement : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -880,6 +944,13 @@ extension Form.TextInputElement : Hashable {
 extension Form.TextInputElement : Sendable {
 }
 #endif
+
+extension Form.TextInputElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.TextInputElement {
+        Form.TextInputElement()
+    }
+}
 
 extension Form.TextInputElement : ProtoMessage {
 
@@ -932,6 +1003,13 @@ extension Form.OptionPickerElement : Sendable {
 }
 #endif
 
+extension Form.OptionPickerElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.OptionPickerElement {
+        Form.OptionPickerElement()
+    }
+}
+
 extension Form.OptionPickerElement : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -983,6 +1061,13 @@ extension Form.DetailRowElement : Sendable {
 }
 #endif
 
+extension Form.DetailRowElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.DetailRowElement {
+        Form.DetailRowElement()
+    }
+}
+
 extension Form.DetailRowElement : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -1033,6 +1118,13 @@ extension Form.CurrencyConversionFlagsElement : Hashable {
 extension Form.CurrencyConversionFlagsElement : Sendable {
 }
 #endif
+
+extension Form.CurrencyConversionFlagsElement : ProtoDefaultedValue {
+
+    public static var defaultedValue: Form.CurrencyConversionFlagsElement {
+        Form.CurrencyConversionFlagsElement()
+    }
+}
 
 extension Form.CurrencyConversionFlagsElement : ProtoMessage {
 

--- a/wire-tests-swift/no-manifest/src/main/swift/Mappy.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Mappy.swift
@@ -41,6 +41,13 @@ extension Mappy : Sendable {
 }
 #endif
 
+extension Mappy : ProtoDefaultedValue {
+
+    public static var defaultedValue: Mappy {
+        Mappy()
+    }
+}
+
 extension Mappy : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/MappyTwo.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MappyTwo.swift
@@ -52,6 +52,13 @@ extension MappyTwo : Sendable {
 }
 #endif
 
+extension MappyTwo : ProtoDefaultedValue {
+
+    public static var defaultedValue: MappyTwo {
+        MappyTwo()
+    }
+}
+
 extension MappyTwo : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {
@@ -134,12 +141,16 @@ extension MappyTwo : Codable {
  */
 extension MappyTwo {
 
-    public enum ValueEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+    public enum ValueEnum : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum,
+            Wire.ProtoDefaultedValue {
 
         case DEFAULT = 0
         case FOO = 1
         case BAR = 2
 
+        public static var defaultedValue: MappyTwo.ValueEnum {
+            MappyTwo.ValueEnum.DEFAULT
+        }
         public var description: Swift.String {
             switch self {
             case .DEFAULT: return "DEFAULT"

--- a/wire-tests-swift/no-manifest/src/main/swift/MessageUsingMultipleEnums.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MessageUsingMultipleEnums.swift
@@ -46,6 +46,13 @@ extension MessageUsingMultipleEnums : Sendable {
 }
 #endif
 
+extension MessageUsingMultipleEnums : ProtoDefaultedValue {
+
+    public static var defaultedValue: MessageUsingMultipleEnums {
+        MessageUsingMultipleEnums()
+    }
+}
+
 extension MessageUsingMultipleEnums : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/MessageWithOptions.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MessageWithOptions.swift
@@ -27,6 +27,13 @@ extension MessageWithOptions : Sendable {
 }
 #endif
 
+extension MessageWithOptions : ProtoDefaultedValue {
+
+    public static var defaultedValue: MessageWithOptions {
+        MessageWithOptions()
+    }
+}
+
 extension MessageWithOptions : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/MessageWithStatus.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MessageWithStatus.swift
@@ -27,6 +27,13 @@ extension MessageWithStatus : Sendable {
 }
 #endif
 
+extension MessageWithStatus : ProtoDefaultedValue {
+
+    public static var defaultedValue: MessageWithStatus {
+        MessageWithStatus()
+    }
+}
+
 extension MessageWithStatus : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/ModelEvaluation.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ModelEvaluation.swift
@@ -20,7 +20,9 @@ import Wire
  */
 public struct ModelEvaluation {
 
+    @ProtoDefaulted
     public var name: String?
+    @ProtoDefaulted
     public var score: Double?
     public var models: [String : ModelEvaluation] = [:]
     public var unknownFields: Foundation.Data = .init()
@@ -41,8 +43,8 @@ extension ModelEvaluation {
         score: Swift.Double? = nil,
         models: [Swift.String : ModelEvaluation] = [:]
     ) {
-        self.name = name
-        self.score = score
+        self._name.wrappedValue = name
+        self._score.wrappedValue = score
         self.models = models
     }
 
@@ -63,6 +65,13 @@ extension ModelEvaluation : Hashable {
 extension ModelEvaluation : Sendable {
 }
 #endif
+
+extension ModelEvaluation : ProtoDefaultedValue {
+
+    public static var defaultedValue: ModelEvaluation {
+        ModelEvaluation()
+    }
+}
 
 extension ModelEvaluation : ProtoMessage {
 
@@ -90,8 +99,8 @@ extension ModelEvaluation : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.name = name
-        self.score = score
+        self._name.wrappedValue = name
+        self._score.wrappedValue = score
         self.models = models
     }
 
@@ -109,8 +118,8 @@ extension ModelEvaluation : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
-        self.score = try container.decodeIfPresent(Swift.Double.self, forKey: "score")
+        self._name.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self._score.wrappedValue = try container.decodeIfPresent(Swift.Double.self, forKey: "score")
         self.models = try container.decodeProtoMap([Swift.String : ModelEvaluation].self, forKey: "models")
     }
 

--- a/wire-tests-swift/no-manifest/src/main/swift/NestedVersionOne.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/NestedVersionOne.swift
@@ -5,6 +5,7 @@ import Wire
 
 public struct NestedVersionOne {
 
+    @ProtoDefaulted
     public var i: Int32?
     public var unknownFields: Foundation.Data = .init()
 
@@ -20,7 +21,7 @@ extension NestedVersionOne {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(i: Swift.Int32? = nil) {
-        self.i = i
+        self._i.wrappedValue = i
     }
 
 }
@@ -40,6 +41,13 @@ extension NestedVersionOne : Hashable {
 extension NestedVersionOne : Sendable {
 }
 #endif
+
+extension NestedVersionOne : ProtoDefaultedValue {
+
+    public static var defaultedValue: NestedVersionOne {
+        NestedVersionOne()
+    }
+}
 
 extension NestedVersionOne : ProtoMessage {
 
@@ -63,7 +71,7 @@ extension NestedVersionOne : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.i = i
+        self._i.wrappedValue = i
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -78,7 +86,7 @@ extension NestedVersionOne : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
+        self._i.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/NestedVersionTwo.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/NestedVersionTwo.swift
@@ -5,10 +5,15 @@ import Wire
 
 public struct NestedVersionTwo {
 
+    @ProtoDefaulted
     public var i: Int32?
+    @ProtoDefaulted
     public var v2_i: Int32?
+    @ProtoDefaulted
     public var v2_s: String?
+    @ProtoDefaulted
     public var v2_f32: UInt32?
+    @ProtoDefaulted
     public var v2_f64: UInt64?
     public var v2_rs: [String] = []
     public var unknownFields: Foundation.Data = .init()
@@ -32,11 +37,11 @@ extension NestedVersionTwo {
         v2_f64: Swift.UInt64? = nil,
         v2_rs: [Swift.String] = []
     ) {
-        self.i = i
-        self.v2_i = v2_i
-        self.v2_s = v2_s
-        self.v2_f32 = v2_f32
-        self.v2_f64 = v2_f64
+        self._i.wrappedValue = i
+        self._v2_i.wrappedValue = v2_i
+        self._v2_s.wrappedValue = v2_s
+        self._v2_f32.wrappedValue = v2_f32
+        self._v2_f64.wrappedValue = v2_f64
         self.v2_rs = v2_rs
     }
 
@@ -57,6 +62,13 @@ extension NestedVersionTwo : Hashable {
 extension NestedVersionTwo : Sendable {
 }
 #endif
+
+extension NestedVersionTwo : ProtoDefaultedValue {
+
+    public static var defaultedValue: NestedVersionTwo {
+        NestedVersionTwo()
+    }
+}
 
 extension NestedVersionTwo : ProtoMessage {
 
@@ -90,11 +102,11 @@ extension NestedVersionTwo : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.i = i
-        self.v2_i = v2_i
-        self.v2_s = v2_s
-        self.v2_f32 = v2_f32
-        self.v2_f64 = v2_f64
+        self._i.wrappedValue = i
+        self._v2_i.wrappedValue = v2_i
+        self._v2_s.wrappedValue = v2_s
+        self._v2_f32.wrappedValue = v2_f32
+        self._v2_f64.wrappedValue = v2_f64
         self.v2_rs = v2_rs
     }
 
@@ -115,11 +127,11 @@ extension NestedVersionTwo : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
-        self.v2_i = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "v2I", "v2_i")
-        self.v2_s = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "v2S", "v2_s")
-        self.v2_f32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "v2F32", "v2_f32")
-        self.v2_f64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "v2F64", "v2_f64")
+        self._i.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
+        self._v2_i.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "v2I", "v2_i")
+        self._v2_s.wrappedValue = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "v2S", "v2_s")
+        self._v2_f32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "v2F32", "v2_f32")
+        self._v2_f64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "v2F64", "v2_f64")
         self.v2_rs = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "v2Rs", "v2_rs")
     }
 

--- a/wire-tests-swift/no-manifest/src/main/swift/NoFields.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/NoFields.swift
@@ -27,6 +27,13 @@ extension NoFields : Sendable {
 }
 #endif
 
+extension NoFields : ProtoDefaultedValue {
+
+    public static var defaultedValue: NoFields {
+        NoFields()
+    }
+}
+
 extension NoFields : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/OneOfMessage.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OneOfMessage.swift
@@ -47,6 +47,13 @@ extension OneOfMessage : Sendable {
 }
 #endif
 
+extension OneOfMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: OneOfMessage {
+        OneOfMessage()
+    }
+}
+
 extension OneOfMessage : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/OptionalEnumUser.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OptionalEnumUser.swift
@@ -41,6 +41,13 @@ extension OptionalEnumUser : Sendable {
 }
 #endif
 
+extension OptionalEnumUser : ProtoDefaultedValue {
+
+    public static var defaultedValue: OptionalEnumUser {
+        OptionalEnumUser()
+    }
+}
+
 extension OptionalEnumUser : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OtherMessageWithStatus.swift
@@ -27,6 +27,13 @@ extension OtherMessageWithStatus : Sendable {
 }
 #endif
 
+extension OtherMessageWithStatus : ProtoDefaultedValue {
+
+    public static var defaultedValue: OtherMessageWithStatus {
+        OtherMessageWithStatus()
+    }
+}
+
 extension OtherMessageWithStatus : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/OuterMessage.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OuterMessage.swift
@@ -5,7 +5,9 @@ import Wire
 
 public struct OuterMessage {
 
+    @ProtoDefaulted
     public var outer_number_before: Int32?
+    @ProtoDefaulted
     public var embedded_message: EmbeddedMessage?
     public var unknownFields: Foundation.Data = .init()
 
@@ -21,8 +23,8 @@ extension OuterMessage {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(outer_number_before: Swift.Int32? = nil, embedded_message: EmbeddedMessage? = nil) {
-        self.outer_number_before = outer_number_before
-        self.embedded_message = embedded_message
+        self._outer_number_before.wrappedValue = outer_number_before
+        self._embedded_message.wrappedValue = embedded_message
     }
 
 }
@@ -42,6 +44,13 @@ extension OuterMessage : Hashable {
 extension OuterMessage : Sendable {
 }
 #endif
+
+extension OuterMessage : ProtoDefaultedValue {
+
+    public static var defaultedValue: OuterMessage {
+        OuterMessage()
+    }
+}
 
 extension OuterMessage : ProtoMessage {
 
@@ -67,8 +76,8 @@ extension OuterMessage : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.outer_number_before = outer_number_before
-        self.embedded_message = embedded_message
+        self._outer_number_before.wrappedValue = outer_number_before
+        self._embedded_message.wrappedValue = embedded_message
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -84,8 +93,8 @@ extension OuterMessage : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.outer_number_before = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "outerNumberBefore", "outer_number_before")
-        self.embedded_message = try container.decodeIfPresent(EmbeddedMessage.self, firstOfKeys: "embeddedMessage", "embedded_message")
+        self._outer_number_before.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "outerNumberBefore", "outer_number_before")
+        self._embedded_message.wrappedValue = try container.decodeIfPresent(EmbeddedMessage.self, firstOfKeys: "embeddedMessage", "embedded_message")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/Percents.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Percents.swift
@@ -8,6 +8,7 @@ public struct Percents {
     /**
      * e.g. "No limits, free to send and just 2.75% to receive".
      */
+    @ProtoDefaulted
     public var text: String?
     public var unknownFields: Foundation.Data = .init()
 
@@ -23,7 +24,7 @@ extension Percents {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(text: Swift.String? = nil) {
-        self.text = text
+        self._text.wrappedValue = text
     }
 
 }
@@ -43,6 +44,13 @@ extension Percents : Hashable {
 extension Percents : Sendable {
 }
 #endif
+
+extension Percents : ProtoDefaultedValue {
+
+    public static var defaultedValue: Percents {
+        Percents()
+    }
+}
 
 extension Percents : ProtoMessage {
 
@@ -66,7 +74,7 @@ extension Percents : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.text = text
+        self._text.wrappedValue = text
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -81,7 +89,7 @@ extension Percents : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.text = try container.decodeIfPresent(Swift.String.self, forKey: "text")
+        self._text.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "text")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/Person.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Person.swift
@@ -19,6 +19,7 @@ public struct Person {
     /**
      * Email address for the customer.
      */
+    @ProtoDefaulted
     public var email: String?
     /**
      * A list of the customer's phone numbers.
@@ -53,7 +54,7 @@ extension Person {
     ) {
         self.id = id
         self.name = name
-        self.email = email
+        self._email.wrappedValue = email
         self.phone = phone
         self.aliases = aliases
     }
@@ -108,7 +109,7 @@ extension Person : Proto2Codable {
 
         self.id = try Person.checkIfMissing(id, "id")
         self.name = try Person.checkIfMissing(name, "name")
-        self.email = email
+        self._email.wrappedValue = email
         self.phone = phone
         self.aliases = aliases
     }
@@ -131,7 +132,7 @@ extension Person : Codable {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.id = try container.decode(Swift.Int32.self, forKey: "id")
         self.name = try container.decode(Swift.String.self, forKey: "name")
-        self.email = try container.decodeIfPresent(Swift.String.self, forKey: "email")
+        self._email.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "email")
         self.phone = try container.decodeProtoArray(Person.PhoneNumber.self, forKey: "phone")
         self.aliases = try container.decodeProtoArray(Swift.String.self, forKey: "aliases")
     }
@@ -166,7 +167,8 @@ extension Person {
     /**
      * Represents the type of the phone number: mobile, home or work.
      */
-    public enum PhoneType : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum {
+    public enum PhoneType : Swift.UInt32, Swift.CaseIterable, Wire.ProtoEnum,
+            Wire.ProtoDefaultedValue {
 
         case MOBILE = 0
         case HOME = 1
@@ -175,6 +177,9 @@ extension Person {
          */
         case WORK = 2
 
+        public static var defaultedValue: Person.PhoneType {
+            Person.PhoneType.MOBILE
+        }
         public var description: Swift.String {
             switch self {
             case .MOBILE: return "MOBILE"
@@ -194,7 +199,7 @@ extension Person {
         /**
          * The type of phone stored here.
          */
-        @Wire.Defaulted(defaultValue: Person.PhoneType.HOME)
+        @Wire.CustomDefaulted(defaultValue: Person.PhoneType.HOME)
         public var type: Person.PhoneType?
         public var unknownFields: Foundation.Data = .init()
 
@@ -219,7 +224,7 @@ extension Person.PhoneNumber {
     @available(*, deprecated)
     public init(number: Swift.String, type: Person.PhoneType? = nil) {
         self.number = number
-        _type.wrappedValue = type
+        self._type.wrappedValue = type
     }
 
 }
@@ -265,7 +270,7 @@ extension Person.PhoneNumber : Proto2Codable {
         self.unknownFields = try protoReader.endMessage(token: token)
 
         self.number = try Person.PhoneNumber.checkIfMissing(number, "number")
-        _type.wrappedValue = type
+        self._type.wrappedValue = type
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -282,7 +287,7 @@ extension Person.PhoneNumber : Codable {
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
         self.number = try container.decode(Swift.String.self, forKey: "number")
-        _type.wrappedValue = try container.decodeIfPresent(Person.PhoneType.self, forKey: "type")
+        self._type.wrappedValue = try container.decodeIfPresent(Person.PhoneType.self, forKey: "type")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/RedactedOneOf.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/RedactedOneOf.swift
@@ -41,6 +41,13 @@ extension RedactedOneOf : Sendable {
 }
 #endif
 
+extension RedactedOneOf : ProtoDefaultedValue {
+
+    public static var defaultedValue: RedactedOneOf {
+        RedactedOneOf()
+    }
+}
+
 extension RedactedOneOf : ProtoMessage {
 
     public static func protoMessageTypeURL() -> Swift.String {

--- a/wire-tests-swift/no-manifest/src/main/swift/Thing.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Thing.swift
@@ -5,6 +5,7 @@ import Wire
 
 public struct Thing {
 
+    @ProtoDefaulted
     public var name: String?
     public var unknownFields: Foundation.Data = .init()
 
@@ -20,7 +21,7 @@ extension Thing {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(name: Swift.String? = nil) {
-        self.name = name
+        self._name.wrappedValue = name
     }
 
 }
@@ -40,6 +41,13 @@ extension Thing : Hashable {
 extension Thing : Sendable {
 }
 #endif
+
+extension Thing : ProtoDefaultedValue {
+
+    public static var defaultedValue: Thing {
+        Thing()
+    }
+}
 
 extension Thing : ProtoMessage {
 
@@ -63,7 +71,7 @@ extension Thing : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.name = name
+        self._name.wrappedValue = name
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -78,7 +86,7 @@ extension Thing : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.name = try container.decodeIfPresent(Swift.String.self, forKey: "name")
+        self._name.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "name")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {

--- a/wire-tests-swift/no-manifest/src/main/swift/VersionOne.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/VersionOne.swift
@@ -5,7 +5,9 @@ import Wire
 
 public struct VersionOne {
 
+    @ProtoDefaulted
     public var i: Int32?
+    @ProtoDefaulted
     public var obj: NestedVersionOne?
     public var en: EnumVersionOne?
     public var unknownFields: Foundation.Data = .init()
@@ -26,8 +28,8 @@ extension VersionOne {
         obj: NestedVersionOne? = nil,
         en: EnumVersionOne? = nil
     ) {
-        self.i = i
-        self.obj = obj
+        self._i.wrappedValue = i
+        self._obj.wrappedValue = obj
         self.en = en
     }
 
@@ -48,6 +50,13 @@ extension VersionOne : Hashable {
 extension VersionOne : Sendable {
 }
 #endif
+
+extension VersionOne : ProtoDefaultedValue {
+
+    public static var defaultedValue: VersionOne {
+        VersionOne()
+    }
+}
 
 extension VersionOne : ProtoMessage {
 
@@ -75,8 +84,8 @@ extension VersionOne : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.i = i
-        self.obj = obj
+        self._i.wrappedValue = i
+        self._obj.wrappedValue = obj
         self.en = en
     }
 
@@ -94,8 +103,8 @@ extension VersionOne : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
-        self.obj = try container.decodeIfPresent(NestedVersionOne.self, forKey: "obj")
+        self._i.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
+        self._obj.wrappedValue = try container.decodeIfPresent(NestedVersionOne.self, forKey: "obj")
         self.en = try container.decodeIfPresent(EnumVersionOne.self, forKey: "en")
     }
 

--- a/wire-tests-swift/no-manifest/src/main/swift/VersionTwo.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/VersionTwo.swift
@@ -5,12 +5,18 @@ import Wire
 
 public struct VersionTwo {
 
+    @ProtoDefaulted
     public var i: Int32?
+    @ProtoDefaulted
     public var v2_i: Int32?
+    @ProtoDefaulted
     public var v2_s: String?
+    @ProtoDefaulted
     public var v2_f32: UInt32?
+    @ProtoDefaulted
     public var v2_f64: UInt64?
     public var v2_rs: [String] = []
+    @ProtoDefaulted
     public var obj: NestedVersionTwo?
     public var en: EnumVersionTwo?
     public var unknownFields: Foundation.Data = .init()
@@ -36,13 +42,13 @@ extension VersionTwo {
         obj: NestedVersionTwo? = nil,
         en: EnumVersionTwo? = nil
     ) {
-        self.i = i
-        self.v2_i = v2_i
-        self.v2_s = v2_s
-        self.v2_f32 = v2_f32
-        self.v2_f64 = v2_f64
+        self._i.wrappedValue = i
+        self._v2_i.wrappedValue = v2_i
+        self._v2_s.wrappedValue = v2_s
+        self._v2_f32.wrappedValue = v2_f32
+        self._v2_f64.wrappedValue = v2_f64
         self.v2_rs = v2_rs
-        self.obj = obj
+        self._obj.wrappedValue = obj
         self.en = en
     }
 
@@ -63,6 +69,13 @@ extension VersionTwo : Hashable {
 extension VersionTwo : Sendable {
 }
 #endif
+
+extension VersionTwo : ProtoDefaultedValue {
+
+    public static var defaultedValue: VersionTwo {
+        VersionTwo()
+    }
+}
 
 extension VersionTwo : ProtoMessage {
 
@@ -100,13 +113,13 @@ extension VersionTwo : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.i = i
-        self.v2_i = v2_i
-        self.v2_s = v2_s
-        self.v2_f32 = v2_f32
-        self.v2_f64 = v2_f64
+        self._i.wrappedValue = i
+        self._v2_i.wrappedValue = v2_i
+        self._v2_s.wrappedValue = v2_s
+        self._v2_f32.wrappedValue = v2_f32
+        self._v2_f64.wrappedValue = v2_f64
         self.v2_rs = v2_rs
-        self.obj = obj
+        self._obj.wrappedValue = obj
         self.en = en
     }
 
@@ -129,13 +142,13 @@ extension VersionTwo : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.i = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
-        self.v2_i = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "v2I", "v2_i")
-        self.v2_s = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "v2S", "v2_s")
-        self.v2_f32 = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "v2F32", "v2_f32")
-        self.v2_f64 = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "v2F64", "v2_f64")
+        self._i.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, forKey: "i")
+        self._v2_i.wrappedValue = try container.decodeIfPresent(Swift.Int32.self, firstOfKeys: "v2I", "v2_i")
+        self._v2_s.wrappedValue = try container.decodeIfPresent(Swift.String.self, firstOfKeys: "v2S", "v2_s")
+        self._v2_f32.wrappedValue = try container.decodeIfPresent(Swift.UInt32.self, firstOfKeys: "v2F32", "v2_f32")
+        self._v2_f64.wrappedValue = try container.decodeIfPresent(stringEncoded: Swift.UInt64.self, firstOfKeys: "v2F64", "v2_f64")
         self.v2_rs = try container.decodeProtoArray(Swift.String.self, firstOfKeys: "v2Rs", "v2_rs")
-        self.obj = try container.decodeIfPresent(NestedVersionTwo.self, forKey: "obj")
+        self._obj.wrappedValue = try container.decodeIfPresent(NestedVersionTwo.self, forKey: "obj")
         self.en = try container.decodeIfPresent(EnumVersionTwo.self, forKey: "en")
     }
 

--- a/wire-tests-swift/no-manifest/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/VeryLongProtoNameCausingBrokenLineBreaks.swift
@@ -8,6 +8,7 @@ import Wire
  */
 public struct VeryLongProtoNameCausingBrokenLineBreaks {
 
+    @ProtoDefaulted
     public var foo: String?
     public var unknownFields: Foundation.Data = .init()
 
@@ -23,7 +24,7 @@ extension VeryLongProtoNameCausingBrokenLineBreaks {
     @_disfavoredOverload
     @available(*, deprecated)
     public init(foo: Swift.String? = nil) {
-        self.foo = foo
+        self._foo.wrappedValue = foo
     }
 
 }
@@ -43,6 +44,13 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Hashable {
 extension VeryLongProtoNameCausingBrokenLineBreaks : Sendable {
 }
 #endif
+
+extension VeryLongProtoNameCausingBrokenLineBreaks : ProtoDefaultedValue {
+
+    public static var defaultedValue: VeryLongProtoNameCausingBrokenLineBreaks {
+        VeryLongProtoNameCausingBrokenLineBreaks()
+    }
+}
 
 extension VeryLongProtoNameCausingBrokenLineBreaks : ProtoMessage {
 
@@ -66,7 +74,7 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Proto2Codable {
         }
         self.unknownFields = try protoReader.endMessage(token: token)
 
-        self.foo = foo
+        self._foo.wrappedValue = foo
     }
 
     public func encode(to protoWriter: Wire.ProtoWriter) throws {
@@ -81,7 +89,7 @@ extension VeryLongProtoNameCausingBrokenLineBreaks : Codable {
 
     public init(from decoder: Swift.Decoder) throws {
         let container = try decoder.container(keyedBy: Wire.StringLiteralCodingKeys.self)
-        self.foo = try container.decodeIfPresent(Swift.String.self, forKey: "foo")
+        self._foo.wrappedValue = try container.decodeIfPresent(Swift.String.self, forKey: "foo")
     }
 
     public func encode(to encoder: Swift.Encoder) throws {


### PR DESCRIPTION
This implements the proto spec:

> If the default value is not specified for an optional element, a type-specific default value is used instead: for strings, the default value is the empty string. For bytes, the default value is the empty byte string. For bools, the default value is false. For numeric types, the default value is zero. For enums, the default value is the first value listed in the enum’s type definition. This means care must be taken when adding a value to the beginning of an enum value list. See the Updating A Message Type section for guidelines on how to safely change definitions.
