### PR TITLE
Add failing test

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -190,17 +190,6 @@ class WirePlugin : Plugin<Project> {
           }
       }
 
-      // TODO: pair up generatedSourceDirectories with their targets so we can be precise.
-      for (generatedSourcesDirectory in generatedSourcesDirectories) {
-        val relativePath = generatedSourcesDirectory.toRelativeString(project.projectDir)
-        if (hasJavaOutput) {
-          source.javaSourceDirectorySet?.srcDir(relativePath)
-        }
-        if (hasKotlinOutput) {
-          source.kotlinSourceDirectorySet?.srcDir(relativePath)
-        }
-      }
-
       val taskName = "generate${source.name.capitalize()}Protos"
       val task = project.tasks.register(taskName, WireTask::class.java) { task: WireTask ->
         task.group = GROUP

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -82,7 +82,7 @@ internal fun WirePlugin.sourceRoots(kotlin: Boolean, java: Boolean): List<Source
     Source(
       type = KotlinPlatformType.jvm,
       kotlinSourceDirectorySet = sourceDirectorySet,
-      javaSourceDirectorySet = sourceDirectorySet,
+      javaSourceDirectorySet = null,
       name = "main",
       sourceSets = listOf("main"),
     ),

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1563,7 +1563,6 @@ class WirePluginTest {
     }
   }
 
-
   private fun GradleRunner.runFixture(
     root: File,
     action: GradleRunner.() -> BuildResult,

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1550,6 +1550,20 @@ class WirePluginTest {
     assertThat(result.task(":generateMainProtos")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
   }
 
+  @Test
+  fun kotlinSourcesJarHasSingleCopyOnly() {
+    val fixtureRoot = File("src/test/projects/kotlinsourcesjar")
+
+    val result = gradleRunner.runFixture(fixtureRoot) {
+      withArguments("clean", "kotlinSourcesJar", "--stacktrace", "--info").build()
+    }
+
+    ZipFile(File(fixtureRoot, "build/libs/kotlinsourcesjar-sources.jar")).use {
+      assertThat(it.stream().filter { it.name.contains("Period.kt") }.count()).isEqualTo(1)
+    }
+  }
+
+
   private fun GradleRunner.runFixture(
     root: File,
     action: GradleRunner.() -> BuildResult,

--- a/wire-gradle-plugin/src/test/projects/kotlinsourcesjar/build.gradle.kts
+++ b/wire-gradle-plugin/src/test/projects/kotlinsourcesjar/build.gradle.kts
@@ -1,0 +1,9 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm") version "1.9.22"
+  id("com.squareup.wire")
+}
+
+wire {
+  kotlin {
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/kotlinsourcesjar/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlinsourcesjar/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
This test demonstrates https://github.com/square/wire/issues/2950, that running `gradle kotlinSourcesJar` on a trivial wire project generates a sources jar with 3 copies of each wire-generated file.