### PR TITLE
Keep wire-generated Kotlin clean under extra compiler checks

### DIFF
--- a/wire-golden-files/build.gradle.kts
+++ b/wire-golden-files/build.gradle.kts
@@ -63,6 +63,23 @@ wire {
   }
 }
 
+// The generated code must stay clean under the Kotlin compiler's extra checks.
+// See https://github.com/square/wire/issues/3700 and https://github.com/square/wire/issues/3701.
+tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile::class.java).configureEach {
+  compilerOptions {
+    extraWarnings.set(true)
+    // KotlinPoet emits explicit visibility modifiers on purpose. Consumers which enable
+    // explicit API mode need them, so this check does not apply to generated code.
+    freeCompilerArgs.add("-Xwarning-level=REDUNDANT_VISIBILITY_MODIFIER:disabled")
+    // Fail the build when these checks flag generated code again. Plain allWarningsAsErrors
+    // is too broad here: it also fails on repo-wide compiler flag deprecation warnings.
+    freeCompilerArgs.add("-Xwarning-level=VARIABLE_INITIALIZER_IS_REDUNDANT:error")
+    freeCompilerArgs.add("-Xwarning-level=CAN_BE_VAL_DELAYED_INITIALIZATION:error")
+    freeCompilerArgs.add("-Xwarning-level=CAN_BE_VAL:error")
+    freeCompilerArgs.add("-Xwarning-level=CAN_BE_VAL_LATEINIT:error")
+  }
+}
+
 tasks.getByName("spotlessJava").dependsOn("generateMainProtos")
 tasks.getByName("spotlessKotlin").dependsOn("generateMainProtos")
 tasks.getByName("spotlessSwift").dependsOn("generateMainProtos")

