### PR TITLE
FileDescriptor generation - descriptor maps chunks

### DIFF
--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -86,7 +86,7 @@ object FileDescriptorGenerator {
     encodedListChunked.forEachIndexed { index: Int, subEncodedList: List<Pair<String, String>> ->
       subDescriptorMapCodeBlock(builder, subEncodedList, index)
       if (index > 0) {
-        initLines.add(" +\n")
+        initLines[index - 1] += " +\n"
       }
       initLines.add("$DESCRIPTOR_MAP_FUNCTION_PREFIX$index()")
     }

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -29,6 +29,7 @@ import com.squareup.wire.schema.Schema
 import com.squareup.wire.schema.internal.SchemaEncoder
 
 object FileDescriptorGenerator {
+
   private val descriptorMapClass = Map::class.parameterizedBy(
     String::class,
     DescriptorProtos.FileDescriptorProto::class,
@@ -100,7 +101,7 @@ object FileDescriptorGenerator {
         .initializer(
           CodeBlock.builder().withIndent {
             initLines.forEach { line ->
-              addStatement(line)
+              this.addStatement(line)
             }
           }.build(),
         ).build(),
@@ -118,7 +119,7 @@ object FileDescriptorGenerator {
         .addModifiers(KModifier.PRIVATE)
         .returns(descriptorMapClass)
         .addCode(
-          encodedList.fold(CodeBlock.builder().add("return mapOf(")) { b, (name, data) ->
+          encodedList.fold(CodeBlock.builder().addStatement("return mapOf(")) { b, (name, data) ->
             b.withIndent {
               this.addStatement("\"$name\" to descriptorFor(arrayOf(")
                 // Split the string to chunks because max string length in a class file is 64k bytes

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -119,9 +119,11 @@ object FileDescriptorGenerator {
         .addModifiers(KModifier.PRIVATE)
         .returns(descriptorMapClass)
         .addCode(
-          encodedList.fold(CodeBlock.builder().addStatement("return mapOf(")) { b, (name, data) ->
+          encodedList.fold(
+            CodeBlock.builder().addStatement("val subMap = mapOf(")
+          ) { b, (name, data) ->
             b.withIndent {
-              this.addStatement("\"$name\" to descriptorFor(arrayOf(")
+              addStatement("\"$name\" to descriptorFor(arrayOf(")
                 // Split the string to chunks because max string length in a class file is 64k bytes
                 .withIndent {
                   data.chunked(FDS_CHUNK_SIZE).fold(this) { b, c ->
@@ -129,8 +131,10 @@ object FileDescriptorGenerator {
                   }
                 }.addStatement(")),")
             }
-          }.addStatement(")").build(),
-        ).build(),
+          }.addStatement(")")
+            .addStatement("return subMap")
+            .build(),
+        ).build()
     )
   }
 

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -172,6 +172,6 @@ object FileDescriptorGenerator {
   }
 
   private const val FDS_CHUNK_SIZE = 80
-  private const val DM_CHUNK_SIZE = 100
+  private const val DM_CHUNK_SIZE = 20
   private const val DESCRIPTOR_MAP_FUNCTION_PREFIX = "createDescriptorMap"
 }

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -79,7 +79,6 @@ object FileDescriptorGenerator {
     builder: TypeSpec.Builder,
     encoded: MutableMap<String, String>,
   ) {
-    val descriptorMapInitializer = CodeBlock.builder()
     val initLines = mutableListOf<String>()
     val encodedListChunked: List<List<Pair<String, String>>> =
       encoded.toList().chunked(DM_CHUNK_SIZE)
@@ -91,12 +90,6 @@ object FileDescriptorGenerator {
       initLines.add("$DESCRIPTOR_MAP_FUNCTION_PREFIX$index()")
     }
 
-    descriptorMapInitializer.withIndent {
-      initLines.forEach { line ->
-        addStatement(line)
-      }
-    }
-
     builder.addProperty(
       PropertySpec
         .builder(
@@ -105,7 +98,11 @@ object FileDescriptorGenerator {
         )
         .addModifiers(KModifier.PRIVATE)
         .initializer(
-          descriptorMapInitializer.build(),
+          CodeBlock.builder().withIndent {
+            initLines.forEach { line ->
+              addStatement(line)
+            }
+          }.build(),
         ).build(),
     )
   }

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -81,17 +81,20 @@ object FileDescriptorGenerator {
   ) {
 
     val descriptorMapInitializer = CodeBlock.builder()
+    val initLines = mutableListOf<String>()
     val encodedListChunked: List<List<Pair<String, String>>> =
       encoded.toList().chunked(DM_CHUNK_SIZE)
     encodedListChunked.forEachIndexed { index: Int, subEncodedList: List<Pair<String, String>> ->
       subDescriptorMapCodeBlock(builder, subEncodedList, index)
+      if (index > 0) {
+        initLines.add(" +\n")
+      }
+      initLines.add("$DESCRIPTOR_MAP_FUNCTION_PREFIX$index()")
+    }
+
+    initLines.forEach { line ->
       descriptorMapInitializer.withIndent {
-        val plusSign = if (index > 0) {
-          "+ "
-        } else {
-          ""
-        }
-        this.addStatement("$plusSign$DESCRIPTOR_MAP_FUNCTION_PREFIX$index")
+        addStatement(line)
       }
     }
 

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -113,7 +113,7 @@ object FileDescriptorGenerator {
   private fun subDescriptorMapCodeBlock(
     builder: TypeSpec.Builder,
     encodedList: List<Pair<String, String>>,
-    index: Int = 0,
+    index: Int,
   ) {
     builder.addFunction(
       FunSpec

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -91,6 +91,13 @@ object FileDescriptorGenerator {
       initLines.add("$DESCRIPTOR_MAP_FUNCTION_PREFIX$index()")
     }
 
+    val initializerBuilder = CodeBlock.builder()
+    initLines.forEach { line ->
+      initializerBuilder.withIndent {
+        addStatement(line)
+      }
+    }
+
     builder.addProperty(
       PropertySpec
         .builder(
@@ -99,11 +106,7 @@ object FileDescriptorGenerator {
         )
         .addModifiers(KModifier.PRIVATE)
         .initializer(
-          CodeBlock.builder().withIndent {
-            initLines.forEach { line ->
-              this.addStatement(line)
-            }
-          }.build(),
+          initializerBuilder.build(),
         ).build(),
     )
   }
@@ -120,7 +123,7 @@ object FileDescriptorGenerator {
         .returns(descriptorMapClass)
         .addCode(
           encodedList.fold(
-            CodeBlock.builder().addStatement("val subMap = mapOf(")
+            CodeBlock.builder().addStatement("val subMap = mapOf("),
           ) { b, (name, data) ->
             b.withIndent {
               addStatement("\"$name\" to descriptorFor(arrayOf(")
@@ -134,7 +137,7 @@ object FileDescriptorGenerator {
           }.addStatement(")")
             .addStatement("return subMap")
             .build(),
-        ).build()
+        ).build(),
     )
   }
 

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -86,7 +86,7 @@ object FileDescriptorGenerator {
     encodedListChunked.forEachIndexed { index: Int, subEncodedList: List<Pair<String, String>> ->
       subDescriptorMapCodeBlock(builder, subEncodedList, index)
       if (index > 0) {
-        initLines[index - 1] += " +\n"
+        initLines[index - 1] += " +"
       }
       initLines.add("$DESCRIPTOR_MAP_FUNCTION_PREFIX$index()")
     }

--- a/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
+++ b/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt
@@ -79,7 +79,6 @@ object FileDescriptorGenerator {
     builder: TypeSpec.Builder,
     encoded: MutableMap<String, String>,
   ) {
-
     val descriptorMapInitializer = CodeBlock.builder()
     val initLines = mutableListOf<String>()
     val encodedListChunked: List<List<Pair<String, String>>> =
@@ -92,8 +91,8 @@ object FileDescriptorGenerator {
       initLines.add("$DESCRIPTOR_MAP_FUNCTION_PREFIX$index()")
     }
 
-    initLines.forEach { line ->
-      descriptorMapInitializer.withIndent {
+    descriptorMapInitializer.withIndent {
+      initLines.forEach { line ->
         addStatement(line)
       }
     }
@@ -122,7 +121,7 @@ object FileDescriptorGenerator {
         .addModifiers(KModifier.PRIVATE)
         .returns(descriptorMapClass)
         .addCode(
-          encodedList.fold(CodeBlock.builder().addStatement("return mapOf(")) { b, (name, data) ->
+          encodedList.fold(CodeBlock.builder().add("return mapOf(")) { b, (name, data) ->
             b.withIndent {
               this.addStatement("\"$name\" to descriptorFor(arrayOf(")
                 // Split the string to chunks because max string length in a class file is 64k bytes

--- a/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
+++ b/wire-grpc-server-generator/src/test/golden/RouteGuideWireGrpc.kt
@@ -43,22 +43,8 @@ public object RouteGuideWireGrpc {
   @Volatile
   private var serviceDescriptor: ServiceDescriptor? = null
 
-  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
-    "src/test/proto/RouteGuideProto.proto" to descriptorFor(arrayOf(
-      "CiRzcmMvdGVzdC9wcm90by9Sb3V0ZUd1aWRlUHJvdG8ucHJvdG8SCnJvdXRlZ3VpZGUiLAoFUG9pbnQS",
-      "EAoIbGF0aXR1ZGUYASABKAUSEQoJbG9uZ2l0dWRlGAIgASgFIkkKCVJlY3RhbmdsZRIdCgJsbxgBIAEo",
-      "CzIRLnJvdXRlZ3VpZGUuUG9pbnQSHQoCaGkYAiABKAsyES5yb3V0ZWd1aWRlLlBvaW50IjwKB0ZlYXR1",
-      "cmUSDAoEbmFtZRgBIAEoCRIjCghsb2NhdGlvbhgCIAEoCzIRLnJvdXRlZ3VpZGUuUG9pbnQiNwoPRmVh",
-      "dHVyZURhdGFiYXNlEiQKB2ZlYXR1cmUYASADKAsyEy5yb3V0ZWd1aWRlLkZlYXR1cmUiQQoJUm91dGVO",
-      "b3RlEiMKCGxvY2F0aW9uGAEgASgLMhEucm91dGVndWlkZS5Qb2ludBIPCgdtZXNzYWdlGAIgASgJImIK",
-      "DFJvdXRlU3VtbWFyeRITCgtwb2ludF9jb3VudBgBIAEoBRIVCg1mZWF0dXJlX2NvdW50GAIgASgFEhAK",
-      "CGRpc3RhbmNlGAMgASgFEhQKDGVsYXBzZWRfdGltZRgEIAEoBTL9AQoKUm91dGVHdWlkZRI0CgpHZXRG",
-      "ZWF0dXJlEhEucm91dGVndWlkZS5Qb2ludBoTLnJvdXRlZ3VpZGUuRmVhdHVyZRI8CgxMaXN0RmVhdHVy",
-      "ZXMSFS5yb3V0ZWd1aWRlLlJlY3RhbmdsZRoTLnJvdXRlZ3VpZGUuRmVhdHVyZTABEjwKC1JlY29yZFJv",
-      "dXRlEhEucm91dGVndWlkZS5Qb2ludBoYLnJvdXRlZ3VpZGUuUm91dGVTdW1tYXJ5KAESPQoJUm91dGVD",
-      "aGF0EhUucm91dGVndWlkZS5Sb3V0ZU5vdGUaFS5yb3V0ZWd1aWRlLlJvdXRlTm90ZSgBMAE=",
-    )),
-  )
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> =
+      createDescriptorMap0()
 
 
   @Volatile
@@ -84,6 +70,26 @@ public object RouteGuideWireGrpc {
     val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
         visited + path) }
     return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
+
+  private fun createDescriptorMap0(): Map<String, DescriptorProtos.FileDescriptorProto> {
+    val subMap = mapOf(
+      "src/test/proto/RouteGuideProto.proto" to descriptorFor(arrayOf(
+        "CiRzcmMvdGVzdC9wcm90by9Sb3V0ZUd1aWRlUHJvdG8ucHJvdG8SCnJvdXRlZ3VpZGUiLAoFUG9pbnQS",
+        "EAoIbGF0aXR1ZGUYASABKAUSEQoJbG9uZ2l0dWRlGAIgASgFIkkKCVJlY3RhbmdsZRIdCgJsbxgBIAEo",
+        "CzIRLnJvdXRlZ3VpZGUuUG9pbnQSHQoCaGkYAiABKAsyES5yb3V0ZWd1aWRlLlBvaW50IjwKB0ZlYXR1",
+        "cmUSDAoEbmFtZRgBIAEoCRIjCghsb2NhdGlvbhgCIAEoCzIRLnJvdXRlZ3VpZGUuUG9pbnQiNwoPRmVh",
+        "dHVyZURhdGFiYXNlEiQKB2ZlYXR1cmUYASADKAsyEy5yb3V0ZWd1aWRlLkZlYXR1cmUiQQoJUm91dGVO",
+        "b3RlEiMKCGxvY2F0aW9uGAEgASgLMhEucm91dGVndWlkZS5Qb2ludBIPCgdtZXNzYWdlGAIgASgJImIK",
+        "DFJvdXRlU3VtbWFyeRITCgtwb2ludF9jb3VudBgBIAEoBRIVCg1mZWF0dXJlX2NvdW50GAIgASgFEhAK",
+        "CGRpc3RhbmNlGAMgASgFEhQKDGVsYXBzZWRfdGltZRgEIAEoBTL9AQoKUm91dGVHdWlkZRI0CgpHZXRG",
+        "ZWF0dXJlEhEucm91dGVndWlkZS5Qb2ludBoTLnJvdXRlZ3VpZGUuRmVhdHVyZRI8CgxMaXN0RmVhdHVy",
+        "ZXMSFS5yb3V0ZWd1aWRlLlJlY3RhbmdsZRoTLnJvdXRlZ3VpZGUuRmVhdHVyZTABEjwKC1JlY29yZFJv",
+        "dXRlEhEucm91dGVndWlkZS5Qb2ludBoYLnJvdXRlZ3VpZGUuUm91dGVTdW1tYXJ5KAESPQoJUm91dGVD",
+        "aGF0EhUucm91dGVndWlkZS5Sb3V0ZU5vdGUaFS5yb3V0ZWd1aWRlLlJvdXRlTm90ZSgBMAE=",
+      )),
+    )
+    return subMap
   }
 
   public fun getServiceDescriptor(): ServiceDescriptor? {

--- a/wire-grpc-server-generator/src/test/golden/ServiceDescriptor.kt
+++ b/wire-grpc-server-generator/src/test/golden/ServiceDescriptor.kt
@@ -17,22 +17,8 @@ public class RouteGuideWireGrpc {
   @Volatile
   private var serviceDescriptor: ServiceDescriptor? = null
 
-  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
-    "src/test/proto/RouteGuideProto.proto" to descriptorFor(arrayOf(
-      "CiRzcmMvdGVzdC9wcm90by9Sb3V0ZUd1aWRlUHJvdG8ucHJvdG8SCnJvdXRlZ3VpZGUiLAoFUG9pbnQS",
-      "EAoIbGF0aXR1ZGUYASABKAUSEQoJbG9uZ2l0dWRlGAIgASgFIkkKCVJlY3RhbmdsZRIdCgJsbxgBIAEo",
-      "CzIRLnJvdXRlZ3VpZGUuUG9pbnQSHQoCaGkYAiABKAsyES5yb3V0ZWd1aWRlLlBvaW50IjwKB0ZlYXR1",
-      "cmUSDAoEbmFtZRgBIAEoCRIjCghsb2NhdGlvbhgCIAEoCzIRLnJvdXRlZ3VpZGUuUG9pbnQiNwoPRmVh",
-      "dHVyZURhdGFiYXNlEiQKB2ZlYXR1cmUYASADKAsyEy5yb3V0ZWd1aWRlLkZlYXR1cmUiQQoJUm91dGVO",
-      "b3RlEiMKCGxvY2F0aW9uGAEgASgLMhEucm91dGVndWlkZS5Qb2ludBIPCgdtZXNzYWdlGAIgASgJImIK",
-      "DFJvdXRlU3VtbWFyeRITCgtwb2ludF9jb3VudBgBIAEoBRIVCg1mZWF0dXJlX2NvdW50GAIgASgFEhAK",
-      "CGRpc3RhbmNlGAMgASgFEhQKDGVsYXBzZWRfdGltZRgEIAEoBTL9AQoKUm91dGVHdWlkZRI0CgpHZXRG",
-      "ZWF0dXJlEhEucm91dGVndWlkZS5Qb2ludBoTLnJvdXRlZ3VpZGUuRmVhdHVyZRI8CgxMaXN0RmVhdHVy",
-      "ZXMSFS5yb3V0ZWd1aWRlLlJlY3RhbmdsZRoTLnJvdXRlZ3VpZGUuRmVhdHVyZTABEjwKC1JlY29yZFJv",
-      "dXRlEhEucm91dGVndWlkZS5Qb2ludBoYLnJvdXRlZ3VpZGUuUm91dGVTdW1tYXJ5KAESPQoJUm91dGVD",
-      "aGF0EhUucm91dGVndWlkZS5Sb3V0ZU5vdGUaFS5yb3V0ZWd1aWRlLlJvdXRlTm90ZSgBMAE=",
-    )),
-  )
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> =
+      createDescriptorMap0()
 
 
   private fun descriptorFor(`data`: Array<String>): DescriptorProtos.FileDescriptorProto {
@@ -46,6 +32,26 @@ public class RouteGuideWireGrpc {
     val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
         visited + path) }
     return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
+
+  private fun createDescriptorMap0(): Map<String, DescriptorProtos.FileDescriptorProto> {
+    val subMap = mapOf(
+      "src/test/proto/RouteGuideProto.proto" to descriptorFor(arrayOf(
+        "CiRzcmMvdGVzdC9wcm90by9Sb3V0ZUd1aWRlUHJvdG8ucHJvdG8SCnJvdXRlZ3VpZGUiLAoFUG9pbnQS",
+        "EAoIbGF0aXR1ZGUYASABKAUSEQoJbG9uZ2l0dWRlGAIgASgFIkkKCVJlY3RhbmdsZRIdCgJsbxgBIAEo",
+        "CzIRLnJvdXRlZ3VpZGUuUG9pbnQSHQoCaGkYAiABKAsyES5yb3V0ZWd1aWRlLlBvaW50IjwKB0ZlYXR1",
+        "cmUSDAoEbmFtZRgBIAEoCRIjCghsb2NhdGlvbhgCIAEoCzIRLnJvdXRlZ3VpZGUuUG9pbnQiNwoPRmVh",
+        "dHVyZURhdGFiYXNlEiQKB2ZlYXR1cmUYASADKAsyEy5yb3V0ZWd1aWRlLkZlYXR1cmUiQQoJUm91dGVO",
+        "b3RlEiMKCGxvY2F0aW9uGAEgASgLMhEucm91dGVndWlkZS5Qb2ludBIPCgdtZXNzYWdlGAIgASgJImIK",
+        "DFJvdXRlU3VtbWFyeRITCgtwb2ludF9jb3VudBgBIAEoBRIVCg1mZWF0dXJlX2NvdW50GAIgASgFEhAK",
+        "CGRpc3RhbmNlGAMgASgFEhQKDGVsYXBzZWRfdGltZRgEIAEoBTL9AQoKUm91dGVHdWlkZRI0CgpHZXRG",
+        "ZWF0dXJlEhEucm91dGVndWlkZS5Qb2ludBoTLnJvdXRlZ3VpZGUuRmVhdHVyZRI8CgxMaXN0RmVhdHVy",
+        "ZXMSFS5yb3V0ZWd1aWRlLlJlY3RhbmdsZRoTLnJvdXRlZ3VpZGUuRmVhdHVyZTABEjwKC1JlY29yZFJv",
+        "dXRlEhEucm91dGVndWlkZS5Qb2ludBoYLnJvdXRlZ3VpZGUuUm91dGVTdW1tYXJ5KAESPQoJUm91dGVD",
+        "aGF0EhUucm91dGVndWlkZS5Sb3V0ZU5vdGUaFS5yb3V0ZWd1aWRlLlJvdXRlTm90ZSgBMAE=",
+      )),
+    )
+    return subMap
   }
 
   public fun getServiceDescriptor(): ServiceDescriptor? {

--- a/wire-grpc-server-generator/src/test/golden/nonSingleMethodService.kt
+++ b/wire-grpc-server-generator/src/test/golden/nonSingleMethodService.kt
@@ -33,13 +33,8 @@ public object FooServiceWireGrpc {
   @Volatile
   private var serviceDescriptor: ServiceDescriptor? = null
 
-  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
-    "service.proto" to descriptorFor(arrayOf(
-      "Cg1zZXJ2aWNlLnByb3RvEgNmb28iCQoHUmVxdWVzdCIKCghSZXNwb25zZTJYCgpGb29TZXJ2aWNlEiQK",
-      "BUNhbGwxEgwuZm9vLlJlcXVlc3QaDS5mb28uUmVzcG9uc2USJAoFQ2FsbDISDC5mb28uUmVxdWVzdBoN",
-      "LmZvby5SZXNwb25zZUINCgtjb20uZm9vLmJhcg==",
-    )),
-  )
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> =
+      createDescriptorMap0()
 
 
   @Volatile
@@ -59,6 +54,17 @@ public object FooServiceWireGrpc {
     val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
         visited + path) }
     return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
+
+  private fun createDescriptorMap0(): Map<String, DescriptorProtos.FileDescriptorProto> {
+    val subMap = mapOf(
+      "service.proto" to descriptorFor(arrayOf(
+        "Cg1zZXJ2aWNlLnByb3RvEgNmb28iCQoHUmVxdWVzdCIKCghSZXNwb25zZTJYCgpGb29TZXJ2aWNlEiQK",
+        "BUNhbGwxEgwuZm9vLlJlcXVlc3QaDS5mb28uUmVzcG9uc2USJAoFQ2FsbDISDC5mb28uUmVxdWVzdBoN",
+        "LmZvby5SZXNwb25zZUINCgtjb20uZm9vLmJhcg==",
+      )),
+    )
+    return subMap
   }
 
   public fun getServiceDescriptor(): ServiceDescriptor? {

--- a/wire-grpc-server-generator/src/test/golden/singleMethodService.kt
+++ b/wire-grpc-server-generator/src/test/golden/singleMethodService.kt
@@ -33,13 +33,8 @@ public object FooServiceWireGrpc {
   @Volatile
   private var serviceDescriptor: ServiceDescriptor? = null
 
-  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
-    "service.proto" to descriptorFor(arrayOf(
-      "Cg1zZXJ2aWNlLnByb3RvEgNmb28iCQoHUmVxdWVzdCIKCghSZXNwb25zZTJYCgpGb29TZXJ2aWNlEiQK",
-      "BUNhbGwxEgwuZm9vLlJlcXVlc3QaDS5mb28uUmVzcG9uc2USJAoFQ2FsbDISDC5mb28uUmVxdWVzdBoN",
-      "LmZvby5SZXNwb25zZUINCgtjb20uZm9vLmJhcg==",
-    )),
-  )
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> =
+      createDescriptorMap0()
 
 
   @Volatile
@@ -59,6 +54,17 @@ public object FooServiceWireGrpc {
     val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
         visited + path) }
     return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
+
+  private fun createDescriptorMap0(): Map<String, DescriptorProtos.FileDescriptorProto> {
+    val subMap = mapOf(
+      "service.proto" to descriptorFor(arrayOf(
+        "Cg1zZXJ2aWNlLnByb3RvEgNmb28iCQoHUmVxdWVzdCIKCghSZXNwb25zZTJYCgpGb29TZXJ2aWNlEiQK",
+        "BUNhbGwxEgwuZm9vLlJlcXVlc3QaDS5mb28uUmVzcG9uc2USJAoFQ2FsbDISDC5mb28uUmVxdWVzdBoN",
+        "LmZvby5SZXNwb25zZUINCgtjb20uZm9vLmJhcg==",
+      )),
+    )
+    return subMap
   }
 
   public fun getServiceDescriptor(): ServiceDescriptor? {

--- a/wire-grpc-server-generator/src/test/golden/unitService.kt
+++ b/wire-grpc-server-generator/src/test/golden/unitService.kt
@@ -30,17 +30,8 @@ public object MyServiceWireGrpc {
   @Volatile
   private var serviceDescriptor: ServiceDescriptor? = null
 
-  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> = mapOf(
-    "service.proto" to descriptorFor(arrayOf(
-      "Cg1zZXJ2aWNlLnByb3RvGhtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8ySgoJTXlTZXJ2aWNlEj0K",
-      "C2RvU29tZXRoaW5nEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5",
-      "YgZwcm90bzM=",
-    )),
-    "google/protobuf/empty.proto" to descriptorFor(arrayOf(
-      "Chtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiIHCgVFbXB0eWIGcHJv",
-      "dG8z",
-    )),
-  )
+  private val descriptorMap: Map<String, DescriptorProtos.FileDescriptorProto> =
+      createDescriptorMap0()
 
 
   @Volatile
@@ -57,6 +48,21 @@ public object MyServiceWireGrpc {
     val deps = proto.dependencyList.filter { !visited.contains(it) }.map { fileDescriptor(it,
         visited + path) }
     return Descriptors.FileDescriptor.buildFrom(proto, deps.toTypedArray())
+  }
+
+  private fun createDescriptorMap0(): Map<String, DescriptorProtos.FileDescriptorProto> {
+    val subMap = mapOf(
+      "service.proto" to descriptorFor(arrayOf(
+        "Cg1zZXJ2aWNlLnByb3RvGhtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8ySgoJTXlTZXJ2aWNlEj0K",
+        "C2RvU29tZXRoaW5nEhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5GhYuZ29vZ2xlLnByb3RvYnVmLkVtcHR5",
+        "YgZwcm90bzM=",
+      )),
+      "google/protobuf/empty.proto" to descriptorFor(arrayOf(
+        "Chtnb29nbGUvcHJvdG9idWYvZW1wdHkucHJvdG8SD2dvb2dsZS5wcm90b2J1ZiIHCgVFbXB0eWIGcHJv",
+        "dG8z",
+      )),
+    )
+    return subMap
   }
 
   public fun getServiceDescriptor(): ServiceDescriptor? {


### PR DESCRIPTION
With large protos, it is possible to have the generated DescriptorMap be too large and break the compiler with a message similar to:

>  org.jetbrains.org.objectweb.asm.MethodTooLargeException: Method too large: .../XXXXServiceWireGrpc.<clinit>

This PR splits the descriptor map into smaller chunks, with each created in their own function to avoid the Method too large.