### PR TITLE
Test confirming Gradle caching improvements made in #3313

### DIFF
--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1217,7 +1217,7 @@ class WirePluginTest {
 
   @Test
   fun cacheRelocation() {
-    // Remove the build cache folder if it is leftover from a previous run
+    // Remove the build cache folder if it is leftover from a previous run.
     val buildCacheDir = File("src/test/projects/.relocation-build-cache")
     if (buildCacheDir.exists()) {
       buildCacheDir.deleteRecursively()
@@ -1263,6 +1263,59 @@ class WirePluginTest {
     assertThat(relocatedResult.task(":generateMainProtos")?.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
     assertThat(relocatedResult.task(":generateProtos")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
     assertThat(File(relocatedRoot, generatedProto)).exists()
+
+    // Clean up on success; leave the dir on failure for easier debugging.
+    buildCacheDir.deleteRecursively()
+  }
+
+  @Test
+  fun cacheRelocationWithMavenSourceJar() {
+    // Remove the build cache folder if it is leftover from a previous run.
+    val buildCacheDir = File("src/test/projects/.source-relocation-build-cache")
+    if (buildCacheDir.exists()) {
+      buildCacheDir.deleteRecursively()
+    }
+    assertThat(buildCacheDir.exists()).isFalse()
+
+    val generatedStatus = "build/generated/source/wire/com/google/rpc/Status.kt"
+
+    val fixtureRoot = File("src/test/projects/cache-source-relocation-1")
+    val result = fixtureGradleRunner(fixtureRoot)
+      .withArguments(
+        "-g",
+        tmpFolder.newFolder("gradle-source-home-1").absolutePath,
+        "generateProtos",
+        "--build-cache",
+        "--stacktrace",
+        "--info",
+        "-PwireVersion=$wireVersion",
+      ).build()
+
+    assertThat(result.task(":generateProtos")).isNotNull()
+    assertThat(result.task(":generateMainProtos")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(result.task(":generateProtos")?.outcome).isEqualTo(TaskOutcome.SUCCESS)
+    assertThat(File(fixtureRoot, generatedStatus)).exists()
+
+    // After the first project, the build cache should exist. It will get used for the second
+    // project.
+    assertThat(buildCacheDir.exists()).isTrue()
+
+    val relocatedRoot = File("src/test/projects/cache-source-relocation-2")
+    val relocatedResult = fixtureGradleRunner(relocatedRoot)
+      .withArguments(
+        "-g",
+        tmpFolder.newFolder("gradle-source-home-2").absolutePath,
+        "generateProtos",
+        "--build-cache",
+        "--stacktrace",
+        "--info",
+        "-PwireVersion=$wireVersion",
+      ).build()
+
+    assertThat(relocatedResult.task(":generateProtos")).isNotNull()
+    assertThat(relocatedResult.task(":generateMainProtos")?.outcome).isEqualTo(TaskOutcome.FROM_CACHE)
+    assertThat(relocatedResult.task(":generateProtos")?.outcome).isEqualTo(TaskOutcome.UP_TO_DATE)
+    assertThat(File(relocatedRoot, generatedStatus)).exists()
 
     // Clean up on success; leave the dir on failure for easier debugging.
     buildCacheDir.deleteRecursively()

--- a/wire-gradle-plugin/src/test/projects/.gitignore
+++ b/wire-gradle-plugin/src/test/projects/.gitignore
@@ -1,3 +1,4 @@
 gradle
 .cache-include-paths-build-cach
 .relocation-build-cache
+.source-relocation-build-cache

--- a/wire-gradle-plugin/src/test/projects/cache-source-relocation-1/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/cache-source-relocation-1/build.gradle
@@ -1,0 +1,41 @@
+buildscript {
+  dependencies {
+    classpath "com.squareup.wire:wire-gradle-plugin:$wireVersion"
+    classpath libs.pluginz.kotlin
+  }
+
+  repositories {
+    maven {
+      url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'application'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.wire'
+
+// The code in this test project should be identical to
+// the one in cache-source-relocation-2; the only difference is
+// that the pathname and gradle user home dirs are different.
+// The test ensures that the gradle task is cacheable even
+// when the project and gradle user home dirs are relocated
+// to a different filesystem path. This ensures the plugin
+// tasks are compatible with being shared across machines
+// via a gradle remote cache, even when using Maven dependencies
+// as source protos (not just proto paths).
+
+repositories {
+  mavenCentral()
+}
+
+wire {
+  sourcePath {
+    srcJar("com.google.api.grpc:proto-google-common-protos:2.57.0")
+    include("google/rpc/status.proto")
+  }
+  kotlin {
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/cache-source-relocation-1/settings.gradle
+++ b/wire-gradle-plugin/src/test/projects/cache-source-relocation-1/settings.gradle
@@ -1,0 +1,15 @@
+buildCache {
+  local {
+    directory = new File(rootDir, '../.source-relocation-build-cache')
+  }
+}
+
+include ':'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/cache-source-relocation-2/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/cache-source-relocation-2/build.gradle
@@ -1,0 +1,41 @@
+buildscript {
+  dependencies {
+    classpath "com.squareup.wire:wire-gradle-plugin:$wireVersion"
+    classpath libs.pluginz.kotlin
+  }
+
+  repositories {
+    maven {
+      url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'application'
+apply plugin: 'org.jetbrains.kotlin.jvm'
+apply plugin: 'com.squareup.wire'
+
+// The code in this test project should be identical to
+// the one in cache-source-relocation-1; the only difference is
+// that the pathname and gradle user home dirs are different.
+// The test ensures that the gradle task is cacheable even
+// when the project and gradle user home dirs are relocated
+// to a different filesystem path. This ensures the plugin
+// tasks are compatible with being shared across machines
+// via a gradle remote cache, even when using Maven dependencies
+// as source protos (not just proto paths).
+
+repositories {
+  mavenCentral()
+}
+
+wire {
+  sourcePath {
+    srcJar("com.google.api.grpc:proto-google-common-protos:2.57.0")
+    include("google/rpc/status.proto")
+  }
+  kotlin {
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/cache-source-relocation-2/settings.gradle
+++ b/wire-gradle-plugin/src/test/projects/cache-source-relocation-2/settings.gradle
@@ -1,0 +1,15 @@
+buildCache {
+  local {
+    directory = new File(rootDir, '../.source-relocation-build-cache')
+  }
+}
+
+include ':'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}


### PR DESCRIPTION
#2842 is already fixed in #3313. Adding a new test here.

A test where Maven dependencies are used as sourcePath `wire { sourcePath { srcJar("...") } }` was missing.