### PR TITLE
Encoding and JSON support for single unknown enum fields

### DIFF
--- a/wire-golden-files/src/main/kotlin/squareup/wire/unrecognized_constant/Easter.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/unrecognized_constant/Easter.kt
@@ -148,16 +148,24 @@ public class Easter private constructor(
       override fun encodedSize(`value`: Easter): Int {
         var size = value.unknownFields.size
         size += EasterAnimal.ADAPTER.encodedSizeWithTag(2, value.optional_easter_animal)
-        if (value.identity_easter_animal != EasterAnimal.EASTER_ANIMAL_DEFAULT) size +=
-            EasterAnimal.ADAPTER.encodedSizeWithTag(3, value.identity_easter_animal)
+        if (value.identity_easter_animal !=
+            squareup.wire.unrecognized_constant.EasterAnimal.EASTER_ANIMAL_DEFAULT) {
+          size += EasterAnimal.ADAPTER.encodedSizeWithTag(3, value.identity_easter_animal)
+        }
         size += EasterAnimal.ADAPTER.asRepeated().encodedSizeWithTag(4, value.easter_animals)
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: Easter) {
-        EasterAnimal.ADAPTER.encodeWithTag(writer, 2, value.optional_easter_animal)
-        if (value.identity_easter_animal != EasterAnimal.EASTER_ANIMAL_DEFAULT)
+        if (value.optional_easter_animal != EasterAnimal.UNRECOGNIZED) {
+          EasterAnimal.ADAPTER.encodeWithTag(writer, 2, value.optional_easter_animal)
+        }
+        if (value.identity_easter_animal !=
+            squareup.wire.unrecognized_constant.EasterAnimal.EASTER_ANIMAL_DEFAULT) {
+          if (value.identity_easter_animal != EasterAnimal.UNRECOGNIZED) {
             EasterAnimal.ADAPTER.encodeWithTag(writer, 3, value.identity_easter_animal)
+          }
+        }
         EasterAnimal.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.easter_animals)
         writer.writeBytes(value.unknownFields)
       }
