### PR TITLE
New API: extraTypeAnnotations

### DIFF
--- a/docs/wire_compiler.md
+++ b/docs/wire_compiler.md
@@ -492,6 +492,9 @@ wire {
 
     // True for emitted services to implement one interface per RPC.
     singleMethodServices = false
+
+    // Fully-qualified type names of annotations to be added to each generated type.
+    extraTypeAnnotations = listOf<String>()
   }
 }
 ```

--- a/wire-compiler/api/wire-compiler.api
+++ b/wire-compiler/api/wire-compiler.api
@@ -111,8 +111,8 @@ public final class com/squareup/wire/schema/JavaTarget : com/squareup/wire/schem
 }
 
 public final class com/squareup/wire/schema/KotlinTarget : com/squareup/wire/schema/Target {
-	public fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZ)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component10 ()Lcom/squareup/wire/kotlin/RpcRole;
 	public final fun component11 ()Z
@@ -121,6 +121,7 @@ public final class com/squareup/wire/schema/KotlinTarget : com/squareup/wire/sch
 	public final fun component14 ()Ljava/lang/String;
 	public final fun component15 ()Z
 	public final fun component16 ()Z
+	public final fun component17 ()Ljava/util/List;
 	public final fun component2 ()Ljava/util/List;
 	public final fun component3 ()Z
 	public final fun component4 ()Ljava/lang/String;
@@ -129,8 +130,8 @@ public final class com/squareup/wire/schema/KotlinTarget : com/squareup/wire/sch
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Lcom/squareup/wire/kotlin/RpcCallStyle;
-	public final fun copy (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZ)Lcom/squareup/wire/schema/KotlinTarget;
-	public static synthetic fun copy$default (Lcom/squareup/wire/schema/KotlinTarget;Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZILjava/lang/Object;)Lcom/squareup/wire/schema/KotlinTarget;
+	public final fun copy (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZLjava/util/List;)Lcom/squareup/wire/schema/KotlinTarget;
+	public static synthetic fun copy$default (Lcom/squareup/wire/schema/KotlinTarget;Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZLjava/util/List;ILjava/lang/Object;)Lcom/squareup/wire/schema/KotlinTarget;
 	public fun copyTarget (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;)Lcom/squareup/wire/schema/Target;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAndroid ()Z
@@ -141,6 +142,7 @@ public final class com/squareup/wire/schema/KotlinTarget : com/squareup/wire/sch
 	public final fun getEscapeKotlinKeywords ()Z
 	public fun getExcludes ()Ljava/util/List;
 	public fun getExclusive ()Z
+	public final fun getExtraTypeAnnotations ()Ljava/util/List;
 	public final fun getGrpcServerCompatible ()Z
 	public fun getIncludes ()Ljava/util/List;
 	public final fun getJavaInterop ()Z

--- a/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -134,6 +134,9 @@ data class KotlinTarget(
 
   /** If true, Kotlin keywords are escaped with backticks. If false, an underscore is added as a suffix. */
   val escapeKotlinKeywords: Boolean = false,
+
+  /** Fully-qualified type names of annotations to be added to each generated type. */
+  val extraTypeAnnotations: List<String> = listOf(),
 ) : Target() {
   override fun newHandler(): SchemaHandler {
     return KotlinSchemaHandler(
@@ -150,6 +153,7 @@ data class KotlinTarget(
       nameSuffix = nameSuffix,
       buildersOnly = buildersOnly,
       escapeKotlinKeywords = escapeKotlinKeywords,
+      extraTypeAnnotations = extraTypeAnnotations,
     )
   }
 

--- a/wire-gradle-plugin/api/wire-gradle-plugin.api
+++ b/wire-gradle-plugin/api/wire-gradle-plugin.api
@@ -64,6 +64,7 @@ public class com/squareup/wire/gradle/KotlinOutput : com/squareup/wire/gradle/Wi
 	public final fun getEscapeKotlinKeywords ()Z
 	public final fun getExcludes ()Ljava/util/List;
 	public final fun getExclusive ()Z
+	public final fun getExtraTypeAnnotations ()Ljava/util/List;
 	public final fun getGrpcServerCompatible ()Z
 	public final fun getIncludes ()Ljava/util/List;
 	public final fun getJavaInterop ()Z
@@ -79,6 +80,7 @@ public class com/squareup/wire/gradle/KotlinOutput : com/squareup/wire/gradle/Wi
 	public final fun setEscapeKotlinKeywords (Z)V
 	public final fun setExcludes (Ljava/util/List;)V
 	public final fun setExclusive (Z)V
+	public final fun setExtraTypeAnnotations (Ljava/util/List;)V
 	public final fun setGrpcServerCompatible (Z)V
 	public final fun setIncludes (Ljava/util/List;)V
 	public final fun setJavaInterop (Z)V

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -88,6 +88,9 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
   /** If true, Kotlin keywords are escaped with backticks. If false, an underscore is added as a suffix. */
   var escapeKotlinKeywords: Boolean = false
 
+  /** Fully-qualified type names of annotations to be added to each generated type. */
+  var extraTypeAnnotations: List<String> = listOf()
+
   override fun toTarget(outputDirectory: String): KotlinTarget {
     val rpcCallStyle = RpcCallStyle.values()
       .singleOrNull { it.toString().equals(rpcCallStyle, ignoreCase = true) }
@@ -117,6 +120,7 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
       nameSuffix = nameSuffix,
       buildersOnly = buildersOnly,
       escapeKotlinKeywords = escapeKotlinKeywords,
+      extraTypeAnnotations = extraTypeAnnotations.toList(),
     )
   }
 }

--- a/wire-kotlin-generator/api/wire-kotlin-generator.api
+++ b/wire-kotlin-generator/api/wire-kotlin-generator.api
@@ -1,6 +1,6 @@
 public final class com/squareup/wire/kotlin/KotlinGenerator {
 	public static final field Companion Lcom/squareup/wire/kotlin/KotlinGenerator$Companion;
-	public synthetic fun <init> (Lcom/squareup/wire/schema/Schema;Ljava/util/Map;Ljava/util/Map;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/squareup/wire/schema/Schema;Ljava/util/Map;Ljava/util/Map;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZLjava/util/List;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun generateGrpcServerAdapter (Lcom/squareup/wire/schema/Service;)Ljava/util/Map;
 	public final fun generateOptionType (Lcom/squareup/wire/schema/Extend;Lcom/squareup/wire/schema/Field;)Lcom/squareup/kotlinpoet/TypeSpec;
 	public final fun generateServiceTypeSpecs (Lcom/squareup/wire/schema/Service;Lcom/squareup/wire/schema/Rpc;)Ljava/util/Map;
@@ -10,20 +10,20 @@ public final class com/squareup/wire/kotlin/KotlinGenerator {
 	public static synthetic fun generatedServiceName$default (Lcom/squareup/wire/kotlin/KotlinGenerator;Lcom/squareup/wire/schema/Service;Lcom/squareup/wire/schema/Rpc;ZILjava/lang/Object;)Lcom/squareup/kotlinpoet/ClassName;
 	public final fun generatedTypeName (Lcom/squareup/wire/schema/ProtoMember;)Lcom/squareup/kotlinpoet/ClassName;
 	public final fun generatedTypeName (Lcom/squareup/wire/schema/Type;)Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZ)Lcom/squareup/wire/kotlin/KotlinGenerator;
+	public static final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZLjava/util/List;)Lcom/squareup/wire/kotlin/KotlinGenerator;
 	public final fun getSchema ()Lcom/squareup/wire/schema/Schema;
 }
 
 public final class com/squareup/wire/kotlin/KotlinGenerator$Companion {
 	public final fun builtInType (Lcom/squareup/wire/schema/ProtoType;)Z
-	public final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZ)Lcom/squareup/wire/kotlin/KotlinGenerator;
-	public static synthetic fun get$default (Lcom/squareup/wire/kotlin/KotlinGenerator$Companion;Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZILjava/lang/Object;)Lcom/squareup/wire/kotlin/KotlinGenerator;
+	public final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZLjava/util/List;)Lcom/squareup/wire/kotlin/KotlinGenerator;
+	public static synthetic fun get$default (Lcom/squareup/wire/kotlin/KotlinGenerator$Companion;Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;IZLjava/lang/String;ZZZLjava/util/List;ILjava/lang/Object;)Lcom/squareup/wire/kotlin/KotlinGenerator;
 }
 
 public final class com/squareup/wire/kotlin/KotlinSchemaHandler : com/squareup/wire/schema/SchemaHandler {
 	public static final field Companion Lcom/squareup/wire/kotlin/KotlinSchemaHandler$Companion;
-	public fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZ)V
-	public synthetic fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZIZLjava/lang/String;ZZLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun handle (Lcom/squareup/wire/schema/Extend;Lcom/squareup/wire/schema/Field;Lcom/squareup/wire/schema/SchemaHandler$Context;)Lokio/Path;
 	public fun handle (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/SchemaHandler$Context;)V
 	public fun handle (Lcom/squareup/wire/schema/Service;Lcom/squareup/wire/schema/SchemaHandler$Context;)Ljava/util/List;

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -132,6 +132,7 @@ class KotlinGenerator private constructor(
   private val buildersOnly: Boolean,
   private val singleMethodServices: Boolean,
   private val escapeKotlinKeywords: Boolean,
+  private val extraTypeAnnotations: List<AnnotationSpec>,
 ) {
   private val nameAllocatorStore = mutableMapOf<Type, NameAllocator>()
 
@@ -336,7 +337,7 @@ class KotlinGenerator private constructor(
           addKdoc("%L\n", service.documentation.sanitizeKdoc())
         }
         if (!isImplementation) {
-          for (annotation in optionAnnotations(service.options)) {
+          for (annotation in optionAnnotations(service.options) + extraTypeAnnotations) {
             addAnnotation(annotation)
           }
         }
@@ -558,7 +559,7 @@ class KotlinGenerator private constructor(
         if (type.documentation.isNotBlank()) {
           addKdoc("%L\n", type.documentation.sanitizeKdoc())
         }
-        for (annotation in optionAnnotations(type.options)) {
+        for (annotation in optionAnnotations(type.options) + extraTypeAnnotations) {
           addAnnotation(annotation)
         }
         if (type.isDeprecated) {
@@ -2249,7 +2250,7 @@ class KotlinGenerator private constructor(
         if (enum.documentation.isNotBlank()) {
           addKdoc("%L\n", enum.documentation.sanitizeKdoc())
         }
-        for (annotation in optionAnnotations(enum.options)) {
+        for (annotation in optionAnnotations(enum.options) + extraTypeAnnotations) {
           addAnnotation(annotation)
         }
         if (enum.isDeprecated) {
@@ -2907,6 +2908,7 @@ class KotlinGenerator private constructor(
       buildersOnly: Boolean = false,
       singleMethodServices: Boolean = false,
       escapeKotlinKeywords: Boolean = false,
+      extraTypeAnnotations: List<String> = listOf(),
     ): KotlinGenerator {
       val typeToKotlinName = mutableMapOf<ProtoType, TypeName>()
       val memberToKotlinName = mutableMapOf<ProtoMember, TypeName>()
@@ -2940,6 +2942,10 @@ class KotlinGenerator private constructor(
 
       typeToKotlinName.putAll(BUILT_IN_TYPES)
 
+      val extraTypeAnnotationsTyped = extraTypeAnnotations.map {
+        AnnotationSpec.builder(ClassName.bestGuess(it)).build()
+      }
+
       return KotlinGenerator(
         schema = schema,
         profile = profile,
@@ -2957,6 +2963,7 @@ class KotlinGenerator private constructor(
         buildersOnly = buildersOnly,
         singleMethodServices = singleMethodServices,
         escapeKotlinKeywords = escapeKotlinKeywords,
+        extraTypeAnnotations = extraTypeAnnotationsTyped,
       )
     }
 

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinSchemaHandler.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinSchemaHandler.kt
@@ -77,6 +77,9 @@ class KotlinSchemaHandler(
 
   /** If true, Kotlin keywords are escaped with backticks. If false, an underscore is added as a suffix. */
   private val escapeKotlinKeywords: Boolean = false,
+
+  /** Fully-qualified type names of annotations to be added to each generated type. */
+  private val extraTypeAnnotations: List<String>,
 ) : SchemaHandler() {
   private lateinit var kotlinGenerator: KotlinGenerator
 
@@ -98,6 +101,7 @@ class KotlinSchemaHandler(
       buildersOnly = buildersOnly,
       singleMethodServices = singleMethodServices,
       escapeKotlinKeywords = escapeKotlinKeywords,
+      extraTypeAnnotations = extraTypeAnnotations,
     )
     context.fileSystem.createDirectories(context.outDirectory)
     super.handle(schema, context)

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -2278,13 +2278,15 @@ class KotlinGeneratorTest {
     assertThat(code).contains(
       """
       |import androidx.compose.runtime.Immutable
-      |""".trimMargin(),
+      |
+      """.trimMargin(),
     )
     assertThat(code).contains(
       """
       |@Immutable
       |public class Person(
-      |""".trimMargin(),
+      |
+      """.trimMargin(),
     )
   }
 

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -2258,6 +2258,36 @@ class KotlinGeneratorTest {
     assertThat(code).contains("import wire_package.Person")
   }
 
+  @Test
+  fun extraTypeAnnotations() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+        |message Person {
+        |	 optional string name = 1;
+        |}
+        """.trimMargin(),
+      )
+    }
+    val generator = KotlinWithProfilesGenerator(schema)
+    val code = generator.generateKotlin(
+      typeName = "Person",
+      extraTypeAnnotations = listOf("androidx.compose.runtime.Immutable"),
+    )
+    assertThat(code).contains(
+      """
+      |import androidx.compose.runtime.Immutable
+      |""".trimMargin(),
+    )
+    assertThat(code).contains(
+      """
+      |@Immutable
+      |public class Person(
+      |""".trimMargin(),
+    )
+  }
+
   companion object {
     private val pointMessage = """
           |message Point {

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinWithProfilesGenerator.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinWithProfilesGenerator.kt
@@ -52,6 +52,7 @@ internal class KotlinWithProfilesGenerator(private val schema: Schema) {
     boxOneOfsMinSize: Int = 5_000,
     buildersOnly: Boolean = false,
     javaInterop: Boolean = false,
+    extraTypeAnnotations: List<String> = listOf(),
   ): String {
     val kotlinGenerator = KotlinGenerator(
       schema,
@@ -59,6 +60,7 @@ internal class KotlinWithProfilesGenerator(private val schema: Schema) {
       boxOneOfsMinSize = boxOneOfsMinSize,
       buildersOnly = buildersOnly,
       javaInterop = javaInterop,
+      extraTypeAnnotations = extraTypeAnnotations,
     )
     val type = schema.getType(typeName)!!
     val typeSpec = kotlinGenerator.generateType(type)


### PR DESCRIPTION
The goal of this new API is to allow users to specify extra annotations that'll apply to the Wire-generated classes. This is specifically useful for the @Immutable annotation offered by Jetpack Compose, and could be useful for other annotations.