### PR TITLE
[swift]: fix a few edge case memory bugs

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
@@ -127,7 +127,7 @@ public final class ProtoReader {
             return -1
         }
 
-        if (messageStackIndex + 1) > ProtoReader.recursionLimit {
+        if (messageStackIndex + 1) >= ProtoReader.recursionLimit {
             throw ProtoDecoder.Error.recursionLimitExceeded
         }
 


### PR DESCRIPTION
this change addresses two issues identified within the swift runtime:

1. an potential memory leak if unknown fields are added but message parsing does not terminate normally (i.e. an error is thrown before `endMessage()` completes)
2. a memory access violation if the nested message recursion limit is exceeded
