### PR TITLE
Revert Kotlin to 2.3.21 and pin the JVM module name

### DIFF
--- a/build-support/src/main/kotlin/com/squareup/wire/buildsupport/WireBuildPlugin.kt
+++ b/build-support/src/main/kotlin/com/squareup/wire/buildsupport/WireBuildPlugin.kt
@@ -233,6 +233,19 @@ class WireBuildPlugin : Plugin<Project> {
         freeCompilerArgs.add("-Xjvm-default=all")
       }
     }
+    // Kotlin 2.4 changed the default JVM module name from the project name to a name derived
+    // from the Maven coordinates. The compiler mangles the module name into the accessors of
+    // internal members, so `getCachedSerializedSize$wire_runtime` became
+    // `getCachedSerializedSize$com_squareup_wire_wire_runtime`. Reflection-based serializers can
+    // embed those accessor names in persisted payloads, so pin the module name to keep the
+    // mangling stable across Kotlin versions. Main compilations only ("compileKotlin" in JVM
+    // modules, "compileKotlinJvm" in the jvm target of multiplatform modules); test module names
+    // keep their defaults.
+    tasks.withType(KotlinJvmCompile::class.java).configureEach {
+      if (name == "compileKotlin" || name == "compileKotlinJvm") {
+        compilerOptions.moduleName.set(project.name)
+      }
+    }
     // Kotlin requires the Java compatibility matches.
     tasks.withType(JavaCompile::class.java).configureEach {
       sourceCompatibility = javaVersion.toString()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ jimfs = "1.3.2"
 jmh = "1.37"
 jsr305 = "3.0.2"
 junit = "4.13.2"
-kotlin = "2.4.10"
+kotlin = "2.3.21"
 # Set to lower version than KGP version to maximize compatibility
 kotlinCoreLibrariesVersion = "2.0.21"
 kotlinpoet = "2.3.0"

--- a/kotlin-js-store/yarn.lock
+++ b/kotlin-js-store/yarn.lock
@@ -1789,16 +1789,7 @@ streamroller@^3.1.5:
     debug "^4.3.4"
     fs-extra "^8.1.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -1816,14 +1807,7 @@ string-width@^5.0.1, string-width@^5.1.2:
     emoji-regex "^9.2.2"
     strip-ansi "^7.0.1"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -2067,16 +2051,7 @@ workerpool@^9.2.0:
   resolved "https://registry.yarnpkg.com/workerpool/-/workerpool-9.3.4.tgz#f6c92395b2141afd78e2a889e80cb338fe9fca41"
   integrity sha512-TmPRQYYSAnnDiEB0P/Ytip7bFGvqnSU6I2BcuSw7Hx+JSg/DsUi5ebYfc8GYaSdpuvOcEs6dXxPurOYpe9QFwg==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==

--- a/wire-schema/api/wire-schema.api
+++ b/wire-schema/api/wire-schema.api
@@ -917,7 +917,7 @@ public final class com/squareup/wire/schema/Service {
 	public static synthetic fun copy$default (Lcom/squareup/wire/schema/Service;Lcom/squareup/wire/schema/ProtoType;Lcom/squareup/wire/schema/Location;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;Lcom/squareup/wire/schema/Options;ILjava/lang/Object;)Lcom/squareup/wire/schema/Service;
 	public final fun documentation ()Ljava/lang/String;
 	public fun equals (Ljava/lang/Object;)Z
-	public static final fun fromElements$com_squareup_wire_wire_schema (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
+	public static final fun fromElements$wire_schema (Ljava/lang/String;Ljava/util/List;)Ljava/util/List;
 	public fun hashCode ()I
 	public final fun link (Lcom/squareup/wire/schema/Linker;)V
 	public final fun linkOptions (Lcom/squareup/wire/schema/Linker;Z)V
@@ -927,7 +927,7 @@ public final class com/squareup/wire/schema/Service {
 	public final fun retainAll (Lcom/squareup/wire/schema/Schema;Lcom/squareup/wire/schema/MarkSet;)Lcom/squareup/wire/schema/Service;
 	public final fun rpc (Ljava/lang/String;)Lcom/squareup/wire/schema/Rpc;
 	public final fun rpcs ()Ljava/util/List;
-	public static final fun toElements$com_squareup_wire_wire_schema (Ljava/util/List;)Ljava/util/List;
+	public static final fun toElements$wire_schema (Ljava/util/List;)Ljava/util/List;
 	public fun toString ()Ljava/lang/String;
 	public final fun type ()Lcom/squareup/wire/schema/ProtoType;
 	public final fun validate (Lcom/squareup/wire/schema/Linker;)V


### PR DESCRIPTION
Kotlin 2.4 changed the default JVM module name from the project name to a name derived from the Maven coordinates. The compiler mangles the module name into the accessors of internal members: `getCachedSerializedSize$wire_runtime` became `getCachedSerializedSize$com_squareup_wire_wire_runtime`. Reflection-based serializers such as Jackson see Wire messages through those accessors. Payloads persisted under one Kotlin version then fail strict deserialization under the other. This broke Temporal workflow replay in cash-server: https://buildkite.com/cash/cash-server/builds/598441 (`CreateOrderWorkflowV2ReplayTest`, `CreateOrderWorkflowV3ReplayTest`).

This PR reverts Kotlin to 2.3.21 and pins the JVM module name so the mangling cannot move again with the next Kotlin bump.

Scope notes:
- Only the Kotlin version line of #3681 is reverted. The js sample removal and the Kotlin/JS plugin drop from that PR stay.
- `wire-schema/api/wire-schema.api` is reverted to the pre-#3681 dump. With 2.3.21 and the pin, `apiCheck` passes.
- `kotlin-js-store/yarn.lock` is regenerated with `kotlinUpgradeYarnLock` under 2.3.21. Only lock-entry grouping changes; all dependency versions are the same.
- The moduleName pin in `WireBuildPlugin` is an addition, not part of the revert. Under 2.3.21 it is a no-op for published jars. It applies to main compilations only (`compileKotlin`, `compileKotlinJvm`); test compilations keep their default module names. Strip it if unwanted.

Renovate caveat: a future Kotlin 2.4 bump is safe only with the pin in place. Without the pin, the mangled accessor names change again and persisted payloads break in both directions.

Verification:
- Pin proof under 2.4.10 (pin applied, toml still at 2.4.10): the `wire-runtime` jvm jar contains `META-INF/wire-runtime.kotlin_module`, and `javap` of `com.squareup.wire.Message` shows `getCachedSerializedSize$wire_runtime`.
- At this commit (2.3.21 plus pin): same jar facts. `wire-runtime` jvmTest passes 65/65. `wire-schema` apiCheck and spotless pass. Test compilations still produce `wire-runtime_test.kotlin_module`.
- End to end: published this commit to mavenLocal as a throwaway version and ran both cash-server replay test classes against it. 6 tests, 0 failures.
