### PR TITLE
Add public dependencies when encoding the schema

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/SchemaEncoder.kt
@@ -109,8 +109,13 @@ class SchemaEncoder(
       enclosingEncoder.asRepeated()
         .encodeWithTag(writer, 4, value.types.filterIsInstance<EnclosingType>())
       // INT32.asRepeated().encodeWithTag(writer, 11, value.weak_dependency)
-      // INT32.asRepeated().encodeWithTag(writer, 10, value.public_dependency)
-      STRING.asRepeated().encodeWithTag(writer, 3, value.imports)
+      val allImports = value.imports + value.publicImports
+      val publicImportIndexes = allImports
+        .withIndex()
+        .filter { value.publicImports.contains(it.value) }
+        .map { it.index }
+      INT32.asRepeated().encodeWithTag(writer, 10, publicImportIndexes)
+      STRING.asRepeated().encodeWithTag(writer, 3, allImports)
       STRING.encodeWithTag(writer, 2, value.packageName)
       STRING.encodeWithTag(writer, 1, value.location.path)
     }


### PR DESCRIPTION
I'm not sure if the is the correct way to encode the public imports, but I'm basing it off the wording in the JavaDoc [here](https://protobuf.dev/reference/java/api-docs/com/google/protobuf/DescriptorProtos.FileDescriptorProto.html#getPublicDependencyList--).

There is an issue where if a file is `import public` it was not being encoded in the `descriptorMap` of generated servers (generated [here](https://github.com/square/wire/blob/master/wire-grpc-server-generator/src/main/java/com/squareup/wire/kotlin/grpcserver/FileDescriptorGenerator.kt#L72)), causing startup failures in services.