### PR TITLE
Reject unused prunes and roots by default

### DIFF
--- a/docs/wire_compiler.md
+++ b/docs/wire_compiler.md
@@ -310,12 +310,12 @@ wire {
 }
 ```
 
-By default this feature is lenient given unknown `root` and `prune` arguments. You may prefer for
-this to be strict instead:
+By default this feature is strict given unknown `root` and `prune` arguments. You may prefer for
+this to be lenient instead:
 
 ```groovy
 wire {
-  rejectUnusedRootsOrPrunes = true
+  rejectUnusedRootsOrPrunes = false
   ...
 }
 ```

--- a/samples/multi-target/build.gradle.kts
+++ b/samples/multi-target/build.gradle.kts
@@ -9,7 +9,6 @@ repositories {
 
 wire {
   root("human.Person")
-  rejectUnusedRootsOrPrunes = true
 
   kotlin {
     javaInterop = true

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -346,6 +346,7 @@ class WireRunTest {
         ),
       ),
       eventListeners = listeners,
+      rejectUnusedRootsOrPrunes = false,
     )
     wireRun.execute(fs, logger)
 

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -591,7 +591,6 @@ class WireRunTest {
         "squareup.colors.Color#name",
       ),
       targets = listOf(KotlinTarget(outDirectory = "generated/kt")),
-      rejectUnusedRootsOrPrunes = true,
     )
     try {
       wireRun.execute(fs, logger)
@@ -617,7 +616,6 @@ class WireRunTest {
       treeShakingRoots = listOf("squareup.colors.Blue"),
       treeShakingRubbish = listOf("squareup.colors.Purple", "squareup.colors.Color#name"),
       targets = listOf(KotlinTarget(outDirectory = "generated/kt")),
-      rejectUnusedRootsOrPrunes = true,
     )
     try {
       wireRun.execute(fs, logger)
@@ -643,7 +641,6 @@ class WireRunTest {
       treeShakingRoots = listOf("squareup.colors.Blue", "squareup.colors.Green"),
       treeShakingRubbish = listOf("squareup.colors.Purple", "squareup.colors.Color#name"),
       targets = listOf(KotlinTarget(outDirectory = "generated/kt")),
-      rejectUnusedRootsOrPrunes = true,
     )
     try {
       wireRun.execute(fs, logger)
@@ -657,6 +654,27 @@ class WireRunTest {
           "  squareup.colors.Color#name",
       )
     }
+  }
+
+  /** Confirm we can disable the `rejectUnusedRootsOrPrunes` check. */
+  @Test
+  fun permitUnusedRootsOrPrunes() {
+    writeBlueProto()
+    writeRedProto()
+    writeTriangleProto()
+
+    val wireRun = WireRun(
+      sourcePath = listOf(Location.get("colors/src/main/proto")),
+      protoPath = listOf(Location.get("polygons/src/main/proto")),
+      treeShakingRoots = listOf("squareup.colors.Blue", "squareup.colors.Green"),
+      treeShakingRubbish = listOf("squareup.colors.Purple", "squareup.colors.Color#name"),
+      targets = listOf(KotlinTarget(outDirectory = "generated/kt")),
+      rejectUnusedRootsOrPrunes = false
+    )
+    wireRun.execute(fs, logger)
+    assertThat(fs.findFiles("generated")).containsExactlyInAnyOrderAsRelativePaths(
+      "generated/kt/squareup/colors/Blue.kt",
+    )
   }
 
   @Test

--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -669,7 +669,7 @@ class WireRunTest {
       treeShakingRoots = listOf("squareup.colors.Blue", "squareup.colors.Green"),
       treeShakingRubbish = listOf("squareup.colors.Purple", "squareup.colors.Color#name"),
       targets = listOf(KotlinTarget(outDirectory = "generated/kt")),
-      rejectUnusedRootsOrPrunes = false
+      rejectUnusedRootsOrPrunes = false,
     )
     wireRun.execute(fs, logger)
     assertThat(fs.findFiles("generated")).containsExactlyInAnyOrderAsRelativePaths(

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
@@ -143,7 +143,7 @@ open class WireExtension(
    */
   @get:Input
   @get:Optional
-  var rejectUnusedRootsOrPrunes = false
+  var rejectUnusedRootsOrPrunes = true
 
   /**
    * True to not write generated types to disk, but emit the names of the source files that would

--- a/wire-gradle-plugin/src/test/projects/reject-unused/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/reject-unused/build.gradle
@@ -10,7 +10,5 @@ wire {
   root 'squareup.dinosaurs.Crustacean'
   prune 'squareup.mammals.Human'
 
-  rejectUnusedRootsOrPrunes = true
-
   kotlin {}
 }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/WireRun.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/WireRun.kt
@@ -198,7 +198,7 @@ class WireRun(
    *
    * If false, unused [treeShakingRoots] and [treeShakingRubbish] will be printed as warnings.
    */
-  val rejectUnusedRootsOrPrunes: Boolean = false,
+  val rejectUnusedRootsOrPrunes: Boolean = true,
 
   /**
    * All qualified named Protobuf types in [opaqueTypes] will be evaluated as being of type `bytes`.


### PR DESCRIPTION
This flips the default from lenient to strict. The option to manually configure this is now necessary for anyone who wants the lenient behavior.