### PR TITLE
[Bug] Propagate the deprecated flag on EnumType after pruning by wire-gradle-plugin

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/EnumType.kt
@@ -164,6 +164,7 @@ data class EnumType(
       reserveds = reserveds,
     )
     result.allowAlias = allowAlias
+    result.deprecated = deprecated
     return result
   }
 

--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/PrunerTest.kt
@@ -1728,6 +1728,7 @@ class PrunerTest {
              |}
              |enum Enum {
              |  option allow_alias = true;
+             |  option deprecated = true;
              |  A = 1;
              |  B = 1;
              |}
@@ -1752,6 +1753,7 @@ class PrunerTest {
 
     val enumType = pruned.getType("Enum") as EnumType
     assertThat(enumType.allowAlias()).isTrue()
+    assertThat(enumType.isDeprecated).isTrue()
   }
 
   @Test


### PR DESCRIPTION
Relates to https://github.com/square/wire/issues/3075

When generating java and kotlin enums that have the option `deprecated = true`; flag the resulting enum generated does not contain the `@Deprecated` annotation. This appears to be due to the pruning functionality not retaining the deprecated flag and only affects the enum classes (enum constants, messages and fields all work as expected)


### Example

`test/period.proto`
```proto2
syntax = "proto2";

enum Period {
  option deprecated = true;
  CRETACEOUS = 1;
}
```

#### Before
```kotlin
public enum class Period(
  override val `value`: Int,
) : WireEnum {
  CRETACEOUS(1),
  ;
```

#### After

```kotlin
@Deprecated(message = "Period is deprecated")
public enum class Period(
  override val `value`: Int,
) : WireEnum {
  CRETACEOUS(1),
  ;
```