### PR TITLE
Add negative-length check in skipGroup

### DIFF
--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ByteArrayProtoReader32.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ByteArrayProtoReader32.kt
@@ -228,6 +228,7 @@ internal class ByteArrayProtoReader32(
         }
         STATE_LENGTH_DELIMITED -> {
           val length = internalReadVarint32()
+          if (length < 0) throw ProtocolException("Negative length: $length. Reader position: $pos. Last read tag: $tag.")
           skip(length)
         }
         STATE_VARINT -> {

--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoReader.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/ProtoReader.kt
@@ -267,6 +267,7 @@ open class ProtoReader(private val source: BufferedSource) {
         }
         STATE_LENGTH_DELIMITED -> {
           val length = internalReadVarint32()
+          if (length < 0) throw ProtocolException("Negative length: $length. Reader position: $pos. Last read tag: $tag.")
           pos += length.toLong()
           source.skip(length.toLong())
         }

--- a/wire-runtime/src/commonTest/kotlin/com/squareup/wire/ProtoReader32Test.kt
+++ b/wire-runtime/src/commonTest/kotlin/com/squareup/wire/ProtoReader32Test.kt
@@ -78,5 +78,15 @@ class ProtoReader32Test {
     }.isInstanceOf<IOException>().hasMessage("Wire recursion limit exceeded")
   }
 
+  /** We had a bug where negative lengths in skipped groups crashed with runtime exceptions. */
+  @Test fun testSkipGroupRejectsNegativeLength() {
+    val data = "9b060a80ffffff0f9c06".decodeHex()
+
+    assertFailure {
+      Person.ADAPTER.decode(data)
+    }.isInstanceOf<IOException>()
+      .hasMessage("Negative length: -128. Reader position: 8. Last read tag: 1.")
+  }
+
   // Consider pasting new tests into ProtoReaderTest.kt also.
 }

--- a/wire-runtime/src/commonTest/kotlin/com/squareup/wire/ProtoReaderTest.kt
+++ b/wire-runtime/src/commonTest/kotlin/com/squareup/wire/ProtoReaderTest.kt
@@ -79,5 +79,15 @@ class ProtoReaderTest {
     }.isInstanceOf<IOException>().hasMessage("Wire recursion limit exceeded")
   }
 
+  /** We had a bug where negative lengths in skipped groups crashed with runtime exceptions. */
+  @Test fun testSkipGroupRejectsNegativeLength() {
+    val data = "9b060a80ffffff0f9c06".decodeHex()
+
+    assertFailure {
+      Person.ADAPTER.decode(Buffer().write(data))
+    }.isInstanceOf<IOException>()
+      .hasMessage("Negative length: -128. Reader position: 8. Last read tag: 1.")
+  }
+
   // Consider pasting new tests into ProtoReader32Test.kt also.
 }


### PR DESCRIPTION
Fixes https://github.com/square/wire/security/advisories/GHSA-7xpr-hc2w-34m9