### PR TITLE
Revert kotlinpoet to 2.3.0, the last version built with Kotlin 2.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,9 @@ junit = "4.13.2"
 kotlin = "2.3.21"
 # Set to lower version than KGP version to maximize compatibility
 kotlinCoreLibrariesVersion = "2.0.21"
-kotlinpoet = "2.4.0"
+# kotlinpoet 2.4.0 is built with Kotlin 2.4. wire-schema exposes kotlinpoet as api,
+# so consumers on Kotlin 2.2 cannot read its metadata. Keep the last Kotlin 2.3 build.
+kotlinpoet = "2.3.0"
 ktlint = "1.5.0"
 moshi = "1.15.2"
 okhttp = "5.5.0"


### PR DESCRIPTION
Reverts kotlinpoet from 2.4.0 to 2.3.0 (the renovate bump in e7ff74c36).

kotlinpoet 2.4.0 is built with Kotlin 2.4: its published module metadata requires kotlin-stdlib 2.4.20, while 2.3.0 requires 2.3.20. wire-schema exposes kotlinpoet as an api dependency, so Wire 7.0.0 puts Kotlin 2.4 metadata on consumer compile classpaths. Consumers that compile with Kotlin 2.2 cannot read that metadata and fail to compile. Evidence: cashapp/misk#3928 (misk pins Kotlin 2.2.21 and needed a kotlinpoet force to build against Wire 7.0.0).

2.3.0 is the newest kotlinpoet release not built with Kotlin 2.4; there is no 2.3.x after it. A comment on the pin marks the constraint, since renovate will re-open the bump.

Wire 7.0.1 follows with this revert.

## Verification

Local, at this head:

- `:wire-schema:compileKotlinJvm`, `:wire-kotlin-generator:compileKotlin`, `:wire-compiler:compileKotlin`: BUILD SUCCESSFUL.
- `:wire-kotlin-generator:spotlessCheck`: BUILD SUCCESSFUL.
- `dependencyInsight` on `:wire-kotlin-generator` compileClasspath resolves kotlinpoet 2.3.0.