@@ -165,9 +173,15 @@ public class Easter private constructor(
       override fun encode(writer: ReverseProtoWriter, `value`: Easter) {
         writer.writeBytes(value.unknownFields)
         EasterAnimal.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.easter_animals)
-        if (value.identity_easter_animal != EasterAnimal.EASTER_ANIMAL_DEFAULT)
+        if (value.identity_easter_animal !=
+            squareup.wire.unrecognized_constant.EasterAnimal.EASTER_ANIMAL_DEFAULT) {
+          if (value.identity_easter_animal != EasterAnimal.UNRECOGNIZED) {
             EasterAnimal.ADAPTER.encodeWithTag(writer, 3, value.identity_easter_animal)
-        EasterAnimal.ADAPTER.encodeWithTag(writer, 2, value.optional_easter_animal)
+          }
+        }
+        if (value.optional_easter_animal != EasterAnimal.UNRECOGNIZED) {
+          EasterAnimal.ADAPTER.encodeWithTag(writer, 2, value.optional_easter_animal)
+        }
       }
 
       override fun decode(reader: ProtoReader): Easter {

--- a/wire-gson-support/src/main/java/com/squareup/wire/GsonJsonIntegration.kt
+++ b/wire-gson-support/src/main/java/com/squareup/wire/GsonJsonIntegration.kt
@@ -21,6 +21,7 @@ import com.google.gson.TypeAdapter
 import com.google.gson.reflect.TypeToken
 import com.google.gson.stream.JsonReader
 import com.google.gson.stream.JsonWriter
+import com.squareup.wire.internal.EnumJsonFormatter
 import com.squareup.wire.internal.JsonFormatter
 import com.squareup.wire.internal.JsonIntegration
 import java.lang.reflect.Type
@@ -82,6 +83,12 @@ internal object GsonJsonIntegration : JsonIntegration<Gson, TypeAdapter<Any?>>()
     private val formatter: JsonFormatter<T>,
   ) : TypeAdapter<T>() {
     override fun write(writer: JsonWriter, value: T) {
+      if (formatter is EnumJsonFormatter && value is Number) {
+        // The value is unknown and we could not get a constant for `value`. We're thus writing the
+        // constant tag instead.
+        writer.value(value)
+        return
+      }
       val stringOrNumber = formatter.toStringOrNumber(value)
       if (stringOrNumber is Number) {
         writer.value(stringOrNumber)

--- a/wire-gson-support/src/test/java/squareup/proto3/AllStructs.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/AllStructs.kt
@@ -369,23 +369,33 @@ public class AllStructs(
 
       override fun encodedSize(`value`: AllStructs): Int {
         var size = value.unknownFields.size
-        if (value.struct != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(1,
-            value.struct)
-        if (value.list != null) size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(2, value.list)
-        if (value.null_value != null) size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(3,
-            value.null_value)
-        if (value.value_a != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(4,
-            value.value_a)
-        if (value.value_b != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(5,
-            value.value_b)
-        if (value.value_c != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(6,
-            value.value_c)
-        if (value.value_d != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(7,
-            value.value_d)
-        if (value.value_e != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(8,
-            value.value_e)
-        if (value.value_f != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(9,
-            value.value_f)
+        if (value.struct != null) {
+          size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(1, value.struct)
+        }
+        if (value.list != null) {
+          size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(2, value.list)
+        }
+        if (value.null_value != null) {
+          size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(3, value.null_value)
+        }
+        if (value.value_a != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(4, value.value_a)
+        }
+        if (value.value_b != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(5, value.value_b)
+        }
+        if (value.value_c != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(6, value.value_c)
+        }
+        if (value.value_d != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(7, value.value_d)
+        }
+        if (value.value_e != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(8, value.value_e)
+        }
+        if (value.value_f != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(9, value.value_f)
+        }
         size += ProtoAdapter.STRUCT_MAP.asRepeated().encodedSizeWithTag(101, value.rep_struct)
         size += ProtoAdapter.STRUCT_LIST.asRepeated().encodedSizeWithTag(102, value.rep_list)
         size += ProtoAdapter.STRUCT_VALUE.asRepeated().encodedSizeWithTag(103, value.rep_value_a)
@@ -400,16 +410,33 @@ public class AllStructs(
       }
 
       override fun encode(writer: ProtoWriter, `value`: AllStructs) {
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
-        if (value.list != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3,
-            value.null_value)
-        if (value.value_a != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
-        if (value.value_b != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
-        if (value.value_c != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
-        if (value.value_d != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
-        if (value.value_e != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
-        if (value.value_f != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        }
+        if (value.list != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3, value.null_value)
+        }
+        if (value.value_a != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
+        }
+        if (value.value_b != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
+        }
+        if (value.value_c != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
+        }
+        if (value.value_d != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
+        }
+        if (value.value_e != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
+        }
+        if (value.value_f != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        }
         ProtoAdapter.STRUCT_MAP.asRepeated().encodeWithTag(writer, 101, value.rep_struct)
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
@@ -435,16 +462,33 @@ public class AllStructs(
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_MAP.asRepeated().encodeWithTag(writer, 101, value.rep_struct)
-        if (value.value_f != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
-        if (value.value_e != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
-        if (value.value_d != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
-        if (value.value_c != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
-        if (value.value_b != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
-        if (value.value_a != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3,
-            value.null_value)
-        if (value.list != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        if (value.value_f != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        }
+        if (value.value_e != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
+        }
+        if (value.value_d != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
+        }
+        if (value.value_c != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
+        }
+        if (value.value_b != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
+        }
+        if (value.value_a != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3, value.null_value)
+        }
+        if (value.list != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
+        }
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        }
       }
 
       override fun decode(reader: ProtoReader): AllStructs {

--- a/wire-gson-support/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -83,18 +83,24 @@ public class BuyOneGetOnePromotion(
     ) {
       override fun encodedSize(`value`: BuyOneGetOnePromotion): Int {
         var size = value.unknownFields.size
-        if (value.coupon != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.coupon)
+        if (value.coupon != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.coupon)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: BuyOneGetOnePromotion) {
-        if (value.coupon != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        if (value.coupon != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: BuyOneGetOnePromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.coupon != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        if (value.coupon != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        }
       }
 
       override fun decode(reader: ProtoReader): BuyOneGetOnePromotion {

--- a/wire-gson-support/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
@@ -85,18 +85,24 @@ public class FreeDrinkPromotion(
     ) {
       override fun encodedSize(`value`: FreeDrinkPromotion): Int {
         var size = value.unknownFields.size
-        if (value.drink != Drink.UNKNOWN) size += Drink.ADAPTER.encodedSizeWithTag(1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          size += Drink.ADAPTER.encodedSizeWithTag(1, value.drink)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: FreeDrinkPromotion) {
-        if (value.drink != Drink.UNKNOWN) Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: FreeDrinkPromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.drink != Drink.UNKNOWN) Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        }
       }
 
       override fun decode(reader: ProtoReader): FreeDrinkPromotion {

--- a/wire-gson-support/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -85,21 +85,24 @@ public class FreeGarlicBreadPromotion(
     ) {
       override fun encodedSize(`value`: FreeGarlicBreadPromotion): Int {
         var size = value.unknownFields.size
-        if (value.is_extra_cheesey != false) size += ProtoAdapter.BOOL.encodedSizeWithTag(1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.is_extra_cheesey)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: FreeGarlicBreadPromotion) {
-        if (value.is_extra_cheesey != false) ProtoAdapter.BOOL.encodeWithTag(writer, 1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.is_extra_cheesey)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: FreeGarlicBreadPromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.is_extra_cheesey != false) ProtoAdapter.BOOL.encodeWithTag(writer, 1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.is_extra_cheesey)
+        }
       }
 
       override fun decode(reader: ProtoReader): FreeGarlicBreadPromotion {

--- a/wire-gson-support/src/test/java/squareup/proto3/PizzaDelivery.kt
+++ b/wire-gson-support/src/test/java/squareup/proto3/PizzaDelivery.kt
@@ -167,47 +167,72 @@ public class PizzaDelivery(
     ) {
       override fun encodedSize(`value`: PizzaDelivery): Int {
         var size = value.unknownFields.size
-        if (value.phone_number != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1,
-            value.phone_number)
-        if (value.address != "") size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.address)
+        if (value.phone_number != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.phone_number)
+        }
+        if (value.address != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.address)
+        }
         size += Pizza.ADAPTER.asRepeated().encodedSizeWithTag(3, value.pizzas)
-        if (value.promotion != null) size += AnyMessage.ADAPTER.encodedSizeWithTag(4,
-            value.promotion)
-        if (value.delivered_within_or_free != null) size +=
-            ProtoAdapter.DURATION.encodedSizeWithTag(5, value.delivered_within_or_free)
-        if (value.loyalty != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(6,
-            value.loyalty)
-        if (value.ordered_at != null) size += ProtoAdapter.INSTANT.encodedSizeWithTag(7,
-            value.ordered_at)
+        if (value.promotion != null) {
+          size += AnyMessage.ADAPTER.encodedSizeWithTag(4, value.promotion)
+        }
+        if (value.delivered_within_or_free != null) {
+          size += ProtoAdapter.DURATION.encodedSizeWithTag(5, value.delivered_within_or_free)
+        }
+        if (value.loyalty != null) {
+          size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(6, value.loyalty)
+        }
+        if (value.ordered_at != null) {
+          size += ProtoAdapter.INSTANT.encodedSizeWithTag(7, value.ordered_at)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: PizzaDelivery) {
-        if (value.phone_number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1,
-            value.phone_number)
-        if (value.address != "") ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        if (value.phone_number != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.phone_number)
+        }
+        if (value.address != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        }
         Pizza.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.pizzas)
-        if (value.promotion != null) AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
-        if (value.delivered_within_or_free != null) ProtoAdapter.DURATION.encodeWithTag(writer, 5,
-            value.delivered_within_or_free)
-        if (value.loyalty != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
-        if (value.ordered_at != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 7,
-            value.ordered_at)
+        if (value.promotion != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        }
+        if (value.delivered_within_or_free != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 5, value.delivered_within_or_free)
+        }
+        if (value.loyalty != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
+        }
+        if (value.ordered_at != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 7, value.ordered_at)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: PizzaDelivery) {
         writer.writeBytes(value.unknownFields)
-        if (value.ordered_at != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 7,
-            value.ordered_at)
-        if (value.loyalty != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
-        if (value.delivered_within_or_free != null) ProtoAdapter.DURATION.encodeWithTag(writer, 5,
-            value.delivered_within_or_free)
-        if (value.promotion != null) AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        if (value.ordered_at != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 7, value.ordered_at)
+        }
+        if (value.loyalty != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
+        }
+        if (value.delivered_within_or_free != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 5, value.delivered_within_or_free)
+        }
+        if (value.promotion != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        }
         Pizza.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.pizzas)
-        if (value.address != "") ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
-        if (value.phone_number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1,
-            value.phone_number)
+        if (value.address != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        }
+        if (value.phone_number != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.phone_number)
+        }
       }
 
       override fun decode(reader: ProtoReader): PizzaDelivery {

--- a/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
+++ b/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
@@ -73,7 +73,8 @@ internal class MessageJsonAdapter<M : Message<M, B>, B : Message.Builder<M, B>>(
       val index = option / 2
       val fieldBinding = messageAdapter.fieldBindingsArray[index]
 
-      // We peekJson in order to be able to read the value twice if need be.
+      // We peekJson in order to be able to read the value twice if need to access for building
+      // unknown values.
       val peekInput = input.peekJson()
       val value = jsonAdapters[index].fromJson(peekInput)
       val protoAdapter = fieldBinding.adapter

--- a/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
+++ b/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
@@ -71,14 +71,28 @@ internal class MessageJsonAdapter<M : Message<M, B>, B : Message.Builder<M, B>>(
         continue
       }
       val index = option / 2
+      val fieldBinding = messageAdapter.fieldBindingsArray[index]
 
-      val value = jsonAdapters[index].fromJson(input)
+      // We peekJson in order to be able to read the value twice if need be.
+      val peekInput = input.peekJson()
+      val value = jsonAdapters[index].fromJson(peekInput)
+      val protoAdapter = fieldBinding.adapter
+      if ((value as? WireEnum)?.value == -1 &&
+        protoAdapter.syntax == Syntax.PROTO_3 &&
+        protoAdapter is EnumAdapter<*>
+      ) {
+        // The tag for this enum's constant is unknown to our runtime. It has been assigned  to
+        // `UNRECOGNIZED(-1)` and we put its actual value in the unknown fields.
+        builder.addUnknownField(fieldBinding.tag, FieldEncoding.VARINT, input.nextInt())
+      } else {
+        // We need to skip it since we passed our peeked Json to the json adapter.
+        input.skipValue()
+      }
 
       // "If a value is missing in the JSON-encoded data or if its value is null, it will be
       // interpreted as the appropriate default value when parsed into a protocol buffer."
       if (value == null) continue
 
-      val fieldBinding = messageAdapter.fieldBindingsArray[index]
       fieldBinding.set(builder, value)
     }
     input.endObject()

--- a/wire-moshi-adapter/src/main/java/com/squareup/wire/MoshiJsonIntegration.kt
+++ b/wire-moshi-adapter/src/main/java/com/squareup/wire/MoshiJsonIntegration.kt
@@ -20,6 +20,7 @@ import com.squareup.moshi.JsonDataException
 import com.squareup.moshi.JsonReader
 import com.squareup.moshi.JsonWriter
 import com.squareup.moshi.Moshi
+import com.squareup.wire.internal.EnumJsonFormatter
 import com.squareup.wire.internal.JsonFormatter
 import com.squareup.wire.internal.JsonIntegration
 import java.lang.reflect.Type
@@ -59,6 +60,12 @@ internal object MoshiJsonIntegration : JsonIntegration<Moshi, JsonAdapter<Any?>>
       writer: JsonWriter,
       value: T?,
     ) {
+      if (formatter is EnumJsonFormatter && value is Number) {
+        // The value is unknown and we could not get a constant for `value`. We're thus writing the
+        // constant tag instead.
+        writer.value(value)
+        return
+      }
       val stringOrNumber = formatter.toStringOrNumber(value!!)
       if (stringOrNumber is Number) {
         writer.value(stringOrNumber)

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/AllStructs.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/AllStructs.kt
@@ -369,23 +369,33 @@ public class AllStructs(
 
       override fun encodedSize(`value`: AllStructs): Int {
         var size = value.unknownFields.size
-        if (value.struct != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(1,
-            value.struct)
-        if (value.list != null) size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(2, value.list)
-        if (value.null_value != null) size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(3,
-            value.null_value)
-        if (value.value_a != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(4,
-            value.value_a)
-        if (value.value_b != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(5,
-            value.value_b)
-        if (value.value_c != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(6,
-            value.value_c)
-        if (value.value_d != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(7,
-            value.value_d)
-        if (value.value_e != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(8,
-            value.value_e)
-        if (value.value_f != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(9,
-            value.value_f)
+        if (value.struct != null) {
+          size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(1, value.struct)
+        }
+        if (value.list != null) {
+          size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(2, value.list)
+        }
+        if (value.null_value != null) {
+          size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(3, value.null_value)
+        }
+        if (value.value_a != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(4, value.value_a)
+        }
+        if (value.value_b != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(5, value.value_b)
+        }
+        if (value.value_c != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(6, value.value_c)
+        }
+        if (value.value_d != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(7, value.value_d)
+        }
+        if (value.value_e != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(8, value.value_e)
+        }
+        if (value.value_f != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(9, value.value_f)
+        }
         size += ProtoAdapter.STRUCT_MAP.asRepeated().encodedSizeWithTag(101, value.rep_struct)
         size += ProtoAdapter.STRUCT_LIST.asRepeated().encodedSizeWithTag(102, value.rep_list)
         size += ProtoAdapter.STRUCT_VALUE.asRepeated().encodedSizeWithTag(103, value.rep_value_a)
@@ -400,16 +410,33 @@ public class AllStructs(
       }
 
       override fun encode(writer: ProtoWriter, `value`: AllStructs) {
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
-        if (value.list != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3,
-            value.null_value)
-        if (value.value_a != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
-        if (value.value_b != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
-        if (value.value_c != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
-        if (value.value_d != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
-        if (value.value_e != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
-        if (value.value_f != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        }
+        if (value.list != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3, value.null_value)
+        }
+        if (value.value_a != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
+        }
+        if (value.value_b != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
+        }
+        if (value.value_c != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
+        }
+        if (value.value_d != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
+        }
+        if (value.value_e != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
+        }
+        if (value.value_f != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        }
         ProtoAdapter.STRUCT_MAP.asRepeated().encodeWithTag(writer, 101, value.rep_struct)
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
@@ -435,16 +462,33 @@ public class AllStructs(
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_MAP.asRepeated().encodeWithTag(writer, 101, value.rep_struct)
-        if (value.value_f != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
-        if (value.value_e != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
-        if (value.value_d != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
-        if (value.value_c != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
-        if (value.value_b != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
-        if (value.value_a != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3,
-            value.null_value)
-        if (value.list != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        if (value.value_f != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        }
+        if (value.value_e != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
+        }
+        if (value.value_d != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
+        }
+        if (value.value_c != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
+        }
+        if (value.value_b != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
+        }
+        if (value.value_a != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3, value.null_value)
+        }
+        if (value.list != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
+        }
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        }
       }
 
       override fun decode(reader: ProtoReader): AllStructs {

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -83,18 +83,24 @@ public class BuyOneGetOnePromotion(
     ) {
       override fun encodedSize(`value`: BuyOneGetOnePromotion): Int {
         var size = value.unknownFields.size
-        if (value.coupon != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.coupon)
+        if (value.coupon != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.coupon)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: BuyOneGetOnePromotion) {
-        if (value.coupon != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        if (value.coupon != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: BuyOneGetOnePromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.coupon != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        if (value.coupon != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        }
       }
 
       override fun decode(reader: ProtoReader): BuyOneGetOnePromotion {

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/FreeDrinkPromotion.kt
@@ -85,18 +85,24 @@ public class FreeDrinkPromotion(
     ) {
       override fun encodedSize(`value`: FreeDrinkPromotion): Int {
         var size = value.unknownFields.size
-        if (value.drink != Drink.UNKNOWN) size += Drink.ADAPTER.encodedSizeWithTag(1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          size += Drink.ADAPTER.encodedSizeWithTag(1, value.drink)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: FreeDrinkPromotion) {
-        if (value.drink != Drink.UNKNOWN) Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: FreeDrinkPromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.drink != Drink.UNKNOWN) Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        }
       }
 
       override fun decode(reader: ProtoReader): FreeDrinkPromotion {

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -85,21 +85,24 @@ public class FreeGarlicBreadPromotion(
     ) {
       override fun encodedSize(`value`: FreeGarlicBreadPromotion): Int {
         var size = value.unknownFields.size
-        if (value.is_extra_cheesey != false) size += ProtoAdapter.BOOL.encodedSizeWithTag(1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.is_extra_cheesey)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: FreeGarlicBreadPromotion) {
-        if (value.is_extra_cheesey != false) ProtoAdapter.BOOL.encodeWithTag(writer, 1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.is_extra_cheesey)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: FreeGarlicBreadPromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.is_extra_cheesey != false) ProtoAdapter.BOOL.encodeWithTag(writer, 1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.is_extra_cheesey)
+        }
       }
 
       override fun decode(reader: ProtoReader): FreeGarlicBreadPromotion {

--- a/wire-moshi-adapter/src/test/java/squareup/proto3/PizzaDelivery.kt
+++ b/wire-moshi-adapter/src/test/java/squareup/proto3/PizzaDelivery.kt
@@ -167,47 +167,72 @@ public class PizzaDelivery(
     ) {
       override fun encodedSize(`value`: PizzaDelivery): Int {
         var size = value.unknownFields.size
-        if (value.phone_number != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1,
-            value.phone_number)
-        if (value.address != "") size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.address)
+        if (value.phone_number != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.phone_number)
+        }
+        if (value.address != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.address)
+        }
         size += Pizza.ADAPTER.asRepeated().encodedSizeWithTag(3, value.pizzas)
-        if (value.promotion != null) size += AnyMessage.ADAPTER.encodedSizeWithTag(4,
-            value.promotion)
-        if (value.delivered_within_or_free != null) size +=
-            ProtoAdapter.DURATION.encodedSizeWithTag(5, value.delivered_within_or_free)
-        if (value.loyalty != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(6,
-            value.loyalty)
-        if (value.ordered_at != null) size += ProtoAdapter.INSTANT.encodedSizeWithTag(7,
-            value.ordered_at)
+        if (value.promotion != null) {
+          size += AnyMessage.ADAPTER.encodedSizeWithTag(4, value.promotion)
+        }
+        if (value.delivered_within_or_free != null) {
+          size += ProtoAdapter.DURATION.encodedSizeWithTag(5, value.delivered_within_or_free)
+        }
+        if (value.loyalty != null) {
+          size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(6, value.loyalty)
+        }
+        if (value.ordered_at != null) {
+          size += ProtoAdapter.INSTANT.encodedSizeWithTag(7, value.ordered_at)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: PizzaDelivery) {
-        if (value.phone_number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1,
-            value.phone_number)
-        if (value.address != "") ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        if (value.phone_number != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.phone_number)
+        }
+        if (value.address != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        }
         Pizza.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.pizzas)
-        if (value.promotion != null) AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
-        if (value.delivered_within_or_free != null) ProtoAdapter.DURATION.encodeWithTag(writer, 5,
-            value.delivered_within_or_free)
-        if (value.loyalty != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
-        if (value.ordered_at != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 7,
-            value.ordered_at)
+        if (value.promotion != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        }
+        if (value.delivered_within_or_free != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 5, value.delivered_within_or_free)
+        }
+        if (value.loyalty != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
+        }
+        if (value.ordered_at != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 7, value.ordered_at)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: PizzaDelivery) {
         writer.writeBytes(value.unknownFields)
-        if (value.ordered_at != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 7,
-            value.ordered_at)
-        if (value.loyalty != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
-        if (value.delivered_within_or_free != null) ProtoAdapter.DURATION.encodeWithTag(writer, 5,
-            value.delivered_within_or_free)
-        if (value.promotion != null) AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        if (value.ordered_at != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 7, value.ordered_at)
+        }
+        if (value.loyalty != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
+        }
+        if (value.delivered_within_or_free != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 5, value.delivered_within_or_free)
+        }
+        if (value.promotion != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        }
         Pizza.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.pizzas)
-        if (value.address != "") ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
-        if (value.phone_number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1,
-            value.phone_number)
+        if (value.address != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        }
+        if (value.phone_number != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.phone_number)
+        }
       }
 
       override fun decode(reader: ProtoReader): PizzaDelivery {

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropChecker.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropChecker.kt
@@ -45,7 +45,7 @@ class InteropChecker(
   private val wireAlternateJsons: List<String> = listOf(),
 
   /** If true, all tests using Gson will be skipped. */
-  private val skipGson : Boolean = false,
+  private val skipGson: Boolean = false,
 ) {
   private var protocBytes: ByteString? = null
 

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropChecker.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropChecker.kt
@@ -43,6 +43,9 @@ class InteropChecker(
 
   /** Alternate forms of JSON we expect Wire to support but protoc doesn't. */
   private val wireAlternateJsons: List<String> = listOf(),
+
+  /** If true, all tests using Gson will be skipped. */
+  private val skipGson : Boolean = false,
 ) {
   private var protocBytes: ByteString? = null
 
@@ -54,7 +57,6 @@ class InteropChecker(
     .usingTypeRegistry(typeRegistry)
 
   private val jsonParser = JsonFormat.parser()
-    // TODO(bquenaudon): add .ignoringUnknownFields()
     .usingTypeRegistry(typeRegistry)
 
   private val gson = GsonBuilder()
@@ -71,7 +73,9 @@ class InteropChecker(
 
     roundtripProtocJson()
     roundtripWireBytes(message)
-    roundtripGson(message)
+    if (!skipGson) {
+      roundtripGson(message)
+    }
     roundtripMoshi(message)
   }
 
@@ -106,7 +110,15 @@ class InteropChecker(
     val adapter = gson.getAdapter(message::class.java) as TypeAdapter<Any>
 
     assertThat(adapter.toJson(message)).isEqualTo(wireCanonicalJson)
-    assertThat(adapter.fromJson(wireCanonicalJson)).isEqualTo(message)
+    val fromJson = adapter.fromJson(wireCanonicalJson)
+    assertThat(fromJson)
+      .overridingErrorMessage {
+        """
+        |Expected :$message (unknownFields: `${(message as com.squareup.wire.Message<*, *>).unknownFields.hex()}`)
+        |Actual   :$fromJson (unknownFields: `${(fromJson as com.squareup.wire.Message<*, *>).unknownFields.hex()}`)
+        """.trimMargin()
+      }
+      .isEqualTo(message)
     for (json in alternateJsons + wireAlternateJsons) {
       assertThat(adapter.fromJson(json)).isEqualTo(message)
     }
@@ -117,7 +129,14 @@ class InteropChecker(
     val adapter = moshi.adapter(message::class.java) as JsonAdapter<Any>
 
     assertThat(adapter.toJson(message)).isEqualTo(wireCanonicalJson)
-    assertThat(adapter.fromJson(wireCanonicalJson)).isEqualTo(message)
+    val fromJson = adapter.fromJson(wireCanonicalJson)
+    assertThat(fromJson)
+      .overridingErrorMessage {
+        """
+        |Expected :$message (unknownFields: `${(message as com.squareup.wire.Message<*, *>).unknownFields.hex()}`)
+        |Actual   :$fromJson (unknownFields: `${(fromJson as com.squareup.wire.Message<*, *>).unknownFields.hex()}`)
+        """.trimMargin()
+      }.isEqualTo(message)
     for (json in alternateJsons + wireAlternateJsons) {
       assertThat(adapter.fromJson(json)).isEqualTo(message)
     }

--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/EnumJsonFormatter.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/EnumJsonFormatter.kt
@@ -30,6 +30,7 @@ class EnumJsonFormatter<E : WireEnum>(
 ) : JsonFormatter<E> {
   private val stringToValue: Map<String, E>
   private val valueToString: Map<E, String>
+
   /**
    * The `UNRECOGNIZED(-1) constant that might have been generated. This only concerns proto3 enums.
    */

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/all_types/AllTypes.kt
@@ -1479,54 +1479,82 @@ public class AllTypes(
 
       override fun encodedSize(`value`: AllTypes): Int {
         var size = value.unknownFields.size
-        if (value.proto3_kotlin_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1,
-            value.proto3_kotlin_int32)
-        if (value.proto3_kotlin_uint32 != 0) size += ProtoAdapter.UINT32.encodedSizeWithTag(2,
-            value.proto3_kotlin_uint32)
-        if (value.proto3_kotlin_sint32 != 0) size += ProtoAdapter.SINT32.encodedSizeWithTag(3,
-            value.proto3_kotlin_sint32)
-        if (value.proto3_kotlin_fixed32 != 0) size += ProtoAdapter.FIXED32.encodedSizeWithTag(4,
-            value.proto3_kotlin_fixed32)
-        if (value.proto3_kotlin_sfixed32 != 0) size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5,
-            value.proto3_kotlin_sfixed32)
-        if (value.proto3_kotlin_int64 != 0L) size += ProtoAdapter.INT64.encodedSizeWithTag(6,
-            value.proto3_kotlin_int64)
-        if (value.proto3_kotlin_uint64 != 0L) size += ProtoAdapter.UINT64.encodedSizeWithTag(7,
-            value.proto3_kotlin_uint64)
-        if (value.proto3_kotlin_sint64 != 0L) size += ProtoAdapter.SINT64.encodedSizeWithTag(8,
-            value.proto3_kotlin_sint64)
-        if (value.proto3_kotlin_fixed64 != 0L) size += ProtoAdapter.FIXED64.encodedSizeWithTag(9,
-            value.proto3_kotlin_fixed64)
-        if (value.proto3_kotlin_sfixed64 != 0L) size += ProtoAdapter.SFIXED64.encodedSizeWithTag(10,
-            value.proto3_kotlin_sfixed64)
-        if (value.proto3_kotlin_bool != false) size += ProtoAdapter.BOOL.encodedSizeWithTag(11,
-            value.proto3_kotlin_bool)
-        if (!value.proto3_kotlin_float.equals(0f)) size += ProtoAdapter.FLOAT.encodedSizeWithTag(12,
-            value.proto3_kotlin_float)
-        if (!value.proto3_kotlin_double.equals(0.0)) size +=
-            ProtoAdapter.DOUBLE.encodedSizeWithTag(13, value.proto3_kotlin_double)
-        if (value.proto3_kotlin_string != "") size += ProtoAdapter.STRING.encodedSizeWithTag(14,
-            value.proto3_kotlin_string)
-        if (value.proto3_kotlin_bytes != ByteString.EMPTY) size +=
-            ProtoAdapter.BYTES.encodedSizeWithTag(15, value.proto3_kotlin_bytes)
-        if (value.nested_enum != NestedEnum.UNKNOWN) size +=
-            NestedEnum.ADAPTER.encodedSizeWithTag(16, value.nested_enum)
-        if (value.nested_message != null) size += NestedMessage.ADAPTER.encodedSizeWithTag(17,
-            value.nested_message)
-        if (value.any != null) size += AnyMessage.ADAPTER.encodedSizeWithTag(18, value.any)
-        if (value.duration != null) size += ProtoAdapter.DURATION.encodedSizeWithTag(19,
-            value.duration)
-        if (value.struct != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(20,
-            value.struct)
-        if (value.list_value != null) size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(21,
-            value.list_value)
-        if (value.value_ != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(22,
-            value.value_)
-        if (value.null_value != null) size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(23,
-            value.null_value)
-        if (value.empty != null) size += ProtoAdapter.EMPTY.encodedSizeWithTag(24, value.empty)
-        if (value.timestamp != null) size += ProtoAdapter.INSTANT.encodedSizeWithTag(25,
-            value.timestamp)
+        if (value.proto3_kotlin_int32 != 0) {
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.proto3_kotlin_int32)
+        }
+        if (value.proto3_kotlin_uint32 != 0) {
+          size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.proto3_kotlin_uint32)
+        }
+        if (value.proto3_kotlin_sint32 != 0) {
+          size += ProtoAdapter.SINT32.encodedSizeWithTag(3, value.proto3_kotlin_sint32)
+        }
+        if (value.proto3_kotlin_fixed32 != 0) {
+          size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.proto3_kotlin_fixed32)
+        }
+        if (value.proto3_kotlin_sfixed32 != 0) {
+          size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5, value.proto3_kotlin_sfixed32)
+        }
+        if (value.proto3_kotlin_int64 != 0L) {
+          size += ProtoAdapter.INT64.encodedSizeWithTag(6, value.proto3_kotlin_int64)
+        }
+        if (value.proto3_kotlin_uint64 != 0L) {
+          size += ProtoAdapter.UINT64.encodedSizeWithTag(7, value.proto3_kotlin_uint64)
+        }
+        if (value.proto3_kotlin_sint64 != 0L) {
+          size += ProtoAdapter.SINT64.encodedSizeWithTag(8, value.proto3_kotlin_sint64)
+        }
+        if (value.proto3_kotlin_fixed64 != 0L) {
+          size += ProtoAdapter.FIXED64.encodedSizeWithTag(9, value.proto3_kotlin_fixed64)
+        }
+        if (value.proto3_kotlin_sfixed64 != 0L) {
+          size += ProtoAdapter.SFIXED64.encodedSizeWithTag(10, value.proto3_kotlin_sfixed64)
+        }
+        if (value.proto3_kotlin_bool != false) {
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(11, value.proto3_kotlin_bool)
+        }
+        if (!value.proto3_kotlin_float.equals(0f)) {
+          size += ProtoAdapter.FLOAT.encodedSizeWithTag(12, value.proto3_kotlin_float)
+        }
+        if (!value.proto3_kotlin_double.equals(0.0)) {
+          size += ProtoAdapter.DOUBLE.encodedSizeWithTag(13, value.proto3_kotlin_double)
+        }
+        if (value.proto3_kotlin_string != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(14, value.proto3_kotlin_string)
+        }
+        if (value.proto3_kotlin_bytes != okio.ByteString.EMPTY) {
+          size += ProtoAdapter.BYTES.encodedSizeWithTag(15, value.proto3_kotlin_bytes)
+        }
+        if (value.nested_enum !=
+            com.squareup.wire.proto3.kotlin.all_types.AllTypes.NestedEnum.UNKNOWN) {
+          size += NestedEnum.ADAPTER.encodedSizeWithTag(16, value.nested_enum)
+        }
+        if (value.nested_message != null) {
+          size += NestedMessage.ADAPTER.encodedSizeWithTag(17, value.nested_message)
+        }
+        if (value.any != null) {
+          size += AnyMessage.ADAPTER.encodedSizeWithTag(18, value.any)
+        }
+        if (value.duration != null) {
+          size += ProtoAdapter.DURATION.encodedSizeWithTag(19, value.duration)
+        }
+        if (value.struct != null) {
+          size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(20, value.struct)
+        }
+        if (value.list_value != null) {
+          size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(21, value.list_value)
+        }
+        if (value.value_ != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(22, value.value_)
+        }
+        if (value.null_value != null) {
+          size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(23, value.null_value)
+        }
+        if (value.empty != null) {
+          size += ProtoAdapter.EMPTY.encodedSizeWithTag(24, value.empty)
+        }
+        if (value.timestamp != null) {
+          size += ProtoAdapter.INSTANT.encodedSizeWithTag(25, value.timestamp)
+        }
         size += ProtoAdapter.INT32.encodedSizeWithTag(101, value.opt_int32)
         size += ProtoAdapter.UINT32.encodedSizeWithTag(102, value.opt_uint32)
         size += ProtoAdapter.SINT32.encodedSizeWithTag(103, value.opt_sint32)
@@ -1607,50 +1635,82 @@ public class AllTypes(
       }
 
       override fun encode(writer: ProtoWriter, `value`: AllTypes) {
-        if (value.proto3_kotlin_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1,
-            value.proto3_kotlin_int32)
-        if (value.proto3_kotlin_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2,
-            value.proto3_kotlin_uint32)
-        if (value.proto3_kotlin_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3,
-            value.proto3_kotlin_sint32)
-        if (value.proto3_kotlin_fixed32 != 0) ProtoAdapter.FIXED32.encodeWithTag(writer, 4,
-            value.proto3_kotlin_fixed32)
-        if (value.proto3_kotlin_sfixed32 != 0) ProtoAdapter.SFIXED32.encodeWithTag(writer, 5,
-            value.proto3_kotlin_sfixed32)
-        if (value.proto3_kotlin_int64 != 0L) ProtoAdapter.INT64.encodeWithTag(writer, 6,
-            value.proto3_kotlin_int64)
-        if (value.proto3_kotlin_uint64 != 0L) ProtoAdapter.UINT64.encodeWithTag(writer, 7,
-            value.proto3_kotlin_uint64)
-        if (value.proto3_kotlin_sint64 != 0L) ProtoAdapter.SINT64.encodeWithTag(writer, 8,
-            value.proto3_kotlin_sint64)
-        if (value.proto3_kotlin_fixed64 != 0L) ProtoAdapter.FIXED64.encodeWithTag(writer, 9,
-            value.proto3_kotlin_fixed64)
-        if (value.proto3_kotlin_sfixed64 != 0L) ProtoAdapter.SFIXED64.encodeWithTag(writer, 10,
-            value.proto3_kotlin_sfixed64)
-        if (value.proto3_kotlin_bool != false) ProtoAdapter.BOOL.encodeWithTag(writer, 11,
-            value.proto3_kotlin_bool)
-        if (!value.proto3_kotlin_float.equals(0f)) ProtoAdapter.FLOAT.encodeWithTag(writer, 12,
-            value.proto3_kotlin_float)
-        if (!value.proto3_kotlin_double.equals(0.0)) ProtoAdapter.DOUBLE.encodeWithTag(writer, 13,
-            value.proto3_kotlin_double)
-        if (value.proto3_kotlin_string != "") ProtoAdapter.STRING.encodeWithTag(writer, 14,
-            value.proto3_kotlin_string)
-        if (value.proto3_kotlin_bytes != ByteString.EMPTY) ProtoAdapter.BYTES.encodeWithTag(writer,
-            15, value.proto3_kotlin_bytes)
-        if (value.nested_enum != NestedEnum.UNKNOWN) NestedEnum.ADAPTER.encodeWithTag(writer, 16,
-            value.nested_enum)
-        if (value.nested_message != null) NestedMessage.ADAPTER.encodeWithTag(writer, 17,
-            value.nested_message)
-        if (value.any != null) AnyMessage.ADAPTER.encodeWithTag(writer, 18, value.any)
-        if (value.duration != null) ProtoAdapter.DURATION.encodeWithTag(writer, 19, value.duration)
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 20, value.struct)
-        if (value.list_value != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 21,
-            value.list_value)
-        if (value.value_ != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 22, value.value_)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 23,
-            value.null_value)
-        if (value.empty != null) ProtoAdapter.EMPTY.encodeWithTag(writer, 24, value.empty)
-        if (value.timestamp != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 25, value.timestamp)
+        if (value.proto3_kotlin_int32 != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 1, value.proto3_kotlin_int32)
+        }
+        if (value.proto3_kotlin_uint32 != 0) {
+          ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.proto3_kotlin_uint32)
+        }
+        if (value.proto3_kotlin_sint32 != 0) {
+          ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.proto3_kotlin_sint32)
+        }
+        if (value.proto3_kotlin_fixed32 != 0) {
+          ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.proto3_kotlin_fixed32)
+        }
+        if (value.proto3_kotlin_sfixed32 != 0) {
+          ProtoAdapter.SFIXED32.encodeWithTag(writer, 5, value.proto3_kotlin_sfixed32)
+        }
+        if (value.proto3_kotlin_int64 != 0L) {
+          ProtoAdapter.INT64.encodeWithTag(writer, 6, value.proto3_kotlin_int64)
+        }
+        if (value.proto3_kotlin_uint64 != 0L) {
+          ProtoAdapter.UINT64.encodeWithTag(writer, 7, value.proto3_kotlin_uint64)
+        }
+        if (value.proto3_kotlin_sint64 != 0L) {
+          ProtoAdapter.SINT64.encodeWithTag(writer, 8, value.proto3_kotlin_sint64)
+        }
+        if (value.proto3_kotlin_fixed64 != 0L) {
+          ProtoAdapter.FIXED64.encodeWithTag(writer, 9, value.proto3_kotlin_fixed64)
+        }
+        if (value.proto3_kotlin_sfixed64 != 0L) {
+          ProtoAdapter.SFIXED64.encodeWithTag(writer, 10, value.proto3_kotlin_sfixed64)
+        }
+        if (value.proto3_kotlin_bool != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 11, value.proto3_kotlin_bool)
+        }
+        if (!value.proto3_kotlin_float.equals(0f)) {
+          ProtoAdapter.FLOAT.encodeWithTag(writer, 12, value.proto3_kotlin_float)
+        }
+        if (!value.proto3_kotlin_double.equals(0.0)) {
+          ProtoAdapter.DOUBLE.encodeWithTag(writer, 13, value.proto3_kotlin_double)
+        }
+        if (value.proto3_kotlin_string != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 14, value.proto3_kotlin_string)
+        }
+        if (value.proto3_kotlin_bytes != okio.ByteString.EMPTY) {
+          ProtoAdapter.BYTES.encodeWithTag(writer, 15, value.proto3_kotlin_bytes)
+        }
+        if (value.nested_enum !=
+            com.squareup.wire.proto3.kotlin.all_types.AllTypes.NestedEnum.UNKNOWN) {
+          NestedEnum.ADAPTER.encodeWithTag(writer, 16, value.nested_enum)
+        }
+        if (value.nested_message != null) {
+          NestedMessage.ADAPTER.encodeWithTag(writer, 17, value.nested_message)
+        }
+        if (value.any != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 18, value.any)
+        }
+        if (value.duration != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 19, value.duration)
+        }
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 20, value.struct)
+        }
+        if (value.list_value != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 21, value.list_value)
+        }
+        if (value.value_ != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 22, value.value_)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 23, value.null_value)
+        }
+        if (value.empty != null) {
+          ProtoAdapter.EMPTY.encodeWithTag(writer, 24, value.empty)
+        }
+        if (value.timestamp != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 25, value.timestamp)
+        }
         ProtoAdapter.INT32.encodeWithTag(writer, 101, value.opt_int32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 102, value.opt_uint32)
         ProtoAdapter.SINT32.encodeWithTag(writer, 103, value.opt_sint32)
@@ -1808,50 +1868,82 @@ public class AllTypes(
         ProtoAdapter.SINT32.encodeWithTag(writer, 103, value.opt_sint32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 102, value.opt_uint32)
         ProtoAdapter.INT32.encodeWithTag(writer, 101, value.opt_int32)
-        if (value.timestamp != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 25, value.timestamp)
-        if (value.empty != null) ProtoAdapter.EMPTY.encodeWithTag(writer, 24, value.empty)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 23,
-            value.null_value)
-        if (value.value_ != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 22, value.value_)
-        if (value.list_value != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 21,
-            value.list_value)
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 20, value.struct)
-        if (value.duration != null) ProtoAdapter.DURATION.encodeWithTag(writer, 19, value.duration)
-        if (value.any != null) AnyMessage.ADAPTER.encodeWithTag(writer, 18, value.any)
-        if (value.nested_message != null) NestedMessage.ADAPTER.encodeWithTag(writer, 17,
-            value.nested_message)
-        if (value.nested_enum != NestedEnum.UNKNOWN) NestedEnum.ADAPTER.encodeWithTag(writer, 16,
-            value.nested_enum)
-        if (value.proto3_kotlin_bytes != ByteString.EMPTY) ProtoAdapter.BYTES.encodeWithTag(writer,
-            15, value.proto3_kotlin_bytes)
-        if (value.proto3_kotlin_string != "") ProtoAdapter.STRING.encodeWithTag(writer, 14,
-            value.proto3_kotlin_string)
-        if (!value.proto3_kotlin_double.equals(0.0)) ProtoAdapter.DOUBLE.encodeWithTag(writer, 13,
-            value.proto3_kotlin_double)
-        if (!value.proto3_kotlin_float.equals(0f)) ProtoAdapter.FLOAT.encodeWithTag(writer, 12,
-            value.proto3_kotlin_float)
-        if (value.proto3_kotlin_bool != false) ProtoAdapter.BOOL.encodeWithTag(writer, 11,
-            value.proto3_kotlin_bool)
-        if (value.proto3_kotlin_sfixed64 != 0L) ProtoAdapter.SFIXED64.encodeWithTag(writer, 10,
-            value.proto3_kotlin_sfixed64)
-        if (value.proto3_kotlin_fixed64 != 0L) ProtoAdapter.FIXED64.encodeWithTag(writer, 9,
-            value.proto3_kotlin_fixed64)
-        if (value.proto3_kotlin_sint64 != 0L) ProtoAdapter.SINT64.encodeWithTag(writer, 8,
-            value.proto3_kotlin_sint64)
-        if (value.proto3_kotlin_uint64 != 0L) ProtoAdapter.UINT64.encodeWithTag(writer, 7,
-            value.proto3_kotlin_uint64)
-        if (value.proto3_kotlin_int64 != 0L) ProtoAdapter.INT64.encodeWithTag(writer, 6,
-            value.proto3_kotlin_int64)
-        if (value.proto3_kotlin_sfixed32 != 0) ProtoAdapter.SFIXED32.encodeWithTag(writer, 5,
-            value.proto3_kotlin_sfixed32)
-        if (value.proto3_kotlin_fixed32 != 0) ProtoAdapter.FIXED32.encodeWithTag(writer, 4,
-            value.proto3_kotlin_fixed32)
-        if (value.proto3_kotlin_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3,
-            value.proto3_kotlin_sint32)
-        if (value.proto3_kotlin_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2,
-            value.proto3_kotlin_uint32)
-        if (value.proto3_kotlin_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1,
-            value.proto3_kotlin_int32)
+        if (value.timestamp != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 25, value.timestamp)
+        }
+        if (value.empty != null) {
+          ProtoAdapter.EMPTY.encodeWithTag(writer, 24, value.empty)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 23, value.null_value)
+        }
+        if (value.value_ != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 22, value.value_)
+        }
+        if (value.list_value != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 21, value.list_value)
+        }
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 20, value.struct)
+        }
+        if (value.duration != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 19, value.duration)
+        }
+        if (value.any != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 18, value.any)
+        }
+        if (value.nested_message != null) {
+          NestedMessage.ADAPTER.encodeWithTag(writer, 17, value.nested_message)
+        }
+        if (value.nested_enum !=
+            com.squareup.wire.proto3.kotlin.all_types.AllTypes.NestedEnum.UNKNOWN) {
+          NestedEnum.ADAPTER.encodeWithTag(writer, 16, value.nested_enum)
+        }
+        if (value.proto3_kotlin_bytes != okio.ByteString.EMPTY) {
+          ProtoAdapter.BYTES.encodeWithTag(writer, 15, value.proto3_kotlin_bytes)
+        }
+        if (value.proto3_kotlin_string != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 14, value.proto3_kotlin_string)
+        }
+        if (!value.proto3_kotlin_double.equals(0.0)) {
+          ProtoAdapter.DOUBLE.encodeWithTag(writer, 13, value.proto3_kotlin_double)
+        }
+        if (!value.proto3_kotlin_float.equals(0f)) {
+          ProtoAdapter.FLOAT.encodeWithTag(writer, 12, value.proto3_kotlin_float)
+        }
+        if (value.proto3_kotlin_bool != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 11, value.proto3_kotlin_bool)
+        }
+        if (value.proto3_kotlin_sfixed64 != 0L) {
+          ProtoAdapter.SFIXED64.encodeWithTag(writer, 10, value.proto3_kotlin_sfixed64)
+        }
+        if (value.proto3_kotlin_fixed64 != 0L) {
+          ProtoAdapter.FIXED64.encodeWithTag(writer, 9, value.proto3_kotlin_fixed64)
+        }
+        if (value.proto3_kotlin_sint64 != 0L) {
+          ProtoAdapter.SINT64.encodeWithTag(writer, 8, value.proto3_kotlin_sint64)
+        }
+        if (value.proto3_kotlin_uint64 != 0L) {
+          ProtoAdapter.UINT64.encodeWithTag(writer, 7, value.proto3_kotlin_uint64)
+        }
+        if (value.proto3_kotlin_int64 != 0L) {
+          ProtoAdapter.INT64.encodeWithTag(writer, 6, value.proto3_kotlin_int64)
+        }
+        if (value.proto3_kotlin_sfixed32 != 0) {
+          ProtoAdapter.SFIXED32.encodeWithTag(writer, 5, value.proto3_kotlin_sfixed32)
+        }
+        if (value.proto3_kotlin_fixed32 != 0) {
+          ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.proto3_kotlin_fixed32)
+        }
+        if (value.proto3_kotlin_sint32 != 0) {
+          ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.proto3_kotlin_sint32)
+        }
+        if (value.proto3_kotlin_uint32 != 0) {
+          ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.proto3_kotlin_uint32)
+        }
+        if (value.proto3_kotlin_int32 != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 1, value.proto3_kotlin_int32)
+        }
       }
 
       override fun decode(reader: ProtoReader): AllTypes {
@@ -2430,18 +2522,24 @@ public class AllTypes(
       ) {
         override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
-          if (value.a != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
+          if (value.a != 0) {
+            size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
+          }
           return size
         }
 
         override fun encode(writer: ProtoWriter, `value`: NestedMessage) {
-          if (value.a != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          if (value.a != 0) {
+            ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          }
           writer.writeBytes(value.unknownFields)
         }
 
         override fun encode(writer: ReverseProtoWriter, `value`: NestedMessage) {
           writer.writeBytes(value.unknownFields)
-          if (value.a != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          if (value.a != 0) {
+            ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          }
         }
 
         override fun decode(reader: ProtoReader): NestedMessage {

--- a/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
+++ b/wire-tests/src/commonTest/proto-kotlin/com/squareup/wire/proto3/kotlin/person/Person.kt
@@ -182,9 +182,15 @@ public class Person(
     ) {
       override fun encodedSize(`value`: Person): Int {
         var size = value.unknownFields.size
-        if (value.name != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
-        if (value.id != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
-        if (value.email != "") size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        if (value.name != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.name)
+        }
+        if (value.id != 0) {
+          size += ProtoAdapter.INT32.encodedSizeWithTag(2, value.id)
+        }
+        if (value.email != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.email)
+        }
         size += PhoneNumber.ADAPTER.asRepeated().encodedSizeWithTag(4, value.phones)
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(5, value.aliases)
         size += ProtoAdapter.INT32.encodedSizeWithTag(6, value.foo)
@@ -193,9 +199,15 @@ public class Person(
       }
 
       override fun encode(writer: ProtoWriter, `value`: Person) {
-        if (value.name != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
-        if (value.id != 0) ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
-        if (value.email != "") ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
+        if (value.name != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        }
+        if (value.id != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
+        }
+        if (value.email != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
+        }
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phones)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
         ProtoAdapter.INT32.encodeWithTag(writer, 6, value.foo)
@@ -209,9 +221,15 @@ public class Person(
         ProtoAdapter.INT32.encodeWithTag(writer, 6, value.foo)
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 5, value.aliases)
         PhoneNumber.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.phones)
-        if (value.email != "") ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
-        if (value.id != 0) ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
-        if (value.name != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        if (value.email != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 3, value.email)
+        }
+        if (value.id != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 2, value.id)
+        }
+        if (value.name != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.name)
+        }
       }
 
       override fun decode(reader: ProtoReader): Person {
@@ -364,22 +382,33 @@ public class Person(
       ) {
         override fun encodedSize(`value`: PhoneNumber): Int {
           var size = value.unknownFields.size
-          if (value.number != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
-          if (value.type != PhoneType.MOBILE) size += PhoneType.ADAPTER.encodedSizeWithTag(2,
-              value.type)
+          if (value.number != "") {
+            size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.number)
+          }
+          if (value.type != com.squareup.wire.proto3.kotlin.person.Person.PhoneType.MOBILE) {
+            size += PhoneType.ADAPTER.encodedSizeWithTag(2, value.type)
+          }
           return size
         }
 
         override fun encode(writer: ProtoWriter, `value`: PhoneNumber) {
-          if (value.number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
-          if (value.type != PhoneType.MOBILE) PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
+          if (value.number != "") {
+            ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
+          }
+          if (value.type != com.squareup.wire.proto3.kotlin.person.Person.PhoneType.MOBILE) {
+            PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
+          }
           writer.writeBytes(value.unknownFields)
         }
 
         override fun encode(writer: ReverseProtoWriter, `value`: PhoneNumber) {
           writer.writeBytes(value.unknownFields)
-          if (value.type != PhoneType.MOBILE) PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
-          if (value.number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
+          if (value.type != com.squareup.wire.proto3.kotlin.person.Person.PhoneType.MOBILE) {
+            PhoneType.ADAPTER.encodeWithTag(writer, 2, value.type)
+          }
+          if (value.number != "") {
+            ProtoAdapter.STRING.encodeWithTag(writer, 1, value.number)
+          }
         }
 
         override fun decode(reader: ProtoReader): PhoneNumber {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/com/squareup/wire/proto3/alltypes/AllTypes.kt
@@ -1823,35 +1823,57 @@ public class AllTypes(
 
       override fun encodedSize(`value`: AllTypes): Int {
         var size = value.unknownFields.size
-        if (value.my_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.my_int32)
-        if (value.my_uint32 != 0) size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.my_uint32)
-        if (value.my_sint32 != 0) size += ProtoAdapter.SINT32.encodedSizeWithTag(3, value.my_sint32)
-        if (value.my_fixed32 != 0) size += ProtoAdapter.FIXED32.encodedSizeWithTag(4,
-            value.my_fixed32)
-        if (value.my_sfixed32 != 0) size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5,
-            value.my_sfixed32)
-        if (value.my_int64 != 0L) size += ProtoAdapter.INT64.encodedSizeWithTag(6, value.my_int64)
-        if (value.my_uint64 != 0L) size += ProtoAdapter.UINT64.encodedSizeWithTag(7,
-            value.my_uint64)
-        if (value.my_sint64 != 0L) size += ProtoAdapter.SINT64.encodedSizeWithTag(8,
-            value.my_sint64)
-        if (value.my_fixed64 != 0L) size += ProtoAdapter.FIXED64.encodedSizeWithTag(9,
-            value.my_fixed64)
-        if (value.my_sfixed64 != 0L) size += ProtoAdapter.SFIXED64.encodedSizeWithTag(10,
-            value.my_sfixed64)
-        if (value.my_bool != false) size += ProtoAdapter.BOOL.encodedSizeWithTag(11, value.my_bool)
-        if (!value.my_float.equals(0f)) size += ProtoAdapter.FLOAT.encodedSizeWithTag(12,
-            value.my_float)
-        if (!value.my_double.equals(0.0)) size += ProtoAdapter.DOUBLE.encodedSizeWithTag(13,
-            value.my_double)
-        if (value.my_string != "") size += ProtoAdapter.STRING.encodedSizeWithTag(14,
-            value.my_string)
-        if (value.my_bytes != ByteString.EMPTY) size += ProtoAdapter.BYTES.encodedSizeWithTag(15,
-            value.my_bytes)
-        if (value.nested_enum != NestedEnum.UNKNOWN) size +=
-            NestedEnum.ADAPTER.encodedSizeWithTag(16, value.nested_enum)
-        if (value.nested_message != null) size += NestedMessage.ADAPTER.encodedSizeWithTag(17,
-            value.nested_message)
+        if (value.my_int32 != 0) {
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.my_int32)
+        }
+        if (value.my_uint32 != 0) {
+          size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.my_uint32)
+        }
+        if (value.my_sint32 != 0) {
+          size += ProtoAdapter.SINT32.encodedSizeWithTag(3, value.my_sint32)
+        }
+        if (value.my_fixed32 != 0) {
+          size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.my_fixed32)
+        }
+        if (value.my_sfixed32 != 0) {
+          size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5, value.my_sfixed32)
+        }
+        if (value.my_int64 != 0L) {
+          size += ProtoAdapter.INT64.encodedSizeWithTag(6, value.my_int64)
+        }
+        if (value.my_uint64 != 0L) {
+          size += ProtoAdapter.UINT64.encodedSizeWithTag(7, value.my_uint64)
+        }
+        if (value.my_sint64 != 0L) {
+          size += ProtoAdapter.SINT64.encodedSizeWithTag(8, value.my_sint64)
+        }
+        if (value.my_fixed64 != 0L) {
+          size += ProtoAdapter.FIXED64.encodedSizeWithTag(9, value.my_fixed64)
+        }
+        if (value.my_sfixed64 != 0L) {
+          size += ProtoAdapter.SFIXED64.encodedSizeWithTag(10, value.my_sfixed64)
+        }
+        if (value.my_bool != false) {
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(11, value.my_bool)
+        }
+        if (!value.my_float.equals(0f)) {
+          size += ProtoAdapter.FLOAT.encodedSizeWithTag(12, value.my_float)
+        }
+        if (!value.my_double.equals(0.0)) {
+          size += ProtoAdapter.DOUBLE.encodedSizeWithTag(13, value.my_double)
+        }
+        if (value.my_string != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(14, value.my_string)
+        }
+        if (value.my_bytes != okio.ByteString.EMPTY) {
+          size += ProtoAdapter.BYTES.encodedSizeWithTag(15, value.my_bytes)
+        }
+        if (value.nested_enum != com.squareup.wire.proto3.alltypes.AllTypes.NestedEnum.UNKNOWN) {
+          size += NestedEnum.ADAPTER.encodedSizeWithTag(16, value.nested_enum)
+        }
+        if (value.nested_message != null) {
+          size += NestedMessage.ADAPTER.encodedSizeWithTag(17, value.nested_message)
+        }
         size += ProtoAdapter.INT32.encodedSizeWithTag(101, value.opt_int32)
         size += ProtoAdapter.UINT32.encodedSizeWithTag(102, value.opt_uint32)
         size += ProtoAdapter.SINT32.encodedSizeWithTag(103, value.opt_sint32)
@@ -1909,29 +1931,57 @@ public class AllTypes(
       }
 
       override fun encode(writer: ProtoWriter, `value`: AllTypes) {
-        if (value.my_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
-        if (value.my_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
-        if (value.my_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
-        if (value.my_fixed32 != 0) ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
-        if (value.my_sfixed32 != 0) ProtoAdapter.SFIXED32.encodeWithTag(writer, 5,
-            value.my_sfixed32)
-        if (value.my_int64 != 0L) ProtoAdapter.INT64.encodeWithTag(writer, 6, value.my_int64)
-        if (value.my_uint64 != 0L) ProtoAdapter.UINT64.encodeWithTag(writer, 7, value.my_uint64)
-        if (value.my_sint64 != 0L) ProtoAdapter.SINT64.encodeWithTag(writer, 8, value.my_sint64)
-        if (value.my_fixed64 != 0L) ProtoAdapter.FIXED64.encodeWithTag(writer, 9, value.my_fixed64)
-        if (value.my_sfixed64 != 0L) ProtoAdapter.SFIXED64.encodeWithTag(writer, 10,
-            value.my_sfixed64)
-        if (value.my_bool != false) ProtoAdapter.BOOL.encodeWithTag(writer, 11, value.my_bool)
-        if (!value.my_float.equals(0f)) ProtoAdapter.FLOAT.encodeWithTag(writer, 12, value.my_float)
-        if (!value.my_double.equals(0.0)) ProtoAdapter.DOUBLE.encodeWithTag(writer, 13,
-            value.my_double)
-        if (value.my_string != "") ProtoAdapter.STRING.encodeWithTag(writer, 14, value.my_string)
-        if (value.my_bytes != ByteString.EMPTY) ProtoAdapter.BYTES.encodeWithTag(writer, 15,
-            value.my_bytes)
-        if (value.nested_enum != NestedEnum.UNKNOWN) NestedEnum.ADAPTER.encodeWithTag(writer, 16,
-            value.nested_enum)
-        if (value.nested_message != null) NestedMessage.ADAPTER.encodeWithTag(writer, 17,
-            value.nested_message)
+        if (value.my_int32 != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
+        }
+        if (value.my_uint32 != 0) {
+          ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
+        }
+        if (value.my_sint32 != 0) {
+          ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
+        }
+        if (value.my_fixed32 != 0) {
+          ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
+        }
+        if (value.my_sfixed32 != 0) {
+          ProtoAdapter.SFIXED32.encodeWithTag(writer, 5, value.my_sfixed32)
+        }
+        if (value.my_int64 != 0L) {
+          ProtoAdapter.INT64.encodeWithTag(writer, 6, value.my_int64)
+        }
+        if (value.my_uint64 != 0L) {
+          ProtoAdapter.UINT64.encodeWithTag(writer, 7, value.my_uint64)
+        }
+        if (value.my_sint64 != 0L) {
+          ProtoAdapter.SINT64.encodeWithTag(writer, 8, value.my_sint64)
+        }
+        if (value.my_fixed64 != 0L) {
+          ProtoAdapter.FIXED64.encodeWithTag(writer, 9, value.my_fixed64)
+        }
+        if (value.my_sfixed64 != 0L) {
+          ProtoAdapter.SFIXED64.encodeWithTag(writer, 10, value.my_sfixed64)
+        }
+        if (value.my_bool != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 11, value.my_bool)
+        }
+        if (!value.my_float.equals(0f)) {
+          ProtoAdapter.FLOAT.encodeWithTag(writer, 12, value.my_float)
+        }
+        if (!value.my_double.equals(0.0)) {
+          ProtoAdapter.DOUBLE.encodeWithTag(writer, 13, value.my_double)
+        }
+        if (value.my_string != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 14, value.my_string)
+        }
+        if (value.my_bytes != okio.ByteString.EMPTY) {
+          ProtoAdapter.BYTES.encodeWithTag(writer, 15, value.my_bytes)
+        }
+        if (value.nested_enum != com.squareup.wire.proto3.alltypes.AllTypes.NestedEnum.UNKNOWN) {
+          NestedEnum.ADAPTER.encodeWithTag(writer, 16, value.nested_enum)
+        }
+        if (value.nested_message != null) {
+          NestedMessage.ADAPTER.encodeWithTag(writer, 17, value.nested_message)
+        }
         ProtoAdapter.INT32.encodeWithTag(writer, 101, value.opt_int32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 102, value.opt_uint32)
         ProtoAdapter.SINT32.encodeWithTag(writer, 103, value.opt_sint32)
@@ -2043,29 +2093,57 @@ public class AllTypes(
         ProtoAdapter.SINT32.encodeWithTag(writer, 103, value.opt_sint32)
         ProtoAdapter.UINT32.encodeWithTag(writer, 102, value.opt_uint32)
         ProtoAdapter.INT32.encodeWithTag(writer, 101, value.opt_int32)
-        if (value.nested_message != null) NestedMessage.ADAPTER.encodeWithTag(writer, 17,
-            value.nested_message)
-        if (value.nested_enum != NestedEnum.UNKNOWN) NestedEnum.ADAPTER.encodeWithTag(writer, 16,
-            value.nested_enum)
-        if (value.my_bytes != ByteString.EMPTY) ProtoAdapter.BYTES.encodeWithTag(writer, 15,
-            value.my_bytes)
-        if (value.my_string != "") ProtoAdapter.STRING.encodeWithTag(writer, 14, value.my_string)
-        if (!value.my_double.equals(0.0)) ProtoAdapter.DOUBLE.encodeWithTag(writer, 13,
-            value.my_double)
-        if (!value.my_float.equals(0f)) ProtoAdapter.FLOAT.encodeWithTag(writer, 12, value.my_float)
-        if (value.my_bool != false) ProtoAdapter.BOOL.encodeWithTag(writer, 11, value.my_bool)
-        if (value.my_sfixed64 != 0L) ProtoAdapter.SFIXED64.encodeWithTag(writer, 10,
-            value.my_sfixed64)
-        if (value.my_fixed64 != 0L) ProtoAdapter.FIXED64.encodeWithTag(writer, 9, value.my_fixed64)
-        if (value.my_sint64 != 0L) ProtoAdapter.SINT64.encodeWithTag(writer, 8, value.my_sint64)
-        if (value.my_uint64 != 0L) ProtoAdapter.UINT64.encodeWithTag(writer, 7, value.my_uint64)
-        if (value.my_int64 != 0L) ProtoAdapter.INT64.encodeWithTag(writer, 6, value.my_int64)
-        if (value.my_sfixed32 != 0) ProtoAdapter.SFIXED32.encodeWithTag(writer, 5,
-            value.my_sfixed32)
-        if (value.my_fixed32 != 0) ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
-        if (value.my_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
-        if (value.my_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
-        if (value.my_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
+        if (value.nested_message != null) {
+          NestedMessage.ADAPTER.encodeWithTag(writer, 17, value.nested_message)
+        }
+        if (value.nested_enum != com.squareup.wire.proto3.alltypes.AllTypes.NestedEnum.UNKNOWN) {
+          NestedEnum.ADAPTER.encodeWithTag(writer, 16, value.nested_enum)
+        }
+        if (value.my_bytes != okio.ByteString.EMPTY) {
+          ProtoAdapter.BYTES.encodeWithTag(writer, 15, value.my_bytes)
+        }
+        if (value.my_string != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 14, value.my_string)
+        }
+        if (!value.my_double.equals(0.0)) {
+          ProtoAdapter.DOUBLE.encodeWithTag(writer, 13, value.my_double)
+        }
+        if (!value.my_float.equals(0f)) {
+          ProtoAdapter.FLOAT.encodeWithTag(writer, 12, value.my_float)
+        }
+        if (value.my_bool != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 11, value.my_bool)
+        }
+        if (value.my_sfixed64 != 0L) {
+          ProtoAdapter.SFIXED64.encodeWithTag(writer, 10, value.my_sfixed64)
+        }
+        if (value.my_fixed64 != 0L) {
+          ProtoAdapter.FIXED64.encodeWithTag(writer, 9, value.my_fixed64)
+        }
+        if (value.my_sint64 != 0L) {
+          ProtoAdapter.SINT64.encodeWithTag(writer, 8, value.my_sint64)
+        }
+        if (value.my_uint64 != 0L) {
+          ProtoAdapter.UINT64.encodeWithTag(writer, 7, value.my_uint64)
+        }
+        if (value.my_int64 != 0L) {
+          ProtoAdapter.INT64.encodeWithTag(writer, 6, value.my_int64)
+        }
+        if (value.my_sfixed32 != 0) {
+          ProtoAdapter.SFIXED32.encodeWithTag(writer, 5, value.my_sfixed32)
+        }
+        if (value.my_fixed32 != 0) {
+          ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
+        }
+        if (value.my_sint32 != 0) {
+          ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
+        }
+        if (value.my_uint32 != 0) {
+          ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
+        }
+        if (value.my_int32 != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
+        }
       }
 
       override fun decode(reader: ProtoReader): AllTypes {
@@ -2531,18 +2609,24 @@ public class AllTypes(
       ) {
         override fun encodedSize(`value`: NestedMessage): Int {
           var size = value.unknownFields.size
-          if (value.a != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
+          if (value.a != 0) {
+            size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.a)
+          }
           return size
         }
 
         override fun encode(writer: ProtoWriter, `value`: NestedMessage) {
-          if (value.a != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          if (value.a != 0) {
+            ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          }
           writer.writeBytes(value.unknownFields)
         }
 
         override fun encode(writer: ReverseProtoWriter, `value`: NestedMessage) {
           writer.writeBytes(value.unknownFields)
-          if (value.a != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          if (value.a != 0) {
+            ProtoAdapter.INT32.encodeWithTag(writer, 1, value.a)
+          }
         }
 
         override fun decode(reader: ProtoReader): NestedMessage {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All32.kt
@@ -661,13 +661,21 @@ public class All32(
 
       override fun encodedSize(`value`: All32): Int {
         var size = value.unknownFields.size
-        if (value.my_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.my_int32)
-        if (value.my_uint32 != 0) size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.my_uint32)
-        if (value.my_sint32 != 0) size += ProtoAdapter.SINT32.encodedSizeWithTag(3, value.my_sint32)
-        if (value.my_fixed32 != 0) size += ProtoAdapter.FIXED32.encodedSizeWithTag(4,
-            value.my_fixed32)
-        if (value.my_sfixed32 != 0) size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5,
-            value.my_sfixed32)
+        if (value.my_int32 != 0) {
+          size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.my_int32)
+        }
+        if (value.my_uint32 != 0) {
+          size += ProtoAdapter.UINT32.encodedSizeWithTag(2, value.my_uint32)
+        }
+        if (value.my_sint32 != 0) {
+          size += ProtoAdapter.SINT32.encodedSizeWithTag(3, value.my_sint32)
+        }
+        if (value.my_fixed32 != 0) {
+          size += ProtoAdapter.FIXED32.encodedSizeWithTag(4, value.my_fixed32)
+        }
+        if (value.my_sfixed32 != 0) {
+          size += ProtoAdapter.SFIXED32.encodedSizeWithTag(5, value.my_sfixed32)
+        }
         size += ProtoAdapter.INT32.asRepeated().encodedSizeWithTag(201, value.rep_int32)
         size += ProtoAdapter.UINT32.asRepeated().encodedSizeWithTag(202, value.rep_uint32)
         size += ProtoAdapter.SINT32.asRepeated().encodedSizeWithTag(203, value.rep_sint32)
@@ -689,12 +697,21 @@ public class All32(
       }
 
       override fun encode(writer: ProtoWriter, `value`: All32) {
-        if (value.my_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
-        if (value.my_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
-        if (value.my_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
-        if (value.my_fixed32 != 0) ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
-        if (value.my_sfixed32 != 0) ProtoAdapter.SFIXED32.encodeWithTag(writer, 5,
-            value.my_sfixed32)
+        if (value.my_int32 != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
+        }
+        if (value.my_uint32 != 0) {
+          ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
+        }
+        if (value.my_sint32 != 0) {
+          ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
+        }
+        if (value.my_fixed32 != 0) {
+          ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
+        }
+        if (value.my_sfixed32 != 0) {
+          ProtoAdapter.SFIXED32.encodeWithTag(writer, 5, value.my_sfixed32)
+        }
         ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32)
         ProtoAdapter.UINT32.asRepeated().encodeWithTag(writer, 202, value.rep_uint32)
         ProtoAdapter.SINT32.asRepeated().encodeWithTag(writer, 203, value.rep_sint32)
@@ -734,12 +751,21 @@ public class All32(
         ProtoAdapter.SINT32.asRepeated().encodeWithTag(writer, 203, value.rep_sint32)
         ProtoAdapter.UINT32.asRepeated().encodeWithTag(writer, 202, value.rep_uint32)
         ProtoAdapter.INT32.asRepeated().encodeWithTag(writer, 201, value.rep_int32)
-        if (value.my_sfixed32 != 0) ProtoAdapter.SFIXED32.encodeWithTag(writer, 5,
-            value.my_sfixed32)
-        if (value.my_fixed32 != 0) ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
-        if (value.my_sint32 != 0) ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
-        if (value.my_uint32 != 0) ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
-        if (value.my_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
+        if (value.my_sfixed32 != 0) {
+          ProtoAdapter.SFIXED32.encodeWithTag(writer, 5, value.my_sfixed32)
+        }
+        if (value.my_fixed32 != 0) {
+          ProtoAdapter.FIXED32.encodeWithTag(writer, 4, value.my_fixed32)
+        }
+        if (value.my_sint32 != 0) {
+          ProtoAdapter.SINT32.encodeWithTag(writer, 3, value.my_sint32)
+        }
+        if (value.my_uint32 != 0) {
+          ProtoAdapter.UINT32.encodeWithTag(writer, 2, value.my_uint32)
+        }
+        if (value.my_int32 != 0) {
+          ProtoAdapter.INT32.encodeWithTag(writer, 1, value.my_int32)
+        }
       }
 
       override fun decode(reader: ProtoReader): All32 {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/All64.kt
@@ -663,15 +663,21 @@ public class All64(
 
       override fun encodedSize(`value`: All64): Int {
         var size = value.unknownFields.size
-        if (value.my_int64 != 0L) size += ProtoAdapter.INT64.encodedSizeWithTag(1, value.my_int64)
-        if (value.my_uint64 != 0L) size += ProtoAdapter.UINT64.encodedSizeWithTag(2,
-            value.my_uint64)
-        if (value.my_sint64 != 0L) size += ProtoAdapter.SINT64.encodedSizeWithTag(3,
-            value.my_sint64)
-        if (value.my_fixed64 != 0L) size += ProtoAdapter.FIXED64.encodedSizeWithTag(4,
-            value.my_fixed64)
-        if (value.my_sfixed64 != 0L) size += ProtoAdapter.SFIXED64.encodedSizeWithTag(5,
-            value.my_sfixed64)
+        if (value.my_int64 != 0L) {
+          size += ProtoAdapter.INT64.encodedSizeWithTag(1, value.my_int64)
+        }
+        if (value.my_uint64 != 0L) {
+          size += ProtoAdapter.UINT64.encodedSizeWithTag(2, value.my_uint64)
+        }
+        if (value.my_sint64 != 0L) {
+          size += ProtoAdapter.SINT64.encodedSizeWithTag(3, value.my_sint64)
+        }
+        if (value.my_fixed64 != 0L) {
+          size += ProtoAdapter.FIXED64.encodedSizeWithTag(4, value.my_fixed64)
+        }
+        if (value.my_sfixed64 != 0L) {
+          size += ProtoAdapter.SFIXED64.encodedSizeWithTag(5, value.my_sfixed64)
+        }
         size += ProtoAdapter.INT64.asRepeated().encodedSizeWithTag(201, value.rep_int64)
         size += ProtoAdapter.UINT64.asRepeated().encodedSizeWithTag(202, value.rep_uint64)
         size += ProtoAdapter.SINT64.asRepeated().encodedSizeWithTag(203, value.rep_sint64)
@@ -693,12 +699,21 @@ public class All64(
       }
 
       override fun encode(writer: ProtoWriter, `value`: All64) {
-        if (value.my_int64 != 0L) ProtoAdapter.INT64.encodeWithTag(writer, 1, value.my_int64)
-        if (value.my_uint64 != 0L) ProtoAdapter.UINT64.encodeWithTag(writer, 2, value.my_uint64)
-        if (value.my_sint64 != 0L) ProtoAdapter.SINT64.encodeWithTag(writer, 3, value.my_sint64)
-        if (value.my_fixed64 != 0L) ProtoAdapter.FIXED64.encodeWithTag(writer, 4, value.my_fixed64)
-        if (value.my_sfixed64 != 0L) ProtoAdapter.SFIXED64.encodeWithTag(writer, 5,
-            value.my_sfixed64)
+        if (value.my_int64 != 0L) {
+          ProtoAdapter.INT64.encodeWithTag(writer, 1, value.my_int64)
+        }
+        if (value.my_uint64 != 0L) {
+          ProtoAdapter.UINT64.encodeWithTag(writer, 2, value.my_uint64)
+        }
+        if (value.my_sint64 != 0L) {
+          ProtoAdapter.SINT64.encodeWithTag(writer, 3, value.my_sint64)
+        }
+        if (value.my_fixed64 != 0L) {
+          ProtoAdapter.FIXED64.encodeWithTag(writer, 4, value.my_fixed64)
+        }
+        if (value.my_sfixed64 != 0L) {
+          ProtoAdapter.SFIXED64.encodeWithTag(writer, 5, value.my_sfixed64)
+        }
         ProtoAdapter.INT64.asRepeated().encodeWithTag(writer, 201, value.rep_int64)
         ProtoAdapter.UINT64.asRepeated().encodeWithTag(writer, 202, value.rep_uint64)
         ProtoAdapter.SINT64.asRepeated().encodeWithTag(writer, 203, value.rep_sint64)
@@ -738,12 +753,21 @@ public class All64(
         ProtoAdapter.SINT64.asRepeated().encodeWithTag(writer, 203, value.rep_sint64)
         ProtoAdapter.UINT64.asRepeated().encodeWithTag(writer, 202, value.rep_uint64)
         ProtoAdapter.INT64.asRepeated().encodeWithTag(writer, 201, value.rep_int64)
-        if (value.my_sfixed64 != 0L) ProtoAdapter.SFIXED64.encodeWithTag(writer, 5,
-            value.my_sfixed64)
-        if (value.my_fixed64 != 0L) ProtoAdapter.FIXED64.encodeWithTag(writer, 4, value.my_fixed64)
-        if (value.my_sint64 != 0L) ProtoAdapter.SINT64.encodeWithTag(writer, 3, value.my_sint64)
-        if (value.my_uint64 != 0L) ProtoAdapter.UINT64.encodeWithTag(writer, 2, value.my_uint64)
-        if (value.my_int64 != 0L) ProtoAdapter.INT64.encodeWithTag(writer, 1, value.my_int64)
+        if (value.my_sfixed64 != 0L) {
+          ProtoAdapter.SFIXED64.encodeWithTag(writer, 5, value.my_sfixed64)
+        }
+        if (value.my_fixed64 != 0L) {
+          ProtoAdapter.FIXED64.encodeWithTag(writer, 4, value.my_fixed64)
+        }
+        if (value.my_sint64 != 0L) {
+          ProtoAdapter.SINT64.encodeWithTag(writer, 3, value.my_sint64)
+        }
+        if (value.my_uint64 != 0L) {
+          ProtoAdapter.UINT64.encodeWithTag(writer, 2, value.my_uint64)
+        }
+        if (value.my_int64 != 0L) {
+          ProtoAdapter.INT64.encodeWithTag(writer, 1, value.my_int64)
+        }
       }
 
       override fun decode(reader: ProtoReader): All64 {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllStructs.kt
@@ -589,23 +589,33 @@ public class AllStructs(
 
       override fun encodedSize(`value`: AllStructs): Int {
         var size = value.unknownFields.size
-        if (value.struct != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(1,
-            value.struct)
-        if (value.list != null) size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(2, value.list)
-        if (value.null_value != null) size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(3,
-            value.null_value)
-        if (value.value_a != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(4,
-            value.value_a)
-        if (value.value_b != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(5,
-            value.value_b)
-        if (value.value_c != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(6,
-            value.value_c)
-        if (value.value_d != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(7,
-            value.value_d)
-        if (value.value_e != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(8,
-            value.value_e)
-        if (value.value_f != null) size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(9,
-            value.value_f)
+        if (value.struct != null) {
+          size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(1, value.struct)
+        }
+        if (value.list != null) {
+          size += ProtoAdapter.STRUCT_LIST.encodedSizeWithTag(2, value.list)
+        }
+        if (value.null_value != null) {
+          size += ProtoAdapter.STRUCT_NULL.encodedSizeWithTag(3, value.null_value)
+        }
+        if (value.value_a != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(4, value.value_a)
+        }
+        if (value.value_b != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(5, value.value_b)
+        }
+        if (value.value_c != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(6, value.value_c)
+        }
+        if (value.value_d != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(7, value.value_d)
+        }
+        if (value.value_e != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(8, value.value_e)
+        }
+        if (value.value_f != null) {
+          size += ProtoAdapter.STRUCT_VALUE.encodedSizeWithTag(9, value.value_f)
+        }
         size += ProtoAdapter.STRUCT_MAP.asRepeated().encodedSizeWithTag(101, value.rep_struct)
         size += ProtoAdapter.STRUCT_LIST.asRepeated().encodedSizeWithTag(102, value.rep_list)
         size += ProtoAdapter.STRUCT_VALUE.asRepeated().encodedSizeWithTag(103, value.rep_value_a)
@@ -620,16 +630,33 @@ public class AllStructs(
       }
 
       override fun encode(writer: ProtoWriter, `value`: AllStructs) {
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
-        if (value.list != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3,
-            value.null_value)
-        if (value.value_a != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
-        if (value.value_b != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
-        if (value.value_c != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
-        if (value.value_d != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
-        if (value.value_e != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
-        if (value.value_f != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        }
+        if (value.list != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3, value.null_value)
+        }
+        if (value.value_a != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
+        }
+        if (value.value_b != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
+        }
+        if (value.value_c != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
+        }
+        if (value.value_d != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
+        }
+        if (value.value_e != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
+        }
+        if (value.value_f != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        }
         ProtoAdapter.STRUCT_MAP.asRepeated().encodeWithTag(writer, 101, value.rep_struct)
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
@@ -655,16 +682,33 @@ public class AllStructs(
         ProtoAdapter.STRUCT_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_value_a)
         ProtoAdapter.STRUCT_LIST.asRepeated().encodeWithTag(writer, 102, value.rep_list)
         ProtoAdapter.STRUCT_MAP.asRepeated().encodeWithTag(writer, 101, value.rep_struct)
-        if (value.value_f != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
-        if (value.value_e != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
-        if (value.value_d != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
-        if (value.value_c != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
-        if (value.value_b != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
-        if (value.value_a != null) ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
-        if (value.null_value != null) ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3,
-            value.null_value)
-        if (value.list != null) ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
-        if (value.struct != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        if (value.value_f != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 9, value.value_f)
+        }
+        if (value.value_e != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 8, value.value_e)
+        }
+        if (value.value_d != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 7, value.value_d)
+        }
+        if (value.value_c != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 6, value.value_c)
+        }
+        if (value.value_b != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 5, value.value_b)
+        }
+        if (value.value_a != null) {
+          ProtoAdapter.STRUCT_VALUE.encodeWithTag(writer, 4, value.value_a)
+        }
+        if (value.null_value != null) {
+          ProtoAdapter.STRUCT_NULL.encodeWithTag(writer, 3, value.null_value)
+        }
+        if (value.list != null) {
+          ProtoAdapter.STRUCT_LIST.encodeWithTag(writer, 2, value.list)
+        }
+        if (value.struct != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 1, value.struct)
+        }
       }
 
       override fun decode(reader: ProtoReader): AllStructs {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/AllWrappers.kt
@@ -791,24 +791,33 @@ public class AllWrappers(
 
       override fun encodedSize(`value`: AllWrappers): Int {
         var size = value.unknownFields.size
-        if (value.double_value != null) size += ProtoAdapter.DOUBLE_VALUE.encodedSizeWithTag(1,
-            value.double_value)
-        if (value.float_value != null) size += ProtoAdapter.FLOAT_VALUE.encodedSizeWithTag(2,
-            value.float_value)
-        if (value.int64_value != null) size += ProtoAdapter.INT64_VALUE.encodedSizeWithTag(3,
-            value.int64_value)
-        if (value.uint64_value != null) size += ProtoAdapter.UINT64_VALUE.encodedSizeWithTag(4,
-            value.uint64_value)
-        if (value.int32_value != null) size += ProtoAdapter.INT32_VALUE.encodedSizeWithTag(5,
-            value.int32_value)
-        if (value.uint32_value != null) size += ProtoAdapter.UINT32_VALUE.encodedSizeWithTag(6,
-            value.uint32_value)
-        if (value.bool_value != null) size += ProtoAdapter.BOOL_VALUE.encodedSizeWithTag(7,
-            value.bool_value)
-        if (value.string_value != null) size += ProtoAdapter.STRING_VALUE.encodedSizeWithTag(8,
-            value.string_value)
-        if (value.bytes_value != null) size += ProtoAdapter.BYTES_VALUE.encodedSizeWithTag(9,
-            value.bytes_value)
+        if (value.double_value != null) {
+          size += ProtoAdapter.DOUBLE_VALUE.encodedSizeWithTag(1, value.double_value)
+        }
+        if (value.float_value != null) {
+          size += ProtoAdapter.FLOAT_VALUE.encodedSizeWithTag(2, value.float_value)
+        }
+        if (value.int64_value != null) {
+          size += ProtoAdapter.INT64_VALUE.encodedSizeWithTag(3, value.int64_value)
+        }
+        if (value.uint64_value != null) {
+          size += ProtoAdapter.UINT64_VALUE.encodedSizeWithTag(4, value.uint64_value)
+        }
+        if (value.int32_value != null) {
+          size += ProtoAdapter.INT32_VALUE.encodedSizeWithTag(5, value.int32_value)
+        }
+        if (value.uint32_value != null) {
+          size += ProtoAdapter.UINT32_VALUE.encodedSizeWithTag(6, value.uint32_value)
+        }
+        if (value.bool_value != null) {
+          size += ProtoAdapter.BOOL_VALUE.encodedSizeWithTag(7, value.bool_value)
+        }
+        if (value.string_value != null) {
+          size += ProtoAdapter.STRING_VALUE.encodedSizeWithTag(8, value.string_value)
+        }
+        if (value.bytes_value != null) {
+          size += ProtoAdapter.BYTES_VALUE.encodedSizeWithTag(9, value.bytes_value)
+        }
         size += ProtoAdapter.DOUBLE_VALUE.asRepeated().encodedSizeWithTag(101,
             value.rep_double_value)
         size += ProtoAdapter.FLOAT_VALUE.asRepeated().encodedSizeWithTag(102, value.rep_float_value)
@@ -835,24 +844,33 @@ public class AllWrappers(
       }
 
       override fun encode(writer: ProtoWriter, `value`: AllWrappers) {
-        if (value.double_value != null) ProtoAdapter.DOUBLE_VALUE.encodeWithTag(writer, 1,
-            value.double_value)
-        if (value.float_value != null) ProtoAdapter.FLOAT_VALUE.encodeWithTag(writer, 2,
-            value.float_value)
-        if (value.int64_value != null) ProtoAdapter.INT64_VALUE.encodeWithTag(writer, 3,
-            value.int64_value)
-        if (value.uint64_value != null) ProtoAdapter.UINT64_VALUE.encodeWithTag(writer, 4,
-            value.uint64_value)
-        if (value.int32_value != null) ProtoAdapter.INT32_VALUE.encodeWithTag(writer, 5,
-            value.int32_value)
-        if (value.uint32_value != null) ProtoAdapter.UINT32_VALUE.encodeWithTag(writer, 6,
-            value.uint32_value)
-        if (value.bool_value != null) ProtoAdapter.BOOL_VALUE.encodeWithTag(writer, 7,
-            value.bool_value)
-        if (value.string_value != null) ProtoAdapter.STRING_VALUE.encodeWithTag(writer, 8,
-            value.string_value)
-        if (value.bytes_value != null) ProtoAdapter.BYTES_VALUE.encodeWithTag(writer, 9,
-            value.bytes_value)
+        if (value.double_value != null) {
+          ProtoAdapter.DOUBLE_VALUE.encodeWithTag(writer, 1, value.double_value)
+        }
+        if (value.float_value != null) {
+          ProtoAdapter.FLOAT_VALUE.encodeWithTag(writer, 2, value.float_value)
+        }
+        if (value.int64_value != null) {
+          ProtoAdapter.INT64_VALUE.encodeWithTag(writer, 3, value.int64_value)
+        }
+        if (value.uint64_value != null) {
+          ProtoAdapter.UINT64_VALUE.encodeWithTag(writer, 4, value.uint64_value)
+        }
+        if (value.int32_value != null) {
+          ProtoAdapter.INT32_VALUE.encodeWithTag(writer, 5, value.int32_value)
+        }
+        if (value.uint32_value != null) {
+          ProtoAdapter.UINT32_VALUE.encodeWithTag(writer, 6, value.uint32_value)
+        }
+        if (value.bool_value != null) {
+          ProtoAdapter.BOOL_VALUE.encodeWithTag(writer, 7, value.bool_value)
+        }
+        if (value.string_value != null) {
+          ProtoAdapter.STRING_VALUE.encodeWithTag(writer, 8, value.string_value)
+        }
+        if (value.bytes_value != null) {
+          ProtoAdapter.BYTES_VALUE.encodeWithTag(writer, 9, value.bytes_value)
+        }
         ProtoAdapter.DOUBLE_VALUE.asRepeated().encodeWithTag(writer, 101, value.rep_double_value)
         ProtoAdapter.FLOAT_VALUE.asRepeated().encodeWithTag(writer, 102, value.rep_float_value)
         ProtoAdapter.INT64_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_int64_value)
@@ -894,24 +912,33 @@ public class AllWrappers(
         ProtoAdapter.INT64_VALUE.asRepeated().encodeWithTag(writer, 103, value.rep_int64_value)
         ProtoAdapter.FLOAT_VALUE.asRepeated().encodeWithTag(writer, 102, value.rep_float_value)
         ProtoAdapter.DOUBLE_VALUE.asRepeated().encodeWithTag(writer, 101, value.rep_double_value)
-        if (value.bytes_value != null) ProtoAdapter.BYTES_VALUE.encodeWithTag(writer, 9,
-            value.bytes_value)
-        if (value.string_value != null) ProtoAdapter.STRING_VALUE.encodeWithTag(writer, 8,
-            value.string_value)
-        if (value.bool_value != null) ProtoAdapter.BOOL_VALUE.encodeWithTag(writer, 7,
-            value.bool_value)
-        if (value.uint32_value != null) ProtoAdapter.UINT32_VALUE.encodeWithTag(writer, 6,
-            value.uint32_value)
-        if (value.int32_value != null) ProtoAdapter.INT32_VALUE.encodeWithTag(writer, 5,
-            value.int32_value)
-        if (value.uint64_value != null) ProtoAdapter.UINT64_VALUE.encodeWithTag(writer, 4,
-            value.uint64_value)
-        if (value.int64_value != null) ProtoAdapter.INT64_VALUE.encodeWithTag(writer, 3,
-            value.int64_value)
-        if (value.float_value != null) ProtoAdapter.FLOAT_VALUE.encodeWithTag(writer, 2,
-            value.float_value)
-        if (value.double_value != null) ProtoAdapter.DOUBLE_VALUE.encodeWithTag(writer, 1,
-            value.double_value)
+        if (value.bytes_value != null) {
+          ProtoAdapter.BYTES_VALUE.encodeWithTag(writer, 9, value.bytes_value)
+        }
+        if (value.string_value != null) {
+          ProtoAdapter.STRING_VALUE.encodeWithTag(writer, 8, value.string_value)
+        }
+        if (value.bool_value != null) {
+          ProtoAdapter.BOOL_VALUE.encodeWithTag(writer, 7, value.bool_value)
+        }
+        if (value.uint32_value != null) {
+          ProtoAdapter.UINT32_VALUE.encodeWithTag(writer, 6, value.uint32_value)
+        }
+        if (value.int32_value != null) {
+          ProtoAdapter.INT32_VALUE.encodeWithTag(writer, 5, value.int32_value)
+        }
+        if (value.uint64_value != null) {
+          ProtoAdapter.UINT64_VALUE.encodeWithTag(writer, 4, value.uint64_value)
+        }
+        if (value.int64_value != null) {
+          ProtoAdapter.INT64_VALUE.encodeWithTag(writer, 3, value.int64_value)
+        }
+        if (value.float_value != null) {
+          ProtoAdapter.FLOAT_VALUE.encodeWithTag(writer, 2, value.float_value)
+        }
+        if (value.double_value != null) {
+          ProtoAdapter.DOUBLE_VALUE.encodeWithTag(writer, 1, value.double_value)
+        }
       }
 
       override fun decode(reader: ProtoReader): AllWrappers {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/BuyOneGetOnePromotion.kt
@@ -97,18 +97,24 @@ public class BuyOneGetOnePromotion(
     ) {
       override fun encodedSize(`value`: BuyOneGetOnePromotion): Int {
         var size = value.unknownFields.size
-        if (value.coupon != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.coupon)
+        if (value.coupon != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.coupon)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: BuyOneGetOnePromotion) {
-        if (value.coupon != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        if (value.coupon != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: BuyOneGetOnePromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.coupon != "") ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        if (value.coupon != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.coupon)
+        }
       }
 
       override fun decode(reader: ProtoReader): BuyOneGetOnePromotion {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/CamelCase.kt
@@ -182,21 +182,25 @@ public class CamelCase(
 
       override fun encodedSize(`value`: CamelCase): Int {
         var size = value.unknownFields.size
-        if (value.nested__message != null) size += NestedCamelCase.ADAPTER.encodedSizeWithTag(1,
-            value.nested__message)
+        if (value.nested__message != null) {
+          size += NestedCamelCase.ADAPTER.encodedSizeWithTag(1, value.nested__message)
+        }
         size += ProtoAdapter.INT32.asPacked().encodedSizeWithTag(2, value._Rep_int32)
-        if (value.IDitIt_my_wAy != "") size += ProtoAdapter.STRING.encodedSizeWithTag(3,
-            value.IDitIt_my_wAy)
+        if (value.IDitIt_my_wAy != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(3, value.IDitIt_my_wAy)
+        }
         size += map_int32_Int32Adapter.encodedSizeWithTag(4, value.map_int32_Int32)
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: CamelCase) {
-        if (value.nested__message != null) NestedCamelCase.ADAPTER.encodeWithTag(writer, 1,
-            value.nested__message)
+        if (value.nested__message != null) {
+          NestedCamelCase.ADAPTER.encodeWithTag(writer, 1, value.nested__message)
+        }
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 2, value._Rep_int32)
-        if (value.IDitIt_my_wAy != "") ProtoAdapter.STRING.encodeWithTag(writer, 3,
-            value.IDitIt_my_wAy)
+        if (value.IDitIt_my_wAy != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 3, value.IDitIt_my_wAy)
+        }
         map_int32_Int32Adapter.encodeWithTag(writer, 4, value.map_int32_Int32)
         writer.writeBytes(value.unknownFields)
       }
@@ -204,11 +208,13 @@ public class CamelCase(
       override fun encode(writer: ReverseProtoWriter, `value`: CamelCase) {
         writer.writeBytes(value.unknownFields)
         map_int32_Int32Adapter.encodeWithTag(writer, 4, value.map_int32_Int32)
-        if (value.IDitIt_my_wAy != "") ProtoAdapter.STRING.encodeWithTag(writer, 3,
-            value.IDitIt_my_wAy)
+        if (value.IDitIt_my_wAy != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 3, value.IDitIt_my_wAy)
+        }
         ProtoAdapter.INT32.asPacked().encodeWithTag(writer, 2, value._Rep_int32)
-        if (value.nested__message != null) NestedCamelCase.ADAPTER.encodeWithTag(writer, 1,
-            value.nested__message)
+        if (value.nested__message != null) {
+          NestedCamelCase.ADAPTER.encodeWithTag(writer, 1, value.nested__message)
+        }
       }
 
       override fun decode(reader: ProtoReader): CamelCase {
@@ -328,19 +334,24 @@ public class CamelCase(
       ) {
         override fun encodedSize(`value`: NestedCamelCase): Int {
           var size = value.unknownFields.size
-          if (value.one_int32 != 0) size += ProtoAdapter.INT32.encodedSizeWithTag(1,
-              value.one_int32)
+          if (value.one_int32 != 0) {
+            size += ProtoAdapter.INT32.encodedSizeWithTag(1, value.one_int32)
+          }
           return size
         }
 
         override fun encode(writer: ProtoWriter, `value`: NestedCamelCase) {
-          if (value.one_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.one_int32)
+          if (value.one_int32 != 0) {
+            ProtoAdapter.INT32.encodeWithTag(writer, 1, value.one_int32)
+          }
           writer.writeBytes(value.unknownFields)
         }
 
         override fun encode(writer: ReverseProtoWriter, `value`: NestedCamelCase) {
           writer.writeBytes(value.unknownFields)
-          if (value.one_int32 != 0) ProtoAdapter.INT32.encodeWithTag(writer, 1, value.one_int32)
+          if (value.one_int32 != 0) {
+            ProtoAdapter.INT32.encodeWithTag(writer, 1, value.one_int32)
+          }
         }
 
         override fun decode(reader: ProtoReader): NestedCamelCase {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeDrinkPromotion.kt
@@ -99,18 +99,24 @@ public class FreeDrinkPromotion(
     ) {
       override fun encodedSize(`value`: FreeDrinkPromotion): Int {
         var size = value.unknownFields.size
-        if (value.drink != Drink.UNKNOWN) size += Drink.ADAPTER.encodedSizeWithTag(1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          size += Drink.ADAPTER.encodedSizeWithTag(1, value.drink)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: FreeDrinkPromotion) {
-        if (value.drink != Drink.UNKNOWN) Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: FreeDrinkPromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.drink != Drink.UNKNOWN) Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        if (value.drink != squareup.proto3.FreeDrinkPromotion.Drink.UNKNOWN) {
+          Drink.ADAPTER.encodeWithTag(writer, 1, value.drink)
+        }
       }
 
       override fun decode(reader: ProtoReader): FreeDrinkPromotion {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/FreeGarlicBreadPromotion.kt
@@ -99,21 +99,24 @@ public class FreeGarlicBreadPromotion(
     ) {
       override fun encodedSize(`value`: FreeGarlicBreadPromotion): Int {
         var size = value.unknownFields.size
-        if (value.is_extra_cheesey != false) size += ProtoAdapter.BOOL.encodedSizeWithTag(1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(1, value.is_extra_cheesey)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: FreeGarlicBreadPromotion) {
-        if (value.is_extra_cheesey != false) ProtoAdapter.BOOL.encodeWithTag(writer, 1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.is_extra_cheesey)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: FreeGarlicBreadPromotion) {
         writer.writeBytes(value.unknownFields)
-        if (value.is_extra_cheesey != false) ProtoAdapter.BOOL.encodeWithTag(writer, 1,
-            value.is_extra_cheesey)
+        if (value.is_extra_cheesey != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 1, value.is_extra_cheesey)
+        }
       }
 
       override fun decode(reader: ProtoReader): FreeGarlicBreadPromotion {

--- a/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
+++ b/wire-tests/src/jvmJsonKotlinTest/proto-kotlin/squareup/proto3/PizzaDelivery.kt
@@ -249,47 +249,72 @@ public class PizzaDelivery(
     ) {
       override fun encodedSize(`value`: PizzaDelivery): Int {
         var size = value.unknownFields.size
-        if (value.phone_number != "") size += ProtoAdapter.STRING.encodedSizeWithTag(1,
-            value.phone_number)
-        if (value.address != "") size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.address)
+        if (value.phone_number != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.phone_number)
+        }
+        if (value.address != "") {
+          size += ProtoAdapter.STRING.encodedSizeWithTag(2, value.address)
+        }
         size += Pizza.ADAPTER.asRepeated().encodedSizeWithTag(3, value.pizzas)
-        if (value.promotion != null) size += AnyMessage.ADAPTER.encodedSizeWithTag(4,
-            value.promotion)
-        if (value.delivered_within_or_free != null) size +=
-            ProtoAdapter.DURATION.encodedSizeWithTag(5, value.delivered_within_or_free)
-        if (value.loyalty != null) size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(6,
-            value.loyalty)
-        if (value.ordered_at != null) size += ProtoAdapter.INSTANT.encodedSizeWithTag(7,
-            value.ordered_at)
+        if (value.promotion != null) {
+          size += AnyMessage.ADAPTER.encodedSizeWithTag(4, value.promotion)
+        }
+        if (value.delivered_within_or_free != null) {
+          size += ProtoAdapter.DURATION.encodedSizeWithTag(5, value.delivered_within_or_free)
+        }
+        if (value.loyalty != null) {
+          size += ProtoAdapter.STRUCT_MAP.encodedSizeWithTag(6, value.loyalty)
+        }
+        if (value.ordered_at != null) {
+          size += ProtoAdapter.INSTANT.encodedSizeWithTag(7, value.ordered_at)
+        }
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: PizzaDelivery) {
-        if (value.phone_number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1,
-            value.phone_number)
-        if (value.address != "") ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        if (value.phone_number != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.phone_number)
+        }
+        if (value.address != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        }
         Pizza.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.pizzas)
-        if (value.promotion != null) AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
-        if (value.delivered_within_or_free != null) ProtoAdapter.DURATION.encodeWithTag(writer, 5,
-            value.delivered_within_or_free)
-        if (value.loyalty != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
-        if (value.ordered_at != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 7,
-            value.ordered_at)
+        if (value.promotion != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        }
+        if (value.delivered_within_or_free != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 5, value.delivered_within_or_free)
+        }
+        if (value.loyalty != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
+        }
+        if (value.ordered_at != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 7, value.ordered_at)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: PizzaDelivery) {
         writer.writeBytes(value.unknownFields)
-        if (value.ordered_at != null) ProtoAdapter.INSTANT.encodeWithTag(writer, 7,
-            value.ordered_at)
-        if (value.loyalty != null) ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
-        if (value.delivered_within_or_free != null) ProtoAdapter.DURATION.encodeWithTag(writer, 5,
-            value.delivered_within_or_free)
-        if (value.promotion != null) AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        if (value.ordered_at != null) {
+          ProtoAdapter.INSTANT.encodeWithTag(writer, 7, value.ordered_at)
+        }
+        if (value.loyalty != null) {
+          ProtoAdapter.STRUCT_MAP.encodeWithTag(writer, 6, value.loyalty)
+        }
+        if (value.delivered_within_or_free != null) {
+          ProtoAdapter.DURATION.encodeWithTag(writer, 5, value.delivered_within_or_free)
+        }
+        if (value.promotion != null) {
+          AnyMessage.ADAPTER.encodeWithTag(writer, 4, value.promotion)
+        }
         Pizza.ADAPTER.asRepeated().encodeWithTag(writer, 3, value.pizzas)
-        if (value.address != "") ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
-        if (value.phone_number != "") ProtoAdapter.STRING.encodeWithTag(writer, 1,
-            value.phone_number)
+        if (value.address != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 2, value.address)
+        }
+        if (value.phone_number != "") {
+          ProtoAdapter.STRING.encodeWithTag(writer, 1, value.phone_number)
+        }
       }
 
       override fun decode(reader: ProtoReader): PizzaDelivery {

--- a/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/Easter.kt
+++ b/wire-tests/src/jvmKotlinInteropTest/proto-kotlin/squareup/Easter.kt
@@ -180,8 +180,9 @@ public class Easter(
       override fun encodedSize(`value`: Easter): Int {
         var size = value.unknownFields.size
         size += EasterAnimal.ADAPTER.encodedSizeWithTag(2, value.optional_easter_animal)
-        if (value.identity_easter_animal != EasterAnimal.EASTER_ANIMAL_DEFAULT) size +=
-            EasterAnimal.ADAPTER.encodedSizeWithTag(3, value.identity_easter_animal)
+        if (value.identity_easter_animal != squareup.EasterAnimal.EASTER_ANIMAL_DEFAULT) {
+          size += EasterAnimal.ADAPTER.encodedSizeWithTag(3, value.identity_easter_animal)
+        }
         size += EasterAnimal.ADAPTER.asRepeated().encodedSizeWithTag(4, value.easter_animals)
         size += EasterAnimal.ADAPTER.asPacked().encodedSizeWithTag(5, value.easter_animals_packed)
         return size
@@ -189,8 +190,9 @@ public class Easter(
 
       override fun encode(writer: ProtoWriter, `value`: Easter) {
         EasterAnimal.ADAPTER.encodeWithTag(writer, 2, value.optional_easter_animal)
-        if (value.identity_easter_animal != EasterAnimal.EASTER_ANIMAL_DEFAULT)
-            EasterAnimal.ADAPTER.encodeWithTag(writer, 3, value.identity_easter_animal)
+        if (value.identity_easter_animal != squareup.EasterAnimal.EASTER_ANIMAL_DEFAULT) {
+          EasterAnimal.ADAPTER.encodeWithTag(writer, 3, value.identity_easter_animal)
+        }
         EasterAnimal.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.easter_animals)
         EasterAnimal.ADAPTER.asPacked().encodeWithTag(writer, 5, value.easter_animals_packed)
         writer.writeBytes(value.unknownFields)
@@ -200,8 +202,9 @@ public class Easter(
         writer.writeBytes(value.unknownFields)
         EasterAnimal.ADAPTER.asPacked().encodeWithTag(writer, 5, value.easter_animals_packed)
         EasterAnimal.ADAPTER.asRepeated().encodeWithTag(writer, 4, value.easter_animals)
-        if (value.identity_easter_animal != EasterAnimal.EASTER_ANIMAL_DEFAULT)
-            EasterAnimal.ADAPTER.encodeWithTag(writer, 3, value.identity_easter_animal)
+        if (value.identity_easter_animal != squareup.EasterAnimal.EASTER_ANIMAL_DEFAULT) {
+          EasterAnimal.ADAPTER.encodeWithTag(writer, 3, value.identity_easter_animal)
+        }
         EasterAnimal.ADAPTER.encodeWithTag(writer, 2, value.optional_easter_animal)
       }
 


### PR DESCRIPTION
When an enum has the specific proto3 generated `UNRECOGNIZED` constant and that the value is set to it, the message needs not to send anything on encoding + needs some magic on JSON serialization to replace it by the actual constant tag.

Look at the first commit to see the actual change without the generated code noise.

#2725