### PR TITLE
Avoid race in duplex pipe for streaming calls

### DIFF
--- a/wire-grpc-client/api/wire-grpc-client.api
+++ b/wire-grpc-client/api/wire-grpc-client.api
@@ -81,9 +81,14 @@ public final class com/squareup/wire/GrpcHttpUrlKt {
 
 public final class com/squareup/wire/GrpcMethod {
 	public fun <init> (Ljava/lang/String;Lcom/squareup/wire/ProtoAdapter;Lcom/squareup/wire/ProtoAdapter;)V
+	public fun <init> (Ljava/lang/String;Lcom/squareup/wire/ProtoAdapter;Lcom/squareup/wire/ProtoAdapter;Z)V
+	public fun <init> (Ljava/lang/String;Lcom/squareup/wire/ProtoAdapter;Lcom/squareup/wire/ProtoAdapter;ZZ)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/squareup/wire/ProtoAdapter;Lcom/squareup/wire/ProtoAdapter;ZZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getPath ()Ljava/lang/String;
 	public final fun getRequestAdapter ()Lcom/squareup/wire/ProtoAdapter;
+	public final fun getRequestStreaming ()Z
 	public final fun getResponseAdapter ()Lcom/squareup/wire/ProtoAdapter;
+	public final fun getResponseStreaming ()Z
 }
 
 public abstract interface class com/squareup/wire/GrpcServerStreamingCall {

--- a/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcMethod.kt
+++ b/wire-grpc-client/src/commonMain/kotlin/com/squareup/wire/GrpcMethod.kt
@@ -15,8 +15,12 @@
  */
 package com.squareup.wire
 
-class GrpcMethod<S : Any, R : Any>(
+import kotlin.jvm.JvmOverloads
+
+class GrpcMethod<S : Any, R : Any> @JvmOverloads constructor(
   val path: String,
   val requestAdapter: ProtoAdapter<S>,
   val responseAdapter: ProtoAdapter<R>,
+  val requestStreaming: Boolean = false,
+  val responseStreaming: Boolean = false,
 )

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/GrpcClient.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/GrpcClient.kt
@@ -16,9 +16,10 @@
 package com.squareup.wire
 
 import com.squareup.wire.internal.RealGrpcCall
+import com.squareup.wire.internal.RealGrpcServerStreamingCall
 import com.squareup.wire.internal.RealGrpcStreamingCall
 import com.squareup.wire.internal.asGrpcClientStreamingCall
-import com.squareup.wire.internal.asGrpcServerStreamingCall
+import com.squareup.wire.internal.asGrpcStreamingCall
 import java.util.concurrent.TimeUnit
 import kotlin.reflect.KClass
 import okhttp3.Call
@@ -183,9 +184,13 @@ internal class WireGrpcClient internal constructor(
 ) : GrpcClient() {
   override fun <S : Any, R : Any> newCall(method: GrpcMethod<S, R>): GrpcCall<S, R> = RealGrpcCall(this, method)
 
-  override fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R> = RealGrpcStreamingCall(this, method)
+  override fun <S : Any, R : Any> newStreamingCall(method: GrpcMethod<S, R>): GrpcStreamingCall<S, R> = if (!method.requestStreaming && method.responseStreaming) {
+    RealGrpcServerStreamingCall(this, method).asGrpcStreamingCall()
+  } else {
+    RealGrpcStreamingCall(this, method)
+  }
 
   override fun <S : Any, R : Any> newClientStreamingCall(method: GrpcMethod<S, R>): GrpcClientStreamingCall<S, R> = RealGrpcStreamingCall(this, method).asGrpcClientStreamingCall()
 
-  override fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R> = RealGrpcStreamingCall(this, method).asGrpcServerStreamingCall()
+  override fun <S : Any, R : Any> newServerStreamingCall(method: GrpcMethod<S, R>): GrpcServerStreamingCall<S, R> = RealGrpcServerStreamingCall(this, method)
 }

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/BlockingMessageSource.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/BlockingMessageSource.kt
@@ -33,7 +33,7 @@ import okio.IOException
  *  * Complete: enqueued when the stream completes normally.
  */
 internal class BlockingMessageSource<R : Any>(
-  val grpcCall: RealGrpcStreamingCall<*, R>,
+  val onResponseMetadata: (Map<String, String>) -> Unit,
   val responseAdapter: ProtoAdapter<R>,
   val call: Call,
 ) : MessageSource<R> {
@@ -66,7 +66,7 @@ internal class BlockingMessageSource<R : Any>(
 
     override fun onResponse(call: Call, response: Response) {
       try {
-        grpcCall.responseMetadata = response.headers.toMap()
+        onResponseMetadata(response.headers.toMap())
         response.use {
           response.messageSource(responseAdapter).use { reader ->
             while (true) {

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcServerStreamingCall.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcServerStreamingCall.kt
@@ -18,12 +18,122 @@ package com.squareup.wire.internal
 import com.squareup.wire.GrpcMethod
 import com.squareup.wire.GrpcServerStreamingCall
 import com.squareup.wire.GrpcStreamingCall
+import com.squareup.wire.MessageSink
 import com.squareup.wire.MessageSource
+import com.squareup.wire.WireGrpcClient
+import java.util.concurrent.TimeUnit
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import okio.ForwardingTimeout
+import okio.IOException
 import okio.Timeout
 
+/**
+ * A [GrpcServerStreamingCall] that sends a single non-duplex request and reads a streaming
+ * response. Using a non-duplex request body ensures the complete request (including END_STREAM) is
+ * sent to the server before responses are read, avoiding delays on servers that wait for the
+ * client's half-close before starting to stream responses.
+ */
 internal class RealGrpcServerStreamingCall<S : Any, R : Any>(
+  private val grpcClient: WireGrpcClient,
+  override val method: GrpcMethod<S, R>,
+) : GrpcServerStreamingCall<S, R> {
+
+  private var call: okhttp3.Call? = null
+  private var canceled = false
+
+  override val timeout: Timeout = ForwardingTimeout(Timeout())
+
+  init {
+    timeout.clearTimeout()
+    timeout.clearDeadline()
+  }
+
+  override var requestMetadata: Map<String, String> = mapOf()
+
+  override var responseMetadata: Map<String, String>? = null
+    internal set
+
+  override fun cancel() {
+    canceled = true
+    call?.cancel()
+  }
+
+  override fun isCanceled(): Boolean = canceled || call?.isCanceled() == true
+
+  override fun isExecuted(): Boolean = call?.isExecuted() ?: false
+
+  override fun clone(): GrpcServerStreamingCall<S, R> {
+    val result = RealGrpcServerStreamingCall(grpcClient, method)
+    val oldTimeout = this.timeout
+    result.timeout.also { newTimeout ->
+      newTimeout.timeout(oldTimeout.timeoutNanos(), TimeUnit.NANOSECONDS)
+      if (oldTimeout.hasDeadline()) {
+        newTimeout.deadlineNanoTime(oldTimeout.deadlineNanoTime())
+      } else {
+        newTimeout.clearDeadline()
+      }
+    }
+    result.requestMetadata += this.requestMetadata
+    return result
+  }
+
+  override suspend fun executeIn(scope: CoroutineScope, request: S): ReceiveChannel<R> {
+    val responseChannel = Channel<R>(1)
+    val call = initCall(request)
+
+    responseChannel.invokeOnClose { cause ->
+      if (cause != null) {
+        call.cancel()
+      }
+    }
+
+    call.enqueue(
+      responseChannel.readFromResponseBodyCallback(
+        onResponseMetadata = { this.responseMetadata = it },
+        responseAdapter = method.responseAdapter,
+      ),
+    )
+
+    return responseChannel
+  }
+
+  override fun executeBlocking(request: S): MessageSource<R> {
+    val call = initCall(request)
+    val messageSource = BlockingMessageSource(
+      onResponseMetadata = { this.responseMetadata = it },
+      responseAdapter = method.responseAdapter,
+      call = call,
+    )
+    call.enqueue(messageSource.readFromResponseBodyCallback())
+    return messageSource
+  }
+
+  private fun initCall(request: S): okhttp3.Call {
+    check(this.call == null) { "already executed" }
+    val requestBody = newRequestBody(
+      minMessageToCompress = grpcClient.minMessageToCompress,
+      requestAdapter = method.requestAdapter,
+      onlyMessage = request,
+    )
+    val result = grpcClient.newCall(method, requestMetadata, requestBody, timeout)
+    this.call = result
+    if (canceled) result.cancel()
+    (timeout as ForwardingTimeout).setDelegate(result.timeout())
+    return result
+  }
+}
+
+/**
+ * Wraps a [GrpcStreamingCall] as a [GrpcServerStreamingCall]. Used for test doubles created via
+ * [com.squareup.wire.GrpcServerStreamingCall] factory functions in GrpcCalls.
+ */
+internal class GrpcStreamingCallServerStreamingAdapter<S : Any, R : Any>(
   private val callDelegate: GrpcStreamingCall<S, R>,
   override val method: GrpcMethod<S, R>,
 ) : GrpcServerStreamingCall<S, R> {
@@ -48,7 +158,7 @@ internal class RealGrpcServerStreamingCall<S : Any, R : Any>(
 
   override fun isExecuted() = callDelegate.isExecuted()
 
-  override fun clone() = RealGrpcServerStreamingCall(callDelegate.clone(), method)
+  override fun clone() = GrpcStreamingCallServerStreamingAdapter(callDelegate.clone(), method)
 
   override suspend fun executeIn(scope: CoroutineScope, request: S): ReceiveChannel<R> {
     val (sendChannel, receiveChannel) = callDelegate.executeIn(scope)
@@ -67,4 +177,125 @@ internal class RealGrpcServerStreamingCall<S : Any, R : Any>(
   }
 }
 
-internal fun <S : Any, R : Any> GrpcStreamingCall<S, R>.asGrpcServerStreamingCall() = RealGrpcServerStreamingCall(this, method)
+internal fun <S : Any, R : Any> GrpcStreamingCall<S, R>.asGrpcServerStreamingCall() = GrpcStreamingCallServerStreamingAdapter(this, method)
+
+/**
+ * Wraps a [GrpcServerStreamingCall] as the legacy [GrpcStreamingCall] API. This is used by
+ * generated clients when explicit streaming call types are disabled.
+ */
+internal class GrpcServerStreamingCallStreamingAdapter<S : Any, R : Any>(
+  private val callDelegate: GrpcServerStreamingCall<S, R>,
+  override val method: GrpcMethod<S, R>,
+) : GrpcStreamingCall<S, R> {
+  private var executed = false
+
+  override val timeout: Timeout
+    get() = callDelegate.timeout
+
+  override var requestMetadata: Map<String, String>
+    get() = callDelegate.requestMetadata
+    set(value) {
+      callDelegate.requestMetadata = value
+    }
+
+  override val responseMetadata: Map<String, String>?
+    get() = callDelegate.responseMetadata
+
+  override fun cancel() {
+    callDelegate.cancel()
+  }
+
+  override fun isCanceled() = callDelegate.isCanceled()
+
+  @Suppress("OPT_IN_USAGE", "OVERRIDE_DEPRECATION")
+  override fun execute(): Pair<SendChannel<S>, ReceiveChannel<R>> = executeIn(GlobalScope)
+
+  override fun executeIn(scope: CoroutineScope): Pair<SendChannel<S>, ReceiveChannel<R>> = executeWithChannels(scope)
+
+  @Suppress("OPT_IN_USAGE")
+  override fun executeBlocking(): Pair<MessageSink<S>, MessageSource<R>> {
+    val (requestChannel, responseChannel) = executeWithChannels(GlobalScope)
+    return requestChannel.toMessageSink() to responseChannel.toMessageSource()
+  }
+
+  override fun isExecuted() = executed || callDelegate.isExecuted()
+
+  override fun clone() = GrpcServerStreamingCallStreamingAdapter(callDelegate.clone(), method)
+
+  private fun executeWithChannels(scope: CoroutineScope): Pair<Channel<S>, Channel<R>> {
+    check(!executed) { "already executed" }
+    executed = true
+
+    val requestChannel = Channel<S>(1)
+    val responseChannel = Channel<R>(1)
+    var delegateResponseChannel: ReceiveChannel<R>? = null
+
+    responseChannel.invokeOnClose { cause ->
+      if (cause != null) {
+        requestChannel.cancel()
+        delegateResponseChannel?.cancel()
+        callDelegate.cancel()
+      }
+    }
+
+    scope.launch {
+      try {
+        val requestResult = requestChannel.receiveCatching()
+        requestResult.exceptionOrNull()?.let { throw it }
+        val request = requestResult.getOrNull()
+          ?: throw ProtocolException("expected 1 message but got none")
+        requestChannel.close()
+        val responses = callDelegate.executeIn(scope, request)
+        delegateResponseChannel = responses
+        for (response in responses) {
+          responseChannel.send(response)
+        }
+        responseChannel.close()
+      } catch (e: Throwable) {
+        responseChannel.close(e)
+      }
+    }
+
+    return requestChannel to responseChannel
+  }
+}
+
+internal fun <S : Any, R : Any> GrpcServerStreamingCall<S, R>.asGrpcStreamingCall() = GrpcServerStreamingCallStreamingAdapter(this, method)
+
+private fun <E : Any> Channel<E>.toMessageSource() = object : MessageSource<E> {
+  override fun read(): E? = runBlocking {
+    try {
+      val result = receiveCatching()
+      result.exceptionOrNull()?.let { throw it }
+      result.getOrNull()
+    } catch (e: Throwable) {
+      throw e.toIOException()
+    }
+  }
+
+  override fun close() {
+    cancel()
+  }
+}
+
+private fun <E : Any> Channel<E>.toMessageSink() = object : MessageSink<E> {
+  override fun write(message: E) {
+    runBlocking {
+      try {
+        send(message)
+      } catch (e: Throwable) {
+        throw e.toIOException()
+      }
+    }
+  }
+
+  override fun cancel() {
+    this@toMessageSink.cancel()
+  }
+
+  override fun close() {
+    this@toMessageSink.close()
+  }
+}
+
+private fun Throwable.toIOException() = this as? IOException ?: IOException(this)

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcStreamingCall.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcStreamingCall.kt
@@ -90,14 +90,23 @@ internal class RealGrpcStreamingCall<S : Any, R : Any>(
         callForCancel = call,
       )
     }
-    call.enqueue(responseChannel.readFromResponseBodyCallback(this, method.responseAdapter))
+    call.enqueue(
+      responseChannel.readFromResponseBodyCallback(
+        onResponseMetadata = { this.responseMetadata = it },
+        responseAdapter = method.responseAdapter,
+      ),
+    )
 
     return requestChannel to responseChannel
   }
 
   override fun executeBlocking(): Pair<MessageSink<S>, MessageSource<R>> {
     val call = initCall()
-    val messageSource = BlockingMessageSource(this, method.responseAdapter, call)
+    val messageSource = BlockingMessageSource(
+      onResponseMetadata = { this.responseMetadata = it },
+      responseAdapter = method.responseAdapter,
+      call = call,
+    )
     val messageSink = requestBody.messageSink(
       minMessageToCompress = grpcClient.minMessageToCompress,
       requestAdapter = method.requestAdapter,

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/grpc.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/grpc.kt
@@ -83,6 +83,15 @@ internal fun <S : Any> PipeDuplexRequestBody.messageSink(
 internal fun <R : Any> SendChannel<R>.readFromResponseBodyCallback(
   grpcCall: RealGrpcStreamingCall<*, R>,
   responseAdapter: ProtoAdapter<R>,
+): Callback = readFromResponseBodyCallback(
+  onResponseMetadata = { grpcCall.responseMetadata = it },
+  responseAdapter = responseAdapter,
+)
+
+/** Sends the response messages to the channel. */
+internal fun <R : Any> SendChannel<R>.readFromResponseBodyCallback(
+  onResponseMetadata: (Map<String, String>) -> Unit,
+  responseAdapter: ProtoAdapter<R>,
 ): Callback {
   return object : Callback {
     override fun onFailure(call: Call, e: IOException) {
@@ -91,7 +100,7 @@ internal fun <R : Any> SendChannel<R>.readFromResponseBodyCallback(
     }
 
     override fun onResponse(call: Call, response: Response) {
-      grpcCall.responseMetadata = response.headers.toMap()
+      onResponseMetadata(response.headers.toMap())
       runBlocking {
         response.use {
           val messageSource = try {

--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcOnMockWebServerTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcOnMockWebServerTest.kt
@@ -18,17 +18,28 @@ package com.squareup.wire
 import assertk.assertThat
 import assertk.assertions.containsExactly
 import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
 import com.squareup.wire.mockwebserver.GrpcDispatcher
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicReference
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.ObsoleteCoroutinesApi
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import okhttp3.Call
+import okhttp3.Headers.Companion.headersOf
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Protocol
+import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
+import okio.Buffer
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -80,6 +91,105 @@ class GrpcOnMockWebServerTest {
       .baseUrl(mockWebServer.url("/"))
       .build()
     routeGuideService = grpcClient.create(RouteGuideClient::class)
+  }
+
+  @Test
+  fun serverStreamingDoesNotNeedDispatchersIoToSendRequest() {
+    enqueueListFeaturesResponse()
+
+    val ioParallelism = System.getProperty("kotlinx.coroutines.io.parallelism")?.toInt()
+      ?: maxOf(64, Runtime.getRuntime().availableProcessors())
+    val started = CountDownLatch(ioParallelism)
+    val release = CountDownLatch(1)
+
+    @Suppress("OPT_IN_USAGE")
+    val blockers = List(ioParallelism) {
+      GlobalScope.launch(Dispatchers.IO) {
+        started.countDown()
+        release.await()
+      }
+    }
+    var callThread: Thread? = null
+
+    try {
+      assertThat(started.await(10, TimeUnit.SECONDS)).isTrue()
+
+      val received = AtomicReference<Any?>()
+      val done = CountDownLatch(1)
+      callThread = Thread {
+        try {
+          runBlocking {
+            val listFeatures = routeGuideService.ListFeatures()
+            val responses = listFeatures.executeIn(
+              this,
+              Rectangle(lo = Point(latitude = 1, longitude = 2), hi = Point(latitude = 3, longitude = 4)),
+            )
+            received.set(responses.receive())
+            responses.cancel()
+          }
+        } catch (e: Throwable) {
+          received.set(e)
+        } finally {
+          done.countDown()
+        }
+      }
+      callThread.start()
+
+      assertThat(done.await(1, TimeUnit.SECONDS)).isTrue()
+      assertThat(received.get()).isEqualTo(Feature(name = "peak"))
+    } finally {
+      release.countDown()
+      callThread?.join(10_000)
+      runBlocking {
+        blockers.joinAll()
+      }
+    }
+  }
+
+  @Test
+  fun legacyServerStreamingListFeatures() {
+    enqueueListFeaturesResponse()
+
+    val listFeatures = grpcClient.newStreamingCall(
+      GrpcMethod(
+        path = "/routeguide.RouteGuide/ListFeatures",
+        requestAdapter = Rectangle.ADAPTER,
+        responseAdapter = Feature.ADAPTER,
+        responseStreaming = true,
+      ),
+    )
+
+    runBlocking {
+      val (requests, responses) = listFeatures.executeIn(this)
+      requests.send(Rectangle(lo = Point(latitude = 1, longitude = 2), hi = Point(latitude = 3, longitude = 4)))
+      requests.close()
+      assertThat(responses.receive()).isEqualTo(Feature(name = "peak"))
+      assertThat(responses.receive()).isEqualTo(Feature(name = "valley"))
+      assertThat(responses.receiveCatching().getOrNull()).isNull()
+      assertThat(listFeatures.isCanceled()).isFalse()
+    }
+  }
+
+  private fun enqueueListFeaturesResponse() {
+    val responseBody = Buffer()
+    for (feature in listOf(Feature(name = "peak"), Feature(name = "valley"))) {
+      val encoded = Feature.ADAPTER.encodeByteString(feature)
+      responseBody.writeByte(0) // not compressed
+      responseBody.writeInt(encoded.size)
+      responseBody.write(encoded)
+    }
+    val grpcDispatcher = mockWebServer.dispatcher
+    mockWebServer.dispatcher = object : okhttp3.mockwebserver.Dispatcher() {
+      override fun dispatch(request: okhttp3.mockwebserver.RecordedRequest): MockResponse {
+        if (request.path == "/routeguide.RouteGuide/ListFeatures") {
+          return MockResponse()
+            .setHeader("Content-Type", "application/grpc")
+            .setTrailers(headersOf("grpc-status", "0"))
+            .setBody(responseBody)
+        }
+        return grpcDispatcher.dispatch(request)
+      }
+    }
   }
 
   @Test

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -479,7 +479,18 @@ class KotlinGenerator private constructor(
         .addStatement("%T(⇥⇥", GrpcMethod::class)
         .addStatement("path = %S,", "/$packageName$serviceName/${rpc.name}")
         .addStatement("requestAdapter = %L,", rpc.requestType!!.getAdapterName())
-        .addStatement("responseAdapter = %L", rpc.responseType!!.getAdapterName())
+        .apply {
+          val streamingArguments = buildList {
+            if (rpc.requestStreaming) add("requestStreaming = true")
+            if (rpc.responseStreaming) add("responseStreaming = true")
+          }
+          val responseAdapterSuffix = if (streamingArguments.isEmpty()) "" else ","
+          addStatement("responseAdapter = %L$responseAdapterSuffix", rpc.responseType!!.getAdapterName())
+          for ((index, argument) in streamingArguments.withIndex()) {
+            val suffix = if (index == streamingArguments.lastIndex) "" else ","
+            addStatement("$argument$suffix")
+          }
+        }
         .add("⇤⇤)")
         .build()
       when {

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -724,7 +724,8 @@ class KotlinGeneratorTest {
           |  override fun RecordRoute(): GrpcStreamingCall<Point, RouteSummary> = client.newStreamingCall(GrpcMethod(
           |      path = "/routeguide.RouteGuide/RecordRoute",
           |      requestAdapter = Point.ADAPTER,
-          |      responseAdapter = RouteSummary.ADAPTER
+          |      responseAdapter = RouteSummary.ADAPTER,
+          |      requestStreaming = true
           |  ))
           |}
           |
@@ -791,7 +792,8 @@ class KotlinGeneratorTest {
           |  override fun ListFeatures(): GrpcStreamingCall<Rectangle, Feature> = client.newStreamingCall(GrpcMethod(
           |      path = "/routeguide.RouteGuide/ListFeatures",
           |      requestAdapter = Rectangle.ADAPTER,
-          |      responseAdapter = Feature.ADAPTER
+          |      responseAdapter = Feature.ADAPTER,
+          |      responseStreaming = true
           |  ))
           |}
           |
@@ -861,7 +863,9 @@ class KotlinGeneratorTest {
           override fun RouteChat(): GrpcStreamingCall<RouteNote, RouteNote> = client.newStreamingCall(GrpcMethod(
               path = "/routeguide.RouteGuide/RouteChat",
               requestAdapter = RouteNote.ADAPTER,
-              responseAdapter = RouteNote.ADAPTER
+              responseAdapter = RouteNote.ADAPTER,
+              requestStreaming = true,
+              responseStreaming = true
           ))
         }
 
@@ -930,7 +934,9 @@ class KotlinGeneratorTest {
            override fun RouteChat(): GrpcStreamingCall<RouteNote, RouteNote> = client.newStreamingCall(GrpcMethod(
                path = "/routeguide.RouteGuide/RouteChat",
                requestAdapter = RouteNote.ADAPTER,
-               responseAdapter = RouteNote.ADAPTER
+               responseAdapter = RouteNote.ADAPTER,
+               requestStreaming = true,
+               responseStreaming = true
            ))
          }
 
@@ -1065,7 +1071,9 @@ class KotlinGeneratorTest {
           |  override fun RouteChat(): GrpcStreamingCall<RouteNote, RouteNote> = client.newStreamingCall(GrpcMethod(
           |      path = "/routeguide.RouteGuide/RouteChat",
           |      requestAdapter = RouteNote.ADAPTER,
-          |      responseAdapter = RouteNote.ADAPTER
+          |      responseAdapter = RouteNote.ADAPTER,
+          |      requestStreaming = true,
+          |      responseStreaming = true
           |  ))
           |}
           |
@@ -1178,7 +1186,9 @@ class KotlinGeneratorTest {
           |  override fun RouteChat(): GrpcStreamingCall<RouteNote, RouteNote> = client.newStreamingCall(GrpcMethod(
           |      path = "/routeguide.RouteGuide/RouteChat",
           |      requestAdapter = RouteNote.ADAPTER,
-          |      responseAdapter = RouteNote.ADAPTER
+          |      responseAdapter = RouteNote.ADAPTER,
+          |      requestStreaming = true,
+          |      responseStreaming = true
           |  ))
           |}
           |


### PR DESCRIPTION
Fixes #3370

From Claude

### Root Cause

`GrpcServerStreamingCall` was implemented by delegating to `GrpcStreamingCall`, which uses a `PipeDuplexRequestBody`, an asynchronous pipe where the request body is written by a background coroutine on `Dispatchers.IO`. This means the request message and the `HTTP/2 END_STREAM` flag are sent asynchronously, after the HTTP call is already enqueued.
Many gRPC server implementations wait for the client's half-close (`END_STREAM`) before starting to stream responses. With the duplex pipe approach, there's a race between when the server receives `END_STREAM` and when it decides to time out the idle stream, causing the reported ~5-minute delay.

### Fix

`RealGrpcServerStreamingCall` now has its own independent implementation using `newRequestBody()` (a non-duplex request body), identical to how `RealGrpcCall` works. The complete request message + `END_STREAM` is written synchronously in OkHttp's `writeTo()` call, ensuring the server receives the full request before any response reading begins.
The old delegation-based class is preserved as `GrpcStreamingCallServerStreamingAdapter`, still used by the test-double factory (`GrpcServerStreamingCall { ... }` in GrpcCalls.kt).

Supporting changes:

- `readFromResponseBodyCallback()` in `grpc.kt`: added an overload accepting `onResponseMetadata: (Map<String, String>) -> Unit` so both `RealGrpcStreamingCall` and `RealGrpcServerStreamingCall` can use it
- `BlockingMessageSource`: replaced `grpcCall: RealGrpcStreamingCall` with `onResponseMetadata: (Map<String, String>) -> Unit` for the same reason
- `GrpcClient.newServerStreamingCall()` — now creates `RealGrpcServerStreamingCall` directly instead of wrapping a streaming call.