### PR TITLE
Prune imports no longer used by retained entities in the schema

### DIFF
--- a/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGeneratorTest.kt
+++ b/wire-grpc-server-generator/src/test/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGeneratorTest.kt
@@ -46,7 +46,9 @@ internal class FileDescriptorGeneratorTest {
       |package test;
       |import "imported.proto";
       |
-      |message Test {}
+      |message Test {
+      |  optional Imported imported = 1;
+      |}
       |
         """.trimMargin(),
       ),

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -612,7 +612,7 @@ public final class com/squareup/wire/schema/ProtoFile {
 	public final fun linkOptions (Lcom/squareup/wire/schema/Linker;Z)V
 	public final fun name ()Ljava/lang/String;
 	public final fun retainAll (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/MarkSet;)Lcom/squareup/wire/schema/ProtoFile;
-	public final fun retainImports (Ljava/util/List;)Lcom/squareup/wire/schema/ProtoFile;
+	public final fun retainImports (Lcom/squareup/wire/schema/Schema;)Lcom/squareup/wire/schema/ProtoFile;
 	public final fun retainLinked (Ljava/util/Set;Ljava/util/Set;)Lcom/squareup/wire/schema/ProtoFile;
 	public final fun toElement ()Lcom/squareup/wire/schema/internal/parser/ProtoFileElement;
 	public final fun toSchema ()Ljava/lang/String;

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -613,6 +613,7 @@ public final class com/squareup/wire/schema/ProtoFile {
 	public final fun name ()Ljava/lang/String;
 	public final fun retainAll (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/MarkSet;)Lcom/squareup/wire/schema/ProtoFile;
 	public final fun retainImports (Lcom/squareup/wire/schema/Schema;)Lcom/squareup/wire/schema/ProtoFile;
+	public final fun retainImports (Ljava/util/List;)Lcom/squareup/wire/schema/ProtoFile;
 	public final fun retainLinked (Ljava/util/Set;Ljava/util/Set;)Lcom/squareup/wire/schema/ProtoFile;
 	public final fun toElement ()Lcom/squareup/wire/schema/internal/parser/ProtoFileElement;
 	public final fun toSchema ()Ljava/lang/String;

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -186,9 +186,12 @@ data class ProtoFile(
 
     val retainedImports = imports.filter { referencedImports.contains(it) }
 
-    val protoFilesInSchema = schema.protoFiles.map { it.location.path }.toSet()
+    val nonEmptyProtoFilesInSchema = schema.protoFiles
+      .filter { it.types.isNotEmpty() || it.services.isNotEmpty() || it.extendList.isNotEmpty() }
+      .map { protoFile -> protoFile.location.path }
+      .toSet()
 
-    val retainedPublicImports = publicImports.filter { protoFilesInSchema.contains(it) }
+    val retainedPublicImports = publicImports.filter { nonEmptyProtoFilesInSchema.contains(it) }
 
     return if (imports.size != retainedImports.size || publicImports.size != retainedPublicImports.size) {
       val result = ProtoFile(
@@ -242,10 +245,6 @@ data class ProtoFile(
         protoFileElement.publicImports, packageName, types, services, wireExtends, options,
         protoFileElement.syntax,
       )
-    }
-
-    private fun findProtoFile(protoFiles: List<ProtoFile>, path: String): ProtoFile? {
-      return protoFiles.find { it.location.path == path }
     }
   }
 }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Pruner.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Pruner.kt
@@ -53,8 +53,9 @@ class Pruner(
   }
 
   private fun retainImports(protoFiles: List<ProtoFile>): List<ProtoFile> {
+    val schema = Schema(protoFiles)
     return protoFiles.map { protoFile ->
-      protoFile.retainImports(protoFiles)
+      protoFile.retainImports(schema)
     }
   }
 

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1462,6 +1462,54 @@ class PrunerTest {
     assertThat(message.imports).containsExactly("title.proto")
   }
 
+  /**
+   * We had a bug in import pruning where we retained imports if the files were non-empty,
+   * even if those imports were unnecessary.
+   */
+
+  @Test
+  fun importPruningIsPrecise() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+             |import 'footer.proto';
+             |
+             |message Message {
+             |  optional string label = 1;
+             |}
+             |
+             |message AnotherMessage {
+             |  optional Footer footer = 1;
+             |}
+        """.trimMargin(),
+      )
+      add(
+        "footer.proto".toPath(),
+        """
+             |message Footer {
+             |  optional string label = 1;
+             |}
+             |
+             |message Shoe {
+             |  optional string label = 1;
+             |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .addRoot("Shoe")
+        .build(),
+    )
+
+    assertThat(pruned.protoFile("footer.proto")!!.types).isNotEmpty()
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).isEmpty()
+  }
+
   @Test
   fun enumsAreKeptsIfUsed() {
     val schema = buildSchema {

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1714,7 +1714,8 @@ class PrunerTest {
           |}
         """.trimMargin(),
       )
