### PR TITLE
Fix code generation for mutable types.

### DIFF
--- a/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePayload.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePayload.kt
@@ -7,6 +7,7 @@
 
 package squareup.wire.mutable
 
+import com.squareup.wire.EnumAdapter
 import com.squareup.wire.FieldEncoding
 import com.squareup.wire.Message
 import com.squareup.wire.ProtoAdapter
@@ -14,8 +15,11 @@ import com.squareup.wire.ProtoReader
 import com.squareup.wire.ProtoWriter
 import com.squareup.wire.ReverseProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
+import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.`internal`.JvmField
+import com.squareup.wire.`internal`.JvmStatic
+import com.squareup.wire.`internal`.sanitize
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Deprecated
@@ -31,10 +35,22 @@ import okio.ByteString
 public class MutablePayload(
   @field:WireField(
     tag = 1,
-    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    adapter = "com.squareup.wire.ProtoAdapter#STRING",
     schemaIndex = 0,
   )
+  public var preamble: String? = null,
+  @field:WireField(
+    tag = 2,
+    adapter = "com.squareup.wire.ProtoAdapter#BYTES",
+    schemaIndex = 1,
+  )
   public var content: ByteString? = null,
+  @field:WireField(
+    tag = 3,
+    adapter = "squareup.wire.mutable.MutablePayload${'$'}Type#ADAPTER",
+    schemaIndex = 2,
+  )
+  public var type: Type? = null,
   override var unknownFields: ByteString = ByteString.EMPTY,
 ) : Message<MutablePayload, Nothing>(ADAPTER, unknownFields) {
   @Deprecated(
@@ -47,20 +63,26 @@ public class MutablePayload(
     if (other === this) return true
     if (other !is MutablePayload) return false
     if (unknownFields != other.unknownFields) return false
+    if (preamble != other.preamble) return false
     if (content != other.content) return false
+    if (type != other.type) return false
     return true
   }
 
   override fun hashCode(): Int {
     var result = 0
     result = unknownFields.hashCode()
+    result = result * 37 + (preamble?.hashCode() ?: 0)
     result = result * 37 + (content?.hashCode() ?: 0)
+    result = result * 37 + (type?.hashCode() ?: 0)
     return result
   }
 
   override fun toString(): String {
     val result = mutableListOf<String>()
+    if (preamble != null) result += """preamble=${sanitize(preamble!!)}"""
     if (content != null) result += """content=$content"""
+    if (type != null) result += """type=$type"""
     return result.joinToString(prefix = "MutablePayload{", separator = ", ", postfix = "}")
   }
 
@@ -76,30 +98,46 @@ public class MutablePayload(
     ) {
       override fun encodedSize(`value`: MutablePayload): Int {
         var size = value.unknownFields.size
-        size += ProtoAdapter.BYTES.encodedSizeWithTag(1, value.content)
+        size += ProtoAdapter.STRING.encodedSizeWithTag(1, value.preamble)
+        size += ProtoAdapter.BYTES.encodedSizeWithTag(2, value.content)
+        size += Type.ADAPTER.encodedSizeWithTag(3, value.type)
         return size
       }
 
       override fun encode(writer: ProtoWriter, `value`: MutablePayload) {
-        ProtoAdapter.BYTES.encodeWithTag(writer, 1, value.content)
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.preamble)
+        ProtoAdapter.BYTES.encodeWithTag(writer, 2, value.content)
+        Type.ADAPTER.encodeWithTag(writer, 3, value.type)
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: MutablePayload) {
         writer.writeBytes(value.unknownFields)
-        ProtoAdapter.BYTES.encodeWithTag(writer, 1, value.content)
+        Type.ADAPTER.encodeWithTag(writer, 3, value.type)
+        ProtoAdapter.BYTES.encodeWithTag(writer, 2, value.content)
+        ProtoAdapter.STRING.encodeWithTag(writer, 1, value.preamble)
       }
 
       override fun decode(reader: ProtoReader): MutablePayload {
+        var preamble: String? = null
         var content: ByteString? = null
+        var type: Type? = null
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
-            1 -> content = ProtoAdapter.BYTES.decode(reader)
+            1 -> preamble = ProtoAdapter.STRING.decode(reader)
+            2 -> content = ProtoAdapter.BYTES.decode(reader)
+            3 -> try {
+              type = Type.ADAPTER.decode(reader)
+            } catch (e: ProtoAdapter.EnumConstantNotFoundException) {
+              reader.addUnknownField(tag, FieldEncoding.VARINT, e.value.toLong())
+            }
             else -> reader.readUnknownField(tag)
           }
         }
         return MutablePayload(
+          preamble = preamble,
           content = content,
+          type = type,
           unknownFields = unknownFields
         )
       }
