### PR TITLE
Generate protos into commonMain for multiplatform projects with an Android target

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+### Gradle plugin
+
+* Fix: generate protos into commonMain again for Kotlin multiplatform projects with an Android target (#3688)
+
 Version 7.0.0-alpha09
 ---------------------
 

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/WirePlugin.kt
@@ -56,7 +56,16 @@ class WirePlugin : Plugin<Project> {
       // When `android.builtInKotlin` property is enabled, AGP provides Kotlin support for all projects without
       // requiring users to apply the `org.jetbrains.kotlin.android` plugin.
       project.extensions.findByName("kotlin")?.let { kotlin.set(true) }
-      applyWirePlugin()
+      if (project.extensions.findByType(KotlinMultiplatformExtension::class.java) != null) {
+        // Multiplatform project with an Android target. Wire generates into commonMain and reads
+        // the wire {} extension eagerly, so the setup must wait for the build script to be
+        // evaluated. This path does not use the Android variant API, so afterEvaluate is safe.
+        project.afterEvaluate { applyWirePlugin() }
+      } else {
+        // The Android setup must run now: the variant API used in forEachWireSource requires
+        // onVariants to be registered before AGP computes its variants.
+        applyWirePlugin()
+      }
     }
     project.plugins.withId("com.android.application", androidPluginHandler)
     project.plugins.withId("com.android.library", androidPluginHandler)

--- a/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
+++ b/wire-gradle-plugin/src/main/kotlin/com/squareup/wire/gradle/kotlin/SourceRoots.kt
@@ -41,6 +41,13 @@ internal fun forEachWireSource(
   sourceHandler: (WireSource) -> Unit,
 ) {
   when {
+    // A multiplatform project can also have an Android target which applies an Android plugin.
+    // The Kotlin Multiplatform check has to come first: Wire generates once into commonMain, and
+    // the Android target consumes commonMain like every other target.
+    hasKotlin && project.extensions.findByType(KotlinMultiplatformExtension::class.java) != null -> {
+      val extension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
+      extension.sourceRoots().forEach(sourceHandler)
+    }
     hasAndroid -> {
       val extension = project.extensions.getByType(AndroidComponentsExtension::class.java)
       extension.onVariants { variant ->
@@ -56,10 +63,6 @@ internal fun forEachWireSource(
         )
         sourceHandler(source)
       }
-    }
-    hasKotlin && project.extensions.findByType(KotlinMultiplatformExtension::class.java) != null -> {
-      val extension = project.extensions.getByType(KotlinMultiplatformExtension::class.java)
-      extension.sourceRoots().forEach(sourceHandler)
     }
     hasKotlin -> {
       val kotlinSourceSets = project.extensions.findByType(KotlinProjectExtension::class.java)?.sourceSets

--- a/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
+++ b/wire-gradle-plugin/src/test/kotlin/com/squareup/wire/gradle/WirePluginTest.kt
@@ -1057,6 +1057,31 @@ class WirePluginTest {
     assertThat(generatedProto2).exists()
   }
 
+  @Test
+  fun kotlinMultiplatformWithAndroidTarget() {
+    val fixtureRoot = File("src/test/projects/kotlin-multiplatform-android")
+
+    val result = fixtureGradleRunner(
+      fixtureRoot,
+      "assemble",
+      "--info",
+      "--no-build-cache",
+    ).build()
+
+    // Wire generates once into commonMain. The Android target consumes commonMain like every
+    // other target, so there must be no per-variant generation task.
+    assertThat(result.task(":generateCommonMainProtos")).isNotNull()
+    assertThat(result.task(":generateDebugProtos")).isNull()
+    assertThat(result.task(":generateReleaseProtos")).isNull()
+
+    val generatedProto1 =
+      File(fixtureRoot, "build/generated/source/wire/com/squareup/dinosaurs/Dinosaur.kt")
+    val generatedProto2 =
+      File(fixtureRoot, "build/generated/source/wire/com/squareup/geology/Period.kt")
+    assertThat(generatedProto1).exists()
+    assertThat(generatedProto2).exists()
+  }
+
   private fun fieldsFromProtoSource(generatedProtoSource: String): List<String> {
     val protoFieldPattern = "@field:WireField.*?(val .*?):"
     val matchedFields = protoFieldPattern.toRegex(setOf(MULTILINE, DOT_MATCHES_ALL))

--- a/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/build.gradle
+++ b/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/build.gradle
@@ -1,0 +1,55 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+buildscript {
+  dependencies {
+    classpath "com.squareup.wire:wire-gradle-plugin:$wireVersion"
+    classpath libs.pluginz.kotlin
+    classpath libs.pluginz.android
+  }
+
+  repositories {
+    maven {
+      url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+    }
+    mavenCentral()
+    google()
+  }
+}
+
+apply plugin: 'org.jetbrains.kotlin.multiplatform'
+apply plugin: 'com.android.library'
+apply plugin: 'com.squareup.wire'
+
+repositories {
+  maven {
+    url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+  }
+  mavenCentral()
+  google()
+}
+
+android {
+  namespace = 'com.squareup.wire.kmpandroid'
+  compileSdk = 36
+}
+
+kotlin {
+  jvm()
+  androidTarget()
+}
+
+wire {
+  kotlin {
+  }
+}
+
+tasks.withType(JavaCompile).configureEach {
+  sourceCompatibility = JavaVersion.VERSION_11.toString()
+  targetCompatibility = JavaVersion.VERSION_11.toString()
+}
+
+tasks.withType(KotlinCompile).configureEach {
+  kotlinOptions {
+    jvmTarget = "11"
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/gradle.properties
+++ b/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/gradle.properties
@@ -1,0 +1,2 @@
+android.builtInKotlin=false
+android.newDsl=false

--- a/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/settings.gradle
+++ b/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/settings.gradle
@@ -1,0 +1,19 @@
+pluginManagement {
+  repositories {
+    maven {
+      url new File(rootDir, "../../../../../build/localMaven").toURI().toString()
+    }
+    google()
+    mavenCentral()
+  }
+}
+
+include ':'
+
+dependencyResolutionManagement {
+  versionCatalogs {
+    libs {
+      from(files('../../../../../gradle/libs.versions.toml'))
+    }
+  }
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/src/commonMain/proto/squareup/dinosaurs/dinosaur.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/src/commonMain/proto/squareup/dinosaurs/dinosaur.proto
@@ -1,0 +1,19 @@
+syntax = "proto2";
+
+package squareup.dinosaurs;
+
+option java_package = "com.squareup.dinosaurs";
+
+import "squareup/geology/period.proto";
+
+message Dinosaur {
+  /** Common name of this dinosaur, like "Stegosaurus". */
+  optional string name = 1;
+
+  /** URLs with images of this dinosaur. */
+  repeated string picture_urls = 2;
+
+  optional double length_meters = 3;
+  optional double mass_kilograms = 4;
+  optional squareup.geology.Period period = 5;
+}

--- a/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/src/commonMain/proto/squareup/geology/period.proto
+++ b/wire-gradle-plugin/src/test/projects/kotlin-multiplatform-android/src/commonMain/proto/squareup/geology/period.proto
@@ -1,0 +1,16 @@
+syntax = "proto2";
+
+package squareup.geology;
+
+option java_package = "com.squareup.geology";
+
+enum Period {
+  /** 145.5 million years ago — 66.0 million years ago. */
+  CRETACEOUS = 1;
+
+  /** 201.3 million years ago — 145.0 million years ago. */
+  JURASSIC = 2;
+
+  /** 252.17 million years ago — 201.3 million years ago. */
+  TRIASSIC = 3;
+}


### PR DESCRIPTION
Fixes #3688.

### Problem

Since 6.0.0-alpha02, a Kotlin multiplatform project with an Android target gets no `generateCommonMainProtos` task. Wire generates into the Android variants only (`generateDebugProtos`, `generateReleaseProtos`). `commonMain` and every non-Android target see no generated code. In 5.5.0, Wire generated once into `commonMain` and every target consumed it.

The trigger is the Android target: `com.android.library` plus `androidTarget()`. A multiplatform project without an Android plugin is not affected. The issue's wire block alone does not reproduce; the Android target does.

### Root cause, two parts

1. #3503 (6.0.0-alpha02) flipped the detection order in `SourceRoots.kt`. `forEachWireSource` checks `hasAndroid` before the Kotlin multiplatform arm. Any project with an Android plugin is treated as an Android-only project.
2. The same rewrite also removed the `afterEvaluate` deferral that 5.5.0 used for Android projects. `applyWirePlugin()` now runs at android-plugin-apply time, before the build script evaluates the `wire {}` block. The Android path tolerates this because `onVariants` defers its callbacks. The multiplatform path reads `extension.outputs` eagerly, so reordering the arms alone wires nothing into the compilations.

### Fix

- `SourceRoots.kt`: the Kotlin multiplatform arm now precedes the `hasAndroid` arm. This restores the 5.5.0 semantics: generate once into `commonMain`, the Android target consumes `commonMain` like every other target.
- `WirePlugin.kt`: when the `KotlinMultiplatformExtension` is present at android-plugin-apply time, the android handler defers `applyWirePlugin()` to `afterEvaluate`. This path does not use the Android variant API, so the deferral is safe, and the `wire {}` block is evaluated by then. Pure Android projects keep the synchronous call that `onVariants` requires.

Known limit: if the build script declares `com.squareup.wire` and the Android plugin before `kotlin("multiplatform")`, the extension is not visible yet when the android handler runs, and Wire still takes the Android path. Declaring the Kotlin plugin first, the common convention, works.

### Test coverage

CI never caught this because the only multiplatform fixture has no Android target. This PR adds the `kotlin-multiplatform-android` fixture (KMP, `com.android.library`, `androidTarget()`, jvm) and a `kotlinMultiplatformWithAndroidTarget` test. The test asserts `generateCommonMainProtos` exists, no per-variant generate task exists, and `assemble` compiles the generated code.

### Verification

- The new test fails on master without the fix (assertion: `:generateCommonMainProtos` is null) and passes with it.
- Full `:wire-gradle-plugin:test` suite green locally, test task forced fresh (`--rerun --no-build-cache`): 104 tests, 0 failures, 5 pre-existing ignores.
- End to end: the reproducer from the issue (two sourcePath blocks, google-common-protos srcJar, protovalidate protoPath, jvm + js + androidTarget) against a locally published plugin. `generateCommonMainProtos` is back, 12 files generate into the commonMain output, and `compileKotlinJvm`, `compileKotlinJs`, `compileDebugKotlinAndroid`, and `compileReleaseKotlinAndroid` all compile them.
