### PR TITLE
Test confirming we don't duplicate sources in jar creation anymore

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -185,8 +185,6 @@ private class AndroidSource(
         }
         is KotlinTarget -> {
           variant.sources.kotlin?.addGeneratedSourceDirectory(wireTask) { it.outputDirectoriesList[index] }
-          // Remove line below when AGP is upgraded to 9.0+ as it will contain fix for https://issuetracker.google.com/446220448
-          variant.sources.java?.addGeneratedSourceDirectory(wireTask) { it.outputDirectoriesList[index] }
         }
         is CustomTarget -> {
           // Custom targets are wildcards, so we add all output directories.

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1378,6 +1378,22 @@ class WirePluginTest {
     }
   }
 
+  /** Regression test for https://github.com/square/wire/issues/3558 */
+  @Test
+  fun androidKotlinSourceReleaseJarNoDuplicates() {
+    val fixtureRoot = File("src/test/projects/android-kotlin-source-release-jar")
+
+    val localProperties = File(fixtureRoot, "local.properties")
+    if (!localProperties.exists()) {
+      val androidHome = System.getenv("ANDROID_HOME")
+        ?: "${System.getProperty("user.home")}/Library/Android/sdk"
+      localProperties.writeText("sdk.dir=$androidHome\n")
+    }
+
+    val result = fixtureGradleRunner(fixtureRoot, "sourceReleaseJar", "--no-build-cache").build()
+    assertThat(result.task(":sourceReleaseJar")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+  }
+
   @Test
   fun taskDependency() {
     val fixtureRoot = File("src/test/projects/task-dependency")

--- a/wire-gradle-plugin/src/test/projects/android-kotlin-source-release-jar/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/android-kotlin-source-release-jar/build.gradle
@@ -1,0 +1,37 @@
+def wireVersion = gradle.startParameter.projectProperties.get('wireVersion')
+
+buildscript {
+  repositories {
+    maven {
+      url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+    }
+    google()
+    mavenCentral()
+  }
+
+  dependencies {
+    classpath("com.squareup.wire:wire-gradle-plugin:${wireVersion}")
+    classpath("com.android.tools.build:gradle:8.13.2")
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:2.2.21")
+  }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
+apply plugin: 'com.squareup.wire'
+apply plugin: 'maven-publish'
+
+android {
+  namespace = "com.example.producer"
+  compileSdk = 36
+
+  publishing {
+    singleVariant('release') {
+      withSourcesJar()
+    }
+  }
+}
+
+wire {
+  kotlin {}
+}

--- a/wire-gradle-plugin/src/test/projects/android-kotlin-source-release-jar/settings.gradle
+++ b/wire-gradle-plugin/src/test/projects/android-kotlin-source-release-jar/settings.gradle
@@ -1,0 +1,22 @@
+pluginManagement {
+  repositories {
+    maven {
+      url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+    }
+    google()
+    mavenCentral()
+  }
+}
+
+dependencyResolutionManagement {
+  repositories {
+    google {
+      mavenContent {
+        includeGroupAndSubgroups("androidx")
+        includeGroupAndSubgroups("com.android")
+        includeGroupAndSubgroups("com.google")
+      }
+    }
+    mavenCentral()
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/android-kotlin-source-release-jar/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/android-kotlin-source-release-jar/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,8 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+enum Period {
+  JURASSIC = 1;
+  CRETACEOUS = 2;
+}


### PR DESCRIPTION
Fixes #3558

Now that we're on AGP 9, the fix should be done without us having to do anything