### PR TITLE
Provide the unpartitioned schema in SchemaHandler.Context

### DIFF
--- a/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
+++ b/wire-compiler/src/test/java/com/squareup/wire/schema/WireRunTest.kt
@@ -1070,7 +1070,7 @@ class WireRunTest {
           logger = EmptyWireLogger(),
           errorCollector = errorCollector,
           claimedPaths = ClaimedPaths(),
-          unpartitionedSchema = schema,
+          fullSchema = schema,
         ),
       )
 

--- a/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/ErrorReportingSchemaHandlerTest.kt
+++ b/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/ErrorReportingSchemaHandlerTest.kt
@@ -64,7 +64,7 @@ class ErrorReportingSchemaHandlerTest {
       outDirectory = "out".toPath(),
       logger = WireTestLogger(),
       errorCollector = errorCollector,
-      unpartitionedSchema = schema,
+      fullSchema = schema,
     )
 
     ErrorReportingSchemaHandler().handle(schema, context)

--- a/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/LogToFileHandlerTest.kt
+++ b/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/LogToFileHandlerTest.kt
@@ -64,7 +64,7 @@ class LogToFileHandlerTest {
       outDirectory = "/".toPath(),
       logger = WireTestLogger(),
       sourcePathPaths = setOf("test/message.proto", "test/service.proto"),
-      unpartitionedSchema = schema,
+      fullSchema = schema,
     )
     LogToFileHandler().handle(schema, context)
 

--- a/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/LogToWireLoggerHandlerTest.kt
+++ b/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/LogToWireLoggerHandlerTest.kt
@@ -66,7 +66,7 @@ class LogToWireLoggerHandlerTest {
       outDirectory = "out".toPath(),
       logger = logger,
       sourcePathPaths = setOf("test/message.proto", "test/service.proto"),
-      unpartitionedSchema = schema,
+      fullSchema = schema,
     )
     LogToWireLoggerHandler().handle(schema, context)
 

--- a/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/MarkdownHandlerTest.kt
+++ b/wire-schema-tests/src/commonTest/kotlin/com/squareup/wire/recipes/MarkdownHandlerTest.kt
@@ -79,7 +79,7 @@ class MarkdownHandlerTest {
       outDirectory = "generated/markdown".toPath(),
       logger = WireTestLogger(),
       sourcePathPaths = setOf("squareup/colors/red.proto", "squareup/colors/blue.proto"),
-      unpartitionedSchema = schema,
+      fullSchema = schema,
     )
     MarkdownHandler().handle(schema, context)
 

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -852,12 +852,12 @@ public final class com/squareup/wire/schema/SchemaHandler$Context {
 	public final fun getEmittingRules ()Lcom/squareup/wire/schema/EmittingRules;
 	public final fun getErrorCollector ()Lcom/squareup/wire/schema/ErrorCollector;
 	public final fun getFileSystem ()Lokio/FileSystem;
+	public final fun getFullSchema ()Lcom/squareup/wire/schema/Schema;
 	public final fun getLogger ()Lcom/squareup/wire/WireLogger;
 	public final fun getModule ()Lcom/squareup/wire/schema/SchemaHandler$Module;
 	public final fun getOutDirectory ()Lokio/Path;
 	public final fun getProfileLoader ()Lcom/squareup/wire/schema/ProfileLoader;
 	public final fun getSourcePathPaths ()Ljava/util/Set;
-	public final fun getUnpartitionedSchema ()Lcom/squareup/wire/schema/Schema;
 	public fun hashCode ()I
 	public final fun inSourcePath (Lcom/squareup/wire/schema/Location;)Z
 	public final fun inSourcePath (Lcom/squareup/wire/schema/ProtoFile;)Z

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/SchemaHandler.kt
@@ -108,8 +108,8 @@ abstract class SchemaHandler {
      */
     val profileLoader: ProfileLoader? = null,
 
-    /** The full [Schema] prior to any partitions. */
-    val unpartitionedSchema: Schema,
+    /** The full refactored [Schema] prior partitioning. See [WireRun.modules]. */
+    val fullSchema: Schema,
   ) {
     /** True if this [protoFile] ia part of a `sourcePath` root. */
     fun inSourcePath(protoFile: ProtoFile): Boolean {

--- a/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/WireRun.kt
+++ b/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/WireRun.kt
@@ -313,7 +313,7 @@ class WireRun(
           sourcePathPaths = sourcePathPaths,
           module = module,
           profileLoader = schemaLoader,
-          unpartitionedSchema = schema,
+          fullSchema = schema,
         )
 
         eventListeners.forEach {


### PR DESCRIPTION
Provides access to the unpartitioned schema within SchemaHandler.Context.

For Swift, when the schema gets partitioned, information can be dropped because the types within the partitioned schema are [stubbed](https://github.com/square/wire/blob/master/wire-schema/src/commonMain/kotlin/com/squareup/wire/schema/PartitionedSchema.kt#L81-L85).

This change provides access to the unpartitioned schema that would contain all the loaded/linked info for all types. This can be leveraged by custom schema handlers that would need to use the unpartitioned schema.