### PR TITLE
Set outputModuleName in samples/js

### DIFF
--- a/samples/js/build.gradle.kts
+++ b/samples/js/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
     }
     nodejs {
     }
+    outputModuleName = "wire-js-module"
   }
 }
 


### PR DESCRIPTION
Trying to repro https://github.com/square/wire/issues/3389
