### PR TITLE
Provide a built in public EmptyWireLoggerFactory class

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -937,7 +937,7 @@ class WireRunTest {
       context = SchemaHandler.Context(
         fileSystem = fs,
         outDirectory = "out".toPath(),
-        logger = NULL_LOGGER,
+        logger = EmptyWireLogger(),
         errorCollector = errorCollector,
         claimedPaths = ClaimedPaths(),
       ),
@@ -1715,26 +1715,6 @@ class WireRunTest {
 
     override fun unusedExcludesInTarget(unusedExcludes: Set<String>) {
       logs.add("unusedExcludesInTarget: $unusedExcludes")
-    }
-  }
-
-  class CustomLoggerFactory : WireLogger.Factory {
-    override fun create(): WireLogger = CustomLogger()
-  }
-
-  companion object {
-    private val NULL_LOGGER = object : WireLogger {
-      override fun artifactHandled(
-        outputPath: Path,
-        qualifiedName: String,
-        targetName: String,
-      ) = Unit
-
-      override fun artifactSkipped(type: ProtoType, targetName: String) = Unit
-      override fun unusedRoots(unusedRoots: Set<String>) = Unit
-      override fun unusedPrunes(unusedPrunes: Set<String>) = Unit
-      override fun unusedIncludesInTarget(unusedIncludes: Set<String>) = Unit
-      override fun unusedExcludesInTarget(unusedExcludes: Set<String>) = Unit
     }
   }
 }

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -89,6 +89,21 @@ public final class com/squareup/wire/schema/EmittingRules$Builder {
 public final class com/squareup/wire/schema/EmittingRules$Companion {
 }
 
+public final class com/squareup/wire/schema/EmptyWireLogger : com/squareup/wire/WireLogger {
+	public fun <init> ()V
+	public fun artifactHandled (Lokio/Path;Ljava/lang/String;Ljava/lang/String;)V
+	public fun artifactSkipped (Lcom/squareup/wire/schema/ProtoType;Ljava/lang/String;)V
+	public fun unusedExcludesInTarget (Ljava/util/Set;)V
+	public fun unusedIncludesInTarget (Ljava/util/Set;)V
+	public fun unusedPrunes (Ljava/util/Set;)V
+	public fun unusedRoots (Ljava/util/Set;)V
+}
+
+public final class com/squareup/wire/schema/EmptyWireLoggerFactory : com/squareup/wire/WireLogger$Factory {
+	public fun <init> ()V
+	public fun create ()Lcom/squareup/wire/WireLogger;
+}
+
 public final class com/squareup/wire/schema/EnclosingType : com/squareup/wire/schema/Type {
 	public fun <init> (Lcom/squareup/wire/schema/Location;Lcom/squareup/wire/schema/ProtoType;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Lcom/squareup/wire/Syntax;)V
 	public final fun component1 ()Lcom/squareup/wire/schema/Location;

--- a/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/WireLoggers.kt
+++ b/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/WireLoggers.kt
@@ -16,6 +16,7 @@
 package com.squareup.wire.schema
 
 import com.squareup.wire.WireLogger
+import okio.Path
 
 /**
  * Create and return an instance of [WireLogger.Factory].
@@ -25,6 +26,26 @@ import com.squareup.wire.WireLogger
  */
 fun newLoggerFactory(loggerFactoryClass: String): WireLogger.Factory {
   return ClassNameLoggerFactory(loggerFactoryClass)
+}
+
+class EmptyWireLoggerFactory : WireLogger.Factory {
+  override fun create(): WireLogger {
+    return EmptyWireLogger()
+  }
+}
+
+class EmptyWireLogger : WireLogger {
+  override fun artifactHandled(
+    outputPath: Path,
+    qualifiedName: String,
+    targetName: String,
+  ) = Unit
+
+  override fun artifactSkipped(type: ProtoType, targetName: String) = Unit
+  override fun unusedRoots(unusedRoots: Set<String>) = Unit
+  override fun unusedPrunes(unusedPrunes: Set<String>) = Unit
+  override fun unusedIncludesInTarget(unusedIncludes: Set<String>) = Unit
+  override fun unusedExcludesInTarget(unusedExcludes: Set<String>) = Unit
 }
 
 /**


### PR DESCRIPTION
It seems there is no `--quiet` option in Wire because it is probably obviated by the usage of `--logger_factory_class` argument.

This PR makes it easy for scripts that use Wire not to have to provide their own JAR for a built in "quiet" mode by exposing an empty logger factory and implementation. This now simply works by adding `"--logger_factory_class=com.squareup.wire.schema.EmptyWireLoggerFactory"` when invoking Wire.