### PR TITLE
Ensure compatibility with older Kotlin consumers

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,8 @@ jmh = "1.37"
 jsr305 = "3.0.2"
 junit = "4.13.2"
 kotlin = "2.2.21"
+# Set to lower version than KGP version to maximize compatibility
+kotlinCoreLibrariesVersion = "2.0.21"
 kotlinpoet = "2.2.0"
 ktlint = "0.48.2"
 moshi = "1.15.2"

--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -49,8 +49,8 @@ dependencies {
 
   compileOnly(gradleApi())
   compileOnly(libs.pluginz.android)
-  compileOnly(libs.pluginz.kotlin)
 
+  implementation(libs.pluginz.kotlin)
   implementation(projects.wireCompiler)
   implementation(projects.wireKotlinGenerator)
   implementation(libs.swiftpoet)


### PR DESCRIPTION
Lowering the bundled stdlib version via coreLibrariesVersion. This prevents forcing a stdlib upgrade on our users. We:
* Set Kotlin API and language versions to 2.0.
* Explicitly set `coreLibrariesVersion` to 2.0.21 to maximize compatibility.
* Force JS and Wasm stdlib dependencies to match the toolchain version as work-around for KT-71032

TESTED: ./gradlew clean check . I also published to local repository and checked the .module files for the artifacts and the kotlin-stdlib was correctly set to 2.0.21