### PR TITLE
Fix Gradle project isolation issue when reading a property

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -297,7 +297,7 @@ class WirePlugin : Plugin<Project> {
     if (!hasJavaOutput && !hasKotlinOutput) return
 
     // Indicates when the plugin is applied inside the Wire repo to Wire's own modules.
-    val isInternalBuild = project.properties["com.squareup.wire.internal"].toString() == "true"
+    val isInternalBuild = project.providers.gradleProperty("com.squareup.wire.internal").getOrElse("false").toBoolean()
     val isMultiplatform = project.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform")
     val isJsOnly =
       if (isMultiplatform) false else project.plugins.hasPlugin("org.jetbrains.kotlin.js")


### PR DESCRIPTION
Project.getProperties is not Gradle project isolation safe as it attempts to also include properties from parent projects.

Instead use providers.gradleProperty that only checks gradle properties in a given project.

Project isolation feature description
https://docs.gradle.org/current/userguide/isolated_projects.html