-      add("message.proto".toPath(),
+      add(
+        "message.proto".toPath(),
         """
           |message Message {
           |  optional string value = 1;
@@ -1723,7 +1724,7 @@ class PrunerTest {
           |message AnotherMessage {
           |  optional string value = 1;
           |}
-        """.trimMargin()
+        """.trimMargin(),
       )
       add(
         "title.proto".toPath(),
@@ -1820,7 +1821,8 @@ class PrunerTest {
           |}
         """.trimMargin(),
       )
-      add("message.proto".toPath(),
+      add(
+        "message.proto".toPath(),
         """
           |message Message {
           |  optional string value = 1;
@@ -1829,7 +1831,7 @@ class PrunerTest {
           |message AnotherMessage {
           |  optional string value = 1;
           |}
-        """.trimMargin()
+        """.trimMargin(),
       )
       add(
         "title.proto".toPath(),

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1748,8 +1748,8 @@ class PrunerTest {
         .build(),
     )
 
-    val message = pruned.protoFile("extension.proto")!!
-    assertThat(message.imports).containsExactly("title.proto")
+    val extension = pruned.protoFile("extension.proto")!!
+    assertThat(extension.imports).containsExactly("title.proto")
   }
 
   @Test
@@ -1854,8 +1854,8 @@ class PrunerTest {
         .build(),
     )
 
-    val message = pruned.protoFile("extension.proto")!!
-    assertThat(message.imports).containsExactly("title.proto")
+    val extension = pruned.protoFile("extension.proto")!!
+    assertThat(extension.imports).containsExactly("title.proto")
   }
 
   @Test
@@ -2205,8 +2205,8 @@ class PrunerTest {
         .build(),
     )
 
-    val enum = pruned.protoFile("service.proto")!!
-    assertThat(enum.imports).containsExactly("option.proto")
+    val service = pruned.protoFile("service.proto")!!
+    assertThat(service.imports).containsExactly("option.proto")
   }
 
   @Test
@@ -2264,8 +2264,8 @@ class PrunerTest {
         .build(),
     )
 
-    val enum = pruned.protoFile("service.proto")!!
-    assertThat(enum.imports).containsExactly("option.proto")
+    val service = pruned.protoFile("service.proto")!!
+    assertThat(service.imports).containsExactly("option.proto")
   }
 
   @Test

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1511,6 +1511,721 @@ class PrunerTest {
   }
 
   @Test
+  fun retainImportWhenUsedForMessageField() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+          |import 'title.proto';
+          |import 'footer.proto';
+          |
+          |message Message {
+          |  optional Title title = 1;
+          |}
+          |
+          |message AnotherMessage {
+          |  optional Footer footer = 1;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "title.proto".toPath(),
+        """
+          |message Title {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "footer.proto".toPath(),
+        """
+          |message Footer {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).containsExactly("title.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForMessageOneOf() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+          |import 'title.proto';
+          |import 'footer.proto';
+          |
+          |message Message {
+          |  oneof title_value {
+          |    Title title = 1;
+          |    string value = 2;
+          |  }
+          |}
+          |
+          |message AnotherMessage {
+          |  oneof footer_value {
+          |    Footer footer = 1;
+          |    string value = 2;
+          |  }
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "title.proto".toPath(),
+        """
+          |message Title {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "footer.proto".toPath(),
+        """
+          |message Footer {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).containsExactly("title.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForServiceRpc() {
+    val schema = buildSchema {
+      add(
+        "service.proto".toPath(),
+        """
+          |import 'call.proto';
+          |import 'another_call.proto';
+          |
+          |service Service {
+          |  rpc Call (CallRequest) returns (CallResponse);
+          |  rpc AnotherCall (AnotherCallRequest) returns (AnotherCallResponse);
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "call.proto".toPath(),
+        """
+          |message CallRequest {
+          |}
+          |
+          |message CallResponse {
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_call.proto".toPath(),
+        """
+          |message AnotherCallRequest {
+          |}
+          |
+          |message AnotherCallResponse {
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Service#Call")
+        .build(),
+    )
+
+    val service = pruned.protoFile("service.proto")!!
+    assertThat(service.imports).containsExactly("call.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForExtendedMessage() {
+    val schema = buildSchema {
+      add(
+        "extension.proto".toPath(),
+        """
+          |import 'message.proto';
+          |import 'title.proto';
+          |import 'footer.proto';
+          |
+          |extend Message {
+          |  optional Title title = 2;
+          |}
+          |
+          |extend AnotherMessage {
+          |  optional Footer footer = 2;
+          |}
+        """.trimMargin(),
+      )
+      add("message.proto".toPath(),
+        """
+          |message Message {
+          |  optional string value = 1;
+          |}
+          |
+          |message AnotherMessage {
+          |  optional string value = 1;
+          |}
+        """.trimMargin()
+      )
+      add(
+        "title.proto".toPath(),
+        """
+          |message Title {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "footer.proto".toPath(),
+        """
+          |message Footer {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("extension.proto")!!
+    assertThat(message.imports).containsExactly("title.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForNestedMessageField() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+          |import 'title.proto';
+          |import 'footer.proto';
+          |
+          |message Outer {
+          |  message Message {
+          |    optional Title title = 1;
+          |  }
+          |
+          |  message AnotherMessage {
+          |    optional Footer footer = 1;
+          |  }
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "title.proto".toPath(),
+        """
+          |message Title {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "footer.proto".toPath(),
+        """
+          |message Footer {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Outer.Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).containsExactly("title.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForNestedExtendedMessage() {
+    val schema = buildSchema {
+      add(
+        "extension.proto".toPath(),
+        """
+          |import 'message.proto';
+          |import 'title.proto';
+          |import 'footer.proto';
+          |
+          |message Outer {
+          |  extend Message {
+          |    optional Title title = 2;
+          |  }
+          |
+          |  extend AnotherMessage {
+          |    optional Footer footer = 2;
+          |  }
+          |}
+        """.trimMargin(),
+      )
+      add("message.proto".toPath(),
+        """
+          |message Message {
+          |  optional string value = 1;
+          |}
+          |
+          |message AnotherMessage {
+          |  optional string value = 1;
+          |}
+        """.trimMargin()
+      )
+      add(
+        "title.proto".toPath(),
+        """
+          |message Title {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "footer.proto".toPath(),
+        """
+          |message Footer {
+          |  optional string label = 1;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("extension.proto")!!
+    assertThat(message.imports).containsExactly("title.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForFileOption() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+          |import 'option.proto';
+          |
+          |option custom_option = true;
+          |
+          |message Message {
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.FileOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).containsExactly("option.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForMessageOption() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+          |import 'option.proto';
+          |import 'another_option.proto';
+          |
+          |message Message {
+          |  option custom_option = true;
+          |}
+          |
+          |message AnotherMessage {
+          |  option another_custom_option = true;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.MessageOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.MessageOptions {
+          |  optional bool another_custom_option = 10001;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).containsExactly("option.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForFieldOption() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+          |import 'option.proto';
+          |import 'another_option.proto';
+          |
+          |message Message {
+          |  optional string value = 1 [custom_option = true];
+          |}
+          |
+          |message AnotherMessage {
+          |  optional string value = 1 [another_custom_option = true];
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.FieldOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.FieldOptions {
+          |  optional bool another_custom_option = 10001;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).containsExactly("option.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForOneOfOption() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+          |import 'option.proto';
+          |import 'another_option.proto';
+          |
+          |message Message {
+          |  oneof value {
+          |    option custom_option = true;
+          |    string value_1 = 1;
+          |    string value_2 = 2;
+          |  }
+          |}
+          |
+          |message AnotherMessage {
+          |  oneof value {
+          |    option another_custom_option = true;
+          |    string value_1 = 1;
+          |    string value_2 = 2;
+          |  }
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.OneofOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.OneofOptions {
+          |  optional bool another_custom_option = 10001;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Message")
+        .build(),
+    )
+
+    val message = pruned.protoFile("message.proto")!!
+    assertThat(message.imports).containsExactly("option.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForEnumOption() {
+    val schema = buildSchema {
+      add(
+        "enum.proto".toPath(),
+        """
+          |import 'option.proto';
+          |import 'another_option.proto';
+          |
+          |enum Enum {
+          |  option custom_option = true;
+          |  ENUM_UNSPECIFIED = 0;
+          |  ENUM_VALUE = 1;
+          |}
+          |
+          |enum AnotherEnum {
+          |  option another_custom_option = true;
+          |  ANOTHER_ENUM_UNSPECIFIED = 0;
+          |  ANOTHER_ENUM_VALUE = 1;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.EnumOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.EnumOptions {
+          |  optional bool another_custom_option = 10001;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Enum")
+        .build(),
+    )
+
+    val enum = pruned.protoFile("enum.proto")!!
+    assertThat(enum.imports).containsExactly("option.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForEnumValueOption() {
+    val schema = buildSchema {
+      add(
+        "enum.proto".toPath(),
+        """
+          |import 'option.proto';
+          |import 'another_option.proto';
+          |
+          |enum Enum {
+          |  ENUM_UNSPECIFIED = 0;
+          |  ENUM_VALUE = 1 [custom_option = true];
+          |}
+          |
+          |enum AnotherEnum {
+          |  ANOTHER_ENUM_UNSPECIFIED = 0;
+          |  ANOTHER_ENUM_VALUE = 1 [another_custom_option = true];
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.EnumValueOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.EnumValueOptions {
+          |  optional bool another_custom_option = 10001;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Enum")
+        .build(),
+    )
+
+    val enum = pruned.protoFile("enum.proto")!!
+    assertThat(enum.imports).containsExactly("option.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForServiceOption() {
+    val schema = buildSchema {
+      add(
+        "service.proto".toPath(),
+        """
+          |import 'option.proto';
+          |import 'another_option.proto';
+          |
+          |message CallRequest {
+          |}
+          |
+          |message CallResponse {
+          |}
+          |
+          |service Service {
+          |  option custom_option = true;
+          |  rpc Call (CallRequest) returns (CallResponse);
+          |}
+          |
+          |service AnotherService {
+          |  option another_custom_option = true;
+          |  rpc Call (CallRequest) returns (CallResponse);
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.ServiceOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.ServiceOptions {
+          |  optional bool another_custom_option = 10001;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Service")
+        .build(),
+    )
+
+    val enum = pruned.protoFile("service.proto")!!
+    assertThat(enum.imports).containsExactly("option.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForMethodOption() {
+    val schema = buildSchema {
+      add(
+        "service.proto".toPath(),
+        """
+          |import 'option.proto';
+          |import 'another_option.proto';
+          |
+          |message CallRequest {
+          |}
+          |
+          |message CallResponse {
+          |}
+          |
+          |service Service {
+          |  rpc Call (CallRequest) returns (CallResponse) {
+          |    option custom_option = true;
+          |  }
+          |}
+          |
+          |service AnotherService {
+          |  rpc Call (CallRequest) returns (CallResponse) {
+          |    option another_custom_option = true;
+          |  }
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.MethodOptions {
+          |  optional bool custom_option = 10000;
+          |}
+        """.trimMargin(),
+      )
+      add(
+        "another_option.proto".toPath(),
+        """
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.MethodOptions {
+          |  optional bool another_custom_option = 10001;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("Service")
+        .build(),
+    )
+
+    val enum = pruned.protoFile("service.proto")!!
+    assertThat(enum.imports).containsExactly("option.proto")
+  }
+
+  @Test
   fun enumsAreKeptsIfUsed() {
     val schema = buildSchema {
       add(


### PR DESCRIPTION
This is a WIP but wanted to get it up to get some feedback on the approach. This started with a discussion with @swankjesse after I discovered that imports are not necessarily being pruned from files when they are no longer needed by retained entities in the schema.

The existing logic appear to retain an imports when the file is being retained in the schema at all, regarless of whether the import is still being used by the file (and not by another file).

This change attempts to resolve the referenced types in the file and resolve them back to their import locations so that the list of actually required imports can be determined.

It's currently passing all existing test cases as well as the new test we added to replicate the issue, but I'm not sure if I'm capturing all ways a type can be referenced at the moment. Any insights into wierd edge cases that I should consider are very welcome.

I'll add some comments in the files where I'm not sure about things.