### PR TITLE
Adds nested builder functions

### DIFF
--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -997,6 +997,30 @@ class KotlinGenerator private constructor(
           }
 
           builder.addProperty(propertyBuilder.build())
+
+          if (fieldOrOneOf.type!!.isMessage) {
+            val fieldType = fieldOrOneOf.type!!.typeName as ClassName
+            val fieldBuilderType = fieldType.nestedClass("Builder")
+
+            val lambdaMethod = FunSpec.builder(fieldName)
+              .addParameter(
+                "builder",
+                LambdaTypeName.get(
+                  receiver = fieldBuilderType,
+                  returnType = Unit::class.asClassName(),
+                ),
+              )
+              .returns(builderClassName)
+              .addStatement(
+                "this.%1N = (%1N?.newBuilder() ?: %2T()).apply(builder).build()",
+                fieldName,
+                fieldBuilderType
+              )
+              .addStatement("return this")
+              .build()
+
+            builder.addFunction(lambdaMethod)
+          }
         }
         is OneOf -> {
           val fieldName = nameAllocator[fieldOrOneOf]

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -2352,6 +2352,29 @@ class KotlinGeneratorTest {
     )
   }
 
+  @Test
+  fun builderLambdaMethods() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+        |message Person {
+        |  optional string name = 1;
+        |  optional Address address = 2;
+        |  message Address {
+        |    optional string street = 1;
+        |    optional string city = 2;
+        |  }
+        |}
+        """.trimMargin(),
+      )
+    }
+    val code = KotlinWithProfilesGenerator(schema)
+      .generateKotlin("Person", buildersOnly = true)
+
+    assertThat(code).contains("public fun address(builder: Address.Builder.() -> Unit): Builder")
+  }
+
   companion object {
     private val pointMessage = """
           |message Point {


### PR DESCRIPTION
I've found myself repeating code working with nested messages. Something along the lines of:

```kotlin
(personBuilder.address?.newBuilder() ?: Address.Builder()).apply {
   city = "London"
}.build()
``` 

I think it'd be cool to inline that into wire generated code.

### Example:
```proto
message Person {
  optional string name = 1;
  optional Address address = 2;
  message Address {
    optional string street = 1;
    optional string city = 2;
  }
}
```

Will generate a new function for the nested message field "address":
```kotlin
public fun address(builder: Address.Builder.() -> Unit): Builder {
  this.address = (address?.newBuilder() ?: Address.Builder()).apply(builder).build()
  return this
}
```

Which can be used like so:
```kotlin
val p = Person.Builder()

// Calls with uninitialized field constructs a new empty builder. 
p.address { city = "London" }

// Calls with initialized field copies existing values into new builder.
p.address { street = "Downing" }

// output Person{address=Address{street=Downing, city=London}}
println(p.build()) 
```



