### PR TITLE
Fix path normalization for Windows OS

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Location.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/Location.kt
@@ -70,7 +70,9 @@ data class Location(
       base: String,
       path: String,
     ): Location {
-      return Location(base.trimEnd('/'), path, -1, -1)
+      val normalizedBase = base.replace('\\', '/')
+      val normalizedPath = path.replace('\\', '/')
+      return Location(normalizedBase.trimEnd('/'), normalizedPath, -1, -1)
     }
   }
 }

--- a/wire-schema/src/commonTest/kotlin/com/squareup/wire/schema/LocationTest.kt
+++ b/wire-schema/src/commonTest/kotlin/com/squareup/wire/schema/LocationTest.kt
@@ -1,8 +1,23 @@
+/*
+ * Copyright (C) 2024 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.squareup.wire.schema
 
-import kotlin.test.Test
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import kotlin.test.Test
 
 class LocationTest {
 
@@ -15,7 +30,7 @@ class LocationTest {
   @Test fun getWithWindowsStylePaths() {
     val location = Location.get(
       "C:\\Users\\protoDir",
-      "languageDir\\language.proto"
+      "languageDir\\language.proto",
     )
     assertThat(location.base).isEqualTo("C:/Users/protoDir")
     assertThat(location.path).isEqualTo("languageDir/language.proto")

--- a/wire-schema/src/commonTest/kotlin/com/squareup/wire/schema/LocationTest.kt
+++ b/wire-schema/src/commonTest/kotlin/com/squareup/wire/schema/LocationTest.kt
@@ -1,0 +1,23 @@
+package com.squareup.wire.schema
+
+import kotlin.test.Test
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+
+class LocationTest {
+
+  @Test fun getWithBaseAndRelativePath() {
+    val location = Location.get("/base/dir", "test/file.proto")
+    assertThat(location.base).isEqualTo("/base/dir")
+    assertThat(location.path).isEqualTo("test/file.proto")
+  }
+
+  @Test fun getWithWindowsStylePaths() {
+    val location = Location.get(
+      "C:\\Users\\protoDir",
+      "languageDir\\language.proto"
+    )
+    assertThat(location.base).isEqualTo("C:/Users/protoDir")
+    assertThat(location.path).isEqualTo("languageDir/language.proto")
+  }
+}


### PR DESCRIPTION
**Issue**:
The issue goes from kafka-ui thread https://github.com/kafbat/kafka-ui/pull/261 which uses 'Location.get(...)' function  from your library.
- Location paths don't work correctly on Windows due to path separator differences
- Windows uses backslashes (\) while proto imports consistently use forward slashes (/)
- This causes multiple NPEs on Linker.link(...) method in kafka-ui tests on Windows as the path from  'Location.get(...)' gets incorrect result.

**Example**:
If in Location.get(...) we pass:
1st param base - C:\Users\username\IdeaProjects\kafka-ui\api\target\test-classes\protobuf-serde
2nd param path - language\language.proto
the result is - C:\Users\username\IdeaProjects\kafka-ui\api\target\test-classes\**protobuf-serde/language\language.proto** 

And then Linker.link(...) throws NPE:
![Screenshot 2024-12-15 130433](https://github.com/user-attachments/assets/c0587434-1e5d-4593-9edc-72ac9d0a04e2)

**Solution**:
- Normalized paths in Location.get(...) method to consistently use forward slashes
- Added unit test coverage for Location.get(...) method
