### PR TITLE
Parse trailers even when an error occurs

### DIFF
--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/GrpcMessageSource.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/internal/GrpcMessageSource.kt
@@ -61,6 +61,8 @@ internal class GrpcMessageSource<T : Any>(
     }
   }
 
+  fun isEmptyBody(): Boolean = source.exhausted()
+
   fun readExactlyOneAndClose(): T {
     use(GrpcMessageSource<T>::close) { reader ->
       val result = reader.read() ?: throw ProtocolException("expected 1 message but got none")


### PR DESCRIPTION
It is possible for gRPC error responses to be empty and for servers to send the error information within trailers without also sending them in headers. In these cases, Wire will propagate an exception due to no response body and will not attempt to read trailers, relying only on headers instead.

This patch allows Wire to attempt to parse the trailers for non-streaming requests instead of only relying on headers.