### PR TITLE
[swift] Improve performance of topological sort algorithm for partitions

### DIFF
--- a/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/DirectedAcyclicGraphTest.kt
+++ b/wire-schema/src/jvmTest/kotlin/com/squareup/wire/schema/DirectedAcyclicGraphTest.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2025 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire.schema
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import kotlin.test.fail
+
+class DirectedAcyclicGraphTest {
+
+  @Test
+  fun singleNode() {
+    val nodes = listOf("A")
+    val graph = DirectedAcyclicGraph(nodes) { emptyList() }
+    val order = graph.topologicalOrder()
+    assertThat(order).containsExactly("A")
+  }
+
+  @Test
+  fun simpleLinearDag() {
+    // A -> B -> C
+    val nodes = listOf("A", "B", "C")
+    val edges = mapOf(
+      "A" to listOf("B"),
+      "B" to listOf("C"),
+      "C" to emptyList(),
+    )
+    val graph = DirectedAcyclicGraph(nodes) { edges[it].orEmpty() }
+    val order = graph.topologicalOrder()
+    assertThat(order).isEqualTo(listOf("A", "B", "C"))
+  }
+
+  @Test
+  fun simpleNonLinearDag() {
+    // A
+    // C -> B
+    val nodes = listOf("A", "B", "C")
+    val edges = mapOf(
+      "A" to emptyList(),
+      "B" to emptyList(),
+      "C" to listOf("B"),
+    )
+    val graph = DirectedAcyclicGraph(nodes) { edges[it].orEmpty() }
+    val order = graph.topologicalOrder()
+    assertThat(order).isEqualTo(listOf("A", "C", "B"))
+  }
+
+  @Test
+  fun branchingDag() {
+    //   A
+    //  / \
+    // B   C
+    //  \ /
+    //   D
+    val nodes = listOf("A", "B", "C", "D")
+    val edges = mapOf(
+      "A" to listOf("B", "C"),
+      "B" to listOf("D"),
+      "C" to listOf("D"),
+      "D" to emptyList(),
+    )
+    val graph = DirectedAcyclicGraph(nodes) { edges[it].orEmpty() }
+    val order = graph.topologicalOrder()
+    assertThat(order).isEqualTo(listOf("A", "B", "C", "D"))
+  }
+
+  @Test
+  fun multipleRoots() {
+    // A -> C
+    // B -> C
+    val nodes = listOf("A", "B", "C")
+    val edges = mapOf(
+      "A" to listOf("C"),
+      "B" to listOf("C"),
+      "C" to emptyList(),
+    )
+    val graph = DirectedAcyclicGraph(nodes) { edges[it].orEmpty() }
+    val order = graph.topologicalOrder()
+    assertThat(order).isEqualTo(listOf("A", "B", "C"))
+  }
+
+  @Test
+  fun cycleThrowsError() {
+    // A -> B -> C -> A
+    val nodes = listOf("A", "B", "C")
+    val edges = mapOf(
+      "A" to listOf("B"),
+      "B" to listOf("C"),
+      "C" to listOf("A"),
+    )
+    val graph = DirectedAcyclicGraph(nodes) { edges[it].orEmpty() }
+
+    try {
+      graph.topologicalOrder()
+      fail()
+    } catch (expected: IllegalStateException) {
+      assertThat(expected).hasMessage("Graph contains a cycle, topological sort not possible!")
+    }
+  }
+}


### PR DESCRIPTION
On larger scale repos that involve many partitions and hundreds of transitive deps, the topological sort of the graph can be quite slow. 

In our case, an internal proto took ~2 minutes to run the Wire compiler (not including the Swift compilation time). This change updates to use the [Kahn topological sort algorithm](https://www.geeksforgeeks.org/dsa/topological-sorting-indegree-based-solution/) for faster speed. We saw the same proto take 10s-15s to run the compiler after this change.

While faster, the algorithm does not produce a stable order so afterwards we sort by depth as the rest of the code was processing dependencies in a bottom-up order.

Added new tests and existing tests should further validate this.