### PR TITLE
Added support for weak imports in ProtoParser, ProtoFile and ProtoFileElement

### DIFF
--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/ProtoFile.kt
@@ -25,6 +25,7 @@ data class ProtoFile(
   val location: Location,
   val imports: List<String>,
   val publicImports: List<String>,
+  val weakImports: List<String>,
   val packageName: String?,
   val types: List<Type>,
   val services: List<Service>,
@@ -42,6 +43,7 @@ data class ProtoFile(
       syntax,
       imports,
       publicImports,
+      weakImports,
       Type.toElements(types),
       Service.toElements(services),
       Extend.toElements(extendList),
@@ -102,7 +104,7 @@ data class ProtoFile(
     val retainedOptions = options.retainAll(schema, markSet)
 
     val result = ProtoFile(
-      location, imports, publicImports, packageName, retainedTypes,
+      location, imports, publicImports, weakImports, packageName, retainedTypes,
       retainedServices, retainedExtends, retainedOptions, syntax,
     )
     result.javaPackage = javaPackage
@@ -121,7 +123,7 @@ data class ProtoFile(
     val retainedOptions = options.retainLinked()
 
     val result = ProtoFile(
-      location, imports, publicImports, packageName, retainedTypes,
+      location, imports, publicImports, weakImports, packageName, retainedTypes,
       retainedServices, retainedExtends, retainedOptions, syntax,
     )
     result.javaPackage = javaPackage
@@ -202,10 +204,13 @@ data class ProtoFile(
 
     val retainedPublicImports = publicImports.filter { nonEmptyProtoFilesInSchema.contains(it) }
 
-    return if (imports.size != retainedImports.size || publicImports.size != retainedPublicImports.size) {
+    val retainedWeakImports = weakImports.filter { referencedImports.contains(it) }
+
+    return if (imports.size != retainedImports.size || publicImports.size != retainedPublicImports.size ||
+               weakImports.size != retainedWeakImports.size) {
       val result = ProtoFile(
-        location, retainedImports, retainedPublicImports, packageName, types, services,
-        extendList, options, syntax,
+        location, retainedImports, retainedPublicImports, retainedWeakImports, packageName,
+        types, services, extendList, options, syntax,
       )
       result.javaPackage = javaPackage
       result.wirePackage = wirePackage
@@ -251,8 +256,8 @@ data class ProtoFile(
 
       return ProtoFile(
         protoFileElement.location, protoFileElement.imports,
-        protoFileElement.publicImports, packageName, types, services, wireExtends, options,
-        protoFileElement.syntax,
+        protoFileElement.publicImports, protoFileElement.weakImports, packageName,
+        types, services, wireExtends, options, protoFileElement.syntax,
       )
     }
   }

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
@@ -26,6 +26,7 @@ data class ProtoFileElement(
   val syntax: Syntax? = null,
   val imports: List<String> = emptyList(),
   val publicImports: List<String> = emptyList(),
+  val weakImports: List<String> = emptyList(),
   val types: List<TypeElement> = emptyList(),
   val services: List<ServiceElement> = emptyList(),
   val extendDeclarations: List<ExtendElement> = emptyList(),
@@ -50,6 +51,9 @@ data class ProtoFileElement(
       }
       for (file in publicImports) {
         append("import public \"$file\";\n")
+      }
+      for (file in weakImports) {
+        append("import weak \"$file\";\n")
       }
     }
     if (options.isNotEmpty()) {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoFileElement.kt
@@ -44,7 +44,7 @@ data class ProtoFileElement(
       append('\n')
       append("package $packageName;\n")
     }
-    if (imports.isNotEmpty() || publicImports.isNotEmpty()) {
+    if (imports.isNotEmpty() || publicImports.isNotEmpty() || weakImports.isNotEmpty()) {
       append('\n')
       for (file in imports) {
         append("import \"$file\";\n")

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/internal/parser/ProtoParser.kt
@@ -30,8 +30,9 @@ class ProtoParser internal constructor(
   data: CharArray,
 ) {
   private val reader: SyntaxReader = SyntaxReader(data, location)
-  private val publicImports = mutableListOf<String>()
   private val imports = mutableListOf<String>()
+  private val publicImports = mutableListOf<String>()
+  private val weakImports = mutableListOf<String>()
   private val nestedTypes = mutableListOf<TypeElement>()
   private val services = mutableListOf<ServiceElement>()
   private val extendsList = mutableListOf<ExtendElement>()
@@ -59,6 +60,7 @@ class ProtoParser internal constructor(
           syntax = syntax,
           imports = imports.map { it.toPath().withUnixSlashes().toString() },
           publicImports = publicImports.map { it.toPath().withUnixSlashes().toString() },
+          weakImports = weakImports.map { it.toPath().withUnixSlashes().toString() },
           types = nestedTypes,
           services = services,
           extendDeclarations = extendsList,
@@ -114,6 +116,7 @@ class ProtoParser internal constructor(
 
       label == "import" && context.permitsImport() -> {
         when (val importString = reader.readString()) {
+          "weak" -> weakImports.add(reader.readString())
           "public" -> publicImports.add(reader.readString())
           else -> imports.add(importString)
         }


### PR DESCRIPTION
I changed `ProtoParser`, `ProtoFile` and `ProtoFileElement` to support weak imports.

I didn't try to compile this, but if it does compile then the new behaviour would be that weak imports are ignored, since I added a field `weakImports` to `ProtoFile` and `ProtoFileElement` that is not read outside of these classes. The current situation is that parsing fails when the file contains a weak import, so I consider that an improvement.

See [issue 3226](https://github.com/square/wire/issues/3226).