### PR TITLE
[swift] Introduce a `ProtoExtensible` protocol that all messages that have been extended conform to.

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoExtensible.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoExtensible.swift
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+
+/// Protocol all messages conform to if they are extensible.
+public protocol ProtoExtensible {
+    var unknownFields: UnknownFields { get set }
+}

--- a/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
+++ b/wire-runtime-swift/src/main/swift/wellknowntypes/OneofOptions.swift
@@ -30,6 +30,9 @@ extension OneofOptions : ProtoDefaultedValue {
     }
 }
 
+extension OneofOptions : ProtoExtensible {
+}
+
 extension OneofOptions : ProtoMessage {
 
     public static func protoMessageTypeURL() -> String {

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -498,6 +498,7 @@ public final class com/squareup/wire/schema/MessageType : com/squareup/wire/sche
 	public fun getType ()Lcom/squareup/wire/schema/ProtoType;
 	public fun hashCode ()I
 	public final fun isDeprecated ()Z
+	public final fun isExtensible ()Z
 	public fun linkMembers (Lcom/squareup/wire/schema/Linker;)V
 	public fun linkOptions (Lcom/squareup/wire/schema/Linker;Lcom/squareup/wire/schema/SyntaxRules;Z)V
 	public final fun oneOf (Ljava/lang/String;)Lcom/squareup/wire/schema/OneOf;

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -50,6 +50,9 @@ data class MessageType(
 ) : Type() {
   private var deprecated: Any? = null
 
+  val isExtensible: Boolean
+    get() = extensionsList.isNotEmpty()
+
   val isDeprecated: Boolean
     get() = "true" == deprecated
 

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -89,6 +89,7 @@ class SwiftGenerator private constructor(
   private val customDefaulted = DeclaredTypeName.typeName("Wire.CustomDefaulted")
   private val protoDefaulted = DeclaredTypeName.typeName("Wire.ProtoDefaulted")
   private val unknownFields = DeclaredTypeName.typeName("Wire.UnknownFields")
+  private val protoExtensible = DeclaredTypeName.typeName("Wire.ProtoExtensible")
 
   private val stringLiteralCodingKeys = DeclaredTypeName.typeName("Wire.StringLiteralCodingKeys")
 
@@ -347,6 +348,14 @@ class SwiftGenerator private constructor(
 
           generateMessageStoragePropertyDelegates(type, storageName, storageType, oneOfEnumNames)
           generateMessageStorageDelegateConstructor(type, storageName, storageType, oneOfEnumNames)
+
+          if (type.isExtensible) {
+            val extensibleExtension = ExtensionSpec.builder(storageType)
+              .addSuperType(protoExtensible)
+              .build()
+            fileMembers += FileMemberSpec.builder(extensibleExtension)
+              .build()
+          }
         } else {
           generateMessageProperties(type, oneOfEnumNames)
           generateMessageConstructor(type, oneOfEnumNames)
@@ -389,6 +398,14 @@ class SwiftGenerator private constructor(
         ).build()
 
       fileMembers += FileMemberSpec.builder(defaultedValueExtension).build()
+    }
+
+    if (type.isExtensible) {
+      val extensibleExtension = ExtensionSpec.builder(structType)
+        .addSuperType(protoExtensible)
+        .build()
+      fileMembers += FileMemberSpec.builder(extensibleExtension)
+        .build()
     }
 
     // Add redaction, which is potentially delegated

--- a/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
@@ -1232,6 +1232,9 @@ public struct AllTypes {
 
 }
 
+extension AllTypes.Storage : ProtoExtensible {
+}
+
 #if !WIRE_REMOVE_EQUATABLE
 extension AllTypes : Equatable {
 }
@@ -1243,6 +1246,9 @@ extension AllTypes : Hashable {
 #endif
 
 extension AllTypes : Sendable {
+}
+
+extension AllTypes : ProtoExtensible {
 }
 
 extension AllTypes : Proto2Codable {

--- a/wire-tests-swift/no-manifest/src/main/swift/ExternalMessage.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ExternalMessage.swift
@@ -34,6 +34,9 @@ extension ExternalMessage : ProtoDefaultedValue {
     }
 }
 
+extension ExternalMessage : ProtoExtensible {
+}
+
 extension ExternalMessage : ProtoMessage {
 
     public static func protoMessageTypeURL() -> String {

--- a/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
@@ -48,6 +48,9 @@ extension FooBar : ProtoDefaultedValue {
     }
 }
 
+extension FooBar : ProtoExtensible {
+}
+
 #if !WIRE_REMOVE_REDACTABLE
 extension FooBar : Redactable {
 

--- a/wire-tests-swift/no-manifest/src/main/swift/ForeignMessage.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ForeignMessage.swift
@@ -34,6 +34,9 @@ extension ForeignMessage : ProtoDefaultedValue {
     }
 }
 
+extension ForeignMessage : ProtoExtensible {
+}
+
 extension ForeignMessage : ProtoMessage {
 
     public static func protoMessageTypeURL() -> String {


### PR DESCRIPTION
This is generally harmless and another tiny step in preparation of a moderate re-design on how Wire proto extensions are generated.