### PR TITLE
Filter extend fields based on the emitting rules

### DIFF
--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1292,6 +1292,28 @@ class WirePluginTest {
   }
 
   @Test
+  fun emitOptionsWithIncludes() {
+    val fixtureRoot = File("src/test/projects/emit-options-with-includes")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":generateProtos")).isNotNull()
+    assertThat(result.output).contains("Writing squareup.options.DocumentationUrlOption")
+    assertThat(result.output).doesNotContain("Writing squareup.other_options.CustomerSupportUrlOption")
+
+    val generatedProto = File(
+      fixtureRoot,
+      "build/generated/source/wire/squareup/polygons/Octagon.kt",
+    )
+    val octagon = generatedProto.readText()
+    assertThat(octagon)
+      .contains("""@DocumentationUrlOption("https://en.wikipedia.org/wiki/Octagon")""")
+    // Although we didn't generate the annotation, we still apply it!
+    assertThat(octagon)
+      .contains("""@CustomerSupportUrlOption("https://en.wikipedia.org/wiki/Customer_support")""")
+  }
+
+  @Test
   fun packageCycles() {
     val fixtureRoot = File("src/test/projects/package-cycles")
 

--- a/wire-gradle-plugin/src/test/projects/emit-options-with-includes/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/emit-options-with-includes/build.gradle
@@ -1,0 +1,13 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  kotlin {
+    includes = ['squareup.polygons.*', 'squareup.options.*']
+    emitDeclaredOptions = true
+    emitAppliedOptions = true
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/emit-options-with-includes/src/main/proto/squareup/options/documentation.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-options-with-includes/src/main/proto/squareup/options/documentation.proto
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package squareup.options;
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MessageOptions {
+  optional string documentation_url = 22200;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-options-with-includes/src/main/proto/squareup/other_options/documentation.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-options-with-includes/src/main/proto/squareup/other_options/documentation.proto
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package squareup.other_options;
+import "google/protobuf/descriptor.proto";
+
+extend google.protobuf.MessageOptions {
+  optional string customer_support_url = 22201;
+}

--- a/wire-gradle-plugin/src/test/projects/emit-options-with-includes/src/main/proto/squareup/polygons/octagon.proto
+++ b/wire-gradle-plugin/src/test/projects/emit-options-with-includes/src/main/proto/squareup/polygons/octagon.proto
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Square Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+syntax = "proto2";
+package squareup.polygons;
+import "squareup/options/documentation.proto";
+import "squareup/other_options/documentation.proto";
+
+message Octagon {
+  option (options.documentation_url) = "https://en.wikipedia.org/wiki/Octagon";
+  option (other_options.customer_support_url) = "https://en.wikipedia.org/wiki/Customer_support";
+  optional bool stop = 1;
+}

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
@@ -174,11 +174,15 @@ abstract class SchemaHandler {
       }
     }
 
-    // TODO(jwilson): extend emitting rules to support include/exclude of extension fields.
     protoFile.extendList
       .flatMap { extend -> extend.fields.map { field -> extend to field } }
       .filter { (extend, field) ->
         claimedDefinitions == null || extend.member(field) !in claimedDefinitions
+      }
+      .filter { (_, field) ->
+        // We append `.*` to the field's package name so that it matches rules defined as
+        // `package.*`.
+        emittingRules.includes(ProtoType.get(field.packageName + ".*"))
       }
       .forEach { (extend, field) ->
         val generatedFilePath = handle(extend, field, context)


### PR DESCRIPTION
Fixes https://github.com/cashapp/misk/pull/3286

This PR filters extend fields (like options) based on the file they are generated in, looking at their package name. Before that, even if one has multiple targets, the first target would generate all the extend fields, all the time.