### PR TITLE
Optimization: Avoid copying of repeated and map types when `mutableTypes` are being used.

### DIFF
--- a/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePacket.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePacket.kt
@@ -16,7 +16,6 @@ import com.squareup.wire.ReverseProtoWriter
 import com.squareup.wire.Syntax.PROTO_2
 import com.squareup.wire.WireField
 import com.squareup.wire.`internal`.JvmField
-import com.squareup.wire.`internal`.immutableCopyOf
 import kotlin.Any
 import kotlin.Boolean
 import kotlin.Deprecated
@@ -38,17 +37,15 @@ public class MutablePacket(
     schemaIndex = 0,
   )
   public var header_: MutableHeader? = null,
-  payload: List<MutablePayload> = emptyList(),
-  override var unknownFields: ByteString = ByteString.EMPTY,
-) : Message<MutablePacket, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 2,
     adapter = "squareup.wire.mutable.MutablePayload#ADAPTER",
     label = WireField.Label.REPEATED,
     schemaIndex = 1,
   )
-  public var payload: List<MutablePayload> = immutableCopyOf("payload", payload)
-
+  public var payload: List<MutablePayload> = emptyList(),
+  override var unknownFields: ByteString = ByteString.EMPTY,
+) : Message<MutablePacket, Nothing>(ADAPTER, unknownFields) {
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN,

--- a/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePayload.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePayload.kt
@@ -19,7 +19,6 @@ import com.squareup.wire.WireEnum
 import com.squareup.wire.WireField
 import com.squareup.wire.`internal`.JvmField
 import com.squareup.wire.`internal`.JvmStatic
-import com.squareup.wire.`internal`.immutableCopyOf
 import com.squareup.wire.`internal`.sanitize
 import kotlin.Any
 import kotlin.Boolean
@@ -53,17 +52,15 @@ public class MutablePayload(
     schemaIndex = 2,
   )
   public var type: Type? = null,
-  footers: List<String> = emptyList(),
-  override var unknownFields: ByteString = ByteString.EMPTY,
-) : Message<MutablePayload, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
     tag = 4,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     label = WireField.Label.REPEATED,
     schemaIndex = 3,
   )
-  public var footers: List<String> = immutableCopyOf("footers", footers)
-
+  public var footers: List<String> = emptyList(),
+  override var unknownFields: ByteString = ByteString.EMPTY,
+) : Message<MutablePayload, Nothing>(ADAPTER, unknownFields) {
   @Deprecated(
     message = "Shouldn't be used in Kotlin",
     level = DeprecationLevel.HIDDEN,

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -1251,12 +1251,17 @@ class KotlinGenerator private constructor(
         CodeBlock.of(if (buildersOnly) "builder.$fieldName" else fieldName)
       }
       field.isRepeated || field.isMap -> {
-        CodeBlock.of(
-          if (buildersOnly) "%M(%S, builder.%N)" else "%M(%S, %N)",
-          MemberName("com.squareup.wire.internal", "immutableCopyOf"),
-          fieldName,
-          fieldName,
-        )
+        if (mutableTypes) {
+          // For mutable types, don't bother using immutableCopyOf(...)
+          CodeBlock.of("%N", fieldName)
+        } else {
+          CodeBlock.of(
+            if (buildersOnly) "%M(%S, builder.%N)" else "%M(%S, %N)",
+            MemberName("com.squareup.wire.internal", "immutableCopyOf"),
+            fieldName,
+            fieldName,
+          )
+        }
       }
       !field.isRepeated && !field.isMap && field.isRequired && buildersOnly -> {
         CodeBlock.of("builder.%N!!", fieldName)


### PR DESCRIPTION
Avoid using `immutableCopyOf()` when `mutableTypes = true`, for `repeated` and `map` types.
- This avoids allocations, when mutable types are enabled for performance sensitive code.
- This is **not thread safe, so be extremely careful when using `mutableTypes`.**

Test: `./gradlew :wire-golden-files:test`