### PR TITLE
Improve Kotlin Multiplatform setup with `applyDefaultHierarchyTemplate`

### DIFF
--- a/wire-grpc-client/build.gradle.kts
+++ b/wire-grpc-client/build.gradle.kts
@@ -3,6 +3,8 @@ plugins {
 }
 
 kotlin {
+  applyDefaultHierarchyTemplate()
+
   jvm {
     withJava()
   }
@@ -45,24 +47,6 @@ kotlin {
     val jvmMain by getting {
       dependencies {
         api(libs.okhttp.core)
-      }
-    }
-    if (System.getProperty("knative", "true").toBoolean()) {
-      val nativeMain by creating {
-        dependsOn(commonMain)
-      }
-      val iosX64Main by getting
-      val iosArm64Main by getting
-      val iosSimulatorArm64Main by getting
-      val linuxX64Main by getting
-      val macosX64Main by getting
-      val macosArm64Main by getting
-      val mingwX64Main by getting
-      val tvosX64Main by getting
-      val tvosArm64Main by getting
-      val tvosSimulatorArm64Main by getting
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main, mingwX64Main, tvosX64Main, tvosArm64Main, tvosSimulatorArm64Main)) {
-        it.dependsOn(nativeMain)
       }
     }
   }

--- a/wire-runtime/build.gradle.kts
+++ b/wire-runtime/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
 }
 
 kotlin {
+  applyDefaultHierarchyTemplate()
   jvm {
     withJava()
   }
@@ -66,52 +67,6 @@ kotlin {
         dependencies {
           implementation(libs.kotlin.test.js)
         }
-      }
-    }
-    if (System.getProperty("knative", "true").toBoolean()) {
-      val nativeMain by creating {
-        dependsOn(commonMain)
-      }
-      val nativeTest by creating {
-        dependsOn(commonTest)
-      }
-      val darwinMain by creating {
-        dependsOn(commonMain)
-      }
-
-      val iosX64Main by getting
-      val iosArm64Main by getting
-      val iosSimulatorArm64Main by getting
-      val linuxX64Main by getting
-      val linuxArm64Main by getting
-      val macosX64Main by getting
-      val macosArm64Main by getting
-      val mingwX64Main by getting
-      val tvosX64Main by getting
-      val tvosArm64Main by getting
-      val tvosSimulatorArm64Main by getting
-      val iosX64Test by getting
-      val iosArm64Test by getting
-      val iosSimulatorArm64Test by getting
-      val linuxX64Test by getting
-      val linuxArm64Test by getting
-      val macosX64Test by getting
-      val macosArm64Test by getting
-      val mingwX64Test by getting
-      val tvosX64Test by getting
-      val tvosArm64Test by getting
-      val tvosSimulatorArm64Test by getting
-
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, linuxArm64Main, macosX64Main, macosArm64Main, mingwX64Main, tvosX64Main, tvosArm64Main, tvosSimulatorArm64Main)) {
-        it.dependsOn(nativeMain)
-      }
-
-      for (it in listOf(iosX64Test, iosArm64Test, iosSimulatorArm64Test, linuxX64Test, linuxArm64Test, macosX64Test, macosArm64Test, mingwX64Test, tvosX64Test, tvosArm64Test, tvosSimulatorArm64Test)) {
-        it.dependsOn(nativeTest)
-      }
-
-      for (it in listOf(iosX64Main, iosArm64Main, macosX64Main, macosArm64Main, tvosX64Main, tvosArm64Main)) {
-        it.dependsOn(darwinMain)
       }
     }
   }

--- a/wire-schema-tests/build.gradle.kts
+++ b/wire-schema-tests/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
 }
 
 kotlin {
+  applyDefaultHierarchyTemplate()
   jvm {
     // Required by MavenPublishBaseExtension even though we do not have Java sources.
     withJava()
@@ -57,43 +58,6 @@ kotlin {
         dependencies {
           implementation(libs.kotlin.test.js)
         }
-      }
-    }
-    if (System.getProperty("knative", "true").toBoolean()) {
-      val nativeMain by creating {
-        dependsOn(commonMain)
-      }
-      val nativeTest by creating {
-        dependsOn(commonTest)
-      }
-
-      val iosX64Main by getting
-      val iosArm64Main by getting
-      val iosSimulatorArm64Main by getting
-      val linuxX64Main by getting
-      val macosX64Main by getting
-      val macosArm64Main by getting
-      val mingwX64Main by getting
-      val tvosX64Main by getting
-      val tvosArm64Main by getting
-      val tvosSimulatorArm64Main by getting
-      val iosX64Test by getting
-      val iosArm64Test by getting
-      val iosSimulatorArm64Test by getting
-      val linuxX64Test by getting
-      val macosX64Test by getting
-      val macosArm64Test by getting
-      val mingwX64Test by getting
-      val tvosX64Test by getting
-      val tvosArm64Test by getting
-      val tvosSimulatorArm64Test by getting
-
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main, mingwX64Main, tvosX64Main, tvosArm64Main, tvosSimulatorArm64Main)) {
-        it.dependsOn(nativeMain)
-      }
-
-      for (it in listOf(iosX64Test, iosArm64Test, iosSimulatorArm64Test, linuxX64Test, macosX64Test, macosArm64Test, mingwX64Test, tvosX64Test, tvosArm64Test, tvosSimulatorArm64Test)) {
-        it.dependsOn(nativeTest)
       }
     }
   }

