### PR TITLE
Skip null list elements in moshi fromJson

### DIFF
--- a/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.kt
+++ b/wire-gson-support/src/main/java/com/squareup/wire/MessageTypeAdapter.kt
@@ -71,7 +71,7 @@ internal class MessageTypeAdapter<M : Message<M, B>, B : Message.Builder<M, B>>(
       // interpreted as the appropriate default value when parsed into a protocol buffer."
       if (value == null) continue
 
-      jsonField.fieldBinding.set(builder, value)
+      jsonField.fieldBinding.set(builder, jsonField.fieldBinding.withoutStrayNullElements(value))
     }
     input.endObject()
     return builder.build()

--- a/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
+++ b/wire-moshi-adapter/src/main/java/com/squareup/wire/MessageJsonAdapter.kt
@@ -79,7 +79,7 @@ internal class MessageJsonAdapter<M : Message<M, B>, B : Message.Builder<M, B>>(
       if (value == null) continue
 
       val fieldBinding = messageAdapter.fieldBindingsArray[index]
-      fieldBinding.set(builder, value)
+      fieldBinding.set(builder, fieldBinding.withoutStrayNullElements(value))
     }
     input.endObject()
     return builder.build()

--- a/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/FieldOrOneOfBinding.kt
+++ b/wire-runtime/src/commonMain/kotlin/com/squareup/wire/internal/FieldOrOneOfBinding.kt
@@ -89,4 +89,23 @@ abstract class FieldOrOneOfBinding<M, B> {
     if (isMap && syntax == Syntax.PROTO_3) return true
     return false
   }
+
+  /**
+   * Returns [value] with any null elements removed when it's the decoded JSON value for a repeated
+   * field. A literal `null` in a JSON array (e.g. `"items": [{...}, null]`) decodes to a null list
+   * element that isn't representable in a proto repeated field; left in place it would trip the
+   * `null !in result` check in [immutableCopyOf]. Struct fields (such as
+   * `repeated google.protobuf.NullValue`) are decoded by the struct adapter and may legitimately
+   * carry null entries, so they're returned unchanged.
+   */
+  fun withoutStrayNullElements(value: Any?): Any? {
+    if (!label.isRepeated || singleAdapter.isStructAdapter() || value !is List<*>) return value
+    if (null !in value) return value
+    return value.filterNotNull()
+  }
+
+  private fun ProtoAdapter<*>.isStructAdapter(): Boolean = this == ProtoAdapter.STRUCT_MAP ||
+    this == ProtoAdapter.STRUCT_LIST ||
+    this == ProtoAdapter.STRUCT_VALUE ||
+    this == ProtoAdapter.STRUCT_NULL
 }

--- a/wire-tests/wire-json-shared-kotlin-tests/com/squareup/wire/WireJsonTest.kt
+++ b/wire-tests/wire-json-shared-kotlin-tests/com/squareup/wire/WireJsonTest.kt
@@ -342,6 +342,44 @@ class WireJsonTest {
     assertThat(parsed).isEqualTo(expected)
   }
 
+  /**
+   * A literal `null` element inside a repeated message field is not representable in proto, so it's
+   * dropped rather than passed to `Internal.immutableCopyOf` (which would throw `contains(null)`).
+   * https://github.com/square/wire/issues/3353
+   */
+  @Test fun nullElementInRepeatedMessageFieldIsDropped() {
+    val json = """{"pizzas":[{"toppings":["pineapple"]},null]}"""
+    val expected = PizzaDelivery.Builder()
+      .pizzas(listOf(Pizza.Builder().toppings(listOf("pineapple")).build()))
+      .build()
+    val parsed = jsonLibrary.fromJson(json, PizzaDelivery::class.java)
+    assertThat(parsed).isEqualTo(expected)
+  }
+
+  /** Same as above but for a repeated scalar field. */
+  @Test fun nullElementInRepeatedScalarFieldIsDropped() {
+    val json = """{"toppings":["pineapple",null,"onion"]}"""
+    val expected = Pizza.Builder().toppings(listOf("pineapple", "onion")).build()
+    val parsed = jsonLibrary.fromJson(json, Pizza::class.java)
+    assertThat(parsed).isEqualTo(expected)
+  }
+
+  /**
+   * Struct values legitimately represent null entries (e.g. inside a `google.protobuf.ListValue`),
+   * so a null element in a struct list must be preserved rather than stripped along with the stray
+   * nulls above.
+   */
+  @Test fun nullElementsInStructListArePreserved() {
+    if (jsonLibrary.writeIdentityValues) return
+
+    val json = """{"list":["a",null,3.0]}"""
+    val expected = AllStructs.Builder()
+      .list(listOf("a", null, 3.0))
+      .build()
+    val parsed = jsonLibrary.fromJson(json, AllStructs::class.java)
+    assertThat(parsed).isEqualTo(expected)
+  }
+
   @Test fun enumCanBeDecodedFromInt() {
     val json = """{"drink":9}"""
     val value = jsonLibrary.fromJson(json, FreeDrinkPromotion::class.java)


### PR DESCRIPTION
## Summary

`MessageJsonAdapter#fromJson` (and the gson `MessageTypeAdapter#read`) skipped a field only when the whole decoded value was null. For a repeated field, a literal `null` array element (e.g. `"items": [{...}, null]`) decodes into a non-null `List<T?>` whose element is null. That list passed the `value == null` guard and reached `fieldBinding.set(...)`, where building the message hit `Internal.immutableCopyOf`'s `require(null !in result) { "$name.contains(null)" }` and threw `IllegalArgumentException: <field>.contains(null)`.

This adds a shared `FieldOrOneOfBinding.withoutStrayNullElements(value)` helper that, for repeated non-struct fields, drops stray null list elements before they reach the builder. Struct fields (e.g. `repeated google.protobuf.NullValue`, `google.protobuf.ListValue`) are decoded by the struct adapter and may legitimately carry null entries, so they are left untouched. Both the moshi and gson adapters route through the helper.

## Why this matters

Decoding otherwise-valid JSON that happens to contain a `null` array element crashed instead of ignoring the unrepresentable entry, matching the report in https://github.com/square/wire/issues/3353 where @oldergod said a PR was welcome.

## Testing

`./gradlew :wire-tests:jvm-json-kotlin:test --tests 'com.squareup.wire.WireJsonTest'` — BUILD SUCCESSFUL (210 tests, parameterized across the moshi and gson libraries). Also ran `:wire-runtime:jvmTest`, `:wire-moshi-adapter-test:test`, and `:wire-gson-support:test` — all green. New cases cover a null element in a repeated message field, a repeated scalar field, and preservation of a null inside a struct list.

Fixes #3353
