### PR TITLE
Expose extension field numbers as generated Swift constants

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoIntCodable.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoIntCodable.swift
@@ -52,3 +52,6 @@ public enum ProtoIntEncoding {
     case signed
     case variable
 }
+
+extension ProtoIntEncoding : Sendable {
+}

--- a/wire-runtime-swift/src/test/swift/ExtensibleTests.swift
+++ b/wire-runtime-swift/src/test/swift/ExtensibleTests.swift
@@ -133,4 +133,35 @@ final class ExtensibleTests: XCTestCase {
         XCTAssertEqual(LargeExtensible.default_ext_value17, "my extension default value")
         XCTAssertEqual(LargeExtensible.default_ext_value18, "")
     }
+
+    func testExtensionFieldNumberAndEncodingConstants() {
+        XCTAssertEqual(Extensible.fieldNumber_ext_int32, 1001)
+        XCTAssertEqual(Extensible.fieldEncoding_ext_int32, .variable)
+        XCTAssertEqual(Extensible.fieldNumber_ext_sint32, 1003)
+        XCTAssertEqual(Extensible.fieldEncoding_ext_sint32, .signed)
+        XCTAssertEqual(Extensible.fieldNumber_ext_fixed32, 1004)
+        XCTAssertEqual(Extensible.fieldEncoding_ext_fixed32, .fixed)
+        XCTAssertEqual(Extensible.fieldNumber_ext_string, 1014)
+        XCTAssertEqual(LargeExtensible.fieldNumber_ext_value17, 17)
+        XCTAssertEqual(LargeExtensible.fieldNumber_rep_ext_sint32, 21)
+        XCTAssertEqual(LargeExtensible.fieldEncoding_rep_ext_sint32, .signed)
+
+        // Round-trip a value through the raw APIs using only generated constants.
+        var message = Extensible()
+        message.setUnknownField(
+            fieldNumber: Extensible.fieldNumber_ext_sint32,
+            newValue: Int32(-42),
+            encoding: Extensible.fieldEncoding_ext_sint32
+        )
+        XCTAssertEqual(
+            message.parseUnknownField(
+                fieldNumber: Extensible.fieldNumber_ext_sint32,
+                type: Int32.self,
+                encoding: Extensible.fieldEncoding_ext_sint32
+            ),
+            -42
+        )
+        // The generated accessor reads the same field the raw APIs just wrote.
+        XCTAssertEqual(message.ext_sint32, -42)
+    }
 }

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -1438,6 +1438,7 @@ class SwiftGenerator private constructor(
               addProperty(defaultProperty)
             }
 
+            // The constants belong on the extended type; the storage pass must skip them or they'd be declared twice.
             if (!forStorageType) {
               addProperty(extensionFieldNumberProperty(field))
               extensionFieldEncodingProperty(field)?.let { addProperty(it) }

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -93,6 +93,7 @@ class SwiftGenerator private constructor(
   private val unknownFields = DeclaredTypeName.typeName("Wire.UnknownFields")
   private val extensibleUnknownFields = DeclaredTypeName.typeName("Wire.ExtensibleUnknownFields")
   private val protoExtensible = DeclaredTypeName.typeName("Wire.ProtoExtensible")
+  private val protoIntEncoding = DeclaredTypeName.typeName("Wire.ProtoIntEncoding")
 
   private val stringLiteralCodingKeys = DeclaredTypeName.typeName("Wire.StringLiteralCodingKeys")
 
@@ -1330,6 +1331,7 @@ class SwiftGenerator private constructor(
             }
 
             addProperty(extensionFieldNumberProperty(field))
+            extensionFieldEncodingProperty(field)?.let { addProperty(it) }
           }
         }
         .build()
@@ -1344,6 +1346,17 @@ class SwiftGenerator private constructor(
     .mutable(false)
     .initializer("%L", field.tag)
     .build()
+
+  // Emitted whenever the accessor passes `encoding:` to parseUnknownField/setUnknownField, so
+  // callers of those APIs can source the (fieldNumber, encoding) pair entirely from codegen.
+  private fun extensionFieldEncodingProperty(field: Field): PropertySpec? {
+    val encoding = field.type!!.encoding ?: return null
+    return PropertySpec.varBuilder("fieldEncoding_${field.safeName}", protoIntEncoding, PUBLIC, STATIC)
+      .addDoc("Integer encoding for the %L extension field.\n", field.safeName)
+      .mutable(false)
+      .initializer(".%N", encoding)
+      .build()
+  }
 
   private fun generateMessageExtensions(
     type: MessageType,
@@ -1427,6 +1440,7 @@ class SwiftGenerator private constructor(
 
             if (!forStorageType) {
               addProperty(extensionFieldNumberProperty(field))
+              extensionFieldEncodingProperty(field)?.let { addProperty(it) }
             }
           }
         }

--- a/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
+++ b/wire-swift-generator/src/main/java/com/squareup/wire/swift/SwiftGenerator.kt
@@ -1328,6 +1328,8 @@ class SwiftGenerator private constructor(
 
               addProperty(defaultProperty)
             }
+
+            addProperty(extensionFieldNumberProperty(field))
           }
         }
         .build()
@@ -1336,6 +1338,12 @@ class SwiftGenerator private constructor(
         .build()
     }
   }
