### PR TITLE
Fix UTF-32 BOM

### DIFF
--- a/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/internal/fileSystems.kt
+++ b/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/internal/fileSystems.kt
@@ -23,8 +23,8 @@ private val UNICODE_BOMS = okio.Options.of(
   "efbbbf".decodeHex(), // UTF-8
   "feff".decodeHex(), // UTF-16BE
   "fffe".decodeHex(), // UTF-16LE
-  "0000ffff".decodeHex(), // UTF-32BE
-  "ffff0000".decodeHex(), // UTF-32LE
+  "0000feff".decodeHex(), // UTF-32BE
+  "fffe0000".decodeHex(), // UTF-32LE
 )
 
 internal fun BufferedSource.readBomAsCharset(default: Charset = Charsets.UTF_8): Charset {

--- a/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/internal/fileSystems.kt
+++ b/wire-schema/src/jvmMain/kotlin/com/squareup/wire/schema/internal/fileSystems.kt
@@ -25,7 +25,7 @@ private val UNICODE_BOMS = okio.Options.of(
   "fffe".decodeHex(), // UTF-16LE
   "0000feff".decodeHex(), // UTF-32BE
   "fffe0000".decodeHex(), // UTF-32LE
-)
+).sortedByDescending { it.size }
 
 internal fun BufferedSource.readBomAsCharset(default: Charset = Charsets.UTF_8): Charset {
   return when (select(UNICODE_BOMS)) {

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaLoaderTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/SchemaLoaderTest.kt
@@ -313,7 +313,7 @@ class SchemaLoaderTest {
         |}
       """.trimMargin(),
       charset = UTF_32BE,
-      bom = "0000ffff".decodeHex(),
+      bom = "0000feff".decodeHex(),
     )
     fs.add(
       "colors/squareup/colors/blue.proto",
@@ -324,7 +324,7 @@ class SchemaLoaderTest {
         |}
       """.trimMargin(),
       charset = UTF_32LE,
-      bom = "ffff0000".decodeHex(),
+      bom = "fffe0000".decodeHex(),
     )
 
     val loader = CommonSchemaLoader(fs)


### PR DESCRIPTION
The UTF-32 BOM is `0000feff`, not `0000ffff`

https://en.wikipedia.org/wiki/Byte_order_mark#Byte-order_marks_by_encoding

Noticed by @JakeWharton [in kotlinlang Slack](https://slack-chats.kotlinlang.org/t/18797847/demo-kt-cpp#30b8a4c1-d483-4cbd-a0bd-4143efe5b1a1)

See also: https://github.com/square/okhttp/pull/8403