--- a/wire-golden-files/src/main/kotlin/Field.kt
+++ b/wire-golden-files/src/main/kotlin/Field.kt
@@ -57,10 +57,7 @@ public class Field(
       null,
       "squareup/wire/hundreds_redacted.proto"
     ) {
-      override fun encodedSize(`value`: Field): Int {
-        var size = value.unknownFields.size
-        return size
-      }
+      override fun encodedSize(`value`: Field): Int = value.unknownFields.size
 
       override fun encode(writer: ProtoWriter, `value`: Field) {
         writer.writeBytes(value.unknownFields)

--- a/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutableHeader.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutableHeader.kt
@@ -52,8 +52,7 @@ public class MutableHeader(
   }
 
   override fun hashCode(): Int {
-    var result = 0
-    result = unknownFields.hashCode()
+    var result = unknownFields.hashCode()
     result = result * 37 + (id?.hashCode() ?: 0)
     return result
   }

--- a/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePacket.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePacket.kt
@@ -63,8 +63,7 @@ public class MutablePacket(
   }
 
   override fun hashCode(): Int {
-    var result = 0
-    result = unknownFields.hashCode()
+    var result = unknownFields.hashCode()
     result = result * 37 + (header_?.hashCode() ?: 0)
     result = result * 37 + payload.hashCode()
     return result

--- a/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePayload.kt
+++ b/wire-golden-files/src/main/kotlin/squareup/wire/mutable/MutablePayload.kt
@@ -79,8 +79,7 @@ public class MutablePayload(
   }
 
   override fun hashCode(): Int {
-    var result = 0
-    result = unknownFields.hashCode()
+    var result = unknownFields.hashCode()
     result = result * 37 + (preamble?.hashCode() ?: 0)
     result = result * 37 + (content?.hashCode() ?: 0)
     result = result * 37 + (type?.hashCode() ?: 0)

--- a/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
+++ b/wire-kotlin-generator/src/main/java/com/squareup/wire/kotlin/KotlinGenerator.kt
@@ -889,10 +889,10 @@ class KotlinGenerator private constructor(
       if (!mutableTypes) {
         addStatement("var %N = super.hashCode", resultName)
         beginControlFlow("if (%N == 0)", resultName)
+        addStatement("%N = unknownFields.hashCode()", resultName)
       } else {
-        addStatement("var %N = 0", resultName)
+        addStatement("var %N = unknownFields.hashCode()", resultName)
       }
-      addStatement("%N = unknownFields.hashCode()", resultName)
 
       for (fieldOrOneOf in type.fieldsAndFlatOneOfFieldsAndBoxedOneOfs()) {
         when (fieldOrOneOf) {
@@ -1784,8 +1784,13 @@ class KotlinGenerator private constructor(
     val sizeName = localNameAllocator.newName("size")
 
     val body = buildCodeBlock {
+      val fieldsAndOneOfs = message.fieldsAndFlatOneOfFieldsAndBoxedOneOfs()
+      if (fieldsAndOneOfs.isEmpty()) {
+        addStatement("return value.unknownFields.size")
+        return@buildCodeBlock
+      }
       addStatement("var %N = value.unknownFields.size", sizeName)
-      for (fieldOrOneOf in message.fieldsAndFlatOneOfFieldsAndBoxedOneOfs()) {
+      for (fieldOrOneOf in fieldsAndOneOfs) {
         when (fieldOrOneOf) {
           is Field -> {
             val fieldName = localNameAllocator[fieldOrOneOf]

--- a/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
+++ b/wire-kotlin-generator/src/test/java/com/squareup/wire/kotlin/KotlinGeneratorTest.kt
@@ -2771,6 +2771,25 @@ class KotlinGeneratorTest {
     assertContains(code, "result = result * 37 + list.hashCode()")
   }
 
+  @Test fun encodedSizeFunctionWithoutFieldsHasNoLocalVariable() {
+    val schema = buildSchema {
+      add(
+        "message.proto".toPath(),
+        """
+        |message NoFields {
+        |}
+        """.trimMargin(),
+      )
+    }
+    val code = KotlinWithProfilesGenerator(schema).generateKotlin("NoFields")
+    assertThat(code).contains(
+      """
+      |      override fun encodedSize(`value`: NoFields): Int = value.unknownFields.size
+      """.trimMargin(),
+    )
+    assertThat(code).doesNotContain("var size")
+  }
+
   @Test
   fun enumConstantConflictingDeclaration() {
     val schema = buildSchema {
@@ -2909,7 +2928,8 @@ class KotlinGeneratorTest {
     assertThat(code).contains("override var unknownFields: ByteString = ByteString.EMPTY")
     assertThat(code).contains("MutableHeader#ADAPTER") // should refer to adapters of Mutable message types.
     assertThat(code).contains("MutablePayload#ADAPTER")
-    assertThat(code).contains("var result = 0") // hashCode() is no longer calling super.hashCode().
+    // hashCode() is no longer calling super.hashCode(), and it has no redundant initializer.
+    assertThat(code).contains("var result = unknownFields.hashCode()")
     assertThat(code).contains(
       "throw UnsupportedOperationException(\"newBuilder() is unsupported for mutable message types\")",
     )


### PR DESCRIPTION
Kotlin 2.1 added extra compiler checks (`-Wextra`). Two of them flag wire-generated code. Users cannot fix generated code, so the fix belongs in wire.

Fixes #3700
Fixes #3701

## Changes

**hashCode() for mutable types (#3701, VARIABLE_INITIALIZER_IS_REDUNDANT).** The generator emitted `var result = 0`, and the next line overwrote the value with `unknownFields.hashCode()`. The generator now initializes the variable with `unknownFields.hashCode()` directly. The immutable path is unchanged: its `super.hashCode` initializer is read by the cache check.

**encodedSize() for messages with no fields (#3700, CAN_BE_VAL_DELAYED_INITIALIZATION).** The body degenerated to `var size = value.unknownFields.size; return size`. The generator now emits `return value.unknownFields.size` with no local variable. KotlinPoet renders this as an expression body.

**Regression gate.** wire-golden-files now compiles with `extraWarnings` enabled. Four diagnostics fail the build via `-Xwarning-level=<NAME>:error`: `VARIABLE_INITIALIZER_IS_REDUNDANT`, `CAN_BE_VAL_DELAYED_INITIALIZATION`, `CAN_BE_VAL`, and `CAN_BE_VAL_LATEINIT`. Plain `allWarningsAsErrors` is too broad here: it also fails on repo-wide compiler warnings that are unrelated to the goldens, for example the deprecated `-Xjvm-default` flag spelling and the deprecated language version 2.0. `REDUNDANT_VISIBILITY_MODIFIER` is disabled for this module: KotlinPoet emits explicit visibility modifiers on purpose, and consumers with explicit API mode need them. Without this, it fires 984 times on the goldens.

## Verification

- Gate discrimination: with the gate and the old generator, `:wire-golden-files:compileKotlin` fails with exactly the four expected sites (three in hashCode, one in encodedSize). With the fixed generator, the build passes.
- The compiler rejects unknown diagnostic names with an error, so a green build proves the four escalated names are valid.
- `:wire-kotlin-generator:test`: 75 tests, 0 failures, forced fresh with `--rerun-tasks --no-build-cache`.
- `spotlessCheck` and `apiCheck` pass. The golden files change shape only. There is no runtime or `.api` change.
- All checked-in generated Kotlin lives in wire-golden-files. A repo-wide grep found no other fixture with the old shapes.
