### PR TITLE
Extract MessageType.isExtensible as extension function in SwiftGen

### DIFF
--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -498,7 +498,6 @@ public final class com/squareup/wire/schema/MessageType : com/squareup/wire/sche
 	public fun getType ()Lcom/squareup/wire/schema/ProtoType;
 	public fun hashCode ()I
 	public final fun isDeprecated ()Z
-	public final fun isExtensible ()Z
 	public fun linkMembers (Lcom/squareup/wire/schema/Linker;)V
 	public fun linkOptions (Lcom/squareup/wire/schema/Linker;Lcom/squareup/wire/schema/SyntaxRules;Z)V
 	public final fun oneOf (Ljava/lang/String;)Lcom/squareup/wire/schema/OneOf;

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/MessageType.kt
@@ -50,9 +50,6 @@ data class MessageType(
 ) : Type() {
   private var deprecated: Any? = null
 
-  val isExtensible: Boolean
-    get() = extensionsList.isNotEmpty()
-
   val isDeprecated: Boolean
     get() = "true" == deprecated
 

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -1784,5 +1784,8 @@ class SwiftGenerator private constructor(
 
       return indirections
     }
+
+    private val MessageType.isExtensible: Boolean
+      get() = extensionsList.isNotEmpty()
   }
 }


### PR DESCRIPTION
I would like to reduce the API changes within wire-schema as much as possible A bit like  Wire Swift was evolving into its own repo; same applies for Wire Java and Wire Kotlin.
Extracting the method created here https://github.com/square/wire/pull/2790