### PR TITLE
Let the WireCompiler handle multiple targets in the same command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.4.0
 
       # We set `SDKROOT` as a workaround for https://github.com/gradle/gradle/pull/29227
       - name: Check test files
@@ -129,7 +129,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.4.0
 
       # We set `SDKROOT` as a workaround for https://github.com/gradle/gradle/pull/29227
       - name: Test Swift Runtime
@@ -206,7 +206,7 @@ jobs:
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: 15.4.0
 
       # We set `SDKROOT` as a workaround for https://github.com/gradle/gradle/pull/29227
       - name: Upload Artifacts

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -150,7 +150,8 @@ class WireCompiler internal constructor(
         emitDeclaredOptions = emitDeclaredOptions,
         emitAppliedOptions = emitAppliedOptions,
       )
-    } else if (kotlinOut != null) {
+    }
+    if (kotlinOut != null) {
       targets += KotlinTarget(
         exclusive = kotlinExclusive,
         outDirectory = kotlinOut,
@@ -167,11 +168,13 @@ class WireCompiler internal constructor(
         escapeKotlinKeywords = kotlinEscapeKeywords,
         emitProtoReader32 = emitProtoReader32,
       )
-    } else if (swiftOut != null) {
+    }
+    if (swiftOut != null) {
       targets += SwiftTarget(
         outDirectory = swiftOut,
       )
-    } else if (customOut != null || schemaHandlerFactoryClass != null) {
+    }
+    if (customOut != null || schemaHandlerFactoryClass != null) {
       if (customOut == null || schemaHandlerFactoryClass == null) {
         throw IllegalArgumentException("Both custom_out and schema_handler_factory_class need to be set")
       }


### PR DESCRIPTION
Not sure why we had this limitation. I will have to followup with adding an exclusive flag for all targets.