### PR TITLE
Avoid crash when parsing an empty `repeated [packed=true]` for fixed-length types

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
@@ -861,6 +861,12 @@ public final class ProtoReader {
     private func decode<T>(into array: inout [T], decode: () throws -> T?) throws {
         switch state {
         case let .lengthDelimited(length):
+            guard length > 0 else {
+                // If the array is empty, there's nothing to do.
+                state = .tag
+                return
+            }
+
             // Preallocate space for the unpacked data.
             // It's allowable to have a packed field spread across multiple places
             // in the buffer, so add to the existing capacity.

--- a/wire-runtime-swift/src/test/swift/ProtoReaderTests.swift
+++ b/wire-runtime-swift/src/test/swift/ProtoReaderTests.swift
@@ -646,6 +646,50 @@ final class ProtoReaderTests: XCTestCase {
         }
     }
 
+    func testDecodePackedRepeatedFixedUInt32Empty() throws {
+        let data = Foundation.Data(hexEncoded: """
+            0A       // (Tag 1 | Length Delimited)
+            00       // Length 0
+        """)!
+
+        try test(data: data) { reader in
+            var values: [UInt64] = []
+            try reader.decode(tag: 1) { try reader.decode(into: &values, encoding: .fixed) }
+
+            XCTAssertEqual(values, [])
+        }
+    }
+
+    func testDecodePackedRepeatedFixedUInt64() throws {
+        let data = Foundation.Data(hexEncoded: """
+            0A               // (Tag 1 | Length Delimited)
+            10               // Length 16
+            0100000000000000 // Value 1
+            FFFFFFFFFFFFFFFF // Value UInt64.max
+        """)!
+
+        try test(data: data) { reader in
+            var values: [UInt64] = []
+            try reader.decode(tag: 1) { try reader.decode(into: &values, encoding: .fixed) }
+
+            XCTAssertEqual(values, [1, .max])
+        }
+    }
+
+    func testDecodePackedRepeatedFixedUInt64Empty() throws {
+        let data = Foundation.Data(hexEncoded: """
+            0A       // (Tag 1 | Length Delimited)
+            00       // Length 0
+        """)!
+
+        try test(data: data) { reader in
+            var values: [UInt64] = []
+            try reader.decode(tag: 1) { try reader.decode(into: &values, encoding: .fixed) }
+
+            XCTAssertEqual(values, [])
+        }
+    }
+
     func testDecodeRepeatedVarintUInt32() throws {
         let data = Foundation.Data(hexEncoded: """
             08         // (Tag 1 | Varint)


### PR DESCRIPTION
As reported in https://github.com/square/wire/issues/3043, parsing an empty `repeated uint64 [packed=true]` (or other fixed-length types) currently results in a `fatalError`.

This change adds a check for zero length when parsing such `repeated ... [packed=true]` fields to avoid the `fatalError`. The first commit adds two unit tests that demonstrate the issue, and the second commit resolves the issue.