### PR TITLE
Client Streaming Enhancements

### DIFF
--- a/gen-tests.gradle.kts
+++ b/gen-tests.gradle.kts
@@ -564,6 +564,7 @@ val generateGrpcTests by tasks.creating(JavaExec::class) {
   args = listOf(
           "--proto_path=wire-grpc-tests/src/test/proto",
           "--kotlin_out=wire-grpc-tests/src/test/proto-grpc",
+          "--kotlin_explicit_streaming_calls",
           "routeguide/RouteGuideProto.proto"
   ) + GRPC_PROTOS
 }

--- a/wire-compiler/api/wire-compiler.api
+++ b/wire-compiler/api/wire-compiler.api
@@ -8,7 +8,7 @@ public final class com/squareup/wire/DryRunFileSystem : okio/ForwardingFileSyste
 public final class com/squareup/wire/WireCompiler {
 	public static final field CODE_GENERATED_BY_WIRE Ljava/lang/String;
 	public static final field Companion Lcom/squareup/wire/WireCompiler$Companion;
-	public synthetic fun <init> (Lokio/FileSystem;Lcom/squareup/wire/WireLogger;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZZZZZZZIZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZLjava/lang/String;ZZZLjava/util/List;Ljava/util/Map;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lokio/FileSystem;Lcom/squareup/wire/WireLogger;Ljava/util/List;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Ljava/util/List;Ljava/util/List;Ljava/util/Map;ZZZZZZZZIZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZLjava/lang/String;ZZZZLjava/util/List;Ljava/util/Map;Ljava/util/List;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun compile ()V
 	public static final fun forArgs (Ljava/nio/file/FileSystem;Lcom/squareup/wire/WireLogger;[Ljava/lang/String;)Lcom/squareup/wire/WireCompiler;
 	public static final fun forArgs (Lokio/FileSystem;Lcom/squareup/wire/WireLogger;[Ljava/lang/String;)Lcom/squareup/wire/WireCompiler;
@@ -31,6 +31,7 @@ public final class com/squareup/wire/WireCompiler {
 	public final fun getKotlinBuildersOnly ()Z
 	public final fun getKotlinEscapeKeywords ()Z
 	public final fun getKotlinExclusive ()Z
+	public final fun getKotlinExplicitStreamingCalls ()Z
 	public final fun getKotlinNameSuffix ()Ljava/lang/String;
 	public final fun getKotlinOut ()Ljava/lang/String;
 	public final fun getKotlinRpcCallStyle ()Lcom/squareup/wire/kotlin/RpcCallStyle;
@@ -117,8 +118,8 @@ public final class com/squareup/wire/schema/JavaTarget : com/squareup/wire/schem
 }
 
 public final class com/squareup/wire/schema/KotlinTarget : com/squareup/wire/schema/Target {
-	public fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZ)V
-	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZ)V
+	public synthetic fun <init> (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/util/List;
 	public final fun component10 ()Lcom/squareup/wire/kotlin/RpcRole;
 	public final fun component11 ()Z
@@ -135,8 +136,8 @@ public final class com/squareup/wire/schema/KotlinTarget : com/squareup/wire/sch
 	public final fun component7 ()Z
 	public final fun component8 ()Z
 	public final fun component9 ()Lcom/squareup/wire/kotlin/RpcCallStyle;
-	public final fun copy (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZ)Lcom/squareup/wire/schema/KotlinTarget;
-	public static synthetic fun copy$default (Lcom/squareup/wire/schema/KotlinTarget;Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZILjava/lang/Object;)Lcom/squareup/wire/schema/KotlinTarget;
+	public final fun copy (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZ)Lcom/squareup/wire/schema/KotlinTarget;
+	public static synthetic fun copy$default (Lcom/squareup/wire/schema/KotlinTarget;Ljava/util/List;Ljava/util/List;ZLjava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZILjava/lang/Object;)Lcom/squareup/wire/schema/KotlinTarget;
 	public fun copyTarget (Ljava/util/List;Ljava/util/List;ZLjava/lang/String;)Lcom/squareup/wire/schema/Target;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getAndroid ()Z

--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -142,6 +142,7 @@ class WireCompiler internal constructor(
   val kotlinBuildersOnly: Boolean,
   val kotlinEscapeKeywords: Boolean,
   val emitProtoReader32: Boolean,
+  val kotlinExplicitStreamingCalls: Boolean,
   val eventListenerFactoryClasses: List<String>,
   val customOptions: Map<String, String>,
   val opaqueTypes: List<String> = listOf(),
@@ -177,6 +178,7 @@ class WireCompiler internal constructor(
         buildersOnly = kotlinBuildersOnly,
         escapeKotlinKeywords = kotlinEscapeKeywords,
         emitProtoReader32 = emitProtoReader32,
+        explicitStreamingCalls = kotlinExplicitStreamingCalls,
       )
     }
     if (swiftOut != null) {
@@ -290,6 +292,7 @@ class WireCompiler internal constructor(
     private const val EMIT_PROTO_READER_32 = "--emit_proto_reader_32"
     private const val CUSTOM_OPTION_FLAG = "--custom_option="
     private const val OPAQUE_TYPES_FLAG = "--opaque_types="
+    private const val KOTLIN_EXPLICIT_STREAMING_CALLS = "--kotlin_explicit_streaming_calls"
 
     @Throws(IOException::class)
     @JvmStatic
@@ -353,6 +356,7 @@ class WireCompiler internal constructor(
       var kotlinBuildersOnly = false
       var kotlinEscapeKeywords = false
       var emitProtoReader32 = false
+      var kotlinExplicitStreamingCalls = false
       var dryRun = false
       val customOptions = mutableMapOf<String, String>()
       val opaqueTypes = mutableListOf<String>()
@@ -473,6 +477,7 @@ class WireCompiler internal constructor(
           arg == LOAD_EXHAUSTIVELY -> loadExhaustively = true
           arg == JAVA_INTEROP -> javaInterop = true
           arg == EMIT_PROTO_READER_32 -> emitProtoReader32 = true
+          arg == KOTLIN_EXPLICIT_STREAMING_CALLS -> kotlinExplicitStreamingCalls = true
           arg.startsWith("--") -> throw IllegalArgumentException("Unknown argument '$arg'.")
           else -> sourceFileNames.add(arg)
         }
@@ -527,6 +532,7 @@ class WireCompiler internal constructor(
         eventListenerFactoryClasses = eventListenerFactoryClasses,
         customOptions = customOptions,
         opaqueTypes = opaqueTypes,
+        kotlinExplicitStreamingCalls = kotlinExplicitStreamingCalls,
       )
     }
   }

--- a/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -147,6 +147,13 @@ data class KotlinTarget(
    * If true, the generated classes will be mutable..
    */
   private val mutableTypes: Boolean = false,
+
+  /**
+   * If true, the generated gRPC client will use explicit classes for client, server,
+   * and bidirectional streaming calls.
+   */
+  private val explicitStreamingCalls: Boolean = false,
+
 ) : Target() {
   override fun newHandler(): SchemaHandler {
     return KotlinSchemaHandler(
@@ -165,6 +172,7 @@ data class KotlinTarget(
       enumMode = enumMode,
       emitProtoReader32 = emitProtoReader32,
       mutableTypes = mutableTypes,
+      explicitStreamingCalls = explicitStreamingCalls,
     )
   }
 

--- a/wire-gradle-plugin/api/wire-gradle-plugin.api
+++ b/wire-gradle-plugin/api/wire-gradle-plugin.api
@@ -52,6 +52,7 @@ public class com/squareup/wire/gradle/KotlinOutput : com/squareup/wire/gradle/Wi
 	public final fun getEscapeKotlinKeywords ()Z
 	public final fun getExcludes ()Ljava/util/List;
 	public final fun getExclusive ()Z
+	public final fun getExplicitStreamingCalls ()Z
 	public final fun getGrpcServerCompatible ()Z
 	public final fun getIncludes ()Ljava/util/List;
 	public final fun getJavaInterop ()Z
@@ -70,6 +71,7 @@ public class com/squareup/wire/gradle/KotlinOutput : com/squareup/wire/gradle/Wi
 	public final fun setEscapeKotlinKeywords (Z)V
 	public final fun setExcludes (Ljava/util/List;)V
 	public final fun setExclusive (Z)V
+	public final fun setExplicitStreamingCalls (Z)V
 	public final fun setGrpcServerCompatible (Z)V
 	public final fun setIncludes (Ljava/util/List;)V
 	public final fun setJavaInterop (Z)V

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -159,6 +159,12 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
    */
   var mutableTypes: Boolean = false
 
+  /**
+   * If true, the generated gRPC client will use explicit classes for client, server,
+   * and bidirectional streaming calls.
+   */
+  var explicitStreamingCalls: Boolean = false
+
   override fun toTarget(outputDirectory: String): KotlinTarget {
     if (grpcServerCompatible) {
       throw IllegalArgumentException(
@@ -203,6 +209,7 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
       enumMode = enumMode,
       emitProtoReader32 = emitProtoReader32,
       mutableTypes = mutableTypes,
+      explicitStreamingCalls = explicitStreamingCalls,
     )
   }
 }

--- a/wire-grpc-client/api/wire-grpc-client.api
+++ b/wire-grpc-client/api/wire-grpc-client.api
@@ -20,6 +20,8 @@ public abstract interface class com/squareup/wire/GrpcCall$Callback {
 
 public final class com/squareup/wire/GrpcCalls {
 	public static final fun grpcCall (Lkotlin/jvm/functions/Function1;)Lcom/squareup/wire/GrpcCall;
+	public static final fun grpcClientStreamingCall (Lkotlin/jvm/functions/Function2;)Lcom/squareup/wire/GrpcClientStreamingCall;
+	public static final fun grpcServerStreamingCall (Lkotlin/jvm/functions/Function3;)Lcom/squareup/wire/GrpcServerStreamingCall;
 	public static final fun grpcStreamingCall (Lkotlin/jvm/functions/Function3;)Lcom/squareup/wire/GrpcStreamingCall;
 }
 
@@ -28,6 +30,8 @@ public abstract class com/squareup/wire/GrpcClient {
 	public final fun create (Lkotlin/reflect/KClass;)Lcom/squareup/wire/Service;
 	public final fun newBuilder ()Lcom/squareup/wire/GrpcClient$Builder;
 	public abstract fun newCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcCall;
+	public abstract fun newClientStreamingCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcClientStreamingCall;
+	public abstract fun newServerStreamingCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcServerStreamingCall;
 	public abstract fun newStreamingCall (Lcom/squareup/wire/GrpcMethod;)Lcom/squareup/wire/GrpcStreamingCall;
 }
 
@@ -39,6 +43,25 @@ public final class com/squareup/wire/GrpcClient$Builder {
 	public final fun callFactory (Lokhttp3/Call$Factory;)Lcom/squareup/wire/GrpcClient$Builder;
 	public final fun client (Lokhttp3/OkHttpClient;)Lcom/squareup/wire/GrpcClient$Builder;
 	public final fun minMessageToCompress (J)Lcom/squareup/wire/GrpcClient$Builder;
+}
+
+public abstract interface class com/squareup/wire/GrpcClientStreamingCall {
+	public abstract fun cancel ()V
+	public abstract fun clone ()Lcom/squareup/wire/GrpcClientStreamingCall;
+	public abstract fun executeBlocking ()Lkotlin/Pair;
+	public abstract fun executeIn (Lkotlinx/coroutines/CoroutineScope;)Lkotlin/Pair;
+	public abstract fun getMethod ()Lcom/squareup/wire/GrpcMethod;
+	public abstract fun getRequestMetadata ()Ljava/util/Map;
+	public abstract fun getResponseMetadata ()Ljava/util/Map;
+	public abstract fun getTimeout ()Lokio/Timeout;
+	public abstract fun isCanceled ()Z
+	public abstract fun isExecuted ()Z
+	public abstract fun setRequestMetadata (Ljava/util/Map;)V
+}
+
+public abstract interface class com/squareup/wire/GrpcDeferredResponse {
+	public abstract fun close ()V
+	public abstract fun get ()Ljava/lang/Object;
 }
 
 public final class com/squareup/wire/GrpcException : java/io/IOException {
@@ -61,6 +84,20 @@ public final class com/squareup/wire/GrpcMethod {
 	public final fun getPath ()Ljava/lang/String;
 	public final fun getRequestAdapter ()Lcom/squareup/wire/ProtoAdapter;
 	public final fun getResponseAdapter ()Lcom/squareup/wire/ProtoAdapter;
+}
+
+public abstract interface class com/squareup/wire/GrpcServerStreamingCall {
+	public abstract fun cancel ()V
+	public abstract fun clone ()Lcom/squareup/wire/GrpcServerStreamingCall;
+	public abstract fun executeBlocking (Ljava/lang/Object;)Lcom/squareup/wire/MessageSource;
+	public abstract fun executeIn (Lkotlinx/coroutines/CoroutineScope;Ljava/lang/Object;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun getMethod ()Lcom/squareup/wire/GrpcMethod;
+	public abstract fun getRequestMetadata ()Ljava/util/Map;
+	public abstract fun getResponseMetadata ()Ljava/util/Map;
+	public abstract fun getTimeout ()Lokio/Timeout;
+	public abstract fun isCanceled ()Z
+	public abstract fun isExecuted ()Z
+	public abstract fun setRequestMetadata (Ljava/util/Map;)V
 }
 
 public final class com/squareup/wire/GrpcStatus : java/io/Serializable {
@@ -104,6 +141,13 @@ public abstract interface class com/squareup/wire/GrpcStreamingCall {
 	public abstract fun isCanceled ()Z
 	public abstract fun isExecuted ()Z
 	public abstract fun setRequestMetadata (Ljava/util/Map;)V
+}
+
+public final class com/squareup/wire/GrpcStreamingCallExtensionsKt {
+	public static final fun bidirectionalStream (Lcom/squareup/wire/GrpcStreamingCall;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function3;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun bidirectionalStreamBlocking (Lcom/squareup/wire/GrpcStreamingCall;Lkotlin/jvm/functions/Function2;)Lcom/squareup/wire/MessageSource;
+	public static final fun clientStream (Lcom/squareup/wire/GrpcClientStreamingCall;Lkotlinx/coroutines/CoroutineScope;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun clientStreamBlocking (Lcom/squareup/wire/GrpcClientStreamingCall;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
 }
 
 public abstract interface annotation class com/squareup/wire/WireGrpcExperimental : java/lang/annotation/Annotation {

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcClientStreamingCall.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcClientStreamingCall.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2025 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,37 +16,25 @@
 package com.squareup.wire
 
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 import okio.IOException
 import okio.Timeout
 
 /**
- * A single streaming call to a remote server. This class handles three streaming call types:
+ * A single streaming call to a remote server.
  *
- *  * Single request, streaming response. The send channel or message sink accept exactly one
- *    message. The receive channel or message source produce zero or more messages. The outbound
- *    request message is sent before any inbound response messages.
- *    NOTE: This is deprecated for this use case in favor of using explicitStreamingCalls
- *    to a GrpcServerStreamingCall.
- *
- *  * Streaming request, single response. The send channel or message sink accept zero or more
- *    messages. The receive channel or message source produce exactly one message. All outbound
- *    request messages are sent before the inbound response message.
- *    NOTE: This is deprecated for this use case in favor of using explicitStreamingCalls
- *  *    to a GrpcClientStreamingCall.
- *
- *  * Streaming request, streaming response. The send channel or message sink accept zero or more
- *    messages, and the receive channel or message source produce any number of messages. Unlike
- *    the above two types, you are free to interleave request and response messages.
+ *  * This class handles a client streaming call . The send channel or message sink accept zero or more
+ *    messages. The returned deferred repsonse will ensure that the corresponding send channel or message sink
+ *    is closed before returning the single response message.
  *
  * A gRPC call cannot be executed twice.
  *
  * gRPC calls can be [suspending][executeIn] or [blocking][executeBlocking]. Use whichever mechanism
  * works at your call site: the bytes transmitted on the network are the same.
  */
-interface GrpcStreamingCall<S : Any, R : Any> {
+interface GrpcClientStreamingCall<S : Any, R : Any> {
   /** The method invoked by this call. */
   val method: GrpcMethod<S, R>
 
@@ -83,33 +71,18 @@ interface GrpcStreamingCall<S : Any, R : Any> {
   fun isCanceled(): Boolean
 
   /**
-   * Enqueues this call for execution and returns channels to send and receive the call's messages.
+   * Enqueues this call for execution and returns a channel to send the call's messages and a deferred
+   * response that will ensure the sender is closed and return the single response.
    * This uses the [Dispatchers.IO] to transmit outbound messages.
    */
-  fun executeIn(scope: CoroutineScope): Pair<SendChannel<S>, ReceiveChannel<R>>
+  fun executeIn(scope: CoroutineScope): Pair<SendChannel<S>, Deferred<R>>
 
   /**
-   * Enqueues this call for execution and returns channels to send and receive the call's messages.
-   * This uses the [Dispatchers.IO] to transmit outbound messages.
-   *
-   * This method is deprecated because it doesn't support structured concurrency. Instead, prefer
-   * [executeIn]. When its scope is canceled, resources held by the function will be released.
-   */
-  @Deprecated(
-    level = DeprecationLevel.WARNING,
-    message = "Provide a scope, preferably not GlobalScope",
-    replaceWith = ReplaceWith(
-      expression = "executeIn(GlobalScope)",
-      imports = ["kotlinx.coroutines.GlobalScope"],
-    ),
-  )
-  fun execute(): Pair<SendChannel<S>, ReceiveChannel<R>>
-
-  /**
-   * Enqueues this call for execution and returns streams to send and receive the call's messages.
+   * Enqueues this call for execution and returns a stream to send call's messages and a deferred
+   * response that will ensure the sender is closed and return the single response.
    * Reads and writes on the returned streams are blocking.
    */
-  fun executeBlocking(): Pair<MessageSink<S>, MessageSource<R>>
+  fun executeBlocking(): Pair<MessageSink<S>, GrpcDeferredResponse<R>>
 
   /**
    * Returns true if [executeIn] or [executeBlocking] was called. It is an error to execute a call
@@ -121,5 +94,5 @@ interface GrpcStreamingCall<S : Any, R : Any> {
    * Create a new, identical gRPC call to this one which can be enqueued or executed even if this
    * call has already been.
    */
-  fun clone(): GrpcStreamingCall<S, R>
+  fun clone(): GrpcClientStreamingCall<S, R>
 }

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcDeferredResponse.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcDeferredResponse.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2025 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,9 +15,9 @@
  */
 package com.squareup.wire
 
-expect abstract class GrpcClient() {
-  abstract fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
-  abstract fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
-  abstract fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R>
-  abstract fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R>
+interface GrpcDeferredResponse<T : Any> {
+
+  fun get(): T
+
+  fun close()
 }

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcServerStreamingCall.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcServerStreamingCall.kt
@@ -69,7 +69,7 @@ interface GrpcServerStreamingCall<S : Any, R : Any> {
   fun isCanceled(): Boolean
 
   /**
-   * Enqueues this call for execution, sends singe request, and returns a channel to receive the call's responses.
+   * Enqueues this call for execution, sends single request, and returns a channel to receive the call's responses.
    * This uses the [Dispatchers.IO] to transmit outbound messages.
    */
   suspend fun executeIn(scope: CoroutineScope, request: S): ReceiveChannel<R>

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcServerStreamingCall.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcServerStreamingCall.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2019 Square, Inc.
+ * Copyright (C) 2025 Square, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,35 +18,21 @@ package com.squareup.wire
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.ReceiveChannel
-import kotlinx.coroutines.channels.SendChannel
 import okio.IOException
 import okio.Timeout
 
 /**
- * A single streaming call to a remote server. This class handles three streaming call types:
+ * A single streaming call to a remote server.
  *
- *  * Single request, streaming response. The send channel or message sink accept exactly one
- *    message. The receive channel or message source produce zero or more messages. The outbound
- *    request message is sent before any inbound response messages.
- *    NOTE: This is deprecated for this use case in favor of using explicitStreamingCalls
- *    to a GrpcServerStreamingCall.
- *
- *  * Streaming request, single response. The send channel or message sink accept zero or more
- *    messages. The receive channel or message source produce exactly one message. All outbound
- *    request messages are sent before the inbound response message.
- *    NOTE: This is deprecated for this use case in favor of using explicitStreamingCalls
- *  *    to a GrpcClientStreamingCall.
- *
- *  * Streaming request, streaming response. The send channel or message sink accept zero or more
- *    messages, and the receive channel or message source produce any number of messages. Unlike
- *    the above two types, you are free to interleave request and response messages.
+ *  * This class handles a server streaming call . A single request is sent and the receive channel or
+ *    message source produce zero or more messages.
  *
  * A gRPC call cannot be executed twice.
  *
  * gRPC calls can be [suspending][executeIn] or [blocking][executeBlocking]. Use whichever mechanism
  * works at your call site: the bytes transmitted on the network are the same.
  */
-interface GrpcStreamingCall<S : Any, R : Any> {
+interface GrpcServerStreamingCall<S : Any, R : Any> {
   /** The method invoked by this call. */
   val method: GrpcMethod<S, R>
 
@@ -83,33 +69,16 @@ interface GrpcStreamingCall<S : Any, R : Any> {
   fun isCanceled(): Boolean
 
   /**
-   * Enqueues this call for execution and returns channels to send and receive the call's messages.
+   * Enqueues this call for execution, sends singe request, and returns a channel to receive the call's responses.
    * This uses the [Dispatchers.IO] to transmit outbound messages.
    */
-  fun executeIn(scope: CoroutineScope): Pair<SendChannel<S>, ReceiveChannel<R>>
+  suspend fun executeIn(scope: CoroutineScope, request: S): ReceiveChannel<R>
 
   /**
-   * Enqueues this call for execution and returns channels to send and receive the call's messages.
-   * This uses the [Dispatchers.IO] to transmit outbound messages.
-   *
-   * This method is deprecated because it doesn't support structured concurrency. Instead, prefer
-   * [executeIn]. When its scope is canceled, resources held by the function will be released.
-   */
-  @Deprecated(
-    level = DeprecationLevel.WARNING,
-    message = "Provide a scope, preferably not GlobalScope",
-    replaceWith = ReplaceWith(
-      expression = "executeIn(GlobalScope)",
-      imports = ["kotlinx.coroutines.GlobalScope"],
-    ),
-  )
-  fun execute(): Pair<SendChannel<S>, ReceiveChannel<R>>
-
-  /**
-   * Enqueues this call for execution and returns streams to send and receive the call's messages.
+   * Enqueues this call for execution, sends singe request, and returns a stream to  receive the call's responses.
    * Reads and writes on the returned streams are blocking.
    */
-  fun executeBlocking(): Pair<MessageSink<S>, MessageSource<R>>
+  fun executeBlocking(request: S): MessageSource<R>
 
   /**
    * Returns true if [executeIn] or [executeBlocking] was called. It is an error to execute a call
@@ -121,5 +90,5 @@ interface GrpcStreamingCall<S : Any, R : Any> {
    * Create a new, identical gRPC call to this one which can be enqueued or executed even if this
    * call has already been.
    */
-  fun clone(): GrpcStreamingCall<S, R>
+  fun clone(): GrpcServerStreamingCall<S, R>
 }

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcStreamingCallExtensions.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcStreamingCallExtensions.kt
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+
+/**
+ * Executes a Client Streaming RPC call This encapsulates the Streaming request, single response use case for wire's
+ * [GrpcStreamingCall] In this use case, all outbound request messages are sent before the inbound response message.
+ *
+ * @param scope The [CoroutineScope] to use for the call. This will be used to create coroutines that will write the
+ *   requests to the client message sync. It will also be the context for calling the [block] function
+ * @param block A function that will be called with a [SendChannel] that the caller can use to send requests to the
+ *   server. The channel will automatically be closed when the block completes.
+ * @return The optional single response from the server
+ */
+suspend inline fun <S : Any, R : Any> GrpcClientStreamingCall<S, R>.clientStream(
+  scope: CoroutineScope,
+  crossinline block: suspend SendChannel<S>.() -> Unit,
+): R {
+  val (requestChannel, responseProvider) = executeIn(scope)
+  try {
+    block(requestChannel)
+  } finally {
+    requestChannel.close()
+  }
+  return responseProvider.await()
+}
+
+/**
+ * Executes a blocking Client Streaming RPC call This encapsulates the Streaming request, single response use case for
+ * wire's [GrpcStreamingCall] In this use case, all outbound request messages are sent before the inbound response
+ * message.
+ *
+ * @param block A function that will be called with a [MessageSink] that the caller can use to send requests to the
+ *   server. The channel will automatically be closed when the block completes.
+ * @return The optional single response from the server
+ */
+inline fun <S : Any, R : Any> GrpcClientStreamingCall<S, R>.clientStreamBlocking(
+  crossinline block: MessageSink<S>.() -> Unit,
+): R {
+  val (sink, responseProvider) = executeBlocking()
+  try {
+    block(sink)
+  } finally {
+    sink.close()
+  }
+  return responseProvider.get()
+}
+
+/**
+ * Executes a Bidirectional Streaming RPC call This encapsulates the Streaming request, streaming response use case for
+ * wire's [GrpcStreamingCall] In this use case, you are free to interleave request and response messages. The caller can
+ * optionally send and receive messages in the supplied block or after the block completes in the returned
+ * [ReceiveChannel].
+ *
+ * @param scope The [CoroutineScope] to use for the call. This will be used to create coroutines that will write the
+ *   requests to the client message sync. It will also be the context for calling the [block] function.
+ * @param block A function that will be called with a [SendChannel] and [ReceiveChannel] that the caller can use to send
+ *   requests to the server and consume responses from the server. The send channel will automatically be closed when
+ *   the block completes.
+ * @return The [ReceiveChannel] that will receive the server's streaming response. The caller can optionally consume
+ *   server responses from this channel.
+ */
+suspend inline fun <S : Any, R : Any> GrpcStreamingCall<S, R>.bidirectionalStream(
+  scope: CoroutineScope,
+  crossinline block: suspend (SendChannel<S>, ReceiveChannel<R>) -> Unit,
+): ReceiveChannel<R> {
+  val (requestChannel, responseChannel) = executeIn(scope)
+  try {
+    block(requestChannel, responseChannel)
+  } finally {
+    requestChannel.close()
+  }
+  return responseChannel
+}
+
+/**
+ * Executes a blocking Bidirectional Streaming RPC call This encapsulates the Streaming request, streaming response use
+ * case for wire's [GrpcStreamingCall] In this use case, you are free to interleave request and response messages. The
+ * caller can optionally send and receive messages in the supplied block or after the block completes in the returned
+ * [MessageSource].
+ *
+ * @param block A function that will be called with a [MessageSink] and [MessageSource] that the caller can use to send
+ *   requests to the server and consume responses from the server. The send channel will automatically be closed when
+ *   the block completes.
+ * @return The [MessageSource] that will receive the server's streaming response. The caller can optionally consume
+ *   server responses from this channel.
+ */
+inline fun <S : Any, R : Any> GrpcStreamingCall<S, R>.bidirectionalStreamBlocking(
+  crossinline block: (MessageSink<S>, MessageSource<R>) -> Unit,
+): MessageSource<R> {
+  val (sink, source) = executeBlocking()
+  try {
+    block(sink, source)
+  } finally {
+    sink.close()
+  }
+  return source
+}

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcStreamingCallExtensions.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcStreamingCallExtensions.kt
@@ -20,14 +20,14 @@ import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.channels.SendChannel
 
 /**
- * Executes a Client Streaming RPC call This encapsulates the Streaming request, single response use case for wire's
- * [GrpcStreamingCall] In this use case, all outbound request messages are sent before the inbound response message.
+ * Executes a Client Streaming RPC call
+ * In this use case, all outbound request messages are sent before the inbound response message.
  *
  * @param scope The [CoroutineScope] to use for the call. This will be used to create coroutines that will write the
  *   requests to the client message sync. It will also be the context for calling the [block] function
  * @param block A function that will be called with a [SendChannel] that the caller can use to send requests to the
  *   server. The channel will automatically be closed when the block completes.
- * @return The optional single response from the server
+ * @return The single response from the server
  */
 suspend inline fun <S : Any, R : Any> GrpcClientStreamingCall<S, R>.clientStream(
   scope: CoroutineScope,
@@ -43,13 +43,12 @@ suspend inline fun <S : Any, R : Any> GrpcClientStreamingCall<S, R>.clientStream
 }
 
 /**
- * Executes a blocking Client Streaming RPC call This encapsulates the Streaming request, single response use case for
- * wire's [GrpcStreamingCall] In this use case, all outbound request messages are sent before the inbound response
- * message.
+ * Executes a blocking Client Streaming RPC call
+ * In this use case, all outbound request messages are sent before the inbound response message.
  *
  * @param block A function that will be called with a [MessageSink] that the caller can use to send requests to the
- *   server. The channel will automatically be closed when the block completes.
- * @return The optional single response from the server
+ *   server. The sink will automatically be closed when the block completes.
+ * @return The single response from the server
  */
 inline fun <S : Any, R : Any> GrpcClientStreamingCall<S, R>.clientStreamBlocking(
   crossinline block: MessageSink<S>.() -> Unit,
@@ -64,10 +63,9 @@ inline fun <S : Any, R : Any> GrpcClientStreamingCall<S, R>.clientStreamBlocking
 }
 
 /**
- * Executes a Bidirectional Streaming RPC call This encapsulates the Streaming request, streaming response use case for
- * wire's [GrpcStreamingCall] In this use case, you are free to interleave request and response messages. The caller can
- * optionally send and receive messages in the supplied block or after the block completes in the returned
- * [ReceiveChannel].
+ * Executes a Bidirectional Streaming RPC call
+ * In this use case, you are free to interleave request and response messages. The caller can optionally send
+ * and receive messages in the supplied block or after the block completes in the returned [ReceiveChannel].
  *
  * @param scope The [CoroutineScope] to use for the call. This will be used to create coroutines that will write the
  *   requests to the client message sync. It will also be the context for calling the [block] function.
@@ -91,10 +89,9 @@ suspend inline fun <S : Any, R : Any> GrpcStreamingCall<S, R>.bidirectionalStrea
 }
 
 /**
- * Executes a blocking Bidirectional Streaming RPC call This encapsulates the Streaming request, streaming response use
- * case for wire's [GrpcStreamingCall] In this use case, you are free to interleave request and response messages. The
- * caller can optionally send and receive messages in the supplied block or after the block completes in the returned
- * [MessageSource].
+ * Executes a blocking Bidirectional Streaming RPC call
+ * In this use case, you are free to interleave request and response messages. The caller can optionally send and
+ * receive messages in the supplied block or after the block completes in the returned [MessageSource].
  *
  * @param block A function that will be called with a [MessageSink] and [MessageSource] that the caller can use to send
  *   requests to the server and consume responses from the server. The send channel will automatically be closed when

--- a/wire-grpc-client/src/jsMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/jsMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -18,4 +18,6 @@ package com.squareup.wire
 actual abstract class GrpcClient {
   actual abstract fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
   actual abstract fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
+  actual abstract fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R>
+  actual abstract fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R>
 }

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -17,6 +17,8 @@ package com.squareup.wire
 
 import com.squareup.wire.internal.RealGrpcCall
 import com.squareup.wire.internal.RealGrpcStreamingCall
+import com.squareup.wire.internal.asGrpcClientStreamingCall
+import com.squareup.wire.internal.asGrpcServerStreamingCall
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 import okhttp3.Call
@@ -29,6 +31,10 @@ actual abstract class GrpcClient actual constructor() {
   actual abstract fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
 
   actual abstract fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
+
+  actual abstract fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R>
+
+  actual abstract fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R>
 
   /** Returns a [T] that makes gRPC calls using this client. */
   inline fun <reified T : Service> create(): T = create(T::class)
@@ -181,5 +187,13 @@ internal class WireGrpcClient internal constructor(
 
   override fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R> {
     return RealGrpcStreamingCall(this, method)
+  }
+
+  override fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R> {
+    return RealGrpcStreamingCall(this, method).asGrpcClientStreamingCall()
+  }
+
+  override fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R> {
+    return RealGrpcStreamingCall(this, method).asGrpcServerStreamingCall()
   }
 }

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcClientStreamingCall.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcClientStreamingCall.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.internal
+
+import com.squareup.wire.GrpcClientStreamingCall
+import com.squareup.wire.GrpcDeferredResponse
+import com.squareup.wire.GrpcMethod
+import com.squareup.wire.GrpcStreamingCall
+import com.squareup.wire.MessageSink
+import java.util.concurrent.locks.ReentrantLock
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart.LAZY
+import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.channels.ClosedReceiveChannelException
+import kotlinx.coroutines.channels.SendChannel
+import okio.Timeout
+import okio.withLock
+
+internal class RealGrpcClientStreamingCall<S : Any, R : Any>(
+  private val callDelegate: GrpcStreamingCall<S, R>,
+  override val method: GrpcMethod<S, R>,
+) : GrpcClientStreamingCall<S, R> {
+  override val timeout: Timeout
+    get() = callDelegate.timeout
+  override var requestMetadata: Map<String, String>
+    get() = callDelegate.requestMetadata
+    set(value) {
+      callDelegate.requestMetadata = value
+    }
+  override val responseMetadata: Map<String, String>?
+    get() = callDelegate.responseMetadata
+
+  override fun cancel() {
+    callDelegate.cancel()
+  }
+
+  override fun isCanceled() = callDelegate.isCanceled()
+
+  override fun executeIn(scope: CoroutineScope): Pair<SendChannel<S>, Deferred<R>> {
+    val (sendChannel, receiveChannel) = callDelegate.executeIn(scope)
+    return sendChannel to scope.async(Dispatchers.Unconfined, start = LAZY) {
+      sendChannel.close()
+      try {
+        receiveChannel.receive()
+      } catch (e: ClosedReceiveChannelException) {
+        throw IllegalStateException("missing expected response", e)
+      }
+    }.apply {
+      invokeOnCompletion { t ->
+        if (t is CancellationException) {
+          callDelegate.cancel()
+        }
+      }
+    }
+  }
+
+  override fun executeBlocking(): Pair<MessageSink<S>, GrpcDeferredResponse<R>> {
+    val (sink, source) = callDelegate.executeBlocking()
+    return sink to object : GrpcDeferredResponse<R> {
+      private val lock = ReentrantLock()
+      private var response: R? = null
+
+      override fun get(): R {
+        sink.close()
+        return response ?: lock.withLock {
+          checkNotNull(response ?: source.read()?.also { response = it }) {
+            "expecting a single response"
+          }
+        }
+      }
+
+      override fun close() {
+        source.close()
+      }
+    }
+  }
+
+  override fun isExecuted() = callDelegate.isExecuted()
+
+  override fun clone() = RealGrpcClientStreamingCall(callDelegate.clone(), method)
+}
+
+internal fun <S : Any, R : Any> GrpcStreamingCall<S, R>.asGrpcClientStreamingCall() =
+  RealGrpcClientStreamingCall(this, method)

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcServerStreamingCall.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcServerStreamingCall.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.internal
+
+import com.squareup.wire.GrpcMethod
+import com.squareup.wire.GrpcServerStreamingCall
+import com.squareup.wire.GrpcStreamingCall
+import com.squareup.wire.MessageSource
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.channels.ReceiveChannel
+import okio.Timeout
+
+internal class RealGrpcServerStreamingCall<S : Any, R : Any>(
+  private val callDelegate: GrpcStreamingCall<S, R>,
+  override val method: GrpcMethod<S, R>,
+) : GrpcServerStreamingCall<S, R> {
+
+  override val timeout: Timeout
+    get() = callDelegate.timeout
+
+  override var requestMetadata: Map<String, String>
+    get() = callDelegate.requestMetadata
+    set(value) { callDelegate.requestMetadata = value }
+
+  override val responseMetadata: Map<String, String>?
+    get() = callDelegate.responseMetadata
+
+  override fun cancel() {
+    callDelegate.cancel()
+  }
+
+  override fun isCanceled() = callDelegate.isCanceled()
+
+  override fun isExecuted() = callDelegate.isExecuted()
+
+  override fun clone() = RealGrpcServerStreamingCall(callDelegate.clone(), method)
+
+  override suspend fun executeIn(scope: CoroutineScope, request: S): ReceiveChannel<R> {
+    val (sendChannel, receiveChannel) = callDelegate.executeIn(scope)
+    try {
+      sendChannel.send(request)
+    } finally {
+      sendChannel.close()
+    }
+    return receiveChannel
+  }
+
+  override fun executeBlocking(request: S): MessageSource<R> {
+    val (sink, source) = callDelegate.executeBlocking()
+    sink.use { it.write(request) }
+    return source
+  }
+}
+
+internal fun <S : Any, R : Any>GrpcStreamingCall<S, R>.asGrpcServerStreamingCall() =
+  RealGrpcServerStreamingCall(this, method)

--- a/wire-grpc-client/src/nativeMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/nativeMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -18,4 +18,6 @@ package com.squareup.wire
 actual abstract class GrpcClient {
   actual abstract fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R>
   actual abstract fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R>
+  actual abstract fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R>
+  actual abstract fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R>
 }

--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcOnMockWebServerTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcOnMockWebServerTest.kt
@@ -102,11 +102,11 @@ class GrpcOnMockWebServerTest {
       return@GrpcCall Feature(name = "tree")
     }
 
-    override fun ListFeatures(): GrpcStreamingCall<Rectangle, Feature> {
+    override fun ListFeatures(): GrpcServerStreamingCall<Rectangle, Feature> {
       TODO("Not yet implemented")
     }
 
-    override fun RecordRoute(): GrpcStreamingCall<Point, RouteSummary> {
+    override fun RecordRoute(): GrpcClientStreamingCall<Point, RouteSummary> {
       TODO("Not yet implemented")
     }
 

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/GrpcRouteGuideClient.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/GrpcRouteGuideClient.kt
@@ -9,7 +9,9 @@ package routeguide
 
 import com.squareup.wire.GrpcCall
 import com.squareup.wire.GrpcClient
+import com.squareup.wire.GrpcClientStreamingCall
 import com.squareup.wire.GrpcMethod
+import com.squareup.wire.GrpcServerStreamingCall
 import com.squareup.wire.GrpcStreamingCall
 import kotlin.Suppress
 
@@ -41,7 +43,7 @@ public class GrpcRouteGuideClient(
    * repeated field), as the rectangle may cover a large area and contain a
    * huge number of features.
    */
-  override fun ListFeatures(): GrpcStreamingCall<Rectangle, Feature> = client.newStreamingCall(GrpcMethod(
+  override fun ListFeatures(): GrpcServerStreamingCall<Rectangle, Feature> = client.newServerStreamingCall(GrpcMethod(
       path = "/routeguide.RouteGuide/ListFeatures",
       requestAdapter = Rectangle.ADAPTER,
       responseAdapter = Feature.ADAPTER
@@ -53,7 +55,7 @@ public class GrpcRouteGuideClient(
    * Accepts a stream of Points on a route being traversed, returning a
    * RouteSummary when traversal is completed.
    */
-  override fun RecordRoute(): GrpcStreamingCall<Point, RouteSummary> = client.newStreamingCall(GrpcMethod(
+  override fun RecordRoute(): GrpcClientStreamingCall<Point, RouteSummary> = client.newClientStreamingCall(GrpcMethod(
       path = "/routeguide.RouteGuide/RecordRoute",
       requestAdapter = Point.ADAPTER,
       responseAdapter = RouteSummary.ADAPTER

--- a/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteGuideClient.kt
+++ b/wire-grpc-tests/src/test/proto-grpc/routeguide/RouteGuideClient.kt
@@ -8,6 +8,8 @@
 package routeguide
 
 import com.squareup.wire.GrpcCall
+import com.squareup.wire.GrpcClientStreamingCall
+import com.squareup.wire.GrpcServerStreamingCall
 import com.squareup.wire.GrpcStreamingCall
 import com.squareup.wire.Service
 import kotlin.Suppress
@@ -34,7 +36,7 @@ public interface RouteGuideClient : Service {
    * repeated field), as the rectangle may cover a large area and contain a
    * huge number of features.
    */
-  public fun ListFeatures(): GrpcStreamingCall<Rectangle, Feature>
+  public fun ListFeatures(): GrpcServerStreamingCall<Rectangle, Feature>
 
   /**
    * A client-to-server streaming RPC.
@@ -42,7 +44,7 @@ public interface RouteGuideClient : Service {
    * Accepts a stream of Points on a route being traversed, returning a
    * RouteSummary when traversal is completed.
    */
-  public fun RecordRoute(): GrpcStreamingCall<Point, RouteSummary>
+  public fun RecordRoute(): GrpcClientStreamingCall<Point, RouteSummary>
 
   /**
    * A Bidirectional streaming RPC.

--- a/wire-kotlin-generator/api/wire-kotlin-generator.api
+++ b/wire-kotlin-generator/api/wire-kotlin-generator.api
@@ -8,7 +8,7 @@ public final class com/squareup/wire/kotlin/EnumMode : java/lang/Enum {
 
 public final class com/squareup/wire/kotlin/KotlinGenerator {
 	public static final field Companion Lcom/squareup/wire/kotlin/KotlinGenerator$Companion;
-	public synthetic fun <init> (Lcom/squareup/wire/schema/Schema;Ljava/util/Map;Ljava/util/Map;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Lcom/squareup/wire/schema/Schema;Ljava/util/Map;Ljava/util/Map;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZLkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun generateOptionType (Lcom/squareup/wire/schema/Extend;Lcom/squareup/wire/schema/Field;)Lcom/squareup/kotlinpoet/TypeSpec;
 	public final fun generateServiceTypeSpecs (Lcom/squareup/wire/schema/Service;Lcom/squareup/wire/schema/Rpc;)Ljava/util/Map;
 	public static synthetic fun generateServiceTypeSpecs$default (Lcom/squareup/wire/kotlin/KotlinGenerator;Lcom/squareup/wire/schema/Service;Lcom/squareup/wire/schema/Rpc;ILjava/lang/Object;)Ljava/util/Map;
@@ -17,20 +17,20 @@ public final class com/squareup/wire/kotlin/KotlinGenerator {
 	public static synthetic fun generatedServiceName$default (Lcom/squareup/wire/kotlin/KotlinGenerator;Lcom/squareup/wire/schema/Service;Lcom/squareup/wire/schema/Rpc;ZILjava/lang/Object;)Lcom/squareup/kotlinpoet/ClassName;
 	public final fun generatedTypeName (Lcom/squareup/wire/schema/ProtoMember;)Lcom/squareup/kotlinpoet/ClassName;
 	public final fun generatedTypeName (Lcom/squareup/wire/schema/Type;)Lcom/squareup/kotlinpoet/ClassName;
-	public static final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZ)Lcom/squareup/wire/kotlin/KotlinGenerator;
+	public static final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZ)Lcom/squareup/wire/kotlin/KotlinGenerator;
 	public final fun getSchema ()Lcom/squareup/wire/schema/Schema;
 }
 
 public final class com/squareup/wire/kotlin/KotlinGenerator$Companion {
 	public final fun builtInType (Lcom/squareup/wire/schema/ProtoType;)Z
-	public final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZ)Lcom/squareup/wire/kotlin/KotlinGenerator;
-	public static synthetic fun get$default (Lcom/squareup/wire/kotlin/KotlinGenerator$Companion;Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZILjava/lang/Object;)Lcom/squareup/wire/kotlin/KotlinGenerator;
+	public final fun get (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZ)Lcom/squareup/wire/kotlin/KotlinGenerator;
+	public static synthetic fun get$default (Lcom/squareup/wire/kotlin/KotlinGenerator$Companion;Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/Profile;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZILjava/lang/Object;)Lcom/squareup/wire/kotlin/KotlinGenerator;
 }
 
 public final class com/squareup/wire/kotlin/KotlinSchemaHandler : com/squareup/wire/schema/SchemaHandler {
 	public static final field Companion Lcom/squareup/wire/kotlin/KotlinSchemaHandler$Companion;
-	public fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZ)V
-	public synthetic fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZ)V
+	public synthetic fun <init> (Ljava/lang/String;ZZZZLcom/squareup/wire/kotlin/RpcCallStyle;Lcom/squareup/wire/kotlin/RpcRole;ZILjava/lang/String;ZZLcom/squareup/wire/kotlin/EnumMode;ZZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getEnumMode ()Lcom/squareup/wire/kotlin/EnumMode;
 	public fun handle (Lcom/squareup/wire/schema/Extend;Lcom/squareup/wire/schema/Field;Lcom/squareup/wire/schema/SchemaHandler$Context;)Lokio/Path;
 	public fun handle (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/SchemaHandler$Context;)V

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinSchemaHandler.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinSchemaHandler.kt
@@ -91,6 +91,11 @@ class KotlinSchemaHandler(
    * If true, the generated classes will be mutable..
    */
   private val mutableTypes: Boolean = false,
+
+  /**
+   * If true, streaming calls will generate explicit call types for client,server, and bidirectional streaming.
+   */
+  private val explicitStreamingCalls: Boolean = false,
 ) : SchemaHandler() {
   private lateinit var kotlinGenerator: KotlinGenerator
 
@@ -113,6 +118,7 @@ class KotlinSchemaHandler(
       enumMode = enumMode,
       emitProtoReader32 = emitProtoReader32,
       mutableTypes = mutableTypes,
+      explicitStreamingCalls = explicitStreamingCalls,
     )
     context.fileSystem.createDirectories(context.outDirectory)
     super.handle(schema, context)

--- a/wire-tests/src/commonTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
+++ b/wire-tests/src/commonTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
@@ -26,4 +26,12 @@ class CommonCustomGrpcClient : GrpcClient() {
   override fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R> {
     TODO("Not yet implemented")
   }
+
+  override fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
+
+  override fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
 }

--- a/wire-tests/src/jsTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
+++ b/wire-tests/src/jsTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
@@ -26,4 +26,12 @@ class CustomGrpcClient : GrpcClient() {
   override fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R> {
     TODO("Not yet implemented")
   }
+
+  override fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
+
+  override fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
 }

--- a/wire-tests/src/jvmTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
+++ b/wire-tests/src/jvmTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
@@ -26,4 +26,12 @@ class CustomGrpcClient : GrpcClient() {
   override fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R> {
     TODO("Not yet implemented")
   }
+
+  override fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
+
+  override fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
 }

--- a/wire-tests/src/nativeTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
+++ b/wire-tests/src/nativeTest/kotlin/com/squareup/wire/CustomGrpcClient.kt
@@ -26,4 +26,12 @@ class CustomGrpcClient : GrpcClient() {
   override fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R> {
     TODO("Not yet implemented")
   }
+
+  override fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
+
+  override fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R> {
+    TODO("Not yet implemented")
+  }
 }


### PR DESCRIPTION
Adds `GrpcServerStreamingCall` and `GrpcClientStreamingCall` to differentiate between server and client streaming gRPC calls. The current logic is to use a `GrpcStreamingCall` , which is used for Server, Client and Bidrectional streaming. 
The `GrpcServerStreamingCall` accepts an  single request and returns a ReceiveChannel/MessageSource for streaming responses
The `GrpcClientStreamingCall` returns SendChannel/Deferred  or MessageSink/GrpcDeferredResponse pair to stream requests from the client and retrieve the single, deferred response

Both the `GrpcServerStreamingCall` and `GrpcClientStreamingCall` make use of a `GrpcStreamingCall` under the hood, but more tightly enforce the calling semantics of the underlying call.

This is optional and defaults to using `GrpcStreamingCall` for every call. The `explicitStreamingCalls` option enables generation of the explicit types. 


NOTE: The use of `Server` vs `Response` streaming and `Client` vs `Request` streaming was chosen to differentiate `Bidirectional` streaming which is both `Response` and `Request` streaming. Its also the terminology used [here](https://grpc.io/docs/what-is-grpc/core-concepts/#rpc-life-cycle) .  Clearly either would work, but that was the reasoning behind the naming.