### PR TITLE
ci: declare workflow-level `contents: read` on 2 workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,9 @@ on:
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 
+permissions:
+  contents: read
+
 jobs:
   jvm:
     runs-on: ubuntu-latest

--- a/.github/workflows/gradle-wrapper.yaml
+++ b/.github/workflows/gradle-wrapper.yaml
@@ -7,6 +7,9 @@ on:
     - 'gradlew.bat'
     - 'gradle/wrapper/**'
 
+permissions:
+  contents: read
+
 jobs:
   validate:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 2 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.