### PR TITLE
EnumMode enum option

### DIFF
--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1314,6 +1314,56 @@ class WirePluginTest {
   }
 
   @Test
+  fun kotlinEnumMode() {
+    val fixtureRoot = File("src/test/projects/kotlin-enum-mode")
+
+    val result = gradleRunner.runFixture(fixtureRoot) { build() }
+
+    assertThat(result.task(":generateProtos")).isNotNull()
+    assertThat(result.output).contains("Writing com.squareup.enum.geology.Period")
+    assertThat(result.output).contains("Writing com.squareup.enum.geology.Continent")
+    assertThat(result.output).contains("Writing com.squareup.enum.geology.Drink")
+    assertThat(result.output).contains("Writing com.squareup.sealed.geology.Period")
+    assertThat(result.output).contains("Writing com.squareup.sealed.geology.Continent")
+    assertThat(result.output).contains("Writing com.squareup.sealed.geology.Drink")
+
+    // Wire has been configured so that `Continent` should always be the opposite of the global
+    // setting while `Period` and `Drink` match it.
+
+    val enumPeriod = File(
+      fixtureRoot,
+      "build/generated/source/wire/com/squareup/enum/geology/Period.kt",
+    ).readText()
+    assertThat(enumPeriod).contains("enum class Period")
+    val enumContinent = File(
+      fixtureRoot,
+      "build/generated/source/wire/com/squareup/enum/geology/Continent.kt",
+    ).readText()
+    assertThat(enumContinent).contains("sealed class Continent")
+    val enumDrink = File(
+      fixtureRoot,
+      "build/generated/source/wire/com/squareup/enum/geology/Drink.kt",
+    ).readText()
+    assertThat(enumDrink).contains("enum class Drink")
+
+    val sealedPeriod = File(
+      fixtureRoot,
+      "build/generated/source/wire/com/squareup/sealed/geology/Period.kt",
+    ).readText()
+    assertThat(sealedPeriod).contains("sealed class Period")
+    val sealedContinent = File(
+      fixtureRoot,
+      "build/generated/source/wire/com/squareup/sealed/geology/Continent.kt",
+    ).readText()
+    assertThat(sealedContinent).contains("enum class Continent")
+    val sealedDrink = File(
+      fixtureRoot,
+      "build/generated/source/wire/com/squareup/sealed/geology/Drink.kt",
+    ).readText()
+    assertThat(sealedDrink).contains("sealed class Drink")
+  }
+
+  @Test
   fun packageCycles() {
     val fixtureRoot = File("src/test/projects/package-cycles")
 

--- a/wire-gradle-plugin/src/test/projects/kotlin-enum-mode/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/kotlin-enum-mode/build.gradle
@@ -1,0 +1,16 @@
+plugins {
+  id 'application'
+  id 'org.jetbrains.kotlin.jvm'
+  id 'com.squareup.wire'
+}
+
+wire {
+  kotlin {
+    includes = ["enum.geology.*"]
+    enumMode = "enum_class"
+  }
+  kotlin {
+    includes = ["sealed.geology.*"]
+    enumMode = "sealed_class"
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-enum-mode/src/main/proto/enum/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-enum-mode/src/main/proto/enum/geology/period.proto
@@ -1,0 +1,33 @@
+syntax = "proto2";
+
+package enum.geology;
+
+import "wire/extensions.proto";
+
+option java_package = "com.squareup.enum.geology";
+
+// Target is set to "enum_class" so the option should not have any effect.
+enum Period {
+  option (wire.enum_mode) = "enum_class";
+  CRETACEOUS = 1;
+  JURASSIC = 2;
+  TRIASSIC = 3;
+}
+
+// Target is set to "enum_class" so the option should takes precedence.
+enum Continent {
+  option (wire.enum_mode) = "sealed_class";
+  AFRICA = 0;
+  AMERICA = 1;
+  ANTARCTICA = 2;
+  ASIA = 3;
+  AUSTRALIA = 4;
+  EUROPE = 5;
+}
+
+enum Drink {
+  UNKNOWN = 0;
+  PEPSI = 1;
+  MOUNTAIN_DEW = 2;
+  ROOT_BEER = 9;
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-enum-mode/src/main/proto/sealed/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-enum-mode/src/main/proto/sealed/geology/period.proto
@@ -1,0 +1,33 @@
+syntax = "proto2";
+
+package sealed.geology;
+
+import "wire/extensions.proto";
+
+option java_package = "com.squareup.sealed.geology";
+
+// Target is set to "sealed_class" so the option should not have any effect.
+enum Period {
+  option (wire.enum_mode) = "sealed_class";
+  CRETACEOUS = 1;
+  JURASSIC = 2;
+  TRIASSIC = 3;
+}
+
+// Target is set to "sealed_class" so the option should takes precedence.
+enum Continent {
+  option (wire.enum_mode) = "enum_class";
+  AFRICA = 0;
+  AMERICA = 1;
+  ANTARCTICA = 2;
+  ASIA = 3;
+  AUSTRALIA = 4;
+  EUROPE = 5;
+}
+
+enum Drink {
+  UNKNOWN = 0;
+  PEPSI = 1;
+  MOUNTAIN_DEW = 2;
+  ROOT_BEER = 9;
+}

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -2257,7 +2257,13 @@ class KotlinGenerator private constructor(
       .addParameter(valueName, Int::class)
     val builder: TypeSpec.Builder
 
-    when (enumMode) {
+    val enumModeOption = when (enum.enumMode?.lowercase()) {
+      "enum_class" -> ENUM_CLASS
+      "sealed_class" -> SEALED_CLASS
+      else -> null
+    }
+
+    when (enumModeOption ?: enumMode) {
       ENUM_CLASS -> {
         builder = TypeSpec.enumBuilder(type.simpleName)
           .apply {

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -178,6 +178,7 @@ public final class com/squareup/wire/schema/EnumType : com/squareup/wire/schema/
 	public static final fun fromElement (Lcom/squareup/wire/schema/ProtoType;Lcom/squareup/wire/schema/internal/parser/EnumElement;Lcom/squareup/wire/Syntax;)Lcom/squareup/wire/schema/EnumType;
 	public final fun getConstants ()Ljava/util/List;
 	public fun getDocumentation ()Ljava/lang/String;
+	public final fun getEnumMode ()Ljava/lang/String;
 	public fun getLocation ()Lcom/squareup/wire/schema/Location;
 	public fun getName ()Ljava/lang/String;
 	public fun getNestedExtendList ()Ljava/util/List;

--- a/wire-schema/api/wire-schema.klib.api
+++ b/wire-schema/api/wire-schema.klib.api
@@ -773,6 +773,8 @@ final class com.squareup.wire.schema/EnumType : com.squareup.wire.schema/Type { 
         final fun <get-constants>(): kotlin.collections/List<com.squareup.wire.schema/EnumConstant> // com.squareup.wire.schema/EnumType.constants.<get-constants>|<get-constants>(){}[0]
     final val documentation // com.squareup.wire.schema/EnumType.documentation|{}documentation[0]
         final fun <get-documentation>(): kotlin/String // com.squareup.wire.schema/EnumType.documentation.<get-documentation>|<get-documentation>(){}[0]
+    final val enumMode // com.squareup.wire.schema/EnumType.enumMode|{}enumMode[0]
+        final fun <get-enumMode>(): kotlin/String? // com.squareup.wire.schema/EnumType.enumMode.<get-enumMode>|<get-enumMode>(){}[0]
     final val isDeprecated // com.squareup.wire.schema/EnumType.isDeprecated|{}isDeprecated[0]
         final fun <get-isDeprecated>(): kotlin/Boolean // com.squareup.wire.schema/EnumType.isDeprecated.<get-isDeprecated>|<get-isDeprecated>(){}[0]
     final val location // com.squareup.wire.schema/EnumType.location|{}location[0]

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -48,6 +48,9 @@ data class EnumType(
   val isDeprecated: Boolean
     get() = "true" == deprecated
 
+  val enumMode: String?
+    get() = options.get(WIRE_ENUM_MODE)?.toString()
+
   /** Returns the constant named `name`, or null if this enum has no such constant.  */
   fun constant(name: String) = constants.find { it.name == name }
 
@@ -197,6 +200,7 @@ data class EnumType(
   companion object {
     internal val ALLOW_ALIAS = ProtoMember.get(ENUM_OPTIONS, "allow_alias")
     internal val DEPRECATED = ProtoMember.get(ENUM_OPTIONS, "deprecated")
+    internal val WIRE_ENUM_MODE = ProtoMember.get(ENUM_OPTIONS, "wire.enum_mode")
 
     @JvmStatic
     fun fromElement(

--- a/wire-schema/src/jvmMain/resources/wire/extensions.proto
+++ b/wire-schema/src/jvmMain/resources/wire/extensions.proto
@@ -43,6 +43,18 @@ extend google.protobuf.FieldOptions {
   optional bool use_array = 1185;
 }
 
+extend google.protobuf.EnumOptions {
+  /**
+   * Defines how an enum type is to be generated. This is only supported by Kotlin generation.
+   * - 'enum_class': the enum type will be generated as a Kotlin enum class.
+   * - 'sealed_class': the enum type will be generated as a Kotlin sealed class.
+   *
+   * When set, the value of this option takes precedence over the global enum mode that may be set
+   * at the Kotlin target level in the Wire Gradle plugin.
+   */
+  optional string enum_mode = 1190;
+}
+
 extend google.protobuf.EnumValueOptions {
   /**
    * Annotates an enum constant that starts to be available with a specified version.


### PR DESCRIPTION
This takes precedence over the newly created `KotlinTarget#enumMode` to allow granular migration.

Extension registered here https://github.com/protocolbuffers/protobuf/pull/17158