### PR TITLE
Enforce user-set gRPC call timeouts on the client

### DIFF
--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcCall.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcCall.kt
@@ -144,11 +144,17 @@ internal class RealGrpcCall<S : Any, R : Any>(
     val result = grpcClient.newCall(method, requestMetadata, requestBody, timeout)
     this.call = result
     if (canceled) result.cancel()
-    // If the timeout doesn't have a deadline or timeout, then the user
-    // didn't set the timeout on this Call manually.
-    if (!timeout.hasDeadline() && (timeout.timeoutNanos() == 0L)) {
-      (timeout as ForwardingTimeout).setDelegate(result.timeout())
+    // Copy the user-set timeout and deadline onto the OkHttp timeout, which enforces them by
+    // canceling the call. The grpc-timeout header alone is not enforced if the server or a proxy
+    // ignores it.
+    val okHttpTimeout = result.timeout()
+    if (timeout.timeoutNanos() != 0L) {
+      okHttpTimeout.timeout(timeout.timeoutNanos(), TimeUnit.NANOSECONDS)
     }
+    if (timeout.hasDeadline()) {
+      okHttpTimeout.deadlineNanoTime(timeout.deadlineNanoTime())
+    }
+    (timeout as ForwardingTimeout).setDelegate(okHttpTimeout)
     return result
   }
 }

--- a/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcStreamingCall.kt
+++ b/wire-grpc-client/src/jvmMain/kotlin/com/squareup/wire/internal/RealGrpcStreamingCall.kt
@@ -131,7 +131,17 @@ internal class RealGrpcStreamingCall<S : Any, R : Any>(
     val result = grpcClient.newCall(method, requestMetadata, requestBody, timeout)
     this.call = result
     if (canceled) result.cancel()
-    (timeout as ForwardingTimeout).setDelegate(result.timeout())
+    // Copy the user-set timeout and deadline onto the OkHttp timeout, which enforces them by
+    // canceling the call. The grpc-timeout header alone is not enforced if the server or a proxy
+    // ignores it.
+    val okHttpTimeout = result.timeout()
+    if (timeout.timeoutNanos() != 0L) {
+      okHttpTimeout.timeout(timeout.timeoutNanos(), TimeUnit.NANOSECONDS)
+    }
+    if (timeout.hasDeadline()) {
+      okHttpTimeout.deadlineNanoTime(timeout.deadlineNanoTime())
+    }
+    (timeout as ForwardingTimeout).setDelegate(okHttpTimeout)
     return result
   }
 }

