### PR TITLE
Fix over pruning imports when only option types are being extended in a file

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -146,6 +146,7 @@ data class ProtoFile(
       .flatMap { rpc -> listOfNotNull(rpc.requestType, rpc.responseType) }
 
     val extendTypes = mutableListOf<ProtoType>().apply {
+      addAll(extendList.mapNotNull { it.type })
       addAll(extendList.flatMap { it.fields }.mapNotNull { it.type })
       addAll(types.flatMap { it.nestedExtendList }.flatMap { it.fields }.mapNotNull { it.type })
     }

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1750,7 +1750,33 @@ class PrunerTest {
     )
 
     val extension = pruned.protoFile("extension.proto")!!
-    assertThat(extension.imports).containsExactly("title.proto")
+    assertThat(extension.imports).containsExactly("message.proto", "title.proto")
+  }
+
+  @Test
+  fun retainImportWhenUsedForExtendingOptions() {
+    val schema = buildSchema {
+      add(
+        "extension.proto".toPath(),
+        """
+          |syntax = "proto2";
+          |
+          |import "google/protobuf/descriptor.proto";
+          |
+          |extend google.protobuf.MessageOptions {
+          |  optional string value = 10000;
+          |}
+        """.trimMargin(),
+      )
+    }
+    val pruned = schema.prune(
+      PruningRules.Builder()
+        .addRoot("google.protobuf.MessageOptions")
+        .build(),
+    )
+
+    val extension = pruned.protoFile("extension.proto")!!
+    assertThat(extension.imports).containsExactly("google/protobuf/descriptor.proto")
   }
 
   @Test


### PR DESCRIPTION
I introduced a bug in #2797 where if the only thing in a file is an extension to an option type, the import for `google/protobuf/descriptor.proto` was being pruned as we were not adding the type being extended to the list of referenced types.

This change does exactly that, plus a test to ensure we don't miss it in the future.