### PR TITLE
Introduce OpaqueTypes

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -271,6 +271,32 @@ class WireRunTest {
   }
 
   @Test
+  fun opaqueBeforeGeneratingKtThenJava() {
+    writeBlueProto()
+    writeTriangleProto()
+
+    val wireRun = WireRun(
+      sourcePath = listOf(Location.get("colors/src/main/proto")),
+      protoPath = listOf(Location.get("polygons/src/main/proto")),
+      opaqueTypes = listOf("squareup.polygons.Triangle"),
+      targets = listOf(
+        KotlinTarget(
+          outDirectory = "generated/kt",
+        ),
+      ),
+    )
+    wireRun.execute(fs, logger)
+
+    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrderAsRelativePaths(
+      "generated/kt/squareup/colors/Blue.kt",
+    )
+    assertThat(fs.readUtf8("generated/kt/squareup/colors/Blue.kt"))
+      .contains("class Blue")
+      // The type `Triangle` has been opaqued.
+      .contains("public val triangle: ByteString? = null")
+  }
+
+  @Test
   fun noSuchClassEventListener() {
     assertThat(
       assertFailsWith<IllegalArgumentException> {

--- a/wire-schema-tests/api/wire-schema-tests.api
+++ b/wire-schema-tests/api/wire-schema-tests.api
@@ -2,6 +2,7 @@ public final class com/squareup/wire/SchemaBuilder {
 	public fun <init> ()V
 	public final fun add (Lokio/Path;Ljava/lang/String;)Lcom/squareup/wire/SchemaBuilder;
 	public final fun add (Lokio/Path;Ljava/lang/String;Lokio/Path;)Lcom/squareup/wire/SchemaBuilder;
+	public final fun addOpaqueTypes ([Lcom/squareup/wire/schema/ProtoType;)Lcom/squareup/wire/SchemaBuilder;
 	public final fun addProtoPath (Lokio/Path;Ljava/lang/String;)Lcom/squareup/wire/SchemaBuilder;
 	public final fun build ()Lcom/squareup/wire/schema/Schema;
 }

--- a/wire-schema-tests/src/commonMain/kotlin/com/squareup/wire/SchemaBuilder.kt
+++ b/wire-schema-tests/src/commonMain/kotlin/com/squareup/wire/SchemaBuilder.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire
 
 import com.squareup.wire.schema.Location
+import com.squareup.wire.schema.ProtoType
 import com.squareup.wire.schema.Schema
 import com.squareup.wire.schema.SchemaLoader
 import okio.FileSystem
@@ -29,6 +30,7 @@ class SchemaBuilder {
   private val sourcePath: Path = "/sourcePath".toPath()
   private val protoPath: Path = "/protoPath".toPath()
   private val fileSystem: FileSystem = FakeFileSystem()
+  private var opaqueTypes = mutableListOf<ProtoType>()
 
   init {
     fileSystem.createDirectories(sourcePath)
@@ -77,8 +79,15 @@ class SchemaBuilder {
     return add(name, protoFile, protoPath)
   }
 
+  /** See [SchemaLoader.opaqueTypes]. */
+  fun addOpaqueTypes(vararg opaqueTypes: ProtoType): SchemaBuilder {
+    this.opaqueTypes.addAll(opaqueTypes)
+    return this
+  }
+
   fun build(): Schema {
     val schemaLoader = SchemaLoader(fileSystem)
+    schemaLoader.opaqueTypes = opaqueTypes.toList()
     schemaLoader.initRoots(
       sourcePath = listOf(Location.get(sourcePath.toString())),
       protoPath = listOf(Location.get(protoPath.toString())),

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -370,6 +370,7 @@ public final class com/squareup/wire/schema/LinkedOptionEntry {
 
 public final class com/squareup/wire/schema/Linker {
 	public fun <init> (Lcom/squareup/wire/schema/Loader;Lcom/squareup/wire/schema/ErrorCollector;ZZ)V
+	public fun <init> (Lcom/squareup/wire/schema/Loader;Lcom/squareup/wire/schema/ErrorCollector;ZZLjava/util/List;)V
 	public final fun addType (Lcom/squareup/wire/schema/ProtoType;Lcom/squareup/wire/schema/Type;)V
 	public final fun dereference (Lcom/squareup/wire/schema/ProtoType;Ljava/lang/String;)Lcom/squareup/wire/schema/Field;
 	public final fun get (Lcom/squareup/wire/schema/ProtoType;)Lcom/squareup/wire/schema/Type;
@@ -883,6 +884,7 @@ public final class com/squareup/wire/schema/SchemaLoader : com/squareup/wire/sch
 	public fun <init> (Ljava/nio/file/FileSystem;)V
 	public fun <init> (Lokio/FileSystem;)V
 	public final fun getLoadExhaustively ()Z
+	public final fun getOpaqueTypes ()Ljava/util/List;
 	public final fun getPermitPackageCycles ()Z
 	public final fun getSourcePathFiles ()Ljava/util/List;
 	public final fun initRoots (Ljava/util/List;Ljava/util/List;)V
@@ -891,6 +893,7 @@ public final class com/squareup/wire/schema/SchemaLoader : com/squareup/wire/sch
 	public fun loadProfile (Ljava/lang/String;Lcom/squareup/wire/schema/Schema;)Lcom/squareup/wire/schema/Profile;
 	public final fun loadSchema ()Lcom/squareup/wire/schema/Schema;
 	public final fun setLoadExhaustively (Z)V
+	public final fun setOpaqueTypes (Ljava/util/List;)V
 	public final fun setPermitPackageCycles (Z)V
 	public synthetic fun withErrors (Lcom/squareup/wire/schema/ErrorCollector;)Lcom/squareup/wire/schema/Loader;
 	public fun withErrors (Lcom/squareup/wire/schema/ErrorCollector;)Lcom/squareup/wire/schema/SchemaLoader;
@@ -985,13 +988,14 @@ public final class com/squareup/wire/schema/WireLoggersKt {
 }
 
 public final class com/squareup/wire/schema/WireRun {
-	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;Z)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;ZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/Map;ZLjava/util/List;ZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun execute (Lokio/FileSystem;Lcom/squareup/wire/WireLogger;)V
 	public final fun getEventListeners ()Ljava/util/List;
 	public final fun getModules ()Ljava/util/Map;
 	public final fun getMoves ()Ljava/util/List;
 	public final fun getOnlyVersion ()Ljava/lang/String;
+	public final fun getOpaqueTypes ()Ljava/util/List;
 	public final fun getPermitPackageCycles ()Z
 	public final fun getProtoPath ()Ljava/util/List;
 	public final fun getRejectUnusedRootsOrPrunes ()Z

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Field.kt
@@ -45,7 +45,7 @@ data class Field(
 
   val default: String?,
 
-  private val elementType: String,
+  private var elementType: String,
 
   val options: Options,
 
@@ -122,6 +122,10 @@ data class Field(
 
   fun link(linker: Linker) {
     type = linker.withContext(this).resolveType(elementType)
+    if (type == ProtoType.BYTES && elementType != "bytes") {
+      // The type has been opaqued, we update its proto definition as well.
+      elementType = "bytes"
+    }
   }
 
   fun linkOptions(linker: Linker, syntaxRules: SyntaxRules, validate: Boolean) {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -27,6 +27,13 @@ expect class SchemaLoader(fileSystem: FileSystem) : Loader, ProfileLoader {
   var permitPackageCycles: Boolean
 
   /**
+   * All qualified named Protobuf types in [opaqueTypes] will be evaluated as being of type `bytes`.
+   * On code generation, the fields of such types will be using the platform equivalent of `bytes`,
+   * like [okio.ByteString] for the JVM. Note that scalar types cannot be opaqued.
+   */
+  var opaqueTypes: List<ProtoType>
+
+  /**
    * If true, the schema loader will load the whole graph, including files and types not used by
    * anything in the source path.
    */

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/WireRun.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/WireRun.kt
@@ -194,6 +194,14 @@ class WireRun(
    * If false, unused [treeShakingRoots] and [treeShakingRubbish] will be printed as warnings.
    */
   val rejectUnusedRootsOrPrunes: Boolean = false,
+
+  /**
+   * All qualified named Protobuf types in [opaqueTypes] will be evaluated as being of type `bytes`.
+   * On code generation, the fields of such types will be using the platform equivalent of `bytes`,
+   * like [okio.ByteString] for the JVM. Note that scalar types cannot be opaqued.
+   * The opaque step will happen before the tree shaking one.
+   */
+  val opaqueTypes: List<String> = listOf(),
 ) {
   data class Module(
     val dependencies: Set<String> = emptySet(),
@@ -227,6 +235,7 @@ class WireRun(
     checkForModuleCycles()
 
     schemaLoader.permitPackageCycles = permitPackageCycles
+    schemaLoader.opaqueTypes = opaqueTypes.map(ProtoType::get)
     schemaLoader.initRoots(sourcePath, protoPath)
 
     // Validate the schema and resolve references

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/CommonSchemaLoader.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/CommonSchemaLoader.kt
@@ -53,6 +53,8 @@ internal class CommonSchemaLoader : Loader, ProfileLoader {
   /** Strict by default. Note that golang cannot build protos with package cycles. */
   var permitPackageCycles = false
 
+  var opaqueTypes: List<ProtoType> = listOf()
+
   /**
    * If true, the schema loader will load the whole graph, including files and types not used by
    * anything in the source path.
@@ -99,7 +101,7 @@ internal class CommonSchemaLoader : Loader, ProfileLoader {
   @Throws(IOException::class)
   fun loadSchema(): Schema {
     sourcePathFiles = loadSourcePathFiles()
-    val linker = Linker(this, errors, permitPackageCycles, loadExhaustively)
+    val linker = Linker(this, errors, permitPackageCycles, loadExhaustively, opaqueTypes)
     val result = linker.link(sourcePathFiles)
     errors.throwIfNonEmpty()
     return result

--- a/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-schema/src/jsMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -38,6 +38,12 @@ actual class SchemaLoader : Loader, ProfileLoader {
       delegate.permitPackageCycles = value
     }
 
+  actual var opaqueTypes: List<ProtoType>
+    get() = delegate.opaqueTypes
+    set(value) {
+      delegate.opaqueTypes = value
+    }
+
   /**
    * If true, the schema loader will load the whole graph, including files and types not used by
    * anything in the source path.

--- a/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -42,6 +42,12 @@ actual class SchemaLoader : Loader, ProfileLoader {
       delegate.permitPackageCycles = value
     }
 
+  actual var opaqueTypes: List<ProtoType>
+    get() = delegate.opaqueTypes
+    set(value) {
+      delegate.opaqueTypes = value
+    }
+
   /**
    * If true, the schema loader will load the whole graph, including files and types not used by
    * anything in the source path.

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -56,6 +56,51 @@ class PrunerTest {
     assertThat(pruned.getType("MessageB")).isNull()
   }
 
+  /**
+   * We test that all references of an opaque type are getting pruned correctly.
+   */
+  @Test
+  fun opaqueTypePrunesItsReferences() {
+    val schema = buildSchema {
+      add(
+        "source-path/cafe/cafe.proto".toPath(),
+        """
+          |syntax = "proto2";
+          |
+          |package cafe;
+          |
+          |message CafeDrink {
+          |  optional int32 size_ounces = 1;
+          |  repeated EspressoShot shots = 2;
+          |}
+          |
+          |message EspressoShot {
+          |  optional Roast roast = 1;
+          |  optional bool decaf = 2;
+          |}
+          |
+          |enum Roast {
+          |  MEDIUM = 1;
+          |  DARK = 2;
+          |}
+        """.trimMargin(),
+      )
+      addOpaqueTypes(ProtoType.get("cafe.EspressoShot"))
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("cafe.CafeDrink")
+        .build(),
+    )
+    assertThat(pruned.getType("cafe.CafeDrink")).isNotNull()
+    // The field should not be pruned, and is of the opaque type `bytes`.
+    assertThat(pruned.getField("cafe.CafeDrink", "shots")!!.type)
+      .isEqualTo(ProtoType.BYTES)
+    // Types which were originally referred by `shots` are now pruned since the field is opaqued.
+    assertThat(pruned.getType("cafe.EspressoShot")).isNull()
+    assertThat(pruned.getType("cafe.Roast")).isNull()
+  }
+
   @Test
   fun retainMap() {
     val schema = buildSchema {

--- a/wire-schema/src/nativeMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
+++ b/wire-schema/src/nativeMain/kotlin/com/squareup/wire/schema/SchemaLoader.kt
@@ -38,6 +38,12 @@ actual class SchemaLoader : Loader, ProfileLoader {
       delegate.permitPackageCycles = value
     }
 
+  actual var opaqueTypes: List<ProtoType>
+    get() = delegate.opaqueTypes
+    set(value) {
+      delegate.opaqueTypes = value
+    }
+
   /**
    * If true, the schema loader will load the whole graph, including files and types not used by
    * anything in the source path.


### PR DESCRIPTION
I've thought about doing like TypeMover but it is actually pretty hard to modify the types of fields after linking happened.
Putting it in the linking step when resolving types felt good so I went this way. It doesn't print unused types, the `Linker` doesn't know when it's finished so it might require some API modeling.

I'll follow up with entries for the Gradle plugin and WireCompiler.