### PR TITLE
fix: use correct class loader for clients and builder

### DIFF
--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -59,7 +59,7 @@ actual abstract class GrpcClient actual constructor() {
     val packageName = interfaceName.substring(0, simpleNameOffset)
     val interfaceSimpleName = interfaceName.substring(simpleNameOffset)
     val implementationName = "${packageName}Grpc$interfaceSimpleName"
-    return Class.forName(implementationName)
+    return Class.forName(implementationName, false, service.java.classLoader)
   }
 
   fun newBuilder(): Builder {

--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/reflection.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/reflection.kt
@@ -107,7 +107,7 @@ private fun <M : Message<M, B>, B : Message.Builder<M, B>> getBuilderType(
   messageType: Class<M>,
 ): Class<B> {
   return runCatching {
-    Class.forName("${messageType.name}\$Builder") as Class<B>
+    Class.forName("${messageType.name}\$Builder", false, messageType.classLoader) as Class<B>
   }
     .getOrNull() ?: KotlinConstructorBuilder::class.java as Class<B>
 }


### PR DESCRIPTION
In a non-flat class path the ClassLoader of the target object may be differnt to the system ClassLoader.