### PR TITLE
Add use-site target field to custom options annotation spec

### DIFF
--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1190,7 +1190,10 @@ class KotlinGenerator private constructor(
           )
         }
         for (annotation in optionAnnotations(field.options)) {
+          // Adds default use-site target for kotlin properties.
           addAnnotation(annotation)
+          // Adds use-site target for java fields.
+          addAnnotation(annotation.toBuilder().useSiteTarget(FIELD).build())
         }
         addAnnotation(wireFieldAnnotation(message, field, schemaIndex))
         if (javaInterOp) {

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -41,6 +41,7 @@ import okio.ByteString
 
 public class FooBar(
   @MyFieldOptionOneOption(17)
+  @field:MyFieldOptionOneOption(17)
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
@@ -48,6 +49,7 @@ public class FooBar(
   )
   public val foo: Int? = null,
   @MyFieldOptionTwoOption(33.5f)
+  @field:MyFieldOptionTwoOption(33.5f)
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
@@ -55,6 +57,7 @@ public class FooBar(
   )
   public val bar: String? = null,
   @MyFieldOptionThreeOption(FooBarBazEnum.BAR)
+  @field:MyFieldOptionThreeOption(FooBarBazEnum.BAR)
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}Nested#ADAPTER",
@@ -62,15 +65,28 @@ public class FooBar(
   )
   public val baz: Nested? = null,
   @MyFieldOptionOneOption(18)
+  @field:MyFieldOptionOneOption(18)
   @MyFieldOptionTwoOption(34.5f)
+  @field:MyFieldOptionTwoOption(34.5f)
   @MyFieldOptionFiveOption([
+    3
+  ])
+  @field:MyFieldOptionFiveOption([
     3
   ])
   @MyFieldOptionSixOption([
     "a",
     "b"
   ])
+  @field:MyFieldOptionSixOption([
+    "a",
+    "b"
+  ])
   @MyFieldOptionSevenOption([
+    ForeignEnum.BAV,
+    ForeignEnum.BAX
+  ])
+  @field:MyFieldOptionSevenOption([
     ForeignEnum.BAV,
     ForeignEnum.BAX
   ])
@@ -110,6 +126,7 @@ public class FooBar(
   unknownFields: ByteString = ByteString.EMPTY,
 ) : Message<FooBar, Nothing>(ADAPTER, unknownFields) {
   @MyFieldOptionTwoOption(99.9f)
+  @field:MyFieldOptionTwoOption(99.9f)
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/com/squareup/wire/protos/custom_options/FooBar.kt
@@ -40,6 +40,7 @@ import okio.ByteString
 
 public class FooBar(
   @MyFieldOptionOneOption(17)
+  @field:MyFieldOptionOneOption(17)
   @field:WireField(
     tag = 1,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
@@ -48,6 +49,7 @@ public class FooBar(
   @JvmField
   public val foo: Int? = null,
   @MyFieldOptionTwoOption(33.5f)
+  @field:MyFieldOptionTwoOption(33.5f)
   @field:WireField(
     tag = 2,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
@@ -56,6 +58,7 @@ public class FooBar(
   @JvmField
   public val bar: String? = null,
   @MyFieldOptionThreeOption(FooBarBazEnum.BAR)
+  @field:MyFieldOptionThreeOption(FooBarBazEnum.BAR)
   @field:WireField(
     tag = 3,
     adapter = "com.squareup.wire.protos.custom_options.FooBar${'$'}Nested#ADAPTER",
@@ -64,15 +67,28 @@ public class FooBar(
   @JvmField
   public val baz: Nested? = null,
   @MyFieldOptionOneOption(18)
+  @field:MyFieldOptionOneOption(18)
   @MyFieldOptionTwoOption(34.5f)
+  @field:MyFieldOptionTwoOption(34.5f)
   @MyFieldOptionFiveOption([
+    3
+  ])
+  @field:MyFieldOptionFiveOption([
     3
   ])
   @MyFieldOptionSixOption([
     "a",
     "b"
   ])
+  @field:MyFieldOptionSixOption([
+    "a",
+    "b"
+  ])
   @MyFieldOptionSevenOption([
+    ForeignEnum.BAV,
+    ForeignEnum.BAX
+  ])
+  @field:MyFieldOptionSevenOption([
     ForeignEnum.BAV,
     ForeignEnum.BAX
   ])
@@ -116,6 +132,7 @@ public class FooBar(
   unknownFields: ByteString = ByteString.EMPTY,
 ) : Message<FooBar, FooBar.Builder>(ADAPTER, unknownFields) {
   @MyFieldOptionTwoOption(99.9f)
+  @field:MyFieldOptionTwoOption(99.9f)
   @field:WireField(
     tag = 5,
     adapter = "com.squareup.wire.ProtoAdapter#FLOAT",


### PR DESCRIPTION
## Description
This change adds a use-site target for fields in the kotlin generated classes. This enables the annotations targeted for a field to be available through the java field via reflection.