### PR TITLE
Best effort to store unknown repeated enums in JSON

### DIFF
--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/java/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/java/interop/interop_test.proto
@@ -68,3 +68,13 @@ message InteropWrappers {
   google.protobuf.StringValue string_value = 8;
   google.protobuf.BytesValue bytes_value = 9;
 }
+
+message InteropRepeatedEnums {
+  enum Size {
+    SMALL = 0;
+    MEDIUM = 1;
+    LARGE = 2;
+  }
+
+  repeated Size available_sizes = 1 [packed = false];
+}

--- a/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/interop/interop_test.proto
+++ b/wire-protoc-compatibility-tests/src/main/proto/squareup/proto3/kotlin/interop/interop_test.proto
@@ -68,3 +68,13 @@ message InteropWrappers {
   google.protobuf.StringValue string_value = 8;
   google.protobuf.BytesValue bytes_value = 9;
 }
+
+message InteropRepeatedEnums {
+  enum Size {
+    SMALL = 0;
+    MEDIUM = 1;
+    LARGE = 2;
+  }
+
+  repeated Size available_sizes = 1 [packed = false];
+}

--- a/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropTest.kt
+++ b/wire-protoc-compatibility-tests/src/test/java/com/squareup/wire/InteropTest.kt
@@ -47,6 +47,7 @@ import squareup.proto3.java.interop.InteropTest.InteropBoxOneOf as InteropBoxOne
 import squareup.proto3.java.interop.InteropTest.InteropCamelCase as InteropCamelCaseP3
 import squareup.proto3.java.interop.InteropTest.InteropDuration as InteropDurationP3
 import squareup.proto3.java.interop.InteropTest.InteropJsonName as InteropJsonNameP3
+import squareup.proto3.java.interop.InteropTest.InteropRepeatedEnums
 import squareup.proto3.java.interop.InteropTest.InteropUint64 as InteropUint64P3
 import squareup.proto3.java.interop.InteropTest.InteropWrappers
 import squareup.proto3.java.interop.InteropUint64 as InteropUint64J3
@@ -56,6 +57,7 @@ import squareup.proto3.kotlin.interop.InteropCamelCase as InteropCamelCaseK3
 import squareup.proto3.kotlin.interop.InteropDuration as InteropDurationK3
 import squareup.proto3.kotlin.interop.InteropJsonName as InteropJsonNameK3
 import squareup.proto3.kotlin.interop.InteropOptional as InteropOptionalK3
+import squareup.proto3.kotlin.interop.InteropRepeatedEnums as InteropRepeatedEnumsK3
 import squareup.proto3.kotlin.interop.InteropUint64 as InteropUint64K3
 import squareup.proto3.kotlin.interop.InteropWrappers as InteropWrappersK3
 import squareup.proto3.kotlin.interop.TestProto3Optional.InteropOptional as InteropOptionalP3
@@ -450,6 +452,45 @@ class InteropTest {
         .bool_value(true)
         .string_value("string")
         .bytes_value(ByteString.of(1))
+        .build(),
+    )
+  }
+
+  @Test fun repeatedEnums() {
+    val checker = InteropChecker(
+      protocMessage = InteropRepeatedEnums.newBuilder()
+        .addAllAvailableSizes(
+          listOf(
+            InteropRepeatedEnums.Size.SMALL,
+            InteropRepeatedEnums.Size.MEDIUM,
+            InteropRepeatedEnums.Size.LARGE,
+          ),
+        )
+        .addAllAvailableSizesValue(listOf(8))
+        .build(),
+      canonicalJson = """{"availableSizes":["SMALL","MEDIUM","LARGE",8]}""",
+    )
+    // TODO(Benoit) Without EnumMode.SEALED_CLASS, Wire fails to print the unknown constant.
+    // checker.check(
+    //   InteropRepeatedEnumsJ3.Builder()
+    //     .available_sizes(listOf(
+    //       InteropRepeatedEnumsJ3.Size.SMALL,
+    //       InteropRepeatedEnumsJ3.Size.MEDIUM,
+    //       InteropRepeatedEnumsJ3.Size.LARGE,
+    //       ))
+    //     .addUnknownField(3, FieldEncoding.VARINT, 8)
+    //     .build(),
+    // )
+    checker.check(
+      InteropRepeatedEnumsK3.Builder()
+        .available_sizes(
+          listOf(
+            InteropRepeatedEnumsK3.Size.SMALL,
+            InteropRepeatedEnumsK3.Size.MEDIUM,
+            InteropRepeatedEnumsK3.Size.LARGE,
+            InteropRepeatedEnumsK3.Size.Unrecognized(8),
+          ),
+        )
         .build(),
     )
   }

