### PR TITLE
TRIVIAL: Update docs on ProtoReader32

### DIFF
--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoReader32.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoReader32.kt
@@ -43,7 +43,8 @@ import okio.IOException
  *
  * This is an alternative to [ProtoReader], which uses `Long` as a cursor. It originates as an
  * optimization for Kotlin/JS, where `Long` cursors are prohibitively expensive. It doesn't subclass
- * [ProtoReader] because [nextTag] and [forEachTag] must each return the appropriate cursor type.
+ * [ProtoReader] because [beginMessage], [endMessageAndGetUnknownFields], and [nextFieldMinLengthInBytes]
+ *    must operate on the correct cursor type.
  */
 interface ProtoReader32 {
   /** Returns a [ProtoReader] that reads the same data as this using a different type. */


### PR DESCRIPTION
The doc explaining the reason ProtoReader and ProtoReader32 are separate was inaccurate.

The "tag" methods listed all operate on int's in both cases (ProtoReader and ProtoReader32).

This clarifies which methods actually care about int vs long, and the reason for the divergence between ProtoReader and ProtoReader32.

Its trivial, but its probably worth updating since its pretty important to one of the bigger surprises in the consumer interfaces for this.

From the relevant [wire-runtime.api](https://github.com/square/wire/blob/6cd83185776a7290554e1d0f19f7d0480be81c67/wire-runtime/api/wire-runtime.api#L275-L318)

```
public class com/squareup/wire/ProtoReader {
  public fun beginMessage ()J
  public fun endMessageAndGetUnknownFields (J)Lokio/ByteString;
  public fun nextFieldMinLengthInBytes ()J
  public fun nextTag ()I
}

public abstract interface class com/squareup/wire/ProtoReader32 {
  public abstract fun beginMessage ()I
  public abstract fun endMessageAndGetUnknownFields (I)Lokio/ByteString;
  public abstract fun nextFieldMinLengthInBytes ()I
  public abstract fun nextTag ()I
}