### PR TITLE
[swift] Remove ProtoCodable conformance from ProtoEnum

### DIFF
--- a/wire-runtime-swift/src/main/swift/Codable/ProtoEnum.swift
+++ b/wire-runtime-swift/src/main/swift/Codable/ProtoEnum.swift
@@ -18,7 +18,19 @@ import Foundation
 /// Common protocol that all Wire generated enums conform to
 /// - Note: All ProtoEnums will convert to/from their field and string equivalent when serializing via Codable.
 /// This matches the Proto3 JSON spec: https://developers.google.com/protocol-buffers/docs/proto3#json
-public protocol ProtoEnum : LosslessStringConvertible, Codable, ProtoCodable {
+public protocol ProtoEnum : LosslessStringConvertible, Codable {
+    static var protoSyntax: ProtoSyntax? { get }
+}
+
+public protocol Proto2Enum: ProtoEnum {}
+public protocol Proto3Enum: ProtoEnum {}
+
+extension Proto2Enum {
+    public static var protoSyntax: ProtoSyntax? { .proto2 }
+}
+
+extension Proto3Enum {
+    public static var protoSyntax: ProtoSyntax? { .proto3 }
 }
 
 extension ProtoEnum where Self : CaseIterable {
@@ -33,15 +45,6 @@ extension ProtoEnum where Self : CaseIterable {
 extension ProtoEnum where Self : RawRepresentable, RawValue == Int32 {
     public static var protoFieldWireType: FieldWireType {
         .varint
-    }
-
-    public init(from reader: ProtoReader) throws {
-        self = try reader.decode(Self.self)
-    }
-
-    public func encode(to writer: ProtoWriter) throws {
-        let uintValue = UInt32(bitPattern: rawValue)
-        writer.writeVarint(uintValue)
     }
 }
 

--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
@@ -304,7 +304,6 @@ public final class ProtoReader {
     }
 
     /** Decode a message field */
-    @_disfavoredOverload
     public func decode<T: ProtoDecodable>(_ type: T.Type) throws -> T {
         isProto3Message = T.self.protoSyntax == .proto3
         return try T(from: self)
@@ -490,7 +489,6 @@ public final class ProtoReader {
     }
 
     /** Decode a repeated message field. */
-    @_disfavoredOverload
     public func decode<T: ProtoDecodable>(into array: inout [T]) throws {
         // These types do not support packing, so no need to test for it.
         isProto3Message = T.self is Proto3Codable.Type
@@ -502,7 +500,6 @@ public final class ProtoReader {
     /**
      Decode a single key-value pair from a map of values keyed by a `string`.
      */
-    @_disfavoredOverload
     public func decode<V: ProtoDecodable>(into dictionary: inout [String: V]) throws {
         try decode(
             into: &dictionary,
@@ -528,7 +525,6 @@ public final class ProtoReader {
     /**
      Decode a single key-value pair from a map of values keyed by an integer type
      */
-    @_disfavoredOverload
     public func decode<K: ProtoIntDecodable, V: ProtoDecodable>(
         into dictionary: inout [K: V], keyEncoding: ProtoIntEncoding = .variable
     ) throws {

--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoWriter.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoWriter.swift
@@ -228,7 +228,6 @@ public final class ProtoWriter {
      Encode a field which has a single encoding mechanism (unlike integers).
      This includes most fields types, such as messages, strings, bytes, and floating point numbers.
      */
-    @_disfavoredOverload
     public func encode(tag: UInt32, value: ProtoEncodable?) throws {
         guard let value = value else { return }
 
@@ -461,7 +460,6 @@ public final class ProtoWriter {
     }
 
     /** Encode a repeated field which has a single encoding mechanism, like messages, strings, and bytes. */
-    @_disfavoredOverload
     public func encode<T: ProtoEncodable>(tag: UInt32, value: [T]) throws {
         guard !value.isEmpty else { return }
 
@@ -479,7 +477,6 @@ public final class ProtoWriter {
 
     // MARK: - Public Methods - Encoding - Maps
 
-    @_disfavoredOverload
     public func encode<V: ProtoEncodable>(tag: UInt32, value: [String: V]) throws {
         guard !value.isEmpty else { return }
 
@@ -498,7 +495,6 @@ public final class ProtoWriter {
         }
     }
 
-    @_disfavoredOverload
     public func encode<K: ProtoIntEncodable, V: ProtoEncodable>(
         tag: UInt32,
         value: [K: V],
@@ -512,11 +508,11 @@ public final class ProtoWriter {
         }
     }
 
-    public func encode<K: ProtoIntEncodable, V: RawRepresentable>(
+    public func encode<K: ProtoIntEncodable, V: ProtoEnum>(
         tag: UInt32,
         value: [K: V],
         keyEncoding: ProtoIntEncoding = .variable
-    ) throws where V.RawValue == Int32 {
+    ) throws where V: RawRepresentable<Int32> {
         guard !value.isEmpty else { return }
 
         try encode(tag: tag, value: value) { key, item in

--- a/wire-runtime-swift/src/test/swift/ProtoEnumCodableTests.swift
+++ b/wire-runtime-swift/src/test/swift/ProtoEnumCodableTests.swift
@@ -18,7 +18,7 @@ import XCTest
 @testable import Wire
 
 final class ProtoEnumCodableTests: XCTestCase {
-    enum EnumType : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    enum EnumType : Int32, CaseIterable, ProtoEnum, Proto2Enum {
         case DO_NOT_USE = 0
         case ONE = 1
         case TWO = 2

--- a/wire-runtime-swift/src/test/swift/sample/Period.swift
+++ b/wire-runtime-swift/src/test/swift/sample/Period.swift
@@ -2,7 +2,7 @@
 // Source: squareup.geology.Period in squareup/geology/period.proto
 import Wire
 
-public enum Period : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum Period : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     /**
      * 145.5 million years ago — 66.0 million years ago.

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -76,6 +76,8 @@ class SwiftGenerator private constructor(
 ) {
   private val proto2Codable = DeclaredTypeName.typeName("Wire.Proto2Codable")
   private val proto3Codable = DeclaredTypeName.typeName("Wire.Proto3Codable")
+  private val proto2Enum = DeclaredTypeName.typeName("Wire.Proto2Enum")
+  private val proto3Enum = DeclaredTypeName.typeName("Wire.Proto3Enum")
   private val protoMessage = DeclaredTypeName.typeName("Wire.ProtoMessage")
   private val protoReader = DeclaredTypeName.typeName("Wire.ProtoReader")
   private val protoWriter = DeclaredTypeName.typeName("Wire.ProtoWriter")
@@ -791,8 +793,8 @@ class SwiftGenerator private constructor(
 
   private val EnumType.protoCodableType: DeclaredTypeName
     get() = when (syntax) {
-      PROTO_2 -> proto2Codable
-      PROTO_3 -> proto3Codable
+      PROTO_2 -> proto2Enum
+      PROTO_3 -> proto3Enum
     }
 
   private fun heapCodableExtension(

--- a/wire-tests-swift/manifest/module_one/SortOrder.swift
+++ b/wire-tests-swift/manifest/module_one/SortOrder.swift
@@ -5,7 +5,7 @@ import Wire
 /**
  * Collides with Foundation.SortOrder
  */
-public enum SortOrder : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum SortOrder : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     case DESC = 0
     case ASC = 1

--- a/wire-tests-swift/manifest/module_one/SwiftModuleOneEnum.swift
+++ b/wire-tests-swift/manifest/module_one/SwiftModuleOneEnum.swift
@@ -2,7 +2,7 @@
 // Source: squareup.protos.kotlin.swift_modules.SwiftModuleOneEnum in swift_module_one.proto
 import Wire
 
-public enum SwiftModuleOneEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum SwiftModuleOneEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     case DO_NOT_USE = 0
     case ONE = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
@@ -1284,7 +1284,7 @@ extension AllTypes : Codable {
  */
 extension AllTypes {
 
-    public enum NestedEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    public enum NestedEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
         case UNKNOWN = 0
         case A = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/DeprecatedEnum.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/DeprecatedEnum.swift
@@ -2,7 +2,7 @@
 // Source: squareup.protos.kotlin.DeprecatedEnum in deprecated_enum.proto
 import Wire
 
-public enum DeprecatedEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum DeprecatedEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     @available(*, deprecated)
     case DISABLED = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/EnumVersionOne.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/EnumVersionOne.swift
@@ -2,7 +2,7 @@
 // Source: squareup.protos.kotlin.unknownfields.EnumVersionOne in unknown_fields.proto
 import Wire
 
-public enum EnumVersionOne : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum EnumVersionOne : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     case SHREK_V1 = 1
     case DONKEY_V1 = 2

--- a/wire-tests-swift/no-manifest/src/main/swift/EnumVersionTwo.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/EnumVersionTwo.swift
@@ -2,7 +2,7 @@
 // Source: squareup.protos.kotlin.unknownfields.EnumVersionTwo in unknown_fields.proto
 import Wire
 
-public enum EnumVersionTwo : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum EnumVersionTwo : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     case SHREK_V2 = 1
     case DONKEY_V2 = 2

--- a/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
@@ -201,7 +201,7 @@ extension FooBar {
 
     }
 
-    public enum FooBarBazEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    public enum FooBarBazEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
         case FOO = 1
         case BAR = 2

--- a/wire-tests-swift/no-manifest/src/main/swift/ForeignEnum.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ForeignEnum.swift
@@ -2,7 +2,7 @@
 // Source: squareup.protos.kotlin.foreign.ForeignEnum in foreign.proto
 import Wire
 
-public enum ForeignEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum ForeignEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     case BAV = 0
     case BAX = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/MappyTwo.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MappyTwo.swift
@@ -118,7 +118,7 @@ extension MappyTwo : Codable {
  */
 extension MappyTwo {
 
-    public enum ValueEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    public enum ValueEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
         case DEFAULT = 0
         case FOO = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/MessageWithStatus.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MessageWithStatus.swift
@@ -72,7 +72,7 @@ extension MessageWithStatus : Codable {
  */
 extension MessageWithStatus {
 
-    public enum Status : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    public enum Status : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
         case A = 1
 

--- a/wire-tests-swift/no-manifest/src/main/swift/NegativeValueEnum.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/NegativeValueEnum.swift
@@ -2,7 +2,7 @@
 // Source: squareup.protos.kotlin.NegativeValueEnum in negative_value_enum.proto
 import Wire
 
-public enum NegativeValueEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+public enum NegativeValueEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
     case DO_NOT_USE = -1
 

--- a/wire-tests-swift/no-manifest/src/main/swift/OptionalEnumUser.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OptionalEnumUser.swift
@@ -88,7 +88,7 @@ extension OptionalEnumUser : Codable {
  */
 extension OptionalEnumUser {
 
-    public enum OptionalEnum : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    public enum OptionalEnum : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
         case FOO = 1
         case BAR = 2

--- a/wire-tests-swift/no-manifest/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OtherMessageWithStatus.swift
@@ -72,7 +72,7 @@ extension OtherMessageWithStatus : Codable {
  */
 extension OtherMessageWithStatus {
 
-    public enum Status : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    public enum Status : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
         case A = 1
 

--- a/wire-tests-swift/no-manifest/src/main/swift/Person.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Person.swift
@@ -142,7 +142,7 @@ extension Person {
     /**
      * Represents the type of the phone number: mobile, home or work.
      */
-    public enum PhoneType : Int32, CaseIterable, ProtoEnum, Proto2Codable {
+    public enum PhoneType : Int32, CaseIterable, ProtoEnum, Proto2Enum {
 
         case MOBILE = 0
         case HOME = 1


### PR DESCRIPTION
Extracted change from https://github.com/square/wire/pull/2793