### PR TITLE
[swift] Further guard against incomplete schema for default value calculation

### DIFF
--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -165,7 +165,7 @@ class SwiftGenerator private constructor(
       // These types' fields aren't properly loaded
       false
     } else {
-      fields.isEmpty() || fields.all { !it.isRequiredParameter }
+      fields.isEmpty() || fields.all { it.encodeMode != null && !it.isRequiredParameter }
     }
 
   private val EnumType.supportsEmptyInitialization: Boolean


### PR DESCRIPTION
When invoking Wire against a single proto, if that proto depends on another proto the Wire schema wont link the second proto. This means that when we try to calculate the default value to use for a potential type ProtoA refers in ProtoB we crash because `encodeMode` is not loaded.

```kotlin
  // Null until this field is linked.
  var encodeMode: EncodeMode? = null
    private set
```

A general fix is for Wire to perhaps "soft"-link proto dependencies when invoking it against a single proto. I do not know much about the linker and how it works, for now this prevents a crasher.