### PR TITLE
CompileOnly deps for KGP

### DIFF
--- a/wire-gradle-plugin/build.gradle.kts
+++ b/wire-gradle-plugin/build.gradle.kts
@@ -49,8 +49,8 @@ dependencies {
 
   compileOnly(gradleApi())
   compileOnly(libs.pluginz.android)
+  compileOnly(libs.pluginz.kotlin)
 
-  implementation(libs.pluginz.kotlin)
   implementation(projects.wireCompiler)
   implementation(projects.wireKotlinGenerator)
   implementation(libs.swiftpoet)


### PR DESCRIPTION
https://github.com/cashapp/misk/pull/3863

It used to be compileOnly so..... hmmm. See the comment here: https://github.com/square/wire/pull/3505#issuecomment-5039078934