### PR TITLE
grpc: Attempt to read trailers always when parsing grpc exception [DO NOT MERGE]

### DIFF
--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/grpc.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/grpc.kt
@@ -203,10 +203,10 @@ private fun Response.checkGrpcResponse() {
 internal fun Response.grpcResponseToException(suppressed: IOException? = null): IOException? {
   var trailers = headersOf()
   var transportException = suppressed
-  if (suppressed == null) {
-    try {
-      trailers = trailers()
-    } catch (e: IOException) {
+  try {
+    trailers = trailers()
+  } catch (e: IOException) {
+    if (suppressed == null) {
       transportException = e
     }
   }

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/grpc.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/grpc.kt
@@ -203,10 +203,13 @@ private fun Response.checkGrpcResponse() {
 internal fun Response.grpcResponseToException(suppressed: IOException? = null): IOException? {
   var trailers = headersOf()
   var transportException = suppressed
-  try {
-    trailers = trailers()
-  } catch (e: IOException) {
-    if (suppressed == null) {
+  // If content-length is 0,
+  // then IO exception is due to reading body when there is none
+  val contentLen = header("content-length") ?: -1
+  if (suppressed == null || contentLen == 0) {
+    try {
+      trailers = trailers()
+    } catch (e: IOException) {
       transportException = e
     }
   }


### PR DESCRIPTION
This should prevent missing grpc-status in case of inability to read message correctly

Unless this is changed, any failure to read body will result in generic IO exception when grpc-status is in trailers