### PR TITLE
Update InputLocation to be more cache-friendly

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/InputLocation.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/InputLocation.kt
@@ -15,15 +15,24 @@
  */
 package com.squareup.wire.gradle
 
-import com.squareup.wire.internal.Serializable
+import org.gradle.api.file.FileCollection
+import org.gradle.api.tasks.Classpath
+import org.gradle.api.tasks.Input
 
 internal data class InputLocation(
-  /** The path to the directory or .jar. This might not exist until the [WireTask] runs! */
-  val path: String,
+  /**
+   * The collection of files to which the below includes and excludes apply. This collection may include
+   * any valid gradle dependency type, including directories, jars, and project dependencies. Therefore,
+   * it needs to be represented as a gradle Classpath to ensure cache-friendly behaviour.
+   */
+  @get:Classpath
+  val configuration: FileCollection,
 
   /** Files to include, following `PatternFilterable` syntax. */
+  @get:Input
   val includes: List<String>,
 
   /** Files to exclude, following `PatternFilterable` syntax. */
+  @get:Input
   val excludes: List<String>,
-) : Serializable
+)

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireInput.kt
@@ -20,6 +20,8 @@ import com.squareup.wire.schema.Location
 import java.io.EOFException
 import java.io.File
 import java.io.RandomAccessFile
+import kotlin.io.relativeTo
+import kotlin.io.startsWith
 import org.gradle.api.internal.file.FileOperations
 
 internal val List<ProtoRootSet>.inputLocations: List<InputLocation>
@@ -39,6 +41,7 @@ private fun ProtoRootSet.inputLocation(): InputLocation {
  */
 internal fun InputLocation.toLocations(
   fileOperations: FileOperations,
+  projectFile: File,
 ): List<Location> {
   return configuration.files.flatMap { base ->
     return@flatMap buildList {
@@ -47,7 +50,7 @@ internal fun InputLocation.toLocations(
         base.isDirectory -> fileOperations.fileTree(base)
         else -> throw IllegalArgumentException(
           """
-          |Invalid path string: "$base".
+          |Invalid path string: "${if (base.startsWith(projectFile)) { base.relativeTo(projectFile) } else { base }}".
           |For individual files, use the following syntax:
           |wire {
           |  sourcePath {

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -34,6 +34,7 @@ import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputDirectories
 import org.gradle.api.tasks.OutputDirectory
@@ -75,10 +76,10 @@ abstract class WireTask @Inject constructor(
   val pluginVersion: Property<String> = objects.property(String::class.java)
     .convention(VERSION)
 
-  @get:Input
+  @get:Nested
   internal abstract val sourceInput: ListProperty<InputLocation>
 
-  @get:Input
+  @get:Nested
   internal abstract val protoInput: ListProperty<InputLocation>
 
   @get:Input
@@ -156,11 +157,10 @@ abstract class WireTask @Inject constructor(
         }
     }
 
-    val projectDirAsFile = projectDir.asFile
     val allTargets = targets.get()
     val wireRun = WireRun(
-      sourcePath = sourceInput.get().flatMap { it.toLocations(fileOperations, projectDirAsFile) },
-      protoPath = protoInput.get().flatMap { it.toLocations(fileOperations, projectDirAsFile) },
+      sourcePath = sourceInput.get().flatMap { it.toLocations(fileOperations) },
+      protoPath = protoInput.get().flatMap { it.toLocations(fileOperations) },
       treeShakingRoots = roots.get().ifEmpty { includes },
       treeShakingRubbish = prunes.get().ifEmpty { excludes },
       moves = moves.get().map { it.toTypeMoverMove() },

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireTask.kt
@@ -157,10 +157,11 @@ abstract class WireTask @Inject constructor(
         }
     }
 
+    val projectDirAsFile = projectDir.asFile
     val allTargets = targets.get()
     val wireRun = WireRun(
-      sourcePath = sourceInput.get().flatMap { it.toLocations(fileOperations) },
-      protoPath = protoInput.get().flatMap { it.toLocations(fileOperations) },
+      sourcePath = sourceInput.get().flatMap { it.toLocations(fileOperations, projectDirAsFile) },
+      protoPath = protoInput.get().flatMap { it.toLocations(fileOperations, projectDirAsFile) },
       treeShakingRoots = roots.get().ifEmpty { includes },
       treeShakingRubbish = prunes.get().ifEmpty { excludes },
       moves = moves.get().map { it.toTypeMoverMove() },

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1259,7 +1259,7 @@ class WirePluginTest {
 
     val fixtureRoot = File("src/test/projects/cache-relocation-1")
     val result = gradleRunner.runFixture(fixtureRoot) {
-      withArguments("generateProtos", "--build-cache", "--stacktrace", "--info").build()
+      withArguments("-g", tmpFolder.newFolder("gradle-home-1").absolutePath, "generateProtos", "--build-cache", "--stacktrace", "--info").build()
     }
 
     assertThat(result.task(":generateProtos")).isNotNull()
@@ -1273,7 +1273,7 @@ class WirePluginTest {
 
     val relocatedRoot = File("src/test/projects/cache-relocation-2")
     val relocatedResult = gradleRunner.runFixture(relocatedRoot) {
-      withArguments("generateProtos", "--build-cache", "--stacktrace", "--info").build()
+      withArguments("-g", tmpFolder.newFolder("gradle-home-2").absolutePath, "generateProtos", "--build-cache", "--stacktrace", "--info").build()
     }
 
     assertThat(relocatedResult.task(":generateProtos")).isNotNull()

--- a/wire-gradle-plugin/src/test/projects/cache-relocation-1/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/cache-relocation-1/build.gradle
@@ -6,9 +6,20 @@ plugins {
 
 // The code in this test project should be identical to
 // the one in cache-relocation-2; the only difference is
-// that the pathname is different. The test ensures that
-// the gradle task is cacheable even when the project
-// gets relocated to a different filesystem path.
+// that the pathname and gradle user home dirs are different.
+// The test ensures that the gradle task is cacheable even
+// when the project and gradle user home dirs are relocated
+// to a different filesystem path. This ensures the plugin
+// tasks are compatible with being shared across machines
+// via a gradle remote cache.
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  protoPath("com.google.api.grpc:proto-google-common-protos:2.57.0")
+}
 
 wire {
   kotlin {

--- a/wire-gradle-plugin/src/test/projects/cache-relocation-2/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/cache-relocation-2/build.gradle
@@ -6,9 +6,20 @@ plugins {
 
 // The code in this test project should be identical to
 // the one in cache-relocation-1; the only difference is
-// that the pathname is different. The test ensures that
-// the gradle task is cacheable even when the project
-// gets relocated to a different filesystem path.
+// that the pathname and gradle user home dirs are different.
+// The test ensures that the gradle task is cacheable even
+// when the project and gradle user home dirs are relocated
+// to a different filesystem path. This ensures the plugin
+// tasks are compatible with being shared across machines
+// via a gradle remote cache.
+
+repositories {
+  mavenCentral()
+}
+
+dependencies {
+  protoPath("com.google.api.grpc:proto-google-common-protos:2.57.0")
+}
 
 wire {
   kotlin {


### PR DESCRIPTION
Instead of storing individual resolved paths, we should use gradle's
`@Classpath` annotation to indicate that we've got a set of input paths
that are a classpath. Importantly, this will normalize files across
varying gradle user home dirs, so jars that are resolved into the gradle
user home dir will not have their full absolute path baked into the
task input.

Fixes https://github.com/square/wire/issues/3312