### PR TITLE
Fix buffer overflow and data corruption when a type has more than 5 layers of nesting

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoWriter.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoWriter.swift
@@ -708,13 +708,13 @@ public final class ProtoWriter {
         }
 
         if let isProto3 = isProto3 {
-            messageStackIndex += 1
-            if messageStackIndex >= messageStackCapacity {
+            if messageStackIndex + 1 >= messageStackCapacity {
                 expandMessageStack()
             }
             let frame = MessageFrame(
                 isProto3: isProto3
             )
+            messageStackIndex += 1
             messageStack.advanced(by: messageStackIndex).initialize(to: frame)
 
             // Cache this value as an ivar for quick access.

--- a/wire-runtime-swift/src/test/proto/nested5.proto
+++ b/wire-runtime-swift/src/test/proto/nested5.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Square Inc.
+ * Copyright 2024 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,12 @@
  * limitations under the License.
  */
 syntax = "proto2";
-import "nested5.proto";
 
-message Nested4 {
+import "nested6.proto";
+
+message Nested5 {
   required string name = 1;
 
-  optional Nested5 nested = 2;
+  optional Nested6 nested = 2;
 }
 

--- a/wire-runtime-swift/src/test/proto/nested6.proto
+++ b/wire-runtime-swift/src/test/proto/nested6.proto
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Square Inc.
+ * Copyright 2024 Square Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,11 +14,8 @@
  * limitations under the License.
  */
 syntax = "proto2";
-import "nested5.proto";
 
-message Nested4 {
+message Nested6 {
   required string name = 1;
-
-  optional Nested5 nested = 2;
 }
 


### PR DESCRIPTION
Fixes https://github.com/square/wire/issues/3202