### PR TITLE
Remove KSP/Kotlin bundling

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,13 +11,6 @@
       automerge: true,
     },
     {
-      groupName: 'Kotlin and KSP',
-      matchPackageNames: [
-        'org.jetbrains.kotlin:kotlin{/,}**',
-        'com.google.devtools.ksp{/,}**',
-      ],
-    },
-    {
       matchPackageNames: ['com.squareup.misk:misk'],
       extends: ['schedule:monthly'],
     },


### PR DESCRIPTION
This repo doesn't use KSP. But also, they're not longer bundled together anyway.