### PR TITLE
Kotlin: escape keyword-named oneofs in toString()

### DIFF
--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -738,9 +738,14 @@ class KotlinGenerator private constructor(
         val countNonNull = MemberName("com.squareup.wire.internal", "countNonNull")
         // FIXME(egor): Revert back to function reference once KotlinPoet compiled with Kotlin
         // 1.4 is released. See https://youtrack.jetbrains.com/issue/KT-37435.
-        val fieldNames = oneOf.fields.joinToString(", ") { field -> nameAllocator[field] }
-        beginControlFlow("require(%M(%L)·<=·1)", countNonNull, fieldNames)
-        addStatement("%S", "At most one of $fieldNames may be non-null")
+        val fieldNames = oneOf.fields.map { field -> nameAllocator[field] }
+        val placeholders = fieldNames.joinToString(", ") { "%N" }
+        beginControlFlow(
+          "require(%M($placeholders)·<=·1)",
+          countNonNull,
+          *fieldNames.toTypedArray(),
+        )
+        addStatement("%S", "At most one of ${fieldNames.joinToString(", ")} may be non-null")
         endControlFlow()
       }
   }
@@ -1170,7 +1175,7 @@ class KotlinGenerator private constructor(
     }
 
     return funBuilder
-      .addStatement("this.%1L = %1L", fieldName)
+      .addStatement("this.%1N = %1N", fieldName)
       .addStatement("return this")
       .build()
   }
@@ -1537,7 +1542,7 @@ class KotlinGenerator private constructor(
                     add("=$DOUBLE_FULL_BLOCK")
                   } else {
                     add("=\$")
-                    add(fieldName)
+                    add("%N", fieldName)
                   }
                 },
               )
@@ -1652,7 +1657,7 @@ class KotlinGenerator private constructor(
       val nameAllocator = nameAllocator(schema.getType(protoType)!!)
       if (!first) add(",")
       first = false
-      add("\n⇥%L·= %L⇤", nameAllocator[field], valueInitializer)
+      add("\n⇥%N·= %L⇤", nameAllocator[field], valueInitializer)
     }
     add("\n)")
   }
