### PR TITLE
Add `ProtoReader` API for length-delimited stream reads

### DIFF
--- a/wire-runtime/api/wire-runtime.api
+++ b/wire-runtime/api/wire-runtime.api
@@ -275,6 +275,7 @@ public final class com/squareup/wire/ProtoReader {
 	public final fun endMessage (J)V
 	public final fun endMessageAndGetUnknownFields (J)Lokio/ByteString;
 	public final fun nextFieldMinLengthInBytes ()J
+	public final fun nextLengthDelimited ()I
 	public final fun nextTag ()I
 	public final fun peekFieldEncoding ()Lcom/squareup/wire/FieldEncoding;
 	public final fun readBytes ()Lokio/ByteString;

--- a/wire-runtime/src/commonTest/kotlin/com/squareup/wire/ProtoReaderTest.kt
+++ b/wire-runtime/src/commonTest/kotlin/com/squareup/wire/ProtoReaderTest.kt
@@ -32,4 +32,30 @@ class ProtoReaderTest {
     assertEquals(-1, reader.nextTag())
     reader.endMessageAndGetUnknownFields(token)
   }
+
+  @Test fun lengthDelimited() {
+    val encoded = (
+      "02" + // varint32 length = 2
+        "0802" + // 1: int32 = 2
+        "06" + // varint32 length = 6
+        "08ffffffff07" // 1: int32 = 2,147,483,647
+      ).decodeHex()
+    val reader = ProtoReader(Buffer().write(encoded))
+
+    assertEquals(2, reader.nextLengthDelimited())
+
+    val firstToken = reader.beginMessage()
+    assertEquals(1, reader.nextTag())
+    assertEquals(2, ProtoAdapter.INT32.decode(reader))
+    assertEquals(-1, reader.nextTag())
+    reader.endMessageAndGetUnknownFields(firstToken)
+
+    assertEquals(6, reader.nextLengthDelimited())
+
+    val secondToken = reader.beginMessage()
+    assertEquals(1, reader.nextTag())
+    assertEquals(Int.MAX_VALUE, ProtoAdapter.INT32.decode(reader))
+    assertEquals(-1, reader.nextTag())
+    reader.endMessageAndGetUnknownFields(secondToken)
+  }
 }


### PR DESCRIPTION
Closes #633