### PR TITLE
[swift] Add ProtoExtensible tests

### DIFF
--- a/wire-runtime-swift/src/test/proto/extensible.proto
+++ b/wire-runtime-swift/src/test/proto/extensible.proto
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+
+import "person.proto";
+
+message Extensible {
+    optional string name = 1;
+    
+    extensions 1000 to 3000;
+}
+
+extend Extensible {
+    optional string ext_string = 1000;
+
+    optional int32 int32 = 1001;
+    optional uint32 uint32 = 1002;
+    optional sint32 sint32 = 1003;
+    optional fixed32 fixed32 = 1004;
+    optional sfixed32 sfixed32 = 1005;
+    optional int64 int64 = 1006;
+    optional uint64 uint64 = 1007;
+    optional sint64 sint64 = 1008;
+    optional fixed64 fixed64 = 1009;
+    optional sfixed64 sfixed64 = 1010;
+    optional bool bool = 1011;
+    optional float float = 1012;
+    optional double double = 1013;
+    optional string string = 1014;
+    optional bytes bytes = 1015;
+
+    optional squareup.protos.person.Person person = 2000;
+    optional squareup.protos.person.Person.PhoneType phone_type = 2001;
+}

--- a/wire-runtime-swift/src/test/swift/ExtensibleTests.swift
+++ b/wire-runtime-swift/src/test/swift/ExtensibleTests.swift
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import Foundation
+import Wire
+import XCTest
+
+final class ExtensibleTests: XCTestCase {
+    func testExtensionEncodeDecode() {
+        let message = Extensible {
+            $0.name = "real field"
+            $0.string = "extension string field"
+            $0.int32 = -4
+            $0.uint32 = 42
+            $0.person = Person(name: "Someone", id: 1, data: Data(json_data: ""))
+            $0.phone_type = .MOBILE
+        }
+        let encoder = ProtoEncoder()
+        let data = try! encoder.encode(message)
+
+        let decoder = ProtoDecoder()
+        let decodedMessage = try! decoder.decode(Extensible.self, from: data)
+        XCTAssertEqual(message, decodedMessage)
+        XCTAssertEqual(message.name, "real field")
+        XCTAssertEqual(message.string, "extension string field")
+        XCTAssertEqual(message.person?.name, "Someone")
+        XCTAssertEqual(message.person?.id, 1)
+        XCTAssertEqual(message.int32, -4)
+        XCTAssertEqual(message.uint32, 42)
+        XCTAssertEqual(message.phone_type, .MOBILE)
+    }
+}


### PR DESCRIPTION
Extracted change from https://github.com/square/wire/pull/2793