### PR TITLE
Avoid eagerly resolving the configuration

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -186,13 +186,18 @@ class WirePlugin : Plugin<Project> {
         task.group = GROUP
         task.description = "Generate protobuf implementation for ${source.name}"
 
+        var addedSourcesDependencies = false
         // Flatten all the input files here. Changes to any of them will cause the task to re-run.
         for (rootSet in protoSourceProtoRootSets) {
           task.source(rootSet.configuration)
+          if (!rootSet.isEmpty) {
+            // Use the isEmpty flag to avoid resolving the configuration eagerly
+            addedSourcesDependencies = true
+          }
         }
         // We only want to add ProtoPath sources if we have other sources already. The WireTask
         // would otherwise run even through we have no sources.
-        if (!task.source.isEmpty) {
+        if (addedSourcesDependencies) {
           for (rootSet in protoPathProtoRootSets) {
             task.source(rootSet.configuration)
           }

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1398,6 +1398,16 @@ class WirePluginTest {
     assertThat(File(outputRoot, "Period.kt")).exists()
   }
 
+  @Test
+  fun lazyConfigurationResolution() {
+    val fixtureRoot = File("src/test/projects/lazy-configuration-resolution")
+
+    val result = gradleRunner.runFixture(fixtureRoot) {
+      withArguments("wire-project:generateProtos", "--stacktrace", "--info").build()
+    }
+    assertThat(result.task(":wire-project:generateProtos")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
   private fun GradleRunner.runFixture(
     root: File,
     action: GradleRunner.() -> BuildResult,

--- a/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/dep-project/build.gradle.kts
+++ b/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/dep-project/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm") version "1.9.22"
+}
+
+// The below is redundant since the kotlin plugin above does it too
+// but some future version of the kotlin plugin may not, and we still
+// want to capture this explicitly. The projectsEvaluated call fails
+// if a gradle mutation guard is in place, which means it fails if
+// wire-project forces this project to be configured while in the middle
+// of applying the wire plugin (i.e. because the wire plugin evaluates
+// the project dependency). Wire should not evaluate the project
+// dependency eagerly.
+gradle.projectsEvaluated {
+}

--- a/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/gradle.properties
+++ b/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.configureondemand=true
+VERSION_NAME=5.4.0-SNAPSHOT

--- a/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/settings.gradle
+++ b/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/settings.gradle
@@ -1,0 +1,2 @@
+include ':wire-project'
+include ':dep-project'

--- a/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/wire-project/build.gradle.kts
+++ b/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/wire-project/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  id("org.jetbrains.kotlin.jvm") version "1.9.22"
+  id("com.squareup.wire")
+}
+
+dependencies {
+  protoSource(project(":dep-project"))
+}
+
+wire {
+  kotlin {
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/wire-project/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/lazy-configuration-resolution/wire-project/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
Calling task.source.isEmpty does some sort of eager resolution of the configurations that were added to the task source. This in turn can trigger other actions within Gradle and cause weird behaviour (in our case, it caused other plugins to get applied and eventually tripped a mutation guard.

The wire rootset code has a isEmpty flag it keeps which, according to the comments, is there explicitly to avoid resolving the configuration, so we can use that instead.