+
+  private fun extensionFieldNumberProperty(field: Field): PropertySpec = PropertySpec.varBuilder("fieldNumber_${field.safeName}", UINT32, PUBLIC, STATIC)
+    .addDoc("Field number for the %L extension field.\n", field.safeName)
+    .mutable(false)
+    .initializer("%L", field.tag)
+    .build()
 
   private fun generateMessageExtensions(
     type: MessageType,
@@ -1415,6 +1423,10 @@ class SwiftGenerator private constructor(
                   .build()
 
               addProperty(defaultProperty)
+            }
+
+            if (!forStorageType) {
+              addProperty(extensionFieldNumberProperty(field))
             }
           }
         }

--- a/wire-swift-generator/src/test/java/com/squareup/wire/swift/SwiftGeneratorTest.kt
+++ b/wire-swift-generator/src/test/java/com/squareup/wire/swift/SwiftGeneratorTest.kt
@@ -164,6 +164,10 @@ class SwiftGeneratorTest {
 
     val code = schema.generateSwift("squareup.protos2.kotlin.BigMessage")
 
+    // Precondition: the message must actually be heap-allocated, or the single-emission
+    // assertion below passes trivially because only one extension block is generated at all.
+    assertThat(code).contains("public struct Storage")
+
     val constant = "public static let fieldNumber_extra: UInt32 = 1000"
     assertThat(code).contains(constant)
     // The constant belongs on the extended type only, not on its CopyOnWrite storage type.

--- a/wire-swift-generator/src/test/java/com/squareup/wire/swift/SwiftGeneratorTest.kt
+++ b/wire-swift-generator/src/test/java/com/squareup/wire/swift/SwiftGeneratorTest.kt
@@ -90,6 +90,40 @@ class SwiftGeneratorTest {
     assertThat(code).contains("public static let fieldNumber_repeated_scalar: UInt32 = 50003")
   }
 
+  @Test fun extensionFieldEncodingsAreExposedAsConstants() {
+    val schema = buildSchema {
+      add(
+        "extensible_message.proto".toPath(),
+        """
+        |syntax = "proto2";
+        |
+        |package squareup.protos2.kotlin;
+        |
+        |message ExtensibleMessage {
+        |  extensions 100 to 200;
+        |}
+        |
+        |extend ExtensibleMessage {
+        |  optional int32 ext_int32 = 100;
+        |  optional sint32 ext_sint32 = 101;
+        |  optional fixed32 ext_fixed32 = 102;
+        |  repeated sint64 rep_ext_sint64 = 103;
+        |  optional string ext_string = 104;
+        |}
+        """.trimMargin(),
+      )
+    }
+
+    val code = schema.generateSwift("squareup.protos2.kotlin.ExtensibleMessage")
+
+    assertThat(code).contains("public static let fieldEncoding_ext_int32: ProtoIntEncoding = .variable")
+    assertThat(code).contains("public static let fieldEncoding_ext_sint32: ProtoIntEncoding = .signed")
+    assertThat(code).contains("public static let fieldEncoding_ext_fixed32: ProtoIntEncoding = .fixed")
+    assertThat(code).contains("public static let fieldEncoding_rep_ext_sint64: ProtoIntEncoding = .signed")
+    // Only integer fields take an explicit encoding in parseUnknownField/setUnknownField.
+    assertThat(code).doesNotContain("fieldEncoding_ext_string")
+  }
+
   @Test fun extensionFieldNumberConstantsAreGeneratedOnceForHeapAllocatedMessages() {
     val schema = buildSchema {
       add(
@@ -122,6 +156,7 @@ class SwiftGeneratorTest {
         |
         |extend BigMessage {
         |  optional string extra = 1000;
+        |  optional sint32 extra_signed = 1001;
         |}
         """.trimMargin(),
       )
@@ -133,6 +168,10 @@ class SwiftGeneratorTest {
     assertThat(code).contains(constant)
     // The constant belongs on the extended type only, not on its CopyOnWrite storage type.
     assertThat(code.indexOf(constant)).isEqualTo(code.lastIndexOf(constant))
+
+    val encodingConstant = "public static let fieldEncoding_extra_signed: ProtoIntEncoding = .signed"
+    assertThat(code).contains(encodingConstant)
+    assertThat(code.indexOf(encodingConstant)).isEqualTo(code.lastIndexOf(encodingConstant))
   }
 
   @Test fun usesFieldMask() {

--- a/wire-swift-generator/src/test/java/com/squareup/wire/swift/SwiftGeneratorTest.kt
+++ b/wire-swift-generator/src/test/java/com/squareup/wire/swift/SwiftGeneratorTest.kt
@@ -18,6 +18,7 @@ package com.squareup.wire.swift
 import assertk.assertThat
 import assertk.assertions.contains
 import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
 import com.squareup.wire.buildSchema
 import com.squareup.wire.schema.Schema
 import io.outfoxx.swiftpoet.FileSpec
@@ -62,6 +63,76 @@ class SwiftGeneratorTest {
 
     assertThat(code).contains("public var repeated_scalar: [String] {")
     assertThat(code).contains("self.parseUnknownField(fieldNumber: 50003)")
+  }
+
+  @Test fun extensionFieldNumbersAreExposedAsConstants() {
+    val schema = buildSchema {
+      add(
+        "custom_options.proto".toPath(),
+        """
+        |syntax = "proto3";
+        |
+        |package squareup.protos3.kotlin.custom_options;
+        |
+        |import "google/protobuf/descriptor.proto";
+        |
+        |extend google.protobuf.MessageOptions {
+        |  string implicit_scalar = 50001;
+        |  repeated string repeated_scalar = 50003;
+        |}
+        """.trimMargin(),
+      )
+    }
+
+    val code = schema.generateSwift("google.protobuf.MessageOptions")
+
+    assertThat(code).contains("public static let fieldNumber_implicit_scalar: UInt32 = 50001")
+    assertThat(code).contains("public static let fieldNumber_repeated_scalar: UInt32 = 50003")
+  }
+
+  @Test fun extensionFieldNumberConstantsAreGeneratedOnceForHeapAllocatedMessages() {
+    val schema = buildSchema {
+      add(
+        "big_message.proto".toPath(),
+        """
+        |syntax = "proto2";
+        |
+        |package squareup.protos2.kotlin;
+        |
+        |message BigMessage {
+        |  optional int32 f1 = 1;
+        |  optional int32 f2 = 2;
+        |  optional int32 f3 = 3;
+        |  optional int32 f4 = 4;
+        |  optional int32 f5 = 5;
+        |  optional int32 f6 = 6;
+        |  optional int32 f7 = 7;
+        |  optional int32 f8 = 8;
+        |  optional int32 f9 = 9;
+        |  optional int32 f10 = 10;
+        |  optional int32 f11 = 11;
+        |  optional int32 f12 = 12;
+        |  optional int32 f13 = 13;
+        |  optional int32 f14 = 14;
+        |  optional int32 f15 = 15;
+        |  optional int32 f16 = 16;
+        |
+        |  extensions 1000 to 1999;
+        |}
+        |
+        |extend BigMessage {
+        |  optional string extra = 1000;
+        |}
+        """.trimMargin(),
+      )
+    }
+
+    val code = schema.generateSwift("squareup.protos2.kotlin.BigMessage")
+
+    val constant = "public static let fieldNumber_extra: UInt32 = 1000"
+    assertThat(code).contains(constant)
+    // The constant belongs on the extended type only, not on its CopyOnWrite storage type.
+    assertThat(code.indexOf(constant)).isEqualTo(code.lastIndexOf(constant))
   }
 
   @Test fun usesFieldMask() {

--- a/wire-tests-swift/manifest/module_one/SwiftModuleOneMessage.swift
+++ b/wire-tests-swift/manifest/module_one/SwiftModuleOneMessage.swift
@@ -38,6 +38,10 @@ extension SwiftModuleOneMessage {
      * Default value for extension_message extension field.
      */
     public static let default_extension_message: ExtensionMessage = .defaultedValue
+    /**
+     * Field number for the extension_message extension field.
+     */
+    public static let fieldNumber_extension_message: UInt32 = 1000
 }
 
 #if !WIRE_REMOVE_EQUATABLE

--- a/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
@@ -1285,6 +1285,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_int32: Int32 = .defaultedValue
     /**
+     * Field number for the ext_opt_int32 extension field.
+     */
+    public static let fieldNumber_ext_opt_int32: UInt32 = 1001
+    /**
      *
      * Source: all_types.proto
      */
@@ -1300,6 +1304,10 @@ extension AllTypes : ProtoExtensible {
      * Default value for ext_opt_uint32 extension field.
      */
     public static let default_ext_opt_uint32: UInt32 = .defaultedValue
+    /**
+     * Field number for the ext_opt_uint32 extension field.
+     */
+    public static let fieldNumber_ext_opt_uint32: UInt32 = 1002
     /**
      *
      * Source: all_types.proto
@@ -1317,6 +1325,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_sint32: Int32 = .defaultedValue
     /**
+     * Field number for the ext_opt_sint32 extension field.
+     */
+    public static let fieldNumber_ext_opt_sint32: UInt32 = 1003
+    /**
      *
      * Source: all_types.proto
      */
@@ -1332,6 +1344,10 @@ extension AllTypes : ProtoExtensible {
      * Default value for ext_opt_fixed32 extension field.
      */
     public static let default_ext_opt_fixed32: UInt32 = .defaultedValue
+    /**
+     * Field number for the ext_opt_fixed32 extension field.
+     */
+    public static let fieldNumber_ext_opt_fixed32: UInt32 = 1004
     /**
      *
      * Source: all_types.proto
@@ -1349,6 +1365,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_sfixed32: Int32 = .defaultedValue
     /**
+     * Field number for the ext_opt_sfixed32 extension field.
+     */
+    public static let fieldNumber_ext_opt_sfixed32: UInt32 = 1005
+    /**
      *
      * Source: all_types.proto
      */
@@ -1364,6 +1384,10 @@ extension AllTypes : ProtoExtensible {
      * Default value for ext_opt_int64 extension field.
      */
     public static let default_ext_opt_int64: Int64 = .defaultedValue
+    /**
+     * Field number for the ext_opt_int64 extension field.
+     */
+    public static let fieldNumber_ext_opt_int64: UInt32 = 1006
     /**
      *
      * Source: all_types.proto
@@ -1381,6 +1405,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_uint64: UInt64 = .defaultedValue
     /**
+     * Field number for the ext_opt_uint64 extension field.
+     */
+    public static let fieldNumber_ext_opt_uint64: UInt32 = 1007
+    /**
      *
      * Source: all_types.proto
      */
@@ -1396,6 +1424,10 @@ extension AllTypes : ProtoExtensible {
      * Default value for ext_opt_sint64 extension field.
      */
     public static let default_ext_opt_sint64: Int64 = .defaultedValue
+    /**
+     * Field number for the ext_opt_sint64 extension field.
+     */
+    public static let fieldNumber_ext_opt_sint64: UInt32 = 1008
     /**
      *
      * Source: all_types.proto
@@ -1413,6 +1445,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_fixed64: UInt64 = .defaultedValue
     /**
+     * Field number for the ext_opt_fixed64 extension field.
+     */
+    public static let fieldNumber_ext_opt_fixed64: UInt32 = 1009
+    /**
      *
      * Source: all_types.proto
      */
@@ -1428,6 +1464,10 @@ extension AllTypes : ProtoExtensible {
      * Default value for ext_opt_sfixed64 extension field.
      */
     public static let default_ext_opt_sfixed64: Int64 = .defaultedValue
+    /**
+     * Field number for the ext_opt_sfixed64 extension field.
+     */
+    public static let fieldNumber_ext_opt_sfixed64: UInt32 = 1010
     /**
      *
      * Source: all_types.proto
@@ -1445,6 +1485,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_bool: Bool = .defaultedValue
     /**
+     * Field number for the ext_opt_bool extension field.
+     */
+    public static let fieldNumber_ext_opt_bool: UInt32 = 1011
+    /**
      *
      * Source: all_types.proto
      */
@@ -1460,6 +1504,10 @@ extension AllTypes : ProtoExtensible {
      * Default value for ext_opt_float extension field.
      */
     public static let default_ext_opt_float: Float = .defaultedValue
+    /**
+     * Field number for the ext_opt_float extension field.
+     */
+    public static let fieldNumber_ext_opt_float: UInt32 = 1012
     /**
      *
      * Source: all_types.proto
@@ -1477,6 +1525,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_double: Double = .defaultedValue
     /**
+     * Field number for the ext_opt_double extension field.
+     */
+    public static let fieldNumber_ext_opt_double: UInt32 = 1013
+    /**
      *
      * Source: all_types.proto
      */
@@ -1492,6 +1544,10 @@ extension AllTypes : ProtoExtensible {
      * Default value for ext_opt_string extension field.
      */
     public static let default_ext_opt_string: String = .defaultedValue
+    /**
+     * Field number for the ext_opt_string extension field.
+     */
+    public static let fieldNumber_ext_opt_string: UInt32 = 1014
     /**
      *
      * Source: all_types.proto
@@ -1509,6 +1565,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_bytes: Foundation.Data = .defaultedValue
     /**
+     * Field number for the ext_opt_bytes extension field.
+     */
+    public static let fieldNumber_ext_opt_bytes: UInt32 = 1015
+    /**
      *
      * Source: all_types.proto
      */
@@ -1520,6 +1580,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_opt_nested_enum = newValue
         }
     }
+    /**
+     * Field number for the ext_opt_nested_enum extension field.
+     */
+    public static let fieldNumber_ext_opt_nested_enum: UInt32 = 1016
     /**
      *
      * Source: all_types.proto
@@ -1537,6 +1601,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let default_ext_opt_nested_message: AllTypes.NestedMessage = .defaultedValue
     /**
+     * Field number for the ext_opt_nested_message extension field.
+     */
+    public static let fieldNumber_ext_opt_nested_message: UInt32 = 1017
+    /**
      *
      * Source: all_types.proto
      */
@@ -1548,6 +1616,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_int32 = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_int32 extension field.
+     */
+    public static let fieldNumber_ext_rep_int32: UInt32 = 1101
     /**
      *
      * Source: all_types.proto
@@ -1561,6 +1633,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_uint32 extension field.
+     */
+    public static let fieldNumber_ext_rep_uint32: UInt32 = 1102
+    /**
      *
      * Source: all_types.proto
      */
@@ -1572,6 +1648,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_sint32 = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_sint32 extension field.
+     */
+    public static let fieldNumber_ext_rep_sint32: UInt32 = 1103
     /**
      *
      * Source: all_types.proto
@@ -1585,6 +1665,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_fixed32 extension field.
+     */
+    public static let fieldNumber_ext_rep_fixed32: UInt32 = 1104
+    /**
      *
      * Source: all_types.proto
      */
@@ -1596,6 +1680,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_sfixed32 = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_sfixed32 extension field.
+     */
+    public static let fieldNumber_ext_rep_sfixed32: UInt32 = 1105
     /**
      *
      * Source: all_types.proto
@@ -1609,6 +1697,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_int64 extension field.
+     */
+    public static let fieldNumber_ext_rep_int64: UInt32 = 1106
+    /**
      *
      * Source: all_types.proto
      */
@@ -1620,6 +1712,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_uint64 = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_uint64 extension field.
+     */
+    public static let fieldNumber_ext_rep_uint64: UInt32 = 1107
     /**
      *
      * Source: all_types.proto
@@ -1633,6 +1729,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_sint64 extension field.
+     */
+    public static let fieldNumber_ext_rep_sint64: UInt32 = 1108
+    /**
      *
      * Source: all_types.proto
      */
@@ -1644,6 +1744,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_fixed64 = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_fixed64 extension field.
+     */
+    public static let fieldNumber_ext_rep_fixed64: UInt32 = 1109
     /**
      *
      * Source: all_types.proto
@@ -1657,6 +1761,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_sfixed64 extension field.
+     */
+    public static let fieldNumber_ext_rep_sfixed64: UInt32 = 1110
+    /**
      *
      * Source: all_types.proto
      */
@@ -1668,6 +1776,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_bool = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_bool extension field.
+     */
+    public static let fieldNumber_ext_rep_bool: UInt32 = 1111
     /**
      *
      * Source: all_types.proto
@@ -1681,6 +1793,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_float extension field.
+     */
+    public static let fieldNumber_ext_rep_float: UInt32 = 1112
+    /**
      *
      * Source: all_types.proto
      */
@@ -1692,6 +1808,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_double = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_double extension field.
+     */
+    public static let fieldNumber_ext_rep_double: UInt32 = 1113
     /**
      *
      * Source: all_types.proto
@@ -1705,6 +1825,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_string extension field.
+     */
+    public static let fieldNumber_ext_rep_string: UInt32 = 1114
+    /**
      *
      * Source: all_types.proto
      */
@@ -1716,6 +1840,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_bytes = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_bytes extension field.
+     */
+    public static let fieldNumber_ext_rep_bytes: UInt32 = 1115
     /**
      *
      * Source: all_types.proto
@@ -1729,6 +1857,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_rep_nested_enum extension field.
+     */
+    public static let fieldNumber_ext_rep_nested_enum: UInt32 = 1116
+    /**
      *
      * Source: all_types.proto
      */
@@ -1740,6 +1872,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_rep_nested_message = newValue
         }
     }
+    /**
+     * Field number for the ext_rep_nested_message extension field.
+     */
+    public static let fieldNumber_ext_rep_nested_message: UInt32 = 1117
     /**
      *
      * Source: all_types.proto
@@ -1753,6 +1889,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_pack_int32 extension field.
+     */
+    public static let fieldNumber_ext_pack_int32: UInt32 = 1201
+    /**
      *
      * Source: all_types.proto
      */
@@ -1764,6 +1904,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_pack_uint32 = newValue
         }
     }
+    /**
+     * Field number for the ext_pack_uint32 extension field.
+     */
+    public static let fieldNumber_ext_pack_uint32: UInt32 = 1202
     /**
      *
      * Source: all_types.proto
@@ -1777,6 +1921,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_pack_sint32 extension field.
+     */
+    public static let fieldNumber_ext_pack_sint32: UInt32 = 1203
+    /**
      *
      * Source: all_types.proto
      */
@@ -1788,6 +1936,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_pack_fixed32 = newValue
         }
     }
+    /**
+     * Field number for the ext_pack_fixed32 extension field.
+     */
+    public static let fieldNumber_ext_pack_fixed32: UInt32 = 1204
     /**
      *
      * Source: all_types.proto
@@ -1801,6 +1953,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_pack_sfixed32 extension field.
+     */
+    public static let fieldNumber_ext_pack_sfixed32: UInt32 = 1205
+    /**
      *
      * Source: all_types.proto
      */
@@ -1812,6 +1968,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_pack_int64 = newValue
         }
     }
+    /**
+     * Field number for the ext_pack_int64 extension field.
+     */
+    public static let fieldNumber_ext_pack_int64: UInt32 = 1206
     /**
      *
      * Source: all_types.proto
@@ -1825,6 +1985,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_pack_uint64 extension field.
+     */
+    public static let fieldNumber_ext_pack_uint64: UInt32 = 1207
+    /**
      *
      * Source: all_types.proto
      */
@@ -1836,6 +2000,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_pack_sint64 = newValue
         }
     }
+    /**
+     * Field number for the ext_pack_sint64 extension field.
+     */
+    public static let fieldNumber_ext_pack_sint64: UInt32 = 1208
     /**
      *
      * Source: all_types.proto
@@ -1849,6 +2017,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_pack_fixed64 extension field.
+     */
+    public static let fieldNumber_ext_pack_fixed64: UInt32 = 1209
+    /**
      *
      * Source: all_types.proto
      */
@@ -1860,6 +2032,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_pack_sfixed64 = newValue
         }
     }
+    /**
+     * Field number for the ext_pack_sfixed64 extension field.
+     */
+    public static let fieldNumber_ext_pack_sfixed64: UInt32 = 1210
     /**
      *
      * Source: all_types.proto
@@ -1873,6 +2049,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_pack_bool extension field.
+     */
+    public static let fieldNumber_ext_pack_bool: UInt32 = 1211
+    /**
      *
      * Source: all_types.proto
      */
@@ -1884,6 +2064,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_pack_float = newValue
         }
     }
+    /**
+     * Field number for the ext_pack_float extension field.
+     */
+    public static let fieldNumber_ext_pack_float: UInt32 = 1212
     /**
      *
      * Source: all_types.proto
@@ -1897,6 +2081,10 @@ extension AllTypes : ProtoExtensible {
         }
     }
     /**
+     * Field number for the ext_pack_double extension field.
+     */
+    public static let fieldNumber_ext_pack_double: UInt32 = 1213
+    /**
      *
      * Source: all_types.proto
      */
@@ -1908,6 +2096,10 @@ extension AllTypes : ProtoExtensible {
             storage.ext_pack_nested_enum = newValue
         }
     }
+    /**
+     * Field number for the ext_pack_nested_enum extension field.
+     */
+    public static let fieldNumber_ext_pack_nested_enum: UInt32 = 1216
 }
 
 #if !WIRE_REMOVE_EQUATABLE

--- a/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/AllTypes.swift
@@ -1289,6 +1289,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_opt_int32: UInt32 = 1001
     /**
+     * Integer encoding for the ext_opt_int32 extension field.
+     */
+    public static let fieldEncoding_ext_opt_int32: ProtoIntEncoding = .variable
+    /**
      *
      * Source: all_types.proto
      */
@@ -1308,6 +1312,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_opt_uint32 extension field.
      */
     public static let fieldNumber_ext_opt_uint32: UInt32 = 1002
+    /**
+     * Integer encoding for the ext_opt_uint32 extension field.
+     */
+    public static let fieldEncoding_ext_opt_uint32: ProtoIntEncoding = .variable
     /**
      *
      * Source: all_types.proto
@@ -1329,6 +1337,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_opt_sint32: UInt32 = 1003
     /**
+     * Integer encoding for the ext_opt_sint32 extension field.
+     */
+    public static let fieldEncoding_ext_opt_sint32: ProtoIntEncoding = .signed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1348,6 +1360,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_opt_fixed32 extension field.
      */
     public static let fieldNumber_ext_opt_fixed32: UInt32 = 1004
+    /**
+     * Integer encoding for the ext_opt_fixed32 extension field.
+     */
+    public static let fieldEncoding_ext_opt_fixed32: ProtoIntEncoding = .fixed
     /**
      *
      * Source: all_types.proto
@@ -1369,6 +1385,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_opt_sfixed32: UInt32 = 1005
     /**
+     * Integer encoding for the ext_opt_sfixed32 extension field.
+     */
+    public static let fieldEncoding_ext_opt_sfixed32: ProtoIntEncoding = .fixed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1388,6 +1408,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_opt_int64 extension field.
      */
     public static let fieldNumber_ext_opt_int64: UInt32 = 1006
+    /**
+     * Integer encoding for the ext_opt_int64 extension field.
+     */
+    public static let fieldEncoding_ext_opt_int64: ProtoIntEncoding = .variable
     /**
      *
      * Source: all_types.proto
@@ -1409,6 +1433,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_opt_uint64: UInt32 = 1007
     /**
+     * Integer encoding for the ext_opt_uint64 extension field.
+     */
+    public static let fieldEncoding_ext_opt_uint64: ProtoIntEncoding = .variable
+    /**
      *
      * Source: all_types.proto
      */
@@ -1428,6 +1456,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_opt_sint64 extension field.
      */
     public static let fieldNumber_ext_opt_sint64: UInt32 = 1008
+    /**
+     * Integer encoding for the ext_opt_sint64 extension field.
+     */
+    public static let fieldEncoding_ext_opt_sint64: ProtoIntEncoding = .signed
     /**
      *
      * Source: all_types.proto
@@ -1449,6 +1481,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_opt_fixed64: UInt32 = 1009
     /**
+     * Integer encoding for the ext_opt_fixed64 extension field.
+     */
+    public static let fieldEncoding_ext_opt_fixed64: ProtoIntEncoding = .fixed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1468,6 +1504,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_opt_sfixed64 extension field.
      */
     public static let fieldNumber_ext_opt_sfixed64: UInt32 = 1010
+    /**
+     * Integer encoding for the ext_opt_sfixed64 extension field.
+     */
+    public static let fieldEncoding_ext_opt_sfixed64: ProtoIntEncoding = .fixed
     /**
      *
      * Source: all_types.proto
@@ -1621,6 +1661,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_rep_int32: UInt32 = 1101
     /**
+     * Integer encoding for the ext_rep_int32 extension field.
+     */
+    public static let fieldEncoding_ext_rep_int32: ProtoIntEncoding = .variable
+    /**
      *
      * Source: all_types.proto
      */
@@ -1636,6 +1680,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_rep_uint32 extension field.
      */
     public static let fieldNumber_ext_rep_uint32: UInt32 = 1102
+    /**
+     * Integer encoding for the ext_rep_uint32 extension field.
+     */
+    public static let fieldEncoding_ext_rep_uint32: ProtoIntEncoding = .variable
     /**
      *
      * Source: all_types.proto
@@ -1653,6 +1701,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_rep_sint32: UInt32 = 1103
     /**
+     * Integer encoding for the ext_rep_sint32 extension field.
+     */
+    public static let fieldEncoding_ext_rep_sint32: ProtoIntEncoding = .signed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1668,6 +1720,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_rep_fixed32 extension field.
      */
     public static let fieldNumber_ext_rep_fixed32: UInt32 = 1104
+    /**
+     * Integer encoding for the ext_rep_fixed32 extension field.
+     */
+    public static let fieldEncoding_ext_rep_fixed32: ProtoIntEncoding = .fixed
     /**
      *
      * Source: all_types.proto
@@ -1685,6 +1741,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_rep_sfixed32: UInt32 = 1105
     /**
+     * Integer encoding for the ext_rep_sfixed32 extension field.
+     */
+    public static let fieldEncoding_ext_rep_sfixed32: ProtoIntEncoding = .fixed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1700,6 +1760,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_rep_int64 extension field.
      */
     public static let fieldNumber_ext_rep_int64: UInt32 = 1106
+    /**
+     * Integer encoding for the ext_rep_int64 extension field.
+     */
+    public static let fieldEncoding_ext_rep_int64: ProtoIntEncoding = .variable
     /**
      *
      * Source: all_types.proto
@@ -1717,6 +1781,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_rep_uint64: UInt32 = 1107
     /**
+     * Integer encoding for the ext_rep_uint64 extension field.
+     */
+    public static let fieldEncoding_ext_rep_uint64: ProtoIntEncoding = .variable
+    /**
      *
      * Source: all_types.proto
      */
@@ -1732,6 +1800,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_rep_sint64 extension field.
      */
     public static let fieldNumber_ext_rep_sint64: UInt32 = 1108
+    /**
+     * Integer encoding for the ext_rep_sint64 extension field.
+     */
+    public static let fieldEncoding_ext_rep_sint64: ProtoIntEncoding = .signed
     /**
      *
      * Source: all_types.proto
@@ -1749,6 +1821,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_rep_fixed64: UInt32 = 1109
     /**
+     * Integer encoding for the ext_rep_fixed64 extension field.
+     */
+    public static let fieldEncoding_ext_rep_fixed64: ProtoIntEncoding = .fixed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1764,6 +1840,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_rep_sfixed64 extension field.
      */
     public static let fieldNumber_ext_rep_sfixed64: UInt32 = 1110
+    /**
+     * Integer encoding for the ext_rep_sfixed64 extension field.
+     */
+    public static let fieldEncoding_ext_rep_sfixed64: ProtoIntEncoding = .fixed
     /**
      *
      * Source: all_types.proto
@@ -1893,6 +1973,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_pack_int32: UInt32 = 1201
     /**
+     * Integer encoding for the ext_pack_int32 extension field.
+     */
+    public static let fieldEncoding_ext_pack_int32: ProtoIntEncoding = .variable
+    /**
      *
      * Source: all_types.proto
      */
@@ -1908,6 +1992,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_pack_uint32 extension field.
      */
     public static let fieldNumber_ext_pack_uint32: UInt32 = 1202
+    /**
+     * Integer encoding for the ext_pack_uint32 extension field.
+     */
+    public static let fieldEncoding_ext_pack_uint32: ProtoIntEncoding = .variable
     /**
      *
      * Source: all_types.proto
@@ -1925,6 +2013,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_pack_sint32: UInt32 = 1203
     /**
+     * Integer encoding for the ext_pack_sint32 extension field.
+     */
+    public static let fieldEncoding_ext_pack_sint32: ProtoIntEncoding = .signed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1940,6 +2032,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_pack_fixed32 extension field.
      */
     public static let fieldNumber_ext_pack_fixed32: UInt32 = 1204
+    /**
+     * Integer encoding for the ext_pack_fixed32 extension field.
+     */
+    public static let fieldEncoding_ext_pack_fixed32: ProtoIntEncoding = .fixed
     /**
      *
      * Source: all_types.proto
@@ -1957,6 +2053,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_pack_sfixed32: UInt32 = 1205
     /**
+     * Integer encoding for the ext_pack_sfixed32 extension field.
+     */
+    public static let fieldEncoding_ext_pack_sfixed32: ProtoIntEncoding = .fixed
+    /**
      *
      * Source: all_types.proto
      */
@@ -1972,6 +2072,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_pack_int64 extension field.
      */
     public static let fieldNumber_ext_pack_int64: UInt32 = 1206
+    /**
+     * Integer encoding for the ext_pack_int64 extension field.
+     */
+    public static let fieldEncoding_ext_pack_int64: ProtoIntEncoding = .variable
     /**
      *
      * Source: all_types.proto
@@ -1989,6 +2093,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_pack_uint64: UInt32 = 1207
     /**
+     * Integer encoding for the ext_pack_uint64 extension field.
+     */
+    public static let fieldEncoding_ext_pack_uint64: ProtoIntEncoding = .variable
+    /**
      *
      * Source: all_types.proto
      */
@@ -2004,6 +2112,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_pack_sint64 extension field.
      */
     public static let fieldNumber_ext_pack_sint64: UInt32 = 1208
+    /**
+     * Integer encoding for the ext_pack_sint64 extension field.
+     */
+    public static let fieldEncoding_ext_pack_sint64: ProtoIntEncoding = .signed
     /**
      *
      * Source: all_types.proto
@@ -2021,6 +2133,10 @@ extension AllTypes : ProtoExtensible {
      */
     public static let fieldNumber_ext_pack_fixed64: UInt32 = 1209
     /**
+     * Integer encoding for the ext_pack_fixed64 extension field.
+     */
+    public static let fieldEncoding_ext_pack_fixed64: ProtoIntEncoding = .fixed
+    /**
      *
      * Source: all_types.proto
      */
@@ -2036,6 +2152,10 @@ extension AllTypes : ProtoExtensible {
      * Field number for the ext_pack_sfixed64 extension field.
      */
     public static let fieldNumber_ext_pack_sfixed64: UInt32 = 1210
+    /**
+     * Integer encoding for the ext_pack_sfixed64 extension field.
+     */
+    public static let fieldEncoding_ext_pack_sfixed64: ProtoIntEncoding = .fixed
     /**
      *
      * Source: all_types.proto

--- a/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
+++ b/wire-tests-swift/no-manifest/src/main/swift/FooBar.swift
@@ -46,6 +46,10 @@ extension FooBar {
         }
     }
     /**
+     * Field number for the ext extension field.
+     */
+    public static let fieldNumber_ext: UInt32 = 101
+    /**
      *
      * Source: custom_options.proto
      */
@@ -57,6 +61,10 @@ extension FooBar {
             self.setUnknownField(fieldNumber: 102, newValue: newValue)
         }
     }
+    /**
+     * Field number for the rep extension field.
+     */
+    public static let fieldNumber_rep: UInt32 = 102
     /**
      *
      * Source: custom_options.proto
@@ -73,6 +81,10 @@ extension FooBar {
      * Default value for more_string extension field.
      */
     public static let default_more_string: String = .defaultedValue
+    /**
+     * Field number for the more_string extension field.
+     */
+    public static let fieldNumber_more_string: UInt32 = 150
 }
 
 #if !WIRE_REMOVE_EQUATABLE


### PR DESCRIPTION
## What

The Swift code generator now emits `public static let` constants alongside every generated extension accessor, mirroring the existing `default_<name>` constants:

- `fieldNumber_<name>: UInt32` for every extension field
- `fieldEncoding_<name>: ProtoIntEncoding` for integer extension fields, whose accessors pass an explicit `encoding:`

```swift
extension FooBar {
    public var ext: FooBar.FooBarBazEnum? {
        get { ... }
        set { ... }
    }
    /**
     * Field number for the ext extension field.
     */
    public static let fieldNumber_ext: UInt32 = 101
}

extension AllTypes {
    public var ext_opt_sint32: Int32? {
        get { self.parseUnknownField(fieldNumber: 1003, type: Int32.self, encoding: .signed) }
        set { self.setUnknownField(fieldNumber: 1003, newValue: newValue, encoding: .signed) }
    }
    /**
     * Field number for the ext_opt_sint32 extension field.
     */
    public static let fieldNumber_ext_opt_sint32: UInt32 = 1003
    /**
     * Integer encoding for the ext_opt_sint32 extension field.
     */
    public static let fieldEncoding_ext_opt_sint32: ProtoIntEncoding = .signed
}
```

## Why

The generated extension accessors hardcode their decoding behavior: `try? ProtoDecoder().decode(...)`, i.e. the default `.throwError` enum strategy with the error swallowed. Consumers that need different semantics — a `.returnNil` decoder so a single unrecognized enum value doesn't nil the entire payload, or an `unknownFields[tag]` presence check to distinguish an absent extension from an undecodable one — must call `parseUnknownField`/`setUnknownField` directly, and those APIs take a raw `fieldNumber: UInt32` plus, for integer fields, an `encoding: ProtoIntEncoding`.

Today no generated symbol carries either value: callers copy the literals out of the `.proto` source by hand, and nothing keeps the copies in sync with codegen. A wrong field number or encoding silently decodes wrong instead of failing to compile. (GPB exposes the same information via `GPBExtensionDescriptor`; Wire has no Swift equivalent.) We hit this while migrating envelopes — a proto2 message whose payloads are all extensions — from GPB to Wire: extension field numbers had to be hardcoded and pinned with hand-written tag-agreement tests. With this change the constants come from codegen, so they are contract-checked at the source.

Scope notes:

- The `fieldNumber_` constant is generated for every extension field, including repeated fields (which get no `default_` constant).
- The `fieldEncoding_` constant is generated exactly when the generated accessor passes `encoding:` — signed, fixed, and variable integer fields, singular and repeated — so the (fieldNumber, encoding) pair travels together. Non-integer fields have no `encoding:` parameter and get no constant.
- For heap-allocated (CopyOnWrite) messages the constants are emitted on the extended type only, not again on its `Storage` type.
- Naming follows the `default_<name>` precedent; the types are `UInt32` and `ProtoIntEncoding` so the constants can be passed straight to `parseUnknownField`/`setUnknownField`.

## Testing

- Three new `SwiftGeneratorTest` cases: field-number constants for singular and repeated extension fields; encoding constants for variable/signed/fixed integer fields (and their absence on non-integer fields); and single emission (extended type only) for heap-allocated messages, with a `public struct Storage` precondition so the single-emission assertions cannot pass trivially.
- A Swift-side `ExtensibleTests` case reads the constants off real generated types (`Extensible`, `LargeExtensible`) and round-trips a value through `setUnknownField`/`parseUnknownField` using only generated constants.
- Goldens regenerated with `./gradlew generateTests` (`AllTypes`, `FooBar`, `SwiftModuleOneMessage`); `git status` is byte-clean after a fresh regeneration.
- `swift test` passes locally on macOS.

Suggested CHANGELOG entry (left out of the diff since entries appear to be authored at release time):

> * New: Swift — generated extension accessors are now accompanied by `fieldNumber_<name>` constants (and, for integer fields, `fieldEncoding_<name>` constants) exposing the extension's field number and wire encoding, mirroring the existing `default_<name>` constants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
