### PR TITLE
[wire-grpc-tests] Reads assertions from backend in tests

### DIFF
--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTest.kt
@@ -1494,6 +1494,8 @@ class GrpcClientTest {
     assertThat(responseChannel.read()).isEqualTo(Feature(name = "house"))
     assertThat(responseChannel.read()).isNull()
     assertThat(grpcCall.responseMetadata!!["response-lucky-animal"]).isEqualTo("horse")
+
+    mockService.awaitSuccessBlocking()
   }
 
   @Test


### PR DESCRIPTION
* Validates the assertions on request shape.
* Question: Should we add a beforeEach rule for this?