--- a/wire-schema/build.gradle.kts
+++ b/wire-schema/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
 }
 
 kotlin {
+  applyDefaultHierarchyTemplate()
   jvm().withJava()
   if (System.getProperty("kjs", "true").toBoolean()) {
     js(IR) {
@@ -69,65 +70,6 @@ kotlin {
         dependencies {
           implementation(libs.kotlin.test.js)
         }
-      }
-    }
-    if (System.getProperty("knative", "true").toBoolean()) {
-      val nativeMain by creating {
-        dependsOn(commonMain)
-      }
-      val nativeTest by creating {
-        dependsOn(commonTest)
-      }
-
-      val iosX64Main by getting
-      val iosArm64Main by getting
-      val iosSimulatorArm64Main by getting
-      val linuxX64Main by getting
-      val macosX64Main by getting
-      val macosArm64Main by getting
-      val mingwX64Main by getting
-      val tvosX64Main by getting
-      val tvosArm64Main by getting
-      val tvosSimulatorArm64Main by getting
-      val iosX64Test by getting
-      val iosArm64Test by getting
-      val iosSimulatorArm64Test by getting
-      val linuxX64Test by getting
-      val macosX64Test by getting
-      val macosArm64Test by getting
-      val mingwX64Test by getting
-      val tvosX64Test by getting
-      val tvosArm64Test by getting
-      val tvosSimulatorArm64Test by getting
-
-      for (it in listOf(
-        iosX64Main,
-        iosArm64Main,
-        iosSimulatorArm64Main,
-        linuxX64Main,
-        macosX64Main,
-        macosArm64Main,
-        mingwX64Main,
-        tvosX64Main,
-        tvosArm64Main,
-        tvosSimulatorArm64Main,
-      )) {
-        it.dependsOn(nativeMain)
-      }
-
-      for (it in listOf(
-        iosX64Test,
-        iosArm64Test,
-        iosSimulatorArm64Test,
-        linuxX64Test,
-        macosX64Test,
-        macosArm64Test,
-        mingwX64Test,
-        tvosX64Test,
-        tvosArm64Test,
-        tvosSimulatorArm64Test,
-      )) {
-        it.dependsOn(nativeTest)
       }
     }
   }

--- a/wire-test-utils/build.gradle.kts
+++ b/wire-test-utils/build.gradle.kts
@@ -19,6 +19,7 @@ plugins {
 }
 
 kotlin {
+  applyDefaultHierarchyTemplate()
   jvm().withJava()
   if (System.getProperty("kjs", "true").toBoolean()) {
     js(IR) {
@@ -67,26 +68,6 @@ kotlin {
         api(libs.kotlinpoet)
         implementation(libs.protobuf.java)
         implementation(libs.assertj)
-      }
-    }
-    if (System.getProperty("knative", "true").toBoolean()) {
-      val nativeMain by creating {
-        dependsOn(commonMain)
-      }
-
-      val iosX64Main by getting
-      val iosArm64Main by getting
-      val iosSimulatorArm64Main by getting
-      val linuxX64Main by getting
-      val macosX64Main by getting
-      val macosArm64Main by getting
-      val mingwX64Main by getting
-      val tvosX64Main by getting
-      val tvosArm64Main by getting
-      val tvosSimulatorArm64Main by getting
-
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main, mingwX64Main, tvosX64Main, tvosArm64Main, tvosSimulatorArm64Main)) {
-        it.dependsOn(nativeMain)
       }
     }
   }

--- a/wire-tests/build.gradle.kts
+++ b/wire-tests/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
 }
 
 kotlin {
+  applyDefaultHierarchyTemplate()
   jvm {
     val kotlinInteropTest by compilations.creating {
       defaultSourceSet {
@@ -125,47 +126,6 @@ kotlin {
         dependencies {
           implementation(libs.kotlin.test.js)
         }
-      }
-    }
-    if (System.getProperty("knative", "true").toBoolean()) {
-      val nativeMain by creating {
-        dependsOn(commonMain)
-      }
-      val nativeTest by creating {
-        dependsOn(commonTest)
-      }
-      val darwinTest by creating {
-        dependsOn(commonTest)
-      }
-
-      val iosX64Main by getting
-      val iosArm64Main by getting
-      val iosSimulatorArm64Main by getting
-      val linuxX64Main by getting
-      val macosX64Main by getting
-      val macosArm64Main by getting
-      val mingwX64Main by getting
-      val tvosX64Main by getting
-      val tvosArm64Main by getting
-      val tvosSimulatorArm64Main by getting
-      val iosX64Test by getting
-      val iosArm64Test by getting
-      val iosSimulatorArm64Test by getting
-      val linuxX64Test by getting
-      val macosX64Test by getting
-      val macosArm64Test by getting
-      val mingwX64Test by getting
-      val tvosX64Test by getting
-      val tvosArm64Test by getting
-      val tvosSimulatorArm64Test by getting
-      for (it in listOf(iosX64Main, iosArm64Main, iosSimulatorArm64Main, linuxX64Main, macosX64Main, macosArm64Main, mingwX64Main, tvosX64Main, tvosArm64Main, tvosSimulatorArm64Main)) {
-        it.dependsOn(nativeMain)
-      }
-      for (it in listOf(iosX64Test, iosArm64Test, iosSimulatorArm64Test, linuxX64Test, macosX64Test, macosArm64Test, mingwX64Test, tvosX64Test, tvosArm64Test, tvosSimulatorArm64Test)) {
-        it.dependsOn(nativeTest)
-      }
-      for (it in listOf(iosX64Test, iosArm64Test, macosX64Test, macosArm64Test, tvosX64Test, tvosArm64Test)) {
-        it.dependsOn(darwinTest)
       }
     }
   }


### PR DESCRIPTION
Remove the custom setup with `dependsOn` with `applyDefaultHierarchyTemplate`