### PR TITLE
Always use relative paths

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -152,13 +152,7 @@ class WirePlugin : Plugin<Project> {
       }
 
       val targets = outputs.map { output ->
-        output.toTarget(
-          when (val out = output.out) {
-            null -> project.relativePath(source.outputDir(project))
-            project.libraryProtoOutputPath() -> project.relativePath(out)
-            else -> out
-          },
-        )
+        output.toTarget(project.relativePath(output.out ?: source.outputDir(project)))
       }
       val generatedSourcesDirectories: Set<File> =
         targets


### PR DESCRIPTION
We weren't using relative paths if the output directory was customized. This was harming remote cache hits.