### PR TITLE
Gradle plugin: register generated sources for third-party WireOutput subclasses

### DIFF
--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -17,7 +17,6 @@ package com.squareup.wire.gradle.kotlin
 
 import com.android.build.api.variant.AndroidComponentsExtension
 import com.android.build.api.variant.Variant
-import com.squareup.wire.gradle.CustomOutput
 import com.squareup.wire.gradle.JavaOutput
 import com.squareup.wire.gradle.KotlinOutput
 import com.squareup.wire.gradle.WireOutput
@@ -144,15 +143,10 @@ private class JvmOrKmpSource(
         is KotlinOutput -> {
           registerKotlinGeneratedSources(kotlinSourceSet, outputDirectory)
         }
-        is CustomOutput -> {
-          // Custom targets are wildcards, so we add all output directories.
+        else -> {
+          // Custom and third-party outputs are wildcards, so we add all output directories.
           javaSourceDirectorySet?.srcDir(outputDirectory)
           registerKotlinGeneratedSources(kotlinSourceSet, outputDirectory)
-        }
-        else -> {
-          throw IllegalArgumentException(
-            "Wire output ${output::class.simpleName} is not supported in project ${project.path}",
-          )
         }
       }
     }
@@ -181,15 +175,10 @@ private class AndroidSource(
           // Registering with variant.sources.kotlin can hide handwritten sources from KSP.
           variant.sources.java?.addGeneratedSourceDirectory(wireTask) { it.outputDirectoriesList[index] }
         }
-        is CustomOutput -> {
-          // Custom targets are wildcards, so we add all output directories.
+        else -> {
+          // Custom and third-party outputs are wildcards, so we add all output directories.
           variant.sources.java?.addGeneratedSourceDirectory(wireTask) { it.outputDirectoriesList[index] }
           variant.sources.kotlin?.addGeneratedSourceDirectory(wireTask) { it.outputDirectoriesList[index] }
-        }
-        else -> {
-          throw IllegalArgumentException(
-            "Wire output ${output::class.simpleName} is not supported in Android project ${project.path}",
-          )
         }
       }
     }

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -955,6 +955,15 @@ class WirePluginTest {
   }
 
   @Test
+  fun thirdPartyOutputRegistersGeneratedSources() {
+    val fixtureRoot = File("src/test/projects/third-party-output")
+
+    val result = fixtureGradleRunner(fixtureRoot, "printSourceDirs").build()
+    assertThat(result.task(":printSourceDirs")).isNotNull()
+    assertThat(result.output).contains("generated${File.separator}thirdParty")
+  }
+
+  @Test
   fun customOutputProviderBackedDsl() {
     val fixtureRoot = File("src/test/projects/custom-output-provider-kotlin-dsl")
 

--- a/wire-gradle-plugin/src/test/projects/third-party-output/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/third-party-output/build.gradle
@@ -1,0 +1,53 @@
+import com.squareup.wire.gradle.WireOutput
+import com.squareup.wire.schema.CustomTarget
+import com.squareup.wire.schema.SchemaHandler
+import com.squareup.wire.schema.Target
+import org.jetbrains.annotations.NotNull
+
+buildscript {
+  dependencies {
+    classpath "com.squareup.wire:wire-gradle-plugin:$wireVersion"
+  }
+
+  repositories {
+    maven {
+      url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'application'
+apply plugin: 'com.squareup.wire'
+
+class ThirdPartyHandlerFactory implements SchemaHandler.Factory {
+  @Override
+  SchemaHandler create(@NotNull List<String> includes, @NotNull List<String> excludes,
+      boolean exclusive, @NotNull String outDirectory, @NotNull Map<String, String> options) {
+    throw new RuntimeException("this test only configures the project; the handler never runs")
+  }
+}
+
+// A third-party WireOutput subclass, as plugins building on top of Wire define them.
+abstract class ThirdPartyOutput extends WireOutput {
+  @Override
+  Target toTarget(String outputDirectory) {
+    return new CustomTarget(['*'], [], false, outputDirectory, [:], new ThirdPartyHandlerFactory())
+  }
+}
+
+wire {
+  sourcePath 'src/main/proto'
+}
+
+def thirdPartyOutput = project.objects.newInstance(ThirdPartyOutput)
+thirdPartyOutput.setOut("${buildDir}/generated/thirdParty")
+wire.outputs.add(thirdPartyOutput)
+
+tasks.register('printSourceDirs') {
+  def srcDirs = project.provider { sourceSets.main.java.srcDirs }
+  doLast {
+    println "sourceDirs: ${srcDirs.get()}"
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/third-party-output/settings.gradle
+++ b/wire-gradle-plugin/src/test/projects/third-party-output/settings.gradle
@@ -1,0 +1,9 @@
+include ':'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/third-party-output/src/main/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/third-party-output/src/main/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
### Problem

Since the Wire 7 Gradle plugin rework, `SourceRoots.registerGeneratedSources` matches on the built-in output classes (`JavaOutput`, `KotlinOutput`, `CustomOutput`) and throws for anything else:

```
Wire output ThirdPartyOutput_Decorated is not supported in project :foo
```

This breaks Gradle plugins that build on top of Wire by adding their own `WireOutput` subclasses to `wire.outputs` (found while rolling Wire 7.0.0-alpha06 out to Cash's build logic, which registers several such outputs). It's a regression from Wire 6, where dispatch happened on the produced `Target` and any output producing a `CustomTarget` worked.

### Fix

Treat unknown `WireOutput` subclasses like `CustomOutput`: custom targets are wildcards, so register the output directory on both the Java and Kotlin source sets (JVM/KMP and Android variants alike). `ProtoOutput` is filtered out before `registerGeneratedSources` is called, so the `else` branch only ever sees third-party outputs.