@@ -1889,7 +1894,7 @@ class KotlinGenerator private constructor(
       val fieldName = nameAllocator[boxOneOf]
       encodeCalls += buildCodeBlock {
         add("if (value.%N != %L) ", fieldName, "null")
-        addStatement("value.%L.encodeWithTag(writer)", fieldName)
+        addStatement("value.%N.encodeWithTag(writer)", fieldName)
       }
     }
     for (sealedOneOf in message.sealedOneOfs()) {
@@ -2134,7 +2139,7 @@ class KotlinGenerator private constructor(
             val choiceKeys = boxedOneOfKeysFieldName(fieldName)
             beginControlFlow("for (%L in %L)", choiceKey, choiceKeys)
             beginControlFlow("if (%L == %L.tag)", tag, choiceKey)
-            addStatement("${if (buildersOnly) "builder.%L" else "%L"} = %L.decode(reader)", fieldName, choiceKey)
+            addStatement("${if (buildersOnly) "builder.%N" else "%N"} = %L.decode(reader)", fieldName, choiceKey)
             addStatement("return@forEachTag %T", Unit::class)
             endControlFlow()
             endControlFlow()
@@ -2346,14 +2351,14 @@ class KotlinGenerator private constructor(
               val fieldName = nameAllocator[fieldOrOneOf]
               val redactedField = fieldOrOneOf.redact(fieldName)
               if (redactedField != null) {
-                add("\n.%1L(%2L)", fieldName, redactedField)
+                add("\n.%1N(%2L)", fieldName, redactedField)
               }
             }
 
             is OneOf -> {
               if (fieldOrOneOf.fields.none { it.isRedacted }) continue
               val fieldName = nameAllocator[fieldOrOneOf]
-              add("\n.%1L(null)", fieldName)
+              add("\n.%1N(null)", fieldName)
             }
 
             else -> throw IllegalArgumentException("Unexpected element: $fieldOrOneOf")

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -2566,6 +2566,66 @@ class KotlinGeneratorTest {
     assertThat(code).doesNotContain("sealed class Method")
   }
 
+  @Test fun toStringEscapesKeywordNames() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+        |syntax = "proto2";
+        |message JwtLocation {
+        |  oneof in {
+        |    string header = 1;
+        |    string query = 2;
+        |  }
+        |  optional int32 object = 3;
+        |}
+        """.trimMargin(),
+      )
+    }
+    val code = KotlinWithProfilesGenerator(schema).generateKotlin(
+      "JwtLocation",
+      oneofMode = OneofMode.SEALED_CLASS,
+      escapeKotlinKeywords = true,
+    )
+    assertThat(code).contains("""if (`in` != null) result += ""${'"'}in=${'$'}`in`""${'"'}""")
+    assertThat(code).contains("""if (`object` != null) result += ""${'"'}object=${'$'}`object`""${'"'}""")
+  }
+
+  @Test fun boxedOneofEscapesKeywordNames() {
+    val code = KotlinWithProfilesGenerator(keywordSchema()).generateKotlin(
+      "JwtLocation",
+      oneofMode = OneofMode.BOXED,
+      escapeKotlinKeywords = true,
+    )
+    // Both the null check and the encode call must be escaped.
+    assertThat(code).contains("if (value.`in` != null) value.`in`.encodeWithTag(writer)")
+    assertThat(code).contains("`in` = choiceKey.decode(reader)")
+  }
+
+  @Test fun flatOneofRequireEscapesKeywordNames() {
+    val code = KotlinWithProfilesGenerator(keywordSchema()).generateKotlin(
+      "JwtLocation",
+      oneofMode = OneofMode.FLAT,
+      escapeKotlinKeywords = true,
+    )
+    assertThat(code).contains("require(countNonNull(`object`, `is`, cookie) <= 1)")
+  }
+
+  @Test fun buildersEscapeKeywordNames() {
+    val code = KotlinWithProfilesGenerator(keywordSchema()).generateKotlin(
+      "JwtLocation",
+      oneofMode = OneofMode.BOXED,
+      escapeKotlinKeywords = true,
+      buildersOnly = true,
+      javaInterop = true,
+    )
+    assertThat(code).contains("this.`in` = `in`")
+    assertThat(code).contains("builder.`in` = choiceKey.decode(reader)")
+    // Redacted keyword-named fields and oneofs in the redact() builder chain.
+    assertThat(code).contains(".`as`(null)")
+    assertThat(code).contains(".`for`(null)")
+  }
+
   @Test fun sealedOneofFieldOptionsAppliedAsAnnotationsOnSubtypes() {
     val schema = buildSchema {
       add(
@@ -2827,6 +2887,41 @@ class KotlinGeneratorTest {
   }
 
   companion object {
+    /** A message whose fields and oneofs are all named after Kotlin keywords. */
+    private fun keywordSchema() = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+        |syntax = "proto2";
+        |import "option_redacted.proto";
+        |message JwtLocation {
+        |  oneof in {
+        |    string object = 1;
+        |    string is = 2;
+        |    string cookie = 3;
+        |  }
+        |  oneof for {
+        |    string val = 4 [(squareup.protos.redacted_option.redacted) = true];
+        |    string in2 = 5;
+        |  }
+        |  optional string as = 6 [(squareup.protos.redacted_option.redacted) = true];
+        |  optional int32 fun = 7;
+        |}
+        """.trimMargin(),
+      )
+      add(
+        "option_redacted.proto".toPath(),
+        """
+        |syntax = "proto2";
+        |package squareup.protos.redacted_option;
+        |import "google/protobuf/descriptor.proto";
+        |extend google.protobuf.FieldOptions {
+        |  optional bool redacted = 22200;
+        |}
+        """.trimMargin(),
+      )
+    }
+
     private val pointMessage = """
           |message Point {
           |  optional int32 latitude = 1;

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinWithProfilesGenerator.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinWithProfilesGenerator.kt
@@ -54,6 +54,7 @@ internal class KotlinWithProfilesGenerator(private val schema: Schema) {
     oneofMode: OneofMode = OneofMode.FLAT,
     mutableTypes: Boolean = false,
     makeImmutableCopies: Boolean = true,
+    escapeKotlinKeywords: Boolean = false,
   ): String {
     val kotlinGenerator = KotlinGenerator(
       schema,
@@ -61,6 +62,7 @@ internal class KotlinWithProfilesGenerator(private val schema: Schema) {
       boxOneOfsMinSize = boxOneOfsMinSize,
       buildersOnly = buildersOnly,
       javaInterop = javaInterop,
+      escapeKotlinKeywords = escapeKotlinKeywords,
       enumMode = enumMode,
       oneofMode = oneofMode,
       mutableTypes = mutableTypes,


### PR DESCRIPTION
Fixes #3674.

With `escapeKotlinKeywords = true`, a oneof whose name is a Kotlin keyword produced a `toString()` that doesn't compile:

```kotlin
if (`in` != null) result += """in=$in"""
```

`generateToStringMethod`'s `OneOf` branch emitted the interpolated value as a raw `add(fieldName)` rather than `add("%N", fieldName)`. `%N` is what makes KotlinPoet backtick-escape a keyword. The null check directly above it already used `%N`, as do both usages in the `Field` branch — only the oneof interpolation was raw, hence the asymmetric output in the issue.

Now:

```kotlin
if (`in` != null) result += """in=$`in`"""
```

The label text on either side (`add(fieldName)` for the `in=` prefix) stays unescaped — that's literal content of the output string, not an identifier.

cc @bjoernmayer @adityaanikam