--- a/wire-runtime/api/wire-runtime.api
+++ b/wire-runtime/api/wire-runtime.api
@@ -620,7 +620,7 @@ public abstract class com/squareup/wire/internal/JsonIntegration {
 	public abstract fun formatterAdapter (Lcom/squareup/wire/internal/JsonFormatter;)Ljava/lang/Object;
 	public abstract fun frameworkAdapter (Ljava/lang/Object;Ljava/lang/reflect/Type;)Ljava/lang/Object;
 	public final fun jsonAdapters (Lcom/squareup/wire/internal/RuntimeMessageAdapter;Ljava/lang/Object;)Ljava/util/List;
-	public abstract fun listAdapter (Ljava/lang/Object;)Ljava/lang/Object;
+	public abstract fun listAdapter (Ljava/lang/Object;Z)Ljava/lang/Object;
 	public abstract fun mapAdapter (Ljava/lang/Object;Lcom/squareup/wire/internal/JsonFormatter;Ljava/lang/Object;)Ljava/lang/Object;
 	public abstract fun structAdapter (Ljava/lang/Object;)Ljava/lang/Object;
 }

--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/EnumJsonFormatter.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/EnumJsonFormatter.kt
@@ -52,7 +52,7 @@ class EnumJsonFormatter<E : WireEnum>(
 
         val field = subClass.declaredFields.first()
         if (field.name == "INSTANCE") {
-          @Suppress("UNCHECKED_CAST") // We know it's a E since we generated it.
+          @Suppress("UNCHECKED_CAST") // We know it's an E since we generated it.
           val subClassInstance = field.get(null) as E
           mutableStringToValue[subClass.simpleName] = subClassInstance
           mutableStringToValue[subClassInstance.value.toString()] = subClassInstance
@@ -94,9 +94,9 @@ class EnumJsonFormatter<E : WireEnum>(
 
   override fun fromString(value: String): E? {
     return stringToValue[value]
-      // If the constant is unknown to our runtime, we return a `Unrecognized` instance if it has
-      // been generated.
-      ?: unrecognizedClassConstructor?.newInstance(value.toInt())
+      // In case the `Unrecognized` instance is generated, we store the value assuming it represents
+      // a constant value (integer), and ignore it otherwise (name as string).
+      ?: value.toIntOrNull()?.let { value -> unrecognizedClassConstructor?.newInstance(value) }
   }
 
   override fun toStringOrNumber(value: E): Any {

--- a/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/JsonIntegration.kt
+++ b/wire-runtime/src/jvmMain/kotlin/com/squareup/wire/internal/JsonIntegration.kt
@@ -32,8 +32,11 @@ abstract class JsonIntegration<F, A> {
   /** Returns [framework]'s built-in adapter for [type]. */
   abstract fun frameworkAdapter(framework: F, type: Type): A
 
-  /** Returns an adapter iterates a list of the target adapter. */
-  abstract fun listAdapter(elementAdapter: A): A
+  /**
+   * Returns an adapter iterates a list of the target adapter. If [skipNull] is true, null evaluated
+   * value will be ignored.
+   */
+  abstract fun listAdapter(elementAdapter: A, skipNull: Boolean): A
 
   /** Returns an adapter iterates keys and values of the target adapter. */
   abstract fun mapAdapter(
@@ -77,7 +80,11 @@ abstract class JsonIntegration<F, A> {
     }
 
     return when {
-      field.label.isRepeated -> listAdapter(singleAdapter)
+      field.label.isRepeated -> listAdapter(
+        elementAdapter = singleAdapter,
+        // We ignore unrecognized constants in repeated fields for enums.
+        skipNull = jsonStringAdapter is EnumJsonFormatter<*>,
+      )
       field.isMap -> mapAdapter(
         framework = framework,
         keyFormatter = mapKeyJsonFormatter(field.keyAdapter),


### PR DESCRIPTION
- Unknown name? protoc either throws or ignore, and we went with ignore them.
- Unknown constant? protoc store their value, and Wire can do that with EnumMode.SEALED_CLASS. But we'll ignore them otherwise.

Fixes #3430