--- a/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTimeoutTest.kt
+++ b/wire-grpc-tests/src/test/java/com/squareup/wire/GrpcClientTimeoutTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2026 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.squareup.wire
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isLessThan
+import assertk.assertions.isTrue
+import java.time.Duration
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import okhttp3.mockwebserver.SocketPolicy
+import okio.IOException
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.Timeout
+import routeguide.Point
+import routeguide.RouteGuideClient
+
+/**
+ * Proves that a timeout or a deadline set on a call's [GrpcCall.timeout] is enforced on the
+ * client. The server in these tests receives each request and never responds. It ignores the
+ * `grpc-timeout` request header, like any server or proxy that does not implement gRPC deadlines.
+ * Only client-side enforcement can bound these calls.
+ *
+ * The OkHttpClient has no call timeout, and its read and write timeouts are far above the bounds
+ * that these tests assert. When a call fails fast, the per-call timeout did it.
+ */
+class GrpcClientTimeoutTest {
+  @JvmField @Rule
+  val mockWebServer = MockWebServer()
+
+  @JvmField @Rule
+  val testTimeout = Timeout(30, TimeUnit.SECONDS)
+
+  private lateinit var routeGuideService: RouteGuideClient
+
+  /** Held until the test ends. The dispatcher blocks on it, so responses never go out. */
+  private val dispatcherRelease = CountDownLatch(1)
+
+  @Before
+  fun setUp() {
+    mockWebServer.dispatcher = object : Dispatcher() {
+      override fun dispatch(request: RecordedRequest): MockResponse {
+        dispatcherRelease.await(1, TimeUnit.MINUTES)
+        return MockResponse().apply { socketPolicy = SocketPolicy.NO_RESPONSE }
+      }
+    }
+    mockWebServer.protocols = listOf(Protocol.H2_PRIOR_KNOWLEDGE)
+
+    val okhttpClient = OkHttpClient.Builder()
+      .protocols(listOf(Protocol.H2_PRIOR_KNOWLEDGE))
+      .readTimeout(Duration.ofSeconds(10))
+      .writeTimeout(Duration.ofSeconds(10))
+      .build()
+    val grpcClient = GrpcClient.Builder()
+      .client(okhttpClient)
+      .baseUrl(mockWebServer.url("/"))
+      .build()
+    routeGuideService = grpcClient.create(RouteGuideClient::class)
+  }
+
+  @After
+  fun tearDown() {
+    dispatcherRelease.countDown()
+  }
+
+  @Test
+  fun unaryCallTimeoutIsEnforcedOnClient() {
+    val grpcCall = routeGuideService.GetFeature()
+    grpcCall.timeout.timeout(500, TimeUnit.MILLISECONDS)
+
+    val elapsedMillis = elapsedMillis {
+      assertFailure {
+        grpcCall.executeBlocking(Point(latitude = 5, longitude = 6))
+      }.isInstanceOf<IOException>()
+    }
+
+    assertThat(grpcCall.isCanceled()).isTrue()
+    assertThat(elapsedMillis).isLessThan(5_000L)
+  }
+
+  @Test
+  fun unaryCallDeadlineIsEnforcedOnClient() {
+    val grpcCall = routeGuideService.GetFeature()
+    grpcCall.timeout.deadline(500, TimeUnit.MILLISECONDS)
+
+    val elapsedMillis = elapsedMillis {
+      assertFailure {
+        grpcCall.executeBlocking(Point(latitude = 5, longitude = 6))
+      }.isInstanceOf<IOException>()
+    }
+
+    assertThat(grpcCall.isCanceled()).isTrue()
+    assertThat(elapsedMillis).isLessThan(5_000L)
+  }
+
+  @Test
+  fun streamingCallTimeoutIsEnforcedOnClient() {
+    val grpcCall = routeGuideService.RouteChat()
+    grpcCall.timeout.timeout(500, TimeUnit.MILLISECONDS)
+
+    val (requestSink, responseSource) = grpcCall.executeBlocking()
+    val elapsedMillis = elapsedMillis {
+      assertFailure {
+        responseSource.read()
+      }.isInstanceOf<IOException>()
+    }
+
+    assertThat(grpcCall.isCanceled()).isTrue()
+    assertThat(elapsedMillis).isLessThan(5_000L)
+
+    try {
+      requestSink.close()
+    } catch (_: IOException) {
+      // Closing the request stream of a canceled call may fail. That is fine here.
+    }
+  }
+
+  @Test
+  fun streamingCallDeadlineIsEnforcedOnClient() {
+    val grpcCall = routeGuideService.RouteChat()
+    grpcCall.timeout.deadline(500, TimeUnit.MILLISECONDS)
+
+    val (requestSink, responseSource) = grpcCall.executeBlocking()
+    val elapsedMillis = elapsedMillis {
+      assertFailure {
+        responseSource.read()
+      }.isInstanceOf<IOException>()
+    }
+
+    assertThat(grpcCall.isCanceled()).isTrue()
+    assertThat(elapsedMillis).isLessThan(5_000L)
+
+    try {
+      requestSink.close()
+    } catch (_: IOException) {
+      // Closing the request stream of a canceled call may fail. That is fine here.
+    }
+  }
+
+  private inline fun elapsedMillis(block: () -> Unit): Long {
+    val startNanos = System.nanoTime()
+    block()
+    return (System.nanoTime() - startNanos) / 1_000_000L
+  }
+}


### PR DESCRIPTION
### Problem

A timeout or a deadline set on `GrpcCall.timeout` or `GrpcStreamingCall.timeout` is serialized into the `grpc-timeout` request header, but the client never enforces it.

In `RealGrpcCall.initCall`, the user-set value stays on an inert `Timeout()` delegate and never reaches OkHttp. `RealGrpcStreamingCall.initCall` swaps the delegate after header serialization, which discards the user-set value. In both cases, only the server sees the bound.

If the server or a proxy ignores `grpc-timeout`, or if the connection stalls, nothing bounds the call on the client. For streaming calls the situation is worse: OkHttp does not apply its read timeout to a stalled duplex call, so such a call can hang without any bound at all.

grpc-java does both halves: it sends the header and it runs a client-side deadline timer that cancels the call. Wire only did the header half.

### Fix

`initCall` now copies the user-set timeout and deadline onto the OkHttp per-call timeout before the call starts, then sets the delegate as before. OkHttp cancels the call when the bound is reached, which matches grpc-java semantics.

When the user sets no value, both copies are no-ops and behavior is unchanged: the OkHttpClient defaults apply. The `grpc-timeout` header logic is unchanged. No public API change (`apiCheck` passes without an `.api` update).

### Tests

New `GrpcClientTimeoutTest` (unary and streaming, duration and deadline). The server receives each request and never responds, and it ignores `grpc-timeout`. The client has no call timeout and a 10 s read timeout. Each test sets a 500 ms per-call bound.

On master, the unary tests fail after 10 s (the read timeout fires, not the per-call bound, and the call is not canceled) and the streaming tests block past the 30 s test limit. With the fix, all 4 tests pass in about 0.5 s and the calls cancel client-side.

`:wire-grpc-tests:test` (121 tests), `spotlessCheck`, and `:wire-grpc-client:apiCheck` all pass.

Context: https://github.com/square/wire/discussions/2338#discussioncomment-18185478
