### PR TITLE
[swift] deprecate extension fields with new API

### DIFF
--- a/wire-runtime-swift/src/test/proto/extensible.proto
+++ b/wire-runtime-swift/src/test/proto/extensible.proto
@@ -39,6 +39,7 @@ extend Extensible {
   optional double ext_double = 1013;
   optional string ext_string = 1014;
   optional bytes ext_bytes = 1015;
+  optional string ext_string_deprecated = 1016 [deprecated = true];
 
   optional squareup.protos.person.Person ext_person = 2000;
   optional squareup.protos.person.Person.PhoneType ext_phone_type = 2001;

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -1201,8 +1201,11 @@ class SwiftGenerator private constructor(
                   addDoc("\n%L\n", field.documentation.sanitizeDoc())
                 }
                 addDoc("\nSource: %L\n", field.location.withPathOnly())
-              }
-              .apply {
+
+                if (field.isDeprecated) {
+                  addAttribute(deprecated)
+                }
+
                 val getterFunctionSpec = FunctionSpec.getterBuilder()
                 var parseMethod = "self.parseUnknownField(fieldNumber: %L"
                 val args = mutableListOf<Any>(field.tag)


### PR DESCRIPTION
tiny regression from https://github.com/square/wire/pull/2793