### PR TITLE
Resolve configurations more lazily

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireExtension.kt
@@ -288,13 +288,17 @@ open class WireExtension(
     internal val project: Project,
     name: String,
   ) {
-    private val configuration = project.configurations.create(name)
+    /** Calling this doesn't resolve the configuration. */
+    internal var isEmpty = true
+
+    internal val configuration = project.configurations.create(name)
       .apply {
         isCanBeConsumed = false
         isTransitive = false
       }
-    private val sourceDirectoriesAndLocalJars = mutableListOf<File>()
+    internal val sourceDirectoriesAndLocalJars = mutableListOf<File>()
 
+    /** Calling this will resolve the configuration. */
     internal val roots: Set<File>
       get() = configuration.files + sourceDirectoriesAndLocalJars
 
@@ -302,10 +306,12 @@ open class WireExtension(
     internal val excludes = mutableListOf<String>()
 
     fun srcDir(dir: String) {
+      isEmpty = false
       sourceDirectoriesAndLocalJars += project.file(dir)
     }
 
     fun srcDirs(vararg dirs: String) {
+      isEmpty = false
       sourceDirectoriesAndLocalJars += dirs.map { project.file(it) }
     }
 
@@ -314,6 +320,7 @@ open class WireExtension(
     }
 
     private fun srcFileOrConfiguration(jar: String) {
+      isEmpty = false
       val parser = FileOrUriNotationConverter.parser()
       val converted = parser.parseNotation(jar)
       when (converted) {
@@ -339,6 +346,7 @@ open class WireExtension(
     }
 
     private fun addDependency(dependencyNotation: Any) {
+      isEmpty = false
       project.dependencies.add(configuration.name, dependencyNotation)
       project.dependencies.add("protoProjectDependenciesJvm", dependencyNotation)
     }

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
@@ -22,7 +22,7 @@ import java.io.File
 import java.io.RandomAccessFile
 import org.gradle.api.internal.file.FileOperations
 
-internal val List<ProtoRootSet>.inputLocations
+internal val List<ProtoRootSet>.inputLocations: List<InputLocation>
   get() = flatMap { rootSet ->
     rootSet.roots.map { file ->
       rootSet.inputLocation(file)

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -17,6 +17,7 @@
 
 package com.squareup.wire.gradle
 
+import java.lang.reflect.Array as JavaArray
 import com.squareup.wire.VERSION
 import com.squareup.wire.gradle.internal.libraryProtoOutputPath
 import com.squareup.wire.gradle.internal.targetDefaultOutputPath
@@ -26,7 +27,6 @@ import com.squareup.wire.schema.ProtoTarget
 import com.squareup.wire.schema.Target
 import com.squareup.wire.schema.newEventListenerFactory
 import java.io.File
-import java.lang.reflect.Array as JavaArray
 import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Plugin
 import org.gradle.api.Project
@@ -140,7 +140,7 @@ class WirePlugin : Plugin<Project> {
 
       // TODO(Benoit) Should we add our default source folders everytime? Right now, someone could
       //  not combine a custom protoSource with our default using variants.
-      if (protoSourceProtoRootSets.all { it.roots.isEmpty() }) {
+      if (protoSourceProtoRootSets.all { it.isEmpty }) {
         val sourceSetProtoRootSet = WireExtension.ProtoRootSet(
           project = project,
           name = "${source.name}ProtoSource",
@@ -207,16 +207,14 @@ class WirePlugin : Plugin<Project> {
         task.description = "Generate protobuf implementation for ${source.name}"
 
         // Flatten all the input files here. Changes to any of them will cause the task to re-run.
-        task.source(
-          buildList {
-            for (rootSet in protoSourceProtoRootSets) {
-              addAll(rootSet.roots)
-            }
-            for (rootSet in protoPathProtoRootSets) {
-              addAll(rootSet.roots)
-            }
-          },
-        )
+        for (rootSet in protoSourceProtoRootSets) {
+          task.source(rootSet.configuration)
+          task.source(*rootSet.sourceDirectoriesAndLocalJars.toTypedArray())
+        }
+        for (rootSet in protoPathProtoRootSets) {
+          task.source(rootSet.configuration)
+          task.source(*rootSet.sourceDirectoriesAndLocalJars.toTypedArray())
+        }
 
         val outputDirectories: List<String> = buildList {
           addAll(
@@ -235,8 +233,8 @@ class WirePlugin : Plugin<Project> {
         if (extension.protoLibrary) {
           task.protoLibraryOutput.set(File(project.libraryProtoOutputPath()))
         }
-        task.sourceInput.set(protoSourceProtoRootSets.inputLocations)
-        task.protoInput.set(protoPathProtoRootSets.inputLocations)
+        task.sourceInput.set(project.provider { protoSourceProtoRootSets.inputLocations })
+        task.protoInput.set(project.provider { protoPathProtoRootSets.inputLocations })
         task.roots.set(extension.roots.toList())
         task.prunes.set(extension.prunes.toList())
         task.moves.set(extension.moves.toList())

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -17,7 +17,6 @@
 
 package com.squareup.wire.gradle
 
-import java.lang.reflect.Array as JavaArray
 import com.squareup.wire.VERSION
 import com.squareup.wire.gradle.internal.libraryProtoOutputPath
 import com.squareup.wire.gradle.internal.targetDefaultOutputPath
@@ -27,6 +26,7 @@ import com.squareup.wire.schema.ProtoTarget
 import com.squareup.wire.schema.Target
 import com.squareup.wire.schema.newEventListenerFactory
 import java.io.File
+import java.lang.reflect.Array as JavaArray
 import java.util.concurrent.atomic.AtomicBoolean
 import org.gradle.api.Plugin
 import org.gradle.api.Project


### PR DESCRIPTION
We're still resolving it when the input locations properties are required. I'd prefer to not resolve until the task runs, but that's a bit more difficult.