### PR TITLE
[swift] Fix edge case for oneof field named `self`

### DIFF
--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -910,11 +910,14 @@ class SwiftGenerator private constructor(
 
                     val typeName = field.typeName.makeNonOptional()
 
+                    val safeName = field.safeName
+                    val fieldName = if (safeName == "self") "self_" else safeName
+
                     if (index == 0) {
                       beginControlFlow(
                         "if",
                         "let %1N = try container.decodeIfPresent(%2T.self, forKey: %3S)",
-                        field.safeName,
+                        fieldName,
                         typeName,
                         keyName,
                       )
@@ -922,12 +925,12 @@ class SwiftGenerator private constructor(
                       nextControlFlow(
                         "else if",
                         "let %1N = try container.decodeIfPresent(%2T.self, forKey: %3S)",
-                        field.safeName,
+                        fieldName,
                         typeName,
                         keyName,
                       )
                     }
-                    addStatement("self.%1N = .%2N(%2N)", oneOf.name, field.safeName)
+                    addStatement("self.%1N = .%2N(%3N)", oneOf.name, field.safeName, fieldName)
                   }
                   nextControlFlow("else", "")
                   addStatement("self.%N = nil", oneOf.name)
@@ -1803,6 +1806,7 @@ class SwiftGenerator private constructor(
         return when (this.simpleName) {
           "Type" -> "Type_"
           "Error" -> "Error_"
+          "Self" -> "Self_"
           else -> this.simpleName
         }
       }

--- a/wire-tests-swift/no-manifest/src/main/swift/Screen.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/Screen.swift
@@ -54,7 +54,8 @@ extension Screen : Proto2Codable {
             case 1: screen = .screen_oneof_string(try protoReader.decode(String.self))
             case 2: screen = .screen_oneof_int32(try protoReader.decode(Int32.self))
             case 3: screen = .screen_oneof_sub_message(try protoReader.decode(Screen.SubMessage.self))
-            case 4: view = .view_oneof_string(try protoReader.decode(String.self))
+            case 4: screen = .`self`(try protoReader.decode(Screen.Self_.self))
+            case 5: view = .view_oneof_string(try protoReader.decode(String.self))
             default: try protoReader.readUnknownField(tag: tag)
             }
         }
@@ -93,6 +94,8 @@ extension Screen : Codable {
             self.screen = .screen_oneof_sub_message(screen_oneof_sub_message)
         } else if let screen_oneof_sub_message = try container.decodeIfPresent(Screen.SubMessage.self, forKey: "screen_oneof_sub_message") {
             self.screen = .screen_oneof_sub_message(screen_oneof_sub_message)
+        } else if let self_ = try container.decodeIfPresent(Screen.Self_.self, forKey: "self") {
+            self.screen = .`self`(self_)
         } else {
             self.screen = nil
         }
@@ -113,6 +116,7 @@ extension Screen : Codable {
         case .screen_oneof_string(let screen_oneof_string): try container.encode(screen_oneof_string, forKey: preferCamelCase ? "screenOneofString" : "screen_oneof_string")
         case .screen_oneof_int32(let screen_oneof_int32): try container.encode(screen_oneof_int32, forKey: preferCamelCase ? "screenOneofInt32" : "screen_oneof_int32")
         case .screen_oneof_sub_message(let screen_oneof_sub_message): try container.encode(screen_oneof_sub_message, forKey: preferCamelCase ? "screenOneofSubMessage" : "screen_oneof_sub_message")
+        case .`self`(let `self`): try container.encode(`self`, forKey: "self")
         case Optional.none: break
         }
         switch self.view {
@@ -134,12 +138,14 @@ extension Screen {
         case screen_oneof_string(String)
         case screen_oneof_int32(Int32)
         case screen_oneof_sub_message(Screen.SubMessage)
+        case `self`(Screen.Self_)
 
         fileprivate func encode(to protoWriter: ProtoWriter) throws {
             switch self {
             case .screen_oneof_string(let screen_oneof_string): try protoWriter.encode(tag: 1, value: screen_oneof_string)
             case .screen_oneof_int32(let screen_oneof_int32): try protoWriter.encode(tag: 2, value: screen_oneof_int32)
             case .screen_oneof_sub_message(let screen_oneof_sub_message): try protoWriter.encode(tag: 3, value: screen_oneof_sub_message)
+            case .`self`(let `self`): try protoWriter.encode(tag: 4, value: `self`)
             }
         }
 
@@ -151,8 +157,17 @@ extension Screen {
 
         fileprivate func encode(to protoWriter: ProtoWriter) throws {
             switch self {
-            case .view_oneof_string(let view_oneof_string): try protoWriter.encode(tag: 4, value: view_oneof_string)
+            case .view_oneof_string(let view_oneof_string): try protoWriter.encode(tag: 5, value: view_oneof_string)
             }
+        }
+
+    }
+
+    public struct Self_ {
+
+        public var unknownFields: UnknownFields = .init()
+
+        public init() {
         }
 
     }
@@ -198,6 +213,62 @@ extension Screen.View : Hashable {
 
 extension Screen.View : Sendable {
 }
+
+#if !WIRE_REMOVE_EQUATABLE
+extension Screen.Self_ : Equatable {
+}
+#endif
+
+#if !WIRE_REMOVE_HASHABLE
+extension Screen.Self_ : Hashable {
+}
+#endif
+
+extension Screen.Self_ : Sendable {
+}
+
+extension Screen.Self_ : ProtoDefaultedValue {
+
+    public static var defaultedValue: Self {
+        .init()
+    }
+}
+
+extension Screen.Self_ : ProtoMessage {
+
+    public static func protoMessageTypeURL() -> String {
+        return "type.googleapis.com/squareup.protos.kotlin.swift_modules.Screen.Self"
+    }
+
+}
+
+extension Screen.Self_ : Proto2Codable {
+
+    public init(from protoReader: ProtoReader) throws {
+        let token = try protoReader.beginMessage()
+        while let tag = try protoReader.nextTag(token: token) {
+            switch tag {
+            default: try protoReader.readUnknownField(tag: tag)
+            }
+        }
+        self.unknownFields = try protoReader.endMessage(token: token)
+
+    }
+
+    public func encode(to protoWriter: ProtoWriter) throws {
+        try protoWriter.writeUnknownFields(unknownFields)
+    }
+
+}
+
+#if !WIRE_REMOVE_CODABLE
+extension Screen.Self_ : Codable {
+
+    public enum CodingKeys : CodingKey {
+    }
+
+}
+#endif
 
 #if !WIRE_REMOVE_EQUATABLE
 extension Screen.SubMessage : Equatable {

--- a/wire-tests/src/commonTest/proto/kotlin/swift_edge_cases.proto
+++ b/wire-tests/src/commonTest/proto/kotlin/swift_edge_cases.proto
@@ -38,11 +38,14 @@ message Screen {
     string screen_oneof_string = 1;
     int32 screen_oneof_int32 = 2;
     SubMessage screen_oneof_sub_message = 3;
+    Self self = 4;
   }
 
   oneof view {
-    string view_oneof_string = 4;
+    string view_oneof_string = 5;
   }
+
+  message Self {}
 
   message SubMessage {
     optional string string = 1;


### PR DESCRIPTION
We have a rather badly named `message Self` in one of our protos that is throwing off again the Swift compiler.

SwiftPoet does the right thing to escape it with backticks however other parts of the generated code start failing.

For Wire, we rename \`Self\` with Self_
