### PR TITLE
Add `@field:` use-site target to custom proto field options for consistency

### DIFF
--- a/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/WireCompiler.kt
@@ -151,6 +151,7 @@ class WireCompiler internal constructor(
   val emitProtoReader32: Boolean,
   val kotlinExplicitStreamingCalls: Boolean,
   val kotlinEnumMode: EnumMode,
+  val kotlinUseFieldAnnotationTarget: Boolean,
   val eventListenerFactoryClasses: List<String>,
   val customOptions: Map<String, String>,
   val opaqueTypes: List<String> = listOf(),
@@ -187,6 +188,7 @@ class WireCompiler internal constructor(
         escapeKotlinKeywords = kotlinEscapeKeywords,
         emitProtoReader32 = emitProtoReader32,
         explicitStreamingCalls = kotlinExplicitStreamingCalls,
+        useFieldAnnotationTarget = kotlinUseFieldAnnotationTarget,
         enumMode = kotlinEnumMode,
       )
     }
@@ -305,6 +307,8 @@ class WireCompiler internal constructor(
     private const val OPAQUE_TYPES_FLAG = "--opaque_types="
     private const val IGNORE_UNUSED_ROOTS_AND_PRUNES = "--ignore_unused_roots_and_prunes"
     private const val KOTLIN_EXPLICIT_STREAMING_CALLS = "--kotlin_explicit_streaming_calls"
+    private const val KOTLIN_USE_FIELD_ANNOTATION_TARGET = "--kotlin_use_field_annotation_target"
+
 
     @Throws(IOException::class)
     @JvmStatic
@@ -370,6 +374,7 @@ class WireCompiler internal constructor(
       var emitProtoReader32 = false
       var kotlinEnumMode = EnumMode.ENUM_CLASS
       var kotlinExplicitStreamingCalls = false
+      var kotlinUseFieldAnnotationTarget = false
       var dryRun = false
       val customOptions = mutableMapOf<String, String>()
       var rejectUnusedRootsOrPrunes = true
@@ -496,6 +501,7 @@ class WireCompiler internal constructor(
           arg == JAVA_INTEROP -> javaInterop = true
           arg == EMIT_PROTO_READER_32 -> emitProtoReader32 = true
           arg == KOTLIN_EXPLICIT_STREAMING_CALLS -> kotlinExplicitStreamingCalls = true
+          arg == KOTLIN_USE_FIELD_ANNOTATION_TARGET -> kotlinUseFieldAnnotationTarget = true
           arg == IGNORE_UNUSED_ROOTS_AND_PRUNES -> rejectUnusedRootsOrPrunes = false
           arg.startsWith("--") -> throw IllegalArgumentException("Unknown argument '$arg'.")
           else -> sourceFileNames.add(arg)
@@ -554,6 +560,7 @@ class WireCompiler internal constructor(
         opaqueTypes = opaqueTypes,
         rejectUnusedRootsOrPrunes = rejectUnusedRootsOrPrunes,
         kotlinExplicitStreamingCalls = kotlinExplicitStreamingCalls,
+        kotlinUseFieldAnnotationTarget = kotlinUseFieldAnnotationTarget,
       )
     }
   }

--- a/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
+++ b/wire-compiler/src/main/java/com/squareup/wire/schema/Target.kt
@@ -138,6 +138,13 @@ data class KotlinTarget(
   val enumMode: EnumMode = EnumMode.ENUM_CLASS,
 
   /**
+   * If true, option annotations on fields will be marked with the `@field:` use-site target.
+   * This ensures the annotations are applied to the backing field rather than the property,
+   * enabling Java reflection access to field-level annotations.
+   */
+  val useFieldAnnotationTarget: Boolean = false,
+
+  /**
    * If true, adapters will generate decode functions for `ProtoReader32`. Use this optimization
    * when targeting Kotlin/JS, where `Long` cursors are inefficient.
    */
@@ -173,6 +180,7 @@ data class KotlinTarget(
       emitProtoReader32 = emitProtoReader32,
       mutableTypes = mutableTypes,
       explicitStreamingCalls = explicitStreamingCalls,
+      useFieldAnnotationTarget = useFieldAnnotationTarget,
     )
   }
 

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WireOutput.kt
@@ -165,6 +165,13 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
    */
   var explicitStreamingCalls: Boolean = false
 
+  /**
+   * If true, option annotations on fields will be marked with the `@field:` use-site target.
+   * This ensures the annotations are applied to the backing field rather than the property,
+   * enabling Java reflection access to field-level annotations.
+   */
+  val useFieldAnnotationTarget: Boolean = false
+
   override fun toTarget(outputDirectory: String): KotlinTarget {
     if (grpcServerCompatible) {
       throw IllegalArgumentException(
@@ -210,6 +217,7 @@ open class KotlinOutput @Inject constructor() : WireOutput() {
       emitProtoReader32 = emitProtoReader32,
       mutableTypes = mutableTypes,
       explicitStreamingCalls = explicitStreamingCalls,
+      useFieldAnnotationTarget = useFieldAnnotationTarget,
     )
   }
 }

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinSchemaHandler.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinSchemaHandler.kt
@@ -96,6 +96,13 @@ class KotlinSchemaHandler(
    * If true, streaming calls will generate explicit call types for client,server, and bidirectional streaming.
    */
   private val explicitStreamingCalls: Boolean = false,
+
+  /**
+   * If true, option annotations on fields will be marked with the `@field:` use-site target.
+   * This ensures the annotations are applied to the backing field rather than the property,
+   * enabling Java reflection access to field-level annotations.
+   */
+  private val useFieldAnnotationTarget: Boolean = false,
 ) : SchemaHandler() {
   private lateinit var kotlinGenerator: KotlinGenerator
 
@@ -119,6 +126,7 @@ class KotlinSchemaHandler(
       emitProtoReader32 = emitProtoReader32,
       mutableTypes = mutableTypes,
       explicitStreamingCalls = explicitStreamingCalls,
+      useFieldAnnotationTarget = useFieldAnnotationTarget,
     )
     context.fileSystem.createDirectories(context.outDirectory)
     super.handle(schema, context)

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinWithProfilesGenerator.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinWithProfilesGenerator.kt
@@ -55,6 +55,7 @@ internal class KotlinWithProfilesGenerator(private val schema: Schema) {
     javaInterop: Boolean = false,
     enumMode: EnumMode = EnumMode.ENUM_CLASS,
     mutableTypes: Boolean = false,
+    useFieldAnnotationTarget: Boolean = false,
   ): String {
     val kotlinGenerator = KotlinGenerator(
       schema,
@@ -64,6 +65,7 @@ internal class KotlinWithProfilesGenerator(private val schema: Schema) {
       javaInterop = javaInterop,
       enumMode = enumMode,
       mutableTypes = mutableTypes,
+      useFieldAnnotationTarget = useFieldAnnotationTarget,
     )
     val type = schema.getType(typeName)!!
     val typeSpec = kotlinGenerator.generateType(type)


### PR DESCRIPTION
## Problem

Custom proto field options are generated as property-level annotations while Wire's own `@WireField` annotation uses the `@field:` use-site target. This inconsistency forces users to use slower Kotlin property reflection instead of Java field reflection.

## Example

### Proto definition
```protobuf
// custom_options.proto
extend google.protobuf.FieldOptions {
  int32 my_field_value = 50000;
}

// usage.proto
message MyMessage {
  repeated Item items = 1 [(my_field_value) = 42];
}
```

### Current generated code
```kotlin
@MyFieldValueOption(42)           // ❌ Property-level (inconsistent)
@field:WireField(             // ✅ Field-level
  tag = 1,
  adapter = "...",
  label = WireField.Label.REPEATED
)
public val items: List<Item>
```

### After this fix
```kotlin
@field:MyFieldValueOption(42)      // ✅ Field-level (consistent)
@field:WireField(
  tag = 1,
  adapter = "...",
  label = WireField.Label.REPEATED
)
public val items: List<Item>
```

## Benefits

1. **Consistency**: Custom field options match Wire's own `@WireField` pattern
2. **Performance**: Java field reflection is significantly faster than Kotlin property reflection
3. **Interoperability**: Works with existing Java reflection code that expects field-level annotations
