### PR TITLE
Preserve unknown singular enum values in unknown fields in Swift

### DIFF
--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoDecoder.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoDecoder.swift
@@ -35,7 +35,9 @@ public final class ProtoDecoder {
         case throwError
         /// Defaults the unknown enum value to nil for single-value fields.
         /// With this option, unknown values in collections are removed from the collection in which they originated.
-        /// When decoding a Proto, unknown values are then added to a collection for the same tag in unknown fields.
+        /// When decoding a Proto, unknown values from both single-value fields and collections are added to
+        /// unknown fields for the same tag (for map fields, the whole key-value entry is added), so they
+        /// are preserved when the message is reencoded.
         case returnNil
     }
 

--- a/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
+++ b/wire-runtime-swift/src/main/swift/ProtoCodable/ProtoReader.swift
@@ -253,6 +253,9 @@ public final class ProtoReader {
 
     /**
      Decode enums.
+
+     Under the `.returnNil` strategy, an unrecognized value returns `nil` and is added to the
+     current message's unknown fields so that it is preserved when the message is reencoded.
      */
     public func decode<T: ProtoEnum>(_ type: T.Type) throws -> T? where T: RawRepresentable<Int32> {
         // Pop the enum int value and pass in to initializer
@@ -260,6 +263,15 @@ public final class ProtoReader {
         guard let enumValue = T(rawValue: intValue) else {
             switch enumDecodingStrategy {
             case .returnNil:
+                guard let tag = currentTag else {
+                    fatalError("The current tag was unexpectedly nil.")
+                }
+
+                // We encountered an unknown enum value. Given the strategy is .returnNil, we'll add this value
+                // to the unknown fields for the current tag, matching the behavior of repeated enum fields.
+                // NB: enum fields use varint encoding.
+                try addUnknownField(tag: tag, value: intValue, encoding: .variable)
+
                 return nil
             case .throwError:
                 throw ProtoDecoder.Error.unknownEnumCase(type: T.self, fieldNumber: intValue)

--- a/wire-runtime-swift/src/test/swift/ProtoReaderTests.swift
+++ b/wire-runtime-swift/src/test/swift/ProtoReaderTests.swift
@@ -301,8 +301,23 @@ final class ProtoReaderTests: XCTestCase {
     func testDecodeUnknownEnumNilStrategy() throws {
         let data = Foundation.Data(hexEncoded: "08_05")!
         try test(data: data, enumStrategy: .returnNil) { reader in
-            let value = try reader.decode(tag: 1) { try reader.decode(Person.PhoneType.self) }
+            var value: Person.PhoneType? = nil
+
+            let fields = try reader.forEachTag { tag in
+                switch tag {
+                case 1:
+                    value = try reader.decode(Person.PhoneType.self)
+                default:
+                    XCTFail("Should not encounter unknown fields")
+                }
+            }
+
             XCTAssertNil(value)
+            let expectedData = Foundation.Data(hexEncoded: """
+                08       // (tag 1 | Varint)
+                05       // Unknown enum
+            """)!
+            XCTAssertEqual(fields, [1: expectedData])
         }
     }
 
@@ -348,6 +363,12 @@ final class ProtoReaderTests: XCTestCase {
         try test(data: data, enumStrategy: .returnNil) { reader in
             let message = OneOfs {
                 $0.standalone_enum = .A
+                $0.unknownFields = [
+                    2: Foundation.Data(hexEncoded: """
+                        10 // (Tag 2 | Varint)
+                        02 // Value 2
+                    """)!
+                ]
             }
             XCTAssertEqual(try reader.decode(OneOfs.self), message)
         }

--- a/wire-runtime-swift/src/test/swift/RoundTripTests.swift
+++ b/wire-runtime-swift/src/test/swift/RoundTripTests.swift
@@ -96,6 +96,28 @@ final class RoundTripTests: XCTestCase {
         XCTAssertEqual(try encoder.encode(decoded), data)
     }
 
+    // a preserved unknown enum value reemits after known fields, so a stale client's edit of the
+    // same field is shadowed for last-wins readers — matching generated Kotlin/Java and GPB proto2
+    func testEditedSingularEnumFieldReemitsPreservedUnknownValue() throws {
+        let data = Foundation.Data(hexEncoded: """
+            20 // (Tag 4 | Varint)
+            05 // Unknown enum value 5
+        """)!
+
+        let decoder = ProtoDecoder(enumDecodingStrategy: .returnNil)
+        var decoded = try decoder.decode(OneOfs.self, from: data)
+        decoded.standalone_enum = .A
+
+        let expected = Foundation.Data(hexEncoded: """
+            20 // (Tag 4 | Varint)
+            01 // Value 1
+            20 // (Tag 4 | Varint)
+            05 // Unknown enum value 5
+        """)!
+        let encoder = ProtoEncoder()
+        XCTAssertEqual(try encoder.encode(decoded), expected)
+    }
+
     // in proto3 the field itself backfills to the zero-value default while the raw unknown
     // value is preserved in unknown fields, keeping the reencoded bytes identical
     func testUnknownEnumValueInProto3SingularFieldRoundTrip() throws {

--- a/wire-runtime-swift/src/test/swift/RoundTripTests.swift
+++ b/wire-runtime-swift/src/test/swift/RoundTripTests.swift
@@ -77,4 +77,44 @@ final class RoundTripTests: XCTestCase {
 
         XCTAssertEqual(decodedValues, values)
     }
+
+    // ensure that an unknown value in a singular enum field decoded with the .returnNil strategy
+    // is preserved in unknown fields and reemitted when the message is reencoded
+    func testUnknownEnumValueInSingularFieldRoundTrip() throws {
+        let data = Foundation.Data(hexEncoded: """
+            20 // (Tag 4 | Varint)
+            05 // Unknown enum value 5
+        """)!
+
+        let decoder = ProtoDecoder(enumDecodingStrategy: .returnNil)
+        let decoded = try decoder.decode(OneOfs.self, from: data)
+
+        XCTAssertNil(decoded.standalone_enum)
+        XCTAssertEqual(decoded.unknownFields, [4: data])
+
+        let encoder = ProtoEncoder()
+        XCTAssertEqual(try encoder.encode(decoded), data)
+    }
+
+    // in proto3 the field itself backfills to the zero-value default while the raw unknown
+    // value is preserved in unknown fields, keeping the reencoded bytes identical
+    func testUnknownEnumValueInProto3SingularFieldRoundTrip() throws {
+        let data = Foundation.Data(hexEncoded: """
+            0A     // (Tag 1 | Length Delimited)
+            03     // Length 3
+            616263 // "abc"
+            10     // (Tag 2 | Varint)
+            05     // Unknown enum value 5
+        """)!
+
+        let decoder = ProtoDecoder(enumDecodingStrategy: .returnNil)
+        let decoded = try decoder.decode(Person3.PhoneNumber.self, from: data)
+
+        XCTAssertEqual(decoded.number, "abc")
+        XCTAssertEqual(decoded.type, .MOBILE)
+        XCTAssertEqual(decoded.unknownFields, [2: Foundation.Data(hexEncoded: "10_05")!])
+
+        let encoder = ProtoEncoder()
+        XCTAssertEqual(try encoder.encode(decoded), data)
+    }
 }


### PR DESCRIPTION
Under `ProtoDecoder`'s `.returnNil` strategy, an unrecognized value in a **singular** (or oneof) enum field is read and discarded: it never reaches `unknownFields`, so reencoding the message silently drops the field. This diverges from:

- the same strategy's handling of **repeated and map** enum fields, which already preserve unrecognized values in unknown fields (`ProtoReader.decode(into:)`);
- **generated Kotlin/Java**, which catches `EnumConstantNotFoundException` and calls `addUnknownField(...)` for singular fields (pinned by `UnknownFieldsTest`, which asserts the raw varint survives in `unknownFields`);
- **proto2 semantics / protobuf C++ & ObjC runtimes**, which treat unknown enum values like unknown fields;
- the `.returnNil` doc comment itself, which already described unknown values as "added to a collection for the same tag in unknown fields" — previously true only for collections.

The practical impact is in fetch → decode → mutate → reencode → full-object update flows: when a server starts sending a new enum value, a stale client that edits any *other* field of the object silently clears the enum field on the way back up.

### Change

Route the unrecognized raw value into the current message frame's unknown fields in the singular enum decode path, mirroring the existing repeated-field path (including its `currentTag` guard). Runtime-only; no generator or generated-code changes.

### Tests

- Updated the two tests that pinned the drop (`testDecodeUnknownEnumNilStrategy` now asserts the preserved bytes; `testDecodeUnknownEnumInOneOfNilStrategy` now expects the value in `unknownFields`).
- New `RoundTripTests` covering a singular/oneof unknown enum (proto2 shape) and a proto3 field (interaction with the zero-value backfill), both asserting the reencoded bytes are identical to the input. A further test pins the edit-shadowing semantics described below (`20 05` decoded, field set to a known value, reencode asserted as `20 01 20 05`).

`swift test`: full suite passing locally; all CI jobs green.

### Behavior change note

Messages decoded under `.returnNil` now carry `unknownFields` entries where they previously had none, which is observable through `Equatable`/`Hashable` and reencoded bytes. Suggested CHANGELOG entry (under `### Swift`):

> * Behavior change: `ProtoDecoder` with `.returnNil` now preserves unrecognized singular enum values in the message's `unknownFields` — matching repeated/map fields, generated Kotlin/Java, and proto2 semantics — so they survive reencoding instead of being silently dropped.

The flip side of preservation, also worth stating: a stale client that *edits the unknown-valued enum field itself* now reencodes `[known value][preserved unknown]`, and last-wins readers keep the unknown — the edit is shadowed until the client learns the new value (previously the drop made the edit win). This matches what generated Kotlin/Java, GPB proto2, and Wire Swift's existing map/repeated enum handling already do, and is pinned by `testEditedSingularEnumFieldReemitsPreservedUnknownValue`. The generator-level clear-on-mutate improvement that would remove the shadow (for singular *and* map/repeated fields) is tracked in #3710.

### Known pre-existing edge (disclosed, not addressed here)

If the same singular enum tag occurs twice on the wire as `[known, unknown]`, generated Swift assigns each decode result unconditionally, so the later unknown occurrence overwrites the previously decoded known value with `nil` (generated Kotlin's `catch` skips the assignment; protobuf runtimes keep the recognized value). That generator shape predates this PR; preservation makes it observable across multiple decode/reencode hops. A generator change (skip assignment when the decode returns `nil`) is noted as a ride-along in #3710.

The Codable path's `JSONDecoder.EnumDecodingStrategy.returnNil` is a distinct type and is unchanged.