@@ -108,5 +146,37 @@ public class MutablePayload(
     }
 
     private const val serialVersionUID: Long = 0L
+  }
+
+  public enum class Type(
+    override val `value`: Int,
+  ) : WireEnum {
+    TYPE_TEXT_PLAIN(1),
+    TYPE_TEXT_HTML(2),
+    TYPE_IMAGE_JPEG(3),
+    TYPE_IMAGE_PNG(4),
+    TYPE_UNKNOWN(10),
+    ;
+
+    public companion object {
+      @JvmField
+      public val ADAPTER: ProtoAdapter<Type> = object : EnumAdapter<Type>(
+        Type::class, 
+        PROTO_2, 
+        null
+      ) {
+        override fun fromValue(`value`: Int): Type? = Type.fromValue(`value`)
+      }
+
+      @JvmStatic
+      public fun fromValue(`value`: Int): Type? = when (`value`) {
+        1 -> TYPE_TEXT_PLAIN
+        2 -> TYPE_TEXT_HTML
+        3 -> TYPE_IMAGE_JPEG
+        4 -> TYPE_IMAGE_PNG
+        10 -> TYPE_UNKNOWN
+        else -> null
+      }
+    }
   }
 }

--- a/wire-golden-files/src/main/proto/squareup/wire/mutable_types.proto
+++ b/wire-golden-files/src/main/proto/squareup/wire/mutable_types.proto
@@ -17,9 +17,10 @@ message Payload {
   optional string preamble = 1;
   optional bytes content = 2;
   optional Type type = 3;
+  repeated string footers = 4;
 }
 
 message Packet {
   optional Header header = 1;
-  optional Payload payload = 2;
+  repeated Payload payload = 2;
 }

--- a/wire-golden-files/src/main/proto/squareup/wire/mutable_types.proto
+++ b/wire-golden-files/src/main/proto/squareup/wire/mutable_types.proto
@@ -7,7 +7,16 @@ message Header {
 }
 
 message Payload {
-  optional bytes content = 1;
+  enum Type {
+    TYPE_TEXT_PLAIN = 1;
+    TYPE_TEXT_HTML = 2;
+    TYPE_IMAGE_JPEG = 3;
+    TYPE_IMAGE_PNG = 4;
+    TYPE_UNKNOWN = 10;
+  }
+  optional string preamble = 1;
+  optional bytes content = 2;
+  optional Type type = 3;
 }
 
 message Packet {

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1382,7 +1382,11 @@ class KotlinGenerator private constructor(
                     add("=$DOUBLE_FULL_BLOCK")
                   } else {
                     if (fieldOrOneOf.type == ProtoType.STRING) {
-                      add("=\${%M(%N)}", sanitizeMember, fieldName)
+                      if (mutableTypes && !fieldOrOneOf.isRepeated) {
+                        add("=\${%M(%N!!)}", sanitizeMember, fieldName)
+                      } else {
+                        add("=\${%M(%N)}", sanitizeMember, fieldName)
+                      }
                     } else if (fieldOrOneOf.useArray) {
                       add("=\${")
                       add("%N", fieldName)
@@ -3138,7 +3142,7 @@ class KotlinGenerator private constructor(
       fun putAll(kotlinPackage: String, enclosingClassName: ClassName?, types: List<Type>) {
         for (type in types) {
           val simpleName = type.type.simpleName
-          val name = if (mutableTypes) "Mutable$simpleName" else simpleName
+          val name = if (mutableTypes && type !is EnumType) "Mutable$simpleName" else simpleName
           val className = enclosingClassName?.nestedClass(name)
             ?: ClassName(kotlinPackage, name)
           typeToKotlinName[type.type] = className

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -2315,7 +2315,15 @@ class KotlinGeneratorTest {
           }
 
           message Payload {
+            enum Type {
+              TYPE_TEXT_PLAIN = 1;
+              TYPE_TEXT_HTML = 2;
+              TYPE_IMAGE_JPEG = 3;
+              TYPE_IMAGE_PNG = 4;
+              TYPE_UNKNOWN = 10;
+            }
             optional bytes content = 1;
+            optional Type type = 2;
           }
 
           message Packet {


### PR DESCRIPTION
* Handle `enum`s gracefully. They will never need to be `Mutable`.
* For `optional` `string` types, use the `!!` operator when dispatching a call to `sanitize(...)`. There are no guarantees of safety here anyway, so this should be okay.

Test: Add golden file tests.