### PR TITLE
Mark generated enums with @objc

### DIFF
--- a/wire-runtime-swift/src/test/swift/sample/Period.swift
+++ b/wire-runtime-swift/src/test/swift/sample/Period.swift
@@ -2,6 +2,7 @@
 // Source: squareup.geology.Period in squareup/geology/period.proto
 import Wire
 
+@objc
 public enum Period : Int32, CaseIterable, Proto2Enum {
 
     /**

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -1661,6 +1661,7 @@ class SwiftGenerator private constructor(
     val enumName = type.typeName
     return TypeSpec.enumBuilder(enumName)
       .addModifiers(PUBLIC)
+      .addAttribute("objc")
       .addSuperTypes(listOf(INT32, CASE_ITERABLE, type.protoCodableType))
       .apply {
         type.protoDefaultedName?.let { protoDefaultedName ->

--- a/wire-tests-swift/manifest/module_one/SortOrder.swift
+++ b/wire-tests-swift/manifest/module_one/SortOrder.swift
@@ -5,6 +5,7 @@ import Wire
 /**
  * Collides with Foundation.SortOrder
  */
+@objc
 public enum SortOrder : Int32, CaseIterable, Proto2Enum {
 
     case DESC = 0

--- a/wire-tests-swift/manifest/module_one/SwiftModuleOneEnum.swift
+++ b/wire-tests-swift/manifest/module_one/SwiftModuleOneEnum.swift
@@ -2,6 +2,7 @@
 // Source: squareup.protos.kotlin.swift_modules.SwiftModuleOneEnum in swift_module_one.proto
 import Wire
 
+@objc
 public enum SwiftModuleOneEnum : Int32, CaseIterable, Proto2Enum {
 
     case DO_NOT_USE = 0

--- a/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
@@ -1932,6 +1932,7 @@ extension AllTypes : Codable {
  */
 extension AllTypes {
 
+    @objc
     public enum NestedEnum : Int32, CaseIterable, Proto2Enum {
 
         case UNKNOWN = 0

--- a/wire-tests-swift/no-manifest/src/main/swift/DeprecatedEnum.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/DeprecatedEnum.swift
@@ -2,6 +2,7 @@
 // Source: squareup.protos.kotlin.DeprecatedEnum in deprecated_enum.proto
 import Wire
 
+@objc
 public enum DeprecatedEnum : Int32, CaseIterable, Proto2Enum {
 
     @available(*, deprecated)

--- a/wire-tests-swift/no-manifest/src/main/swift/EnumVersionOne.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/EnumVersionOne.swift
@@ -2,6 +2,7 @@
 // Source: squareup.protos.kotlin.unknownfields.EnumVersionOne in unknown_fields.proto
 import Wire
 
+@objc
 public enum EnumVersionOne : Int32, CaseIterable, Proto2Enum {
 
     case SHREK_V1 = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/EnumVersionTwo.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/EnumVersionTwo.swift
@@ -2,6 +2,7 @@
 // Source: squareup.protos.kotlin.unknownfields.EnumVersionTwo in unknown_fields.proto
 import Wire
 
+@objc
 public enum EnumVersionTwo : Int32, CaseIterable, Proto2Enum {
 
     case SHREK_V2 = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/Error_.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Error_.swift
@@ -2,6 +2,7 @@
 // Source: squareup.protos.kotlin.swift_modules.Error in swift_edge_cases.proto
 import Wire
 
+@objc
 public enum Error_ : Int32, CaseIterable, Proto2Enum {
 
     case UNKNOWN = 0

--- a/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
@@ -223,6 +223,7 @@ extension FooBar {
 
     }
 
+    @objc
     public enum FooBarBazEnum : Int32, CaseIterable, Proto2Enum {
 
         case FOO = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/ForeignEnum.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/ForeignEnum.swift
@@ -2,6 +2,7 @@
 // Source: squareup.protos.kotlin.foreign.ForeignEnum in foreign.proto
 import Wire
 
+@objc
 public enum ForeignEnum : Int32, CaseIterable, Proto2Enum {
 
     case BAV = 0

--- a/wire-tests-swift/no-manifest/src/main/swift/MappyTwo.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MappyTwo.swift
@@ -118,6 +118,7 @@ extension MappyTwo : Codable {
  */
 extension MappyTwo {
 
+    @objc
     public enum ValueEnum : Int32, CaseIterable, Proto2Enum {
 
         case DEFAULT = 0

--- a/wire-tests-swift/no-manifest/src/main/swift/MessageWithStatus.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/MessageWithStatus.swift
@@ -72,6 +72,7 @@ extension MessageWithStatus : Codable {
  */
 extension MessageWithStatus {
 
+    @objc
     public enum Status : Int32, CaseIterable, Proto2Enum {
 
         case A = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/NegativeValueEnum.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/NegativeValueEnum.swift
@@ -2,6 +2,7 @@
 // Source: squareup.protos.kotlin.NegativeValueEnum in negative_value_enum.proto
 import Wire
 
+@objc
 public enum NegativeValueEnum : Int32, CaseIterable, Proto2Enum {
 
     case DO_NOT_USE = -1

--- a/wire-tests-swift/no-manifest/src/main/swift/OptionalEnumUser.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OptionalEnumUser.swift
@@ -88,6 +88,7 @@ extension OptionalEnumUser : Codable {
  */
 extension OptionalEnumUser {
 
+    @objc
     public enum OptionalEnum : Int32, CaseIterable, Proto2Enum {
 
         case FOO = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/OtherMessageWithStatus.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/OtherMessageWithStatus.swift
@@ -72,6 +72,7 @@ extension OtherMessageWithStatus : Codable {
  */
 extension OtherMessageWithStatus {
 
+    @objc
     public enum Status : Int32, CaseIterable, Proto2Enum {
 
         case A = 1

--- a/wire-tests-swift/no-manifest/src/main/swift/Person.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Person.swift
@@ -142,6 +142,7 @@ extension Person {
     /**
      * Represents the type of the phone number: mobile, home or work.
      */
+    @objc
     public enum PhoneType : Int32, CaseIterable, Proto2Enum {
 
         case MOBILE = 0

--- a/wire-tests-swift/no-manifest/src/main/swift/SwiftEdgeCases.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/SwiftEdgeCases.swift
@@ -102,6 +102,7 @@ extension SwiftEdgeCases : Codable {
  */
 extension SwiftEdgeCases {
 
+    @objc
     public enum Error_ : Int32, CaseIterable, Proto2Enum {
 
         case UNKNOWN = 0
@@ -116,6 +117,7 @@ extension SwiftEdgeCases {
 
     }
 
+    @objc
     public enum Type_ : Int32, CaseIterable, Proto2Enum {
 
         case INACTIVE = 0


### PR DESCRIPTION
Those can be represented in ObjC and could help with mixed language support with better interop.