### PR TITLE
[swift] Add minor doc/comment in ProtoMessage for unknown fields

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoMessage.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoMessage.swift
@@ -15,6 +15,7 @@
  */
 import Foundation
 
+/// This Data value should be a valid proto data blob with the tagged field number.
 public typealias UnknownFields = [UInt32: Data]
 
 /// Interface that every Protobuf `message` conforms to.


### PR DESCRIPTION
Extracted change from https://github.com/square/wire/pull/2793