### PR TITLE
Trim leading dots when parsing message/enum/service

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
@@ -212,7 +212,7 @@ class ProtoParser internal constructor(
 
     return MessageElement(
       location = location,
-      name = name,
+      name = name.trimStart('.'),
       documentation = documentation,
       nestedTypes = nestedTypes,
       options = options,
@@ -269,7 +269,7 @@ class ProtoParser internal constructor(
 
     return ServiceElement(
       location = location,
-      name = name,
+      name = name.trimStart('.'),
       documentation = documentation,
       rpcs = rpcs,
       options = options,
@@ -299,7 +299,7 @@ class ProtoParser internal constructor(
       }
     }
 
-    return EnumElement(location, name, documentation, options, constants, reserveds)
+    return EnumElement(location, name.trimStart('.'), documentation, options, constants, reserveds)
   }
 
   private fun readField(documentation: String, location: Location, word: String): Any {

--- a/wire-schema/src/commonTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
+++ b/wire-schema/src/commonTest/kotlin/com/squareup/wire/schema/internal/parser/ProtoParserTest.kt
@@ -322,6 +322,19 @@ class ProtoParserTest {
   }
 
   @Test
+  fun leadingDotsAreNormalized() {
+    val proto = """
+        |message ..package.Message {}
+        |enum .package.Enum {}
+        |service .package.Service {}
+    """.trimMargin()
+    val parsed = ProtoParser.parse(location, proto)
+    assertThat(parsed.types[0].name).isEqualTo("package.Message")
+    assertThat(parsed.types[1].name).isEqualTo("package.Enum")
+    assertThat(parsed.services[0].name).isEqualTo("package.Service")
+  }
+
+  @Test
   fun multipleSingleLineComments() {
     val proto = """
         |// Test all


### PR DESCRIPTION
Related to https://github.com/square/wire/issues/2927

Not so happy with the... ad-hoc-ness of it